### PR TITLE
fix: CJK 貼上亂碼與貼上邏輯整理,git graph 移到 launcher

### DIFF
--- a/src-tauri/src/modules/clipboard.rs
+++ b/src-tauri/src/modules/clipboard.rs
@@ -76,9 +76,21 @@ fn clipboard_image_paths() -> Result<Vec<String>, String> {
     Ok(Vec::new())
 }
 
+/// Spawn a macOS helper with a forced UTF-8 codeset. A GUI (Finder) launch
+/// inherits no UTF-8 locale, so `pbpaste`/`osascript` fall back to the region's
+/// legacy encoding (e.g. Big5 for zh-Hant) and their non-ASCII output then
+/// fails to decode as UTF-8, leaving replacement characters. `LC_ALL` outranks
+/// any inherited locale, so it reliably pins the codeset to UTF-8.
+#[cfg(target_os = "macos")]
+fn utf8_command(program: &str) -> Command {
+    let mut cmd = Command::new(program);
+    cmd.env("LC_ALL", "en_US.UTF-8");
+    cmd
+}
+
 #[cfg(target_os = "macos")]
 fn clipboard_text() -> Result<String, String> {
-    let output = Command::new("pbpaste")
+    let output = utf8_command("pbpaste")
         .output()
         .map_err(|e| format!("failed to run pbpaste: {e}"))?;
     if !output.status.success() {
@@ -219,7 +231,7 @@ end try
 
 #[cfg(target_os = "macos")]
 fn run_osascript(script: &str) -> Result<String, String> {
-    let output = Command::new("osascript")
+    let output = utf8_command("osascript")
         .arg("-e")
         .arg(script)
         .output()
@@ -321,6 +333,23 @@ fn applescript_string(path: &Path) -> String {
 mod tests {
     use super::{image_extension, is_image_path, is_valid_clipboard_file_path, unique_paths};
     use std::path::Path;
+
+    // A GUI (Finder) launch inherits no UTF-8 locale, so helpers like `pbpaste`
+    // fall back to the region's legacy encoding (e.g. Big5) for CJK text. The
+    // helper command must force a UTF-8 codeset so its output decodes cleanly.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn helper_command_forces_a_utf8_locale() {
+        let cmd = super::utf8_command("pbpaste");
+        let forces_utf8 = cmd.get_envs().any(|(k, v)| {
+            (k == "LC_ALL" || k == "LC_CTYPE" || k == "LANG")
+                && v
+                    .and_then(|v| v.to_str())
+                    .map(|v| v.to_ascii_uppercase().contains("UTF-8"))
+                    .unwrap_or(false)
+        });
+        assert!(forces_utf8);
+    }
 
     #[test]
     fn detects_image_paths_by_extension() {

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -67,7 +67,12 @@ fn build_shell_command(cwd: Option<String>) -> (CommandBuilder, String) {
     if let Some(dir) = cwd.filter(|d| !d.trim().is_empty()) {
         cmd.cwd(dir);
     }
-    for (key, value) in terminal_env(std::env::var("LANG").ok()) {
+    let locale_env = terminal_env(
+        std::env::var("LC_ALL").ok(),
+        std::env::var("LC_CTYPE").ok(),
+        std::env::var("LANG").ok(),
+    );
+    for (key, value) in locale_env {
         cmd.env(key, value);
     }
 

--- a/src-tauri/src/modules/pty/shell.rs
+++ b/src-tauri/src/modules/pty/shell.rs
@@ -29,12 +29,38 @@ fn default_shell() -> String {
     std::env::var("COMSPEC").unwrap_or_else(|_| "powershell.exe".to_string())
 }
 
+/// A UTF-8 locale that is reliably present on the target platform. We only need
+/// a UTF-8 codeset for `LC_CTYPE`; the territory is incidental.
+#[cfg(target_os = "macos")]
+fn utf8_locale() -> &'static str {
+    // Always shipped on macOS.
+    "en_US.UTF-8"
+}
+
+#[cfg(not(target_os = "macos"))]
+fn utf8_locale() -> &'static str {
+    // Language-neutral and present on modern glibc/musl.
+    "C.UTF-8"
+}
+
+/// True when a locale value carries a UTF-8 codeset (e.g. `zh_TW.UTF-8`).
+fn is_utf8_locale(value: &str) -> bool {
+    value.to_lowercase().replace('-', "").contains("utf8")
+}
+
 /// Build the base environment a terminal session should run with.
 ///
-/// `existing_lang` is whatever `$LANG` currently holds. When it is missing or
-/// empty we inject a UTF-8 locale so multi-byte output (including CJK) is not
-/// mangled by a C/POSIX locale.
-pub fn terminal_env(existing_lang: Option<String>) -> Vec<(String, String)> {
+/// `lc_all`, `lc_ctype` and `lang` are whatever those variables currently hold.
+/// The effective character encoding follows the POSIX precedence
+/// `LC_ALL` > `LC_CTYPE` > `LANG`. When the winning value is not a UTF-8 locale
+/// (missing, `C`, `POSIX`, or any non-UTF-8 codeset) we force a UTF-8 locale so
+/// multi-byte input/output (including CJK) is not mangled. A GUI launch from
+/// Finder inherits no shell locale at all, which is exactly this case.
+pub fn terminal_env(
+    lc_all: Option<String>,
+    lc_ctype: Option<String>,
+    lang: Option<String>,
+) -> Vec<(String, String)> {
     let mut env = vec![
         ("TERM".to_string(), "xterm-256color".to_string()),
         ("COLORTERM".to_string(), "truecolor".to_string()),
@@ -42,12 +68,19 @@ pub fn terminal_env(existing_lang: Option<String>) -> Vec<(String, String)> {
         ("TEMPOTERM".to_string(), "1".to_string()),
     ];
 
-    let lang_missing = existing_lang
-        .as_deref()
-        .map(|l| l.trim().is_empty())
-        .unwrap_or(true);
-    if lang_missing {
-        env.push(("LANG".to_string(), "en_US.UTF-8".to_string()));
+    let non_empty = |v: Option<String>| v.filter(|s| !s.trim().is_empty());
+    let lc_all = non_empty(lc_all);
+    let effective = lc_all
+        .clone()
+        .or_else(|| non_empty(lc_ctype))
+        .or_else(|| non_empty(lang));
+
+    let already_utf8 = effective.as_deref().map(is_utf8_locale).unwrap_or(false);
+    if !already_utf8 {
+        // `LC_ALL` outranks `LC_CTYPE`, so when it is the (non-UTF-8) value in
+        // effect we must override it directly; otherwise `LC_CTYPE` is enough.
+        let key = if lc_all.is_some() { "LC_ALL" } else { "LC_CTYPE" };
+        env.push((key.to_string(), utf8_locale().to_string()));
     }
 
     env
@@ -101,22 +134,46 @@ mod tests {
 
     #[test]
     fn terminal_env_always_sets_term_and_colorterm() {
-        let env = terminal_env(Some("en_US.UTF-8".to_string()));
+        let env = terminal_env(None, None, Some("en_US.UTF-8".to_string()));
         assert!(env.contains(&("TERM".to_string(), "xterm-256color".to_string())));
         assert!(env.contains(&("COLORTERM".to_string(), "truecolor".to_string())));
     }
 
-    #[test]
-    fn terminal_env_injects_utf8_lang_when_missing() {
-        let env = terminal_env(None);
-        assert!(env
-            .iter()
-            .any(|(k, v)| k == "LANG" && v.contains("UTF-8")));
+    fn has_utf8(env: &[(String, String)], key: &str) -> bool {
+        env.iter()
+            .any(|(k, v)| k == key && v.to_lowercase().replace('-', "").contains("utf8"))
     }
 
     #[test]
-    fn terminal_env_keeps_existing_lang() {
-        let env = terminal_env(Some("zh_TW.UTF-8".to_string()));
-        assert!(!env.iter().any(|(k, _)| k == "LANG"));
+    fn forces_utf8_ctype_when_lang_is_c() {
+        let env = terminal_env(None, None, Some("C".to_string()));
+        assert!(has_utf8(&env, "LC_CTYPE"));
+    }
+
+    #[test]
+    fn forces_utf8_ctype_when_no_locale_is_set() {
+        // A Finder/Dock launch inherits no shell locale at all.
+        let env = terminal_env(None, None, None);
+        assert!(has_utf8(&env, "LC_CTYPE"));
+    }
+
+    #[test]
+    fn keeps_existing_utf8_lang_untouched() {
+        let env = terminal_env(None, None, Some("zh_TW.UTF-8".to_string()));
+        assert!(!env.iter().any(|(k, _)| k.starts_with("LC_") || k == "LANG"));
+    }
+
+    #[test]
+    fn respects_lc_ctype_precedence_over_lang() {
+        // LC_CTYPE outranks LANG, so a UTF-8 LC_CTYPE means we leave it alone.
+        let env = terminal_env(None, Some("en_US.UTF-8".to_string()), Some("C".to_string()));
+        assert!(!env.iter().any(|(k, _)| k.starts_with("LC_") || k == "LANG"));
+    }
+
+    #[test]
+    fn overrides_lc_all_when_it_forces_a_non_utf8_locale() {
+        // LC_ALL outranks LC_CTYPE, so patching LC_CTYPE alone would not win.
+        let env = terminal_env(Some("C".to_string()), None, Some("zh_TW.UTF-8".to_string()));
+        assert!(has_utf8(&env, "LC_ALL"));
     }
 }

--- a/src/components/LauncherPanel.tsx
+++ b/src/components/LauncherPanel.tsx
@@ -5,6 +5,7 @@ import {
   FolderOpen,
   Globe,
   SquareTerminal,
+  Waypoints,
   type LucideIcon,
 } from "lucide-react";
 import { useTabsStore } from "@/stores/tabsStore";
@@ -56,6 +57,7 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
   const openEditorTab = useTabsStore((s) => s.openEditorTab);
   const openNoteTab = useTabsStore((s) => s.openNoteTab);
   const openPreviewTab = useTabsStore((s) => s.openPreviewTab);
+  const openGitGraphTab = useTabsStore((s) => s.openGitGraphTab);
   const setPaneContent = useTabsStore((s) => s.setPaneContent);
   const closeTab = useTabsStore((s) => s.closeTab);
   const setRoot = useWorkspaceStore((s) => s.setRoot);
@@ -85,6 +87,8 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
         openPreviewTab(content.url);
         break;
       case "git-graph":
+        openGitGraphTab();
+        break;
       case "launcher":
         break;
     }
@@ -150,6 +154,12 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
           label: t("preview:title"),
           icon: Globe,
           run: () => apply({ kind: "preview", url: DEFAULT_PREVIEW_URL }),
+        },
+        {
+          key: "git-graph",
+          label: t("nav.gitGraph"),
+          icon: Waypoints,
+          run: () => apply({ kind: "git-graph" }),
         },
       ],
     },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,11 +1,10 @@
 import { useTranslation } from "react-i18next";
-import { Bot, FolderTree, GitBranch, NotebookPen, Waypoints, type LucideIcon } from "lucide-react";
+import { Bot, FolderTree, GitBranch, NotebookPen, type LucideIcon } from "lucide-react";
 import { ExplorerView } from "@/modules/explorer/ExplorerView";
 import { SourceControlView } from "@/modules/source-control/SourceControlView";
 import { AIView } from "@/modules/ai/AIView";
 import { NotesSidebar } from "@/modules/notes/NotesSidebar";
 import { Tooltip } from "@/components/Tooltip";
-import { useTabsStore } from "@/stores/tabsStore";
 import { useUiStore, type SidebarView } from "@/stores/uiStore";
 
 interface SidebarTab {
@@ -25,7 +24,6 @@ export function Sidebar() {
   const { t } = useTranslation();
   const sidebarView = useUiStore((s) => s.sidebarView);
   const selectSidebar = useUiStore((s) => s.selectSidebar);
-  const openGitGraphTab = useTabsStore((s) => s.openGitGraphTab);
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden border-r border-border bg-bg-inset">
@@ -48,18 +46,6 @@ export function Sidebar() {
             </Tooltip>
           );
         })}
-
-        {/* Git graph opens full-width in the main area (not a sidebar view). */}
-        <Tooltip label={t("nav.gitGraph")} side="bottom">
-          <button
-            type="button"
-            aria-label={t("nav.gitGraph")}
-            onClick={() => openGitGraphTab()}
-            className="flex h-7 w-8 items-center justify-center rounded-md text-fg-subtle transition-colors hover:text-fg"
-          >
-            <Waypoints size={15} />
-          </button>
-        </Tooltip>
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -9,7 +9,7 @@
     "git": "Git",
     "ai": "AI 助手",
     "notes": "筆記",
-    "gitGraph": "Git 圖",
+    "gitGraph": "Git 線圖",
     "settings": "設定"
   },
   "statusBar": {

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -115,17 +115,22 @@ export function TerminalView({
         return;
       }
       // Text wins, so read it first and skip the (costlier) path/image probes
-      // when a normal copy is on the clipboard.
+      // when a normal copy is on the clipboard. Each probe spawns a macOS
+      // helper (osascript/ps), so fetch them lazily and in order: file paths
+      // shadow images in resolvePasteAction, and the foreground command only
+      // matters when there is exactly one path that could be an attachment.
       const clipboardText = await terminalClipboardText().catch(() => "");
       let filePaths: string[] = [];
       let imagePaths: string[] = [];
       let command: string | null = null;
       if (!clipboardText) {
-        [command, filePaths, imagePaths] = await Promise.all([
-          session.foregroundCommand().catch(() => null),
-          terminalClipboardPaths().catch(() => []),
-          terminalClipboardImagePaths().catch(() => []),
-        ]);
+        filePaths = await terminalClipboardPaths().catch(() => []);
+        if (filePaths.length === 0) {
+          imagePaths = await terminalClipboardImagePaths().catch(() => []);
+        }
+        if (filePaths.length === 1 || imagePaths.length === 1) {
+          command = await session.foregroundCommand().catch(() => null);
+        }
       }
       const action = resolvePasteAction({
         shortcut: kind,

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -12,6 +12,7 @@ import { imageFilesFromDrop, pathsFromDrop } from "./lib/terminalDrop";
 import {
   formatPathsForTerminal,
   prepareClipboardImageAttachment,
+  resolvePasteAction,
   saveDroppedImage,
   terminalClipboardImagePaths,
   terminalClipboardPaths,
@@ -113,37 +114,43 @@ export function TerminalView({
       if (!session) {
         return;
       }
-      const [command, clipboardPaths] = await Promise.all([
-        session.foregroundCommand().catch(() => null),
-        terminalClipboardPaths().catch(() => []),
-      ]);
-      if (clipboardPaths.length > 0) {
-        if (shouldAttachImage(command, clipboardPaths)) {
-          await prepareClipboardImageAttachment(clipboardPaths[0]).catch(() => {});
+      // Text wins, so read it first and skip the (costlier) path/image probes
+      // when a normal copy is on the clipboard.
+      const clipboardText = await terminalClipboardText().catch(() => "");
+      let filePaths: string[] = [];
+      let imagePaths: string[] = [];
+      let command: string | null = null;
+      if (!clipboardText) {
+        [command, filePaths, imagePaths] = await Promise.all([
+          session.foregroundCommand().catch(() => null),
+          terminalClipboardPaths().catch(() => []),
+          terminalClipboardImagePaths().catch(() => []),
+        ]);
+      }
+      const action = resolvePasteAction({
+        shortcut: kind,
+        clipboardText,
+        filePaths,
+        imagePaths,
+        foregroundCommand: command,
+      });
+      switch (action.kind) {
+        case "text":
+          term.paste(action.text);
+          break;
+        case "attach-image":
+          await prepareClipboardImageAttachment(action.path).catch(() => {});
           await session.write("\x16");
-        } else {
-          term.paste(formatPathsForTerminal(clipboardPaths));
-        }
-        return;
-      }
-      const imagePaths = await terminalClipboardImagePaths().catch(() => []);
-      if (imagePaths.length > 0) {
-        if (shouldAttachImage(command, imagePaths)) {
-          await prepareClipboardImageAttachment(imagePaths[0]).catch(() => {});
+          break;
+        case "paste-paths":
+          term.paste(formatPathsForTerminal(action.paths));
+          break;
+        case "control":
           await session.write("\x16");
-        } else {
-          term.paste(formatPathsForTerminal(imagePaths));
-        }
-        return;
+          break;
+        case "none":
+          break;
       }
-      if (kind === "cmd") {
-        const text = await terminalClipboardText().catch(() => "");
-        if (text) {
-          term.paste(text);
-        }
-        return;
-      }
-      await session.write("\x16");
     }
 
     function isTerminalPasteShortcut(event: KeyboardEvent): "ctrl" | "cmd" | null {

--- a/src/modules/terminal/lib/terminalClipboard.test.ts
+++ b/src/modules/terminal/lib/terminalClipboard.test.ts
@@ -4,6 +4,7 @@ import {
   formatPathsForTerminal,
   isImageAttachmentCli,
   isImagePath,
+  resolvePasteAction,
   shellQuotePath,
   shouldAttachImage,
 } from "./terminalClipboard";
@@ -45,5 +46,61 @@ describe("terminal clipboard helpers", () => {
   it("shell-quotes paths only when needed", () => {
     expect(shellQuotePath("/tmp/a.png")).toBe("/tmp/a.png");
     expect(shellQuotePath("/tmp/it's here.png")).toBe("'/tmp/it'\\''s here.png'");
+  });
+});
+
+describe("resolvePasteAction", () => {
+  it("pastes clipboard text verbatim, even when it looks like a path", () => {
+    expect(
+      resolvePasteAction({
+        shortcut: "cmd",
+        clipboardText: "/usr/local/bin",
+        filePaths: [],
+        imagePaths: [],
+        foregroundCommand: "zsh",
+      }),
+    ).toEqual({ kind: "text", text: "/usr/local/bin" });
+  });
+
+  it("pastes a copied file's path when the clipboard has no text", () => {
+    expect(
+      resolvePasteAction({
+        shortcut: "cmd",
+        clipboardText: "",
+        filePaths: ["/Users/me/My File.txt"],
+        imagePaths: [],
+        foregroundCommand: "zsh",
+      }),
+    ).toEqual({ kind: "paste-paths", paths: ["/Users/me/My File.txt"] });
+  });
+
+  it("attaches a copied image when the foreground command is an image-aware CLI", () => {
+    expect(
+      resolvePasteAction({
+        shortcut: "cmd",
+        clipboardText: "",
+        filePaths: [],
+        imagePaths: ["/tmp/shot.png"],
+        foregroundCommand: "claude",
+      }),
+    ).toEqual({ kind: "attach-image", path: "/tmp/shot.png" });
+  });
+
+  it("pastes the image path instead of attaching when the shell is not image-aware", () => {
+    expect(
+      resolvePasteAction({
+        shortcut: "cmd",
+        clipboardText: "",
+        filePaths: [],
+        imagePaths: ["/tmp/shot.png"],
+        foregroundCommand: "zsh",
+      }),
+    ).toEqual({ kind: "paste-paths", paths: ["/tmp/shot.png"] });
+  });
+
+  it("falls back to the control byte for Ctrl+V with an empty clipboard", () => {
+    const base = { clipboardText: "", filePaths: [], imagePaths: [], foregroundCommand: null };
+    expect(resolvePasteAction({ ...base, shortcut: "ctrl" })).toEqual({ kind: "control" });
+    expect(resolvePasteAction({ ...base, shortcut: "cmd" })).toEqual({ kind: "none" });
   });
 });

--- a/src/modules/terminal/lib/terminalClipboard.ts
+++ b/src/modules/terminal/lib/terminalClipboard.ts
@@ -55,3 +55,48 @@ export function shellQuotePath(path: string): string {
   }
   return `'${path.replace(/'/g, "'\\''")}'`;
 }
+
+export type PasteAction =
+  | { kind: "text"; text: string }
+  | { kind: "attach-image"; path: string }
+  | { kind: "paste-paths"; paths: string[] }
+  | { kind: "control" }
+  | { kind: "none" };
+
+interface PasteInput {
+  shortcut: "ctrl" | "cmd";
+  clipboardText: string;
+  filePaths: string[];
+  imagePaths: string[];
+  foregroundCommand: string | null;
+}
+
+/**
+ * Decide what a terminal paste should do, in priority order:
+ *
+ * 1. Clipboard text wins and is pasted verbatim — no path detection, no shell
+ *    quoting — so an ordinary copy (or a path-looking string) lands exactly as
+ *    copied. This ordering is what keeps plain text from being mis-quoted.
+ * 2. With no text, a copied image handed to an image-aware CLI is attached.
+ * 3. Otherwise a genuine file reference (or a screenshot's temp path) is pasted
+ *    as a shell-quoted path.
+ * 4. A bare Ctrl+V with nothing to paste falls back to the raw control byte.
+ */
+export function resolvePasteAction(input: PasteInput): PasteAction {
+  if (input.clipboardText) {
+    return { kind: "text", text: input.clipboardText };
+  }
+  if (shouldAttachImage(input.foregroundCommand, input.filePaths)) {
+    return { kind: "attach-image", path: input.filePaths[0] };
+  }
+  if (shouldAttachImage(input.foregroundCommand, input.imagePaths)) {
+    return { kind: "attach-image", path: input.imagePaths[0] };
+  }
+  if (input.filePaths.length > 0) {
+    return { kind: "paste-paths", paths: input.filePaths };
+  }
+  if (input.imagePaths.length > 0) {
+    return { kind: "paste-paths", paths: input.imagePaths };
+  }
+  return input.shortcut === "ctrl" ? { kind: "control" } : { kind: "none" };
+}


### PR DESCRIPTION
## 概要

修好終端機在正式版(從 Finder 啟動)貼上中日韓文字會變亂碼的問題,並順手把貼上邏輯整理乾淨、把 git graph 入口搬到比較合理的位置

## 改了什麼

**1. CJK 貼上亂碼(主要修正)**

從 Finder 啟動的 App 不繼承 shell 的 UTF-8 locale,自訂的剪貼簿讀取用 `pbpaste` 子行程在這種環境下會退回區域舊編碼(zh-Hant 是 Big5)輸出,再經 `from_utf8_lossy` 就全變替換字元。改成 spawn `pbpaste` / `osascript` 時強制帶 `LC_ALL=en_US.UTF-8`,中日韓一次解決。終端機 session 的 locale 判斷也一併補強,改成依 POSIX 優先序 `LC_ALL` > `LC_CTYPE` > `LANG`,非 UTF-8 才補

**2. 貼上把純文字誤判成路徑**

Cmd+V 原本先猜剪貼簿是不是檔案路徑,導致以 `/` 開頭的純文字被加引號、反斜線甚至貼不完整。抽出純函式 `resolvePasteAction`,改成文字優先,只有在沒有文字時才走圖片附加或檔案路徑,兩種需求都保留且不再互相干擾

**3. git graph 入口位置**

git graph 開的是整頁分頁,本來就不屬於側邊欄。從側邊欄移到 launcher 的工具區,沿用既有的 `openGitGraphTab`,zh-Hant 標籤改成 Git 線圖

## 測試

- 後端 `cargo test` 全過,新增 locale 與剪貼簿 helper 的單元測試
- 前端 `vitest` 247 個全過,新增 `resolvePasteAction` 的行為測試
- 以 `pbcopy` / `pbpaste` 在清空 locale 的環境下實測中日韓 bytes,確認修正前後差異
- 手動實測:Finder 啟動的正式版,語音輸入與貼上中文已正常,純文字不再被加引號,從 Finder 複製檔案貼上路徑正常,截圖貼進 Claude Code 圖片附加正常

## 測試計畫(reviewer)

- [ ] Finder 啟動正式版,貼上中文/日文/韓文確認不亂碼
- [ ] 貼上以 `/` 開頭的純文字,確認不被加引號
- [ ] 從 Finder 複製檔案 Cmd+V,確認貼出路徑
- [ ] 截圖在 Claude Code 內貼上,確認圖片附加
