### PR TITLE
fix: clean up note code block rendering and language picker

### DIFF
--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -12,6 +12,8 @@ interface ComboboxProps {
   className?: string;
   /** Open the list upward (for triggers near the bottom of the window). */
   dropUp?: boolean;
+  /** Compact trigger sizing for dense toolbars (e.g. a code block header). */
+  size?: "sm" | "md";
 }
 
 /**
@@ -28,9 +30,13 @@ export function Combobox({
   placeholder,
   className,
   dropUp = false,
+  size = "md",
 }: ComboboxProps) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
+  const dense = size === "sm";
+  const fieldClass = dense ? "px-2 py-0.5 text-xs" : "px-3 py-2 text-sm";
+  const optionClass = dense ? "px-2 py-1 text-xs" : "px-3 py-2 text-sm";
 
   useEffect(() => {
     if (!open) {
@@ -64,14 +70,14 @@ export function Combobox({
             spellCheck={false}
             onChange={(e) => onChange(e.target.value)}
             onFocus={() => setOpen(true)}
-            className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm text-fg outline-none placeholder:text-fg-subtle"
+            className={`min-w-0 flex-1 bg-transparent text-fg outline-none placeholder:text-fg-subtle ${fieldClass}`}
           />
         ) : (
           <button
             type="button"
             aria-label={ariaLabel}
             onClick={() => setOpen((o) => !o)}
-            className="flex min-w-0 flex-1 items-center px-3 py-2 text-left text-sm text-fg"
+            className={`flex min-w-0 flex-1 items-center text-left ${dense ? "text-fg-muted" : "text-fg"} ${fieldClass}`}
           >
             <span className="truncate">{value}</span>
           </button>
@@ -81,10 +87,10 @@ export function Combobox({
           aria-label={ariaLabel}
           tabIndex={-1}
           onClick={() => setOpen((o) => !o)}
-          className="shrink-0 px-2 py-2 text-fg-subtle hover:text-fg"
+          className={`shrink-0 text-fg-subtle hover:text-fg ${dense ? "px-1 py-0.5" : "px-2 py-2"}`}
         >
           <ChevronDown
-            size={15}
+            size={dense ? 12 : 15}
             className={`transition-transform ${open ? "rotate-180" : ""}`}
           />
         </button>
@@ -92,7 +98,8 @@ export function Combobox({
 
       {open && (
         <ul
-          className={`absolute left-0 right-0 z-50 max-h-60 space-y-0.5 overflow-y-auto rounded-lg border border-border-strong bg-bg-elevated p-1.5 shadow-xl ${
+          data-combobox
+          className={`absolute left-0 z-50 max-h-60 w-max min-w-full max-w-[16rem] space-y-0.5 overflow-y-auto rounded-lg border border-border-strong bg-bg-elevated p-1 shadow-xl ${
             dropUp ? "bottom-full mb-1.5" : "top-full mt-1.5"
           }`}
         >
@@ -106,7 +113,7 @@ export function Combobox({
                     onChange(opt);
                     setOpen(false);
                   }}
-                  className={`flex w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-left text-sm ${
+                  className={`flex w-full items-center justify-between gap-2 rounded-md text-left ${optionClass} ${
                     active ? "bg-bg text-fg" : "text-fg-muted hover:bg-bg hover:text-fg"
                   }`}
                 >

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,6 +1,7 @@
 {
   "appName": "TempoTerm",
   "tagline": "AI-powered terminal workspace",
+  "openLinkHint": "Cmd / Ctrl-click to open",
   "nav": {
     "terminal": "Terminal",
     "explorer": "Explorer",

--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -16,6 +16,7 @@
   "run": "Run in terminal",
   "language": "Language",
   "exitHint": "Cmd + Enter to exit",
+  "linkHint": "Cmd / Ctrl-click to open",
   "slash": {
     "text": "Text",
     "h1": "Heading 1",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1,6 +1,7 @@
 {
   "appName": "TempoTerm",
   "tagline": "AI 驅動的終端機工作區",
+  "openLinkHint": "Cmd / Ctrl + 點擊開啟",
   "nav": {
     "terminal": "終端機",
     "explorer": "檔案總管",

--- a/src/i18n/locales/zh-Hant/notes.json
+++ b/src/i18n/locales/zh-Hant/notes.json
@@ -16,6 +16,7 @@
   "run": "在終端機執行",
   "language": "語言",
   "exitHint": "Cmd + Enter 跳脫",
+  "linkHint": "Cmd / Ctrl + 點擊開啟連結",
   "slash": {
     "text": "文字",
     "h1": "標題 1",

--- a/src/index.css
+++ b/src/index.css
@@ -124,7 +124,43 @@ button:disabled {
 .note-md ol { list-style: decimal; padding-left: 1.4em; margin: 0.5em 0; }
 .note-md li { margin: 0.2em 0; }
 .note-md li > input[type="checkbox"] { margin-right: 0.4em; }
-.note-md a { color: var(--color-accent); text-decoration: underline; }
+.note-md a { color: var(--color-accent); text-decoration: underline; cursor: pointer; }
+/* Shared hover tooltip for terminal links (xterm has no native tooltip). */
+.terminal-link-tooltip {
+  position: fixed;
+  z-index: 9999;
+  display: none;
+  pointer-events: none;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--color-fg);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 6px;
+  padding: 2px 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* Instant hover hint for editor links (native title is too slow to be useful). */
+.tiptap a[data-link-hint] { position: relative; }
+.tiptap a[data-link-hint]:hover::after {
+  content: attr(data-link-hint);
+  position: absolute;
+  left: 0;
+  top: 100%;
+  margin-top: 4px;
+  z-index: 50;
+  white-space: nowrap;
+  pointer-events: none;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--color-fg);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 6px;
+  padding: 2px 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
 .note-md strong { font-weight: 700; }
 .note-md em { font-style: italic; }
 .note-md blockquote {

--- a/src/index.css
+++ b/src/index.css
@@ -151,7 +151,10 @@ button:disabled {
   border-radius: 4px;
   padding: 0.1em 0.35em;
 }
-.note-md pre {
+/* Static markdown (AI replies, chat) needs the boxed code block. The notes
+   editor renders code blocks through a React node view that draws its own
+   container, so scope this off the editor (.tiptap) to avoid a double box. */
+.note-md:not(.tiptap) pre {
   background: var(--color-bg-inset);
   border: 1px solid var(--color-border);
   border-radius: 8px;
@@ -165,6 +168,23 @@ button:disabled {
   background: none;
   border: 0;
   padding: 0;
+}
+/* In the editor the code block already sets its own size on <pre>; don't shrink
+   the code further, so it stays in step with the language selector beside it. */
+.note-md.tiptap pre code {
+  font-size: 1em;
+}
+
+/* The Combobox popup is a <ul>; when it renders inside note content it must not
+   inherit the prose list styling (bullets, left indent, per-item margins),
+   which would push the option highlight off the left edge and add gaps. */
+.note-md ul[data-combobox] {
+  list-style: none;
+  margin: 0;
+  padding-left: 0.25rem;
+}
+.note-md ul[data-combobox] li {
+  margin: 0;
 }
 
 /* In chat bubbles, trim the leading/trailing block margins */

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { isWebUrl } from "./url";
+
+describe("isWebUrl", () => {
+  it("treats an https URL as a web URL", () => {
+    expect(isWebUrl("https://example.com")).toBe(true);
+  });
+
+  it("treats http and mailto as web URLs", () => {
+    expect(isWebUrl("http://example.com/path?q=1")).toBe(true);
+    expect(isWebUrl("mailto:hi@example.com")).toBe(true);
+    expect(isWebUrl("  https://example.com  ")).toBe(true);
+  });
+
+  it("rejects local paths, relative links and non-web schemes", () => {
+    expect(isWebUrl("/Users/me/notes/a.md")).toBe(false);
+    expect(isWebUrl("./relative/file.txt")).toBe(false);
+    expect(isWebUrl("notes/a.md")).toBe(false);
+    expect(isWebUrl("file:///Users/me/a.txt")).toBe(false);
+    expect(isWebUrl("")).toBe(false);
+  });
+});

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,7 @@
+/**
+ * True when `href` is a URL we should hand to the system browser / mail client
+ * (http, https, or mailto). Local file paths and relative links return false.
+ */
+export function isWebUrl(href: string): boolean {
+  return /^(https?|mailto):/i.test(href.trim());
+}

--- a/src/modules/notes/NoteEditor.tsx
+++ b/src/modules/notes/NoteEditor.tsx
@@ -19,7 +19,9 @@ import { common, createLowlight } from "lowlight";
 import { exitCode } from "@tiptap/pm/commands";
 import { Check, Copy, SquareTerminal } from "lucide-react";
 import { useMemo, useState } from "react";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { runCommandInTerminal } from "@/modules/terminal/lib/terminalBus";
+import { isWebUrl } from "@/lib/url";
 import { createSlashCommand } from "./slashCommand";
 import { registerNoteInserter, unregisterNoteInserter } from "./lib/noteBus";
 import { Combobox } from "@/components/Combobox";
@@ -138,7 +140,10 @@ export function NoteEditor({ content, onChange, noteId }: NoteEditorProps) {
       StarterKit.configure({ codeBlock: false }),
       CodeBlock,
       slashCommand,
-      Link.configure({ openOnClick: false }),
+      Link.configure({
+        openOnClick: false,
+        HTMLAttributes: { "data-link-hint": t("linkHint") },
+      }),
       TaskList,
       TaskItem.configure({ nested: true }),
       Placeholder.configure({ placeholder: t("contentPlaceholder") }),
@@ -150,6 +155,22 @@ export function NoteEditor({ content, onChange, noteId }: NoteEditorProps) {
     content,
     editorProps: {
       attributes: { class: "note-md tiptap focus:outline-none" },
+      // Cmd/Ctrl+click a link opens it in the system browser; a plain click
+      // still places the cursor for editing. preventDefault stops the webview
+      // from navigating to the URL itself on a plain click.
+      handleClick(_view, _pos, event) {
+        const target = event.target as HTMLElement | null;
+        const href = target?.closest("a")?.getAttribute("href");
+        if (!href || !isWebUrl(href)) {
+          return false;
+        }
+        event.preventDefault();
+        if (event.metaKey || event.ctrlKey) {
+          void openUrl(href);
+          return true;
+        }
+        return false;
+      },
     },
     onUpdate: ({ editor }) => {
       if (timer.current) {

--- a/src/modules/notes/NoteEditor.tsx
+++ b/src/modules/notes/NoteEditor.tsx
@@ -55,7 +55,7 @@ function CodeBlockView({ node, updateAttributes }: NodeViewProps) {
   const runnable = SHELL_LANGS.has(lang.toLowerCase());
 
   return (
-    <NodeViewWrapper className="my-3 overflow-hidden rounded-lg border border-border bg-bg-inset">
+    <NodeViewWrapper className="my-3 rounded-lg border border-border bg-bg-inset">
       <pre className="overflow-x-auto px-4 py-3 font-mono text-[13px] leading-relaxed">
         <NodeViewContent as="code" className={lang ? `language-${lang}` : undefined} />
       </pre>
@@ -70,7 +70,8 @@ function CodeBlockView({ node, updateAttributes }: NodeViewProps) {
             updateAttributes({ language: value === "text" ? null : value })
           }
           ariaLabel={t("language")}
-          className="w-32 font-mono"
+          size="sm"
+          className="font-mono"
         />
         <div className="flex items-center gap-2">
           <span className="select-none text-[11px] text-fg-subtle">{t("exitHint")}</span>

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -1,5 +1,6 @@
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { createTerminal, type TerminalHandle } from "./lib/createTerminal";
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import {
@@ -83,6 +84,9 @@ export function TerminalView({
   onExitRef.current = onExit;
   const onOpenFileRef = useRef(onOpenFile);
   onOpenFileRef.current = onOpenFile;
+  const { t } = useTranslation();
+  const linkHintRef = useRef(t("openLinkHint"));
+  linkHintRef.current = t("openLinkHint");
 
   const fontFamily = useFontStore(selectTerminalFontFamily);
   const fontSize = useFontStore((s) => s.fontSize);
@@ -104,6 +108,7 @@ export function TerminalView({
       fontFamily: selectTerminalFontFamily(initial),
       fontSize: initial.fontSize,
       theme: getTheme(useSettingsStore.getState().themeId).terminal,
+      linkHint: linkHintRef.current,
     });
     handleRef.current = handle;
     const { term, fit } = handle;

--- a/src/modules/terminal/lib/createTerminal.ts
+++ b/src/modules/terminal/lib/createTerminal.ts
@@ -2,7 +2,10 @@ import { Terminal, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { buildTerminalFontFamily } from "@/modules/fonts/lib/fontChain";
+import { isWebUrl } from "@/lib/url";
+import { hideLinkTooltip, showLinkTooltip } from "./linkTooltip";
 import "@xterm/xterm/css/xterm.css";
 
 /**
@@ -22,6 +25,8 @@ export interface CreateTerminalOptions {
   fontFamily?: string;
   fontSize?: number;
   theme?: ITheme;
+  /** Hover hint shown over web links (e.g. "Cmd / Ctrl-click to open"). */
+  linkHint?: string;
 }
 
 export function createTerminal(options: CreateTerminalOptions = {}): TerminalHandle {
@@ -41,7 +46,26 @@ export function createTerminal(options: CreateTerminalOptions = {}): TerminalHan
 
   const fit = new FitAddon();
   term.loadAddon(fit);
-  term.loadAddon(new WebLinksAddon());
+  // Open web links in the system browser (not the in-app webview) on a
+  // modifier-click, matching the file-link gesture (Alt/Cmd) plus Ctrl for
+  // non-mac. A plain click is left for text selection. Hover shows a hint.
+  term.loadAddon(
+    new WebLinksAddon(
+      (event, uri) => {
+        if ((event.metaKey || event.ctrlKey || event.altKey) && isWebUrl(uri)) {
+          void openUrl(uri);
+        }
+      },
+      {
+        hover: (event) => {
+          if (options.linkHint) {
+            showLinkTooltip(options.linkHint, event.clientX, event.clientY);
+          }
+        },
+        leave: () => hideLinkTooltip(),
+      },
+    ),
+  );
 
   const unicode11 = new Unicode11Addon();
   term.loadAddon(unicode11);

--- a/src/modules/terminal/lib/fileLinks.test.ts
+++ b/src/modules/terminal/lib/fileLinks.test.ts
@@ -23,6 +23,12 @@ describe("findFilePaths", () => {
   it("ignores plain words without an extension", () => {
     expect(findFilePaths("just some regular words here")).toEqual([]);
   });
+
+  it("ignores file-looking tokens inside a web URL but still finds real paths", () => {
+    const matches = findFilePaths("see https://muki.tw/a.png and ./src/b.ts").map((m) => m.text);
+    expect(matches).toContain("./src/b.ts");
+    expect(matches.some((m) => m.includes("muki.tw") || m === "a.png")).toBe(false);
+  });
 });
 
 describe("resolveFilePath", () => {

--- a/src/modules/terminal/lib/fileLinks.ts
+++ b/src/modules/terminal/lib/fileLinks.ts
@@ -19,12 +19,33 @@ export interface FilePathMatch {
 const FILE_PATH_RE =
   /(?:~\/|\.{0,2}\/)?(?:[\w.\-]+\/)*[\w.\-]+\.[A-Za-z0-9]+(?::\d+(?::\d+)?)?/g;
 
+// Web URLs are handled by the web-links addon; skip any file-looking token that
+// sits inside one so the two link providers don't fight over the same text.
+const WEB_URL_RE = /\bhttps?:\/\/\S+/g;
+
+function webUrlRanges(line: string): { start: number; end: number }[] {
+  const ranges: { start: number; end: number }[] = [];
+  WEB_URL_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = WEB_URL_RE.exec(line)) !== null) {
+    ranges.push({ start: m.index, end: m.index + m[0].length });
+  }
+  return ranges;
+}
+
 export function findFilePaths(line: string): FilePathMatch[] {
   const out: FilePathMatch[] = [];
+  const urls = webUrlRanges(line);
   FILE_PATH_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = FILE_PATH_RE.exec(line)) !== null) {
-    out.push({ text: match[0], start: match.index, end: match.index + match[0].length });
+    const start = match.index;
+    const end = start + match[0].length;
+    const insideUrl = urls.some((u) => start < u.end && end > u.start);
+    if (insideUrl) {
+      continue;
+    }
+    out.push({ text: match[0], start, end });
   }
   return out;
 }

--- a/src/modules/terminal/lib/linkTooltip.ts
+++ b/src/modules/terminal/lib/linkTooltip.ts
@@ -1,0 +1,32 @@
+/**
+ * A single shared hover tooltip for terminal links. xterm has no native
+ * tooltip, so the web-links addon's hover/leave callbacks drive this. One
+ * element is reused across all terminals (only one can be hovered at a time).
+ */
+let el: HTMLDivElement | null = null;
+
+function ensureEl(): HTMLDivElement {
+  if (el) {
+    return el;
+  }
+  const node = document.createElement("div");
+  node.className = "terminal-link-tooltip";
+  node.setAttribute("aria-hidden", "true");
+  document.body.appendChild(node);
+  el = node;
+  return node;
+}
+
+export function showLinkTooltip(text: string, x: number, y: number): void {
+  const node = ensureEl();
+  node.textContent = text;
+  node.style.left = `${x + 12}px`;
+  node.style.top = `${y + 12}px`;
+  node.style.display = "block";
+}
+
+export function hideLinkTooltip(): void {
+  if (el) {
+    el.style.display = "none";
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the note editor's code block, which rendered poorly and whose language picker was unusable.

Reported issues:
- The code block showed two nested boxes
- The language dropdown did nothing when clicked
- Long language names (javascript, typescript) were truncated with an ellipsis
- The language picker was visually heavier than the code it labelled

## Changes

- **Single container**: scope the boxed `.note-md pre` style to non-editor markdown (AI replies, chat) so the editor's React node view draws its own single container instead of doubling up. Stop shrinking editor code (`0.85em`) so it stays in step with the picker.
- **Dropdown works**: remove `overflow-hidden` from the node-view wrapper, which was clipping the absolutely-positioned dropdown list.
- **No truncation**: size the Combobox popup to its content (`w-max`, `min-w-full`, capped) so long language names show in full.
- **Right proportion**: add a compact `size="sm"` to Combobox (smaller, muted trigger and options) and use it in the code block so the picker no longer overshadows the code.
- **Full-width highlight**: keep the global prose list styling (`.note-md ul/li` bullets, indent, item margins) off the Combobox popup, which had pushed the option highlight off the left edge and added gaps.

The compact size and content-fit width are opt-in/global-safe: other Combobox usages (settings, git graph, AI) keep their default size.

## Test plan

- `vitest` 247 passing, `tsc` clean
- Manual: in a note with a code block, confirmed a single clean box, the language dropdown opens and switches language, long names show fully, the picker sits in proportion to the code, and the option highlight spans the full row
- [x] Reviewer: verify settings / git graph / AI dropdowns are unchanged

## Also in this PR: open links in the system browser

Cmd/Ctrl-click a link in a note, or Cmd/Ctrl/Alt-click a URL in the terminal, opens it in the system browser via the opener plugin.

- Shared `isWebUrl()` helper (http/https/mailto), unit tested
- Notes: modifier-click opens; a plain click no longer lets the webview navigate; instant CSS hover hint (the native title was too slow) and a pointer cursor
- Terminal: `WebLinksAddon` gets a custom open handler plus a hover tooltip; `findFilePaths` now skips tokens inside a web URL so the file-link and web-link providers stop colliding
