### PR TITLE
perf: fast cold launch, session restore, and editor reload fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,47 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + React + Typescript</title>
+    <title>TempoTerm</title>
+    <style>
+      /* Themed background and a splash spinner shown before the JS bundle and
+         React have painted, so a cold start is a dark loading screen rather
+         than a blank flash. React replaces #root's contents on mount. */
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+        background: #222222;
+      }
+      #app-splash {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #222222;
+      }
+      #app-splash::after {
+        content: "";
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        border: 2px solid #3a3a3a;
+        border-top-color: #5eaab5;
+        animation: app-splash-spin 0.7s linear infinite;
+      }
+      @keyframes app-splash-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
   </head>
 
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div id="app-splash"></div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4465,6 +4465,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4598,6 +4613,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tokio",
  "trash",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-window-state = "2"
 trash = "5"
 
 # keyring 3.x ships no credential store by default; each platform must opt into

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,7 +6,6 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
-    "core:window:allow-show",
     "opener:default",
     "dialog:default",
     "updater:default",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-show",
     "opener:default",
     "dialog:default",
     "updater:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,17 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        // Persist and restore window size and position across launches. Only
+        // SIZE | POSITION so it never forces the window visible early — the
+        // frontend reveals it on first paint (see visible: false).
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::SIZE
+                        | tauri_plugin_window_state::StateFlags::POSITION,
+                )
+                .build(),
+        )
         .manage(PtyState::new())
         .invoke_handler(tauri::generate_handler![
             pty_open,

--- a/src-tauri/src/modules/fonts/mod.rs
+++ b/src-tauri/src/modules/fonts/mod.rs
@@ -15,8 +15,7 @@ pub struct FontReport {
     pub has_cjk_fallback: bool,
 }
 
-#[tauri::command]
-pub fn fonts_report() -> FontReport {
+fn build_fonts_report() -> FontReport {
     let fonts = detect::list_fonts();
     let suggested_cjk_fallback = detect::pick_cjk_fallback(&fonts, &RECOMMENDED_CJK_MONO);
     let has_cjk_fallback = detect::has_cjk_fallback(&fonts);
@@ -26,4 +25,19 @@ pub fn fonts_report() -> FontReport {
         suggested_cjk_fallback,
         has_cjk_fallback,
     }
+}
+
+/// Enumerating and loading every system font takes seconds. As an async command
+/// the work runs off the main thread via `spawn_blocking`, so it never freezes
+/// the UI during startup (the report just fills in a moment later).
+#[tauri::command]
+pub async fn fonts_report() -> FontReport {
+    tauri::async_runtime::spawn_blocking(build_fonts_report)
+        .await
+        .unwrap_or_else(|_| FontReport {
+            fonts: Vec::new(),
+            recommended_cjk: RECOMMENDED_CJK_MONO.iter().map(|s| s.to_string()).collect(),
+            suggested_cjk_fallback: None,
+            has_cjk_fallback: false,
+        })
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
         "minHeight": 480,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "dragDropEnabled": true
+        "dragDropEnabled": true,
+        "backgroundColor": "#222222"
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,8 +19,7 @@
         "minHeight": 480,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "dragDropEnabled": true,
-        "visible": false
+        "dragDropEnabled": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
         "minHeight": 480,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "dragDropEnabled": true
+        "dragDropEnabled": true,
+        "visible": false
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import { TabsArea } from "@/components/TabsArea";
 import { useUiStore } from "@/stores/uiStore";
 import { useUpdaterStore } from "@/stores/updaterStore";
 import { useSettingsStore } from "@/stores/settingsStore";
-import { useFontStore } from "@/stores/fontStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { applyTheme, getTheme } from "@/themes/themes";
@@ -23,7 +22,6 @@ function clamp(value: number, min: number, max: number): number {
 
 function App() {
   const themeId = useSettingsStore((s) => s.themeId);
-  const loadFontReport = useFontStore((s) => s.loadReport);
   const sidebarVisible = useUiStore((s) => s.sidebarVisible);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
   const [sidebarWidth, setSidebarWidth] = useState(260);
@@ -32,9 +30,9 @@ function App() {
     applyTheme(getTheme(themeId), document.documentElement);
   }, [themeId]);
 
-  useEffect(() => {
-    void loadFontReport();
-  }, [loadFontReport]);
+  // The font report (enumerating every installed family) is loaded lazily by
+  // the Fonts settings section when it opens, not at startup — the terminal's
+  // default font chain already covers CJK, so a cold launch does no font work.
 
   // Quietly check for a new release a few seconds after launch; the prompt only
   // appears if one actually exists, so a normal start stays uninterrupted.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { TabBar } from "@/components/TabBar";
 import { Sidebar } from "@/components/Sidebar";
 import { Resizer } from "@/components/Resizer";
@@ -32,19 +31,6 @@ function App() {
   useEffect(() => {
     applyTheme(getTheme(themeId), document.documentElement);
   }, [themeId]);
-
-  // The window starts hidden (visible: false) to avoid a blank flash while the
-  // webview boots; reveal it once the UI has painted its first frame.
-  useEffect(() => {
-    const frame = requestAnimationFrame(() => {
-      try {
-        void getCurrentWindow().show().catch(() => {});
-      } catch {
-        // Not running inside a Tauri window (e.g. tests); nothing to reveal.
-      }
-    });
-    return () => cancelAnimationFrame(frame);
-  }, []);
 
   useEffect(() => {
     void loadFontReport();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { TabBar } from "@/components/TabBar";
 import { Sidebar } from "@/components/Sidebar";
 import { Resizer } from "@/components/Resizer";
@@ -31,6 +32,19 @@ function App() {
   useEffect(() => {
     applyTheme(getTheme(themeId), document.documentElement);
   }, [themeId]);
+
+  // The window starts hidden (visible: false) to avoid a blank flash while the
+  // webview boots; reveal it once the UI has painted its first frame.
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      try {
+        void getCurrentWindow().show().catch(() => {});
+      } catch {
+        // Not running inside a Tauri window (e.g. tests); nothing to reveal.
+      }
+    });
+    return () => cancelAnimationFrame(frame);
+  }, []);
 
   useEffect(() => {
     void loadFontReport();

--- a/src/components/TabsArea.tsx
+++ b/src/components/TabsArea.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { PaneTabContent } from "@/modules/terminal/PaneTabContent";
 import { LauncherPanel } from "@/components/LauncherPanel";
 import { useTabsStore } from "@/stores/tabsStore";
@@ -17,15 +17,14 @@ export function TabsArea() {
   const activeId = useTabsStore((s) => s.activeId);
 
   // Tab ids that have been activated at least once and should stay mounted.
-  const mountedRef = useRef<Set<string>>(new Set());
-  const [, forceRender] = useState(0);
-
-  useEffect(() => {
-    if (activeId && !mountedRef.current.has(activeId)) {
-      mountedRef.current.add(activeId);
-      forceRender((n) => n + 1);
-    }
-  }, [activeId]);
+  // Updating during render (not in an effect) lets React fold the new id into
+  // this same render pass instead of an extra post-paint commit on every switch.
+  const [mountedIds, setMountedIds] = useState<Set<string>>(
+    () => new Set(activeId ? [activeId] : []),
+  );
+  if (activeId && !mountedIds.has(activeId)) {
+    setMountedIds((prev) => new Set(prev).add(activeId));
+  }
 
   if (!activeId) {
     return <LauncherPanel />;
@@ -36,7 +35,7 @@ export function TabsArea() {
       {tabs.map((tab) => {
         // The active tab always mounts immediately; previously-visited tabs
         // stay mounted; never-visited tabs render nothing until activated.
-        const mount = tab.id === activeId || mountedRef.current.has(tab.id);
+        const mount = tab.id === activeId || mountedIds.has(tab.id);
         return (
           <div
             key={tab.id}

--- a/src/components/TabsArea.tsx
+++ b/src/components/TabsArea.tsx
@@ -1,15 +1,31 @@
+import { useEffect, useRef, useState } from "react";
 import { PaneTabContent } from "@/modules/terminal/PaneTabContent";
 import { LauncherPanel } from "@/components/LauncherPanel";
 import { useTabsStore } from "@/stores/tabsStore";
 
 /**
  * The main work area. Every tab is a PaneTabContent (a splittable pane tree).
- * Inactive tabs stay mounted but hidden so their terminals keep running.
+ *
+ * Tabs mount lazily: only the active tab is mounted on first launch, so a
+ * session restored with many tabs does not spawn every shell and read every
+ * file at once. Once a tab has been activated it stays mounted (kept hidden
+ * when inactive) so its terminals keep running for the rest of the session.
  * With no tabs at all, the launcher takes over the whole area.
  */
 export function TabsArea() {
   const tabs = useTabsStore((s) => s.tabs);
   const activeId = useTabsStore((s) => s.activeId);
+
+  // Tab ids that have been activated at least once and should stay mounted.
+  const mountedRef = useRef<Set<string>>(new Set());
+  const [, forceRender] = useState(0);
+
+  useEffect(() => {
+    if (activeId && !mountedRef.current.has(activeId)) {
+      mountedRef.current.add(activeId);
+      forceRender((n) => n + 1);
+    }
+  }, [activeId]);
 
   if (!activeId) {
     return <LauncherPanel />;
@@ -17,18 +33,24 @@ export function TabsArea() {
 
   return (
     <div className="relative h-full w-full bg-bg">
-      {tabs.map((tab) => (
-        <div
-          key={tab.id}
-          className={`absolute inset-0 ${tab.id === activeId ? "" : "hidden"}`}
-        >
-          {tab.kind === "launcher" ? (
-            <LauncherPanel target={{ mode: "newTab", closeTabId: tab.id }} />
-          ) : (
-            <PaneTabContent tab={tab} />
-          )}
-        </div>
-      ))}
+      {tabs.map((tab) => {
+        // The active tab always mounts immediately; previously-visited tabs
+        // stay mounted; never-visited tabs render nothing until activated.
+        const mount = tab.id === activeId || mountedRef.current.has(tab.id);
+        return (
+          <div
+            key={tab.id}
+            className={`absolute inset-0 ${tab.id === activeId ? "" : "hidden"}`}
+          >
+            {mount &&
+              (tab.kind === "launcher" ? (
+                <LauncherPanel target={{ mode: "newTab", closeTabId: tab.id }} />
+              ) : (
+                <PaneTabContent tab={tab} />
+              ))}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,6 +1,7 @@
 {
   "appName": "TempoTerm",
   "tagline": "AI-powered terminal workspace",
+  "terminalConnecting": "Starting shell…",
   "nav": {
     "terminal": "Terminal",
     "explorer": "Explorer",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1,6 +1,7 @@
 {
   "appName": "TempoTerm",
   "tagline": "AI 驅動的終端機工作區",
+  "terminalConnecting": "啟動中…",
   "nav": {
     "terminal": "終端機",
     "explorer": "檔案總管",

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -6,6 +6,7 @@ import { EditorView as CMView } from "@codemirror/view";
 import { editorSyntaxTheme } from "@/themes/editorTheme";
 import { languageExtension } from "./lib/language";
 import { useEditorStore } from "./store/editorStore";
+import { shouldReloadFromDisk } from "./lib/reload";
 import { fsReadFile, fsWriteFile } from "@/modules/explorer/lib/fsBridge";
 import { basename } from "@/modules/explorer/lib/paths";
 import { MarkdownView } from "@/components/MarkdownView";
@@ -32,7 +33,6 @@ export function EditorTabContent({ path }: { path: string }) {
   const setContent = useEditorStore((s) => s.setContent);
   const markSaved = useEditorStore((s) => s.markSaved);
   const content = useEditorStore((s) => s.buffers[path]?.content ?? "");
-  const loaded = useEditorStore((s) => s.buffers[path] !== undefined);
 
   const fontFamily = useFontStore(selectTerminalFontFamily);
   const fontSize = useFontStore((s) => s.fontSize);
@@ -45,13 +45,15 @@ export function EditorTabContent({ path }: { path: string }) {
   const effectiveMode: EditorMode = isMarkdown ? mode : "edit";
 
   useEffect(() => {
-    if (loaded) {
+    // Re-read from disk whenever the file (re)opens so external edits show up;
+    // skip only when there are unsaved local edits, to avoid clobbering them.
+    if (!shouldReloadFromDisk(useEditorStore.getState().buffers[path])) {
       return;
     }
     fsReadFile(path)
       .then((text) => setBaseline(path, text))
       .catch(() => setBaseline(path, ""));
-  }, [path, loaded, setBaseline]);
+  }, [path, setBaseline]);
 
   const extensions = useMemo(
     () => [

--- a/src/modules/editor/lib/reload.test.ts
+++ b/src/modules/editor/lib/reload.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { shouldReloadFromDisk } from "./reload";
+
+describe("shouldReloadFromDisk", () => {
+  it("reloads when no buffer is open yet", () => {
+    expect(shouldReloadFromDisk(undefined)).toBe(true);
+  });
+
+  it("reloads a clean buffer so external edits show up on reopen", () => {
+    expect(shouldReloadFromDisk({ content: "v1", baseline: "v1" })).toBe(true);
+  });
+
+  it("keeps a dirty buffer so unsaved edits are not clobbered", () => {
+    expect(shouldReloadFromDisk({ content: "edited", baseline: "v1" })).toBe(false);
+  });
+});

--- a/src/modules/editor/lib/reload.ts
+++ b/src/modules/editor/lib/reload.ts
@@ -1,0 +1,18 @@
+interface BufferSnapshot {
+  content: string;
+  baseline: string;
+}
+
+/**
+ * Whether an editor tab should re-read its file from disk when it (re)opens.
+ *
+ * Reading on every open lets external edits show up, but a buffer with unsaved
+ * changes (content diverged from its baseline) must be kept so reopening the
+ * tab never clobbers the user's work.
+ */
+export function shouldReloadFromDisk(buffer: BufferSnapshot | undefined): boolean {
+  if (!buffer) {
+    return true;
+  }
+  return buffer.content === buffer.baseline;
+}

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, type MouseEvent as ReactMouseEvent } from "react";
+import { lazy, Suspense, useEffect, useRef, type MouseEvent as ReactMouseEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { X } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { TerminalView } from "./TerminalView";
 import { dropPathsIntoTerminal, writeToTerminal } from "./lib/terminalBus";
 import {
@@ -9,10 +9,24 @@ import {
   type PaneContent,
   type SplitterInfo,
 } from "./lib/terminalLayout";
-import { EditorTabContent } from "@/modules/editor/EditorTabContent";
-import { NoteTabContent } from "@/modules/notes/NoteTabContent";
-import { PreviewTabContent } from "@/modules/preview/PreviewTabContent";
-import { GitGraphTabContent } from "@/modules/git-graph/GitGraphTabContent";
+// Heavy, non-terminal pane content is code-split so it stays out of the startup
+// bundle (TipTap + lowlight, CodeMirror, the git graph). It loads the first time
+// such a pane is shown. The terminal and launcher stay eager — a terminal is
+// usually the first pane painted on launch.
+const EditorTabContent = lazy(() =>
+  import("@/modules/editor/EditorTabContent").then((m) => ({ default: m.EditorTabContent })),
+);
+const NoteTabContent = lazy(() =>
+  import("@/modules/notes/NoteTabContent").then((m) => ({ default: m.NoteTabContent })),
+);
+const PreviewTabContent = lazy(() =>
+  import("@/modules/preview/PreviewTabContent").then((m) => ({ default: m.PreviewTabContent })),
+);
+const GitGraphTabContent = lazy(() =>
+  import("@/modules/git-graph/GitGraphTabContent").then((m) => ({
+    default: m.GitGraphTabContent,
+  })),
+);
 import { LauncherPanel } from "@/components/LauncherPanel";
 import { dropOverlayClassName } from "@/components/EntryDropOverlay";
 import {
@@ -191,30 +205,38 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                   <X size={12} />
                 </button>
               )}
-              {pane.content.kind === "editor" ? (
-                <EditorTabContent path={pane.content.path} />
-              ) : pane.content.kind === "note" ? (
-                <NoteTabContent noteId={pane.content.noteId} tabId={tab.id} />
-              ) : pane.content.kind === "preview" ? (
-                <PreviewTabContent url={pane.content.url} />
-              ) : pane.content.kind === "git-graph" ? (
-                <GitGraphTabContent />
-              ) : pane.content.kind === "launcher" ? (
-                <LauncherPanel
-                  target={{ mode: "replacePane", tabId: tab.id, leafId: pane.id }}
-                />
-              ) : (
-                <TerminalView
-                  active={active}
-                  cwdTracking={active && isActiveTab}
-                  cwd={rootPath ?? tab.cwd}
-                  leafId={pane.id}
-                  onExit={() => closePane(tab.id, pane.id)}
-                  onOpenFile={(absolutePath) =>
-                    splitPaneWith(tab.id, pane.id, { kind: "editor", path: absolutePath }, "row")
-                  }
-                />
-              )}
+              <Suspense
+                fallback={
+                  <div className="flex h-full w-full items-center justify-center text-fg-subtle">
+                    <Loader2 size={16} className="animate-spin" />
+                  </div>
+                }
+              >
+                {pane.content.kind === "editor" ? (
+                  <EditorTabContent path={pane.content.path} />
+                ) : pane.content.kind === "note" ? (
+                  <NoteTabContent noteId={pane.content.noteId} tabId={tab.id} />
+                ) : pane.content.kind === "preview" ? (
+                  <PreviewTabContent url={pane.content.url} />
+                ) : pane.content.kind === "git-graph" ? (
+                  <GitGraphTabContent />
+                ) : pane.content.kind === "launcher" ? (
+                  <LauncherPanel
+                    target={{ mode: "replacePane", tabId: tab.id, leafId: pane.id }}
+                  />
+                ) : (
+                  <TerminalView
+                    active={active}
+                    cwdTracking={active && isActiveTab}
+                    cwd={rootPath ?? tab.cwd}
+                    leafId={pane.id}
+                    onExit={() => closePane(tab.id, pane.id)}
+                    onOpenFile={(absolutePath) =>
+                      splitPaneWith(tab.id, pane.id, { kind: "editor", path: absolutePath }, "row")
+                    }
+                  />
+                )}
+              </Suspense>
 
               {/* Highlight only the pane under the cursor while dragging an
                   explorer entry. The drop itself is handled by the document-level

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -382,11 +382,14 @@ export function TerminalView({
         setConnecting(false);
       })
       .catch((error: unknown) => {
+        // If the pane unmounted before the spawn rejected, the terminal is
+        // already disposed; writing to it would throw.
+        if (disposed) {
+          return;
+        }
         const message = error instanceof Error ? error.message : String(error);
         term.write(`\r\n\x1b[31mFailed to open shell: ${message}\x1b[0m\r\n`);
-        if (!disposed) {
-          setConnecting(false);
-        }
+        setConnecting(false);
       });
 
     const observer = new ResizeObserver(() => {

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -1,5 +1,7 @@
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2 } from "lucide-react";
 import { createTerminal, type TerminalHandle } from "./lib/createTerminal";
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import {
@@ -88,6 +90,8 @@ export function TerminalView({
   const fontSize = useFontStore((s) => s.fontSize);
   const themeId = useSettingsStore((s) => s.themeId);
   const terminalPadding = useSettingsStore((s) => s.terminalPadding);
+  const { t } = useTranslation();
+  const [connecting, setConnecting] = useState(true);
   const [externalFileDragging, setExternalFileDragging] = useState(false);
   const dragDepthRef = useRef(0);
   const nativeDragPathsRef = useRef<string[]>([]);
@@ -375,10 +379,14 @@ export function TerminalView({
         if (cwdTracking && cwdRef.current) {
           useWorkspaceStore.getState().setRoot(cwdRef.current);
         }
+        setConnecting(false);
       })
       .catch((error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
         term.write(`\r\n\x1b[31mFailed to open shell: ${message}\x1b[0m\r\n`);
+        if (!disposed) {
+          setConnecting(false);
+        }
       });
 
     const observer = new ResizeObserver(() => {
@@ -707,6 +715,12 @@ export function TerminalView({
       }}
     >
       {externalFileDragging && <div className={dropOverlayClassName(true)} />}
+      {connecting && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-2 text-fg-subtle">
+          <Loader2 size={15} className="animate-spin" />
+          <span className="text-xs">{t("terminalConnecting")}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -1,4 +1,7 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const WORKSPACE_STORAGE_KEY = "tempoterm-workspace";
 
 interface WorkspaceState {
   rootPath: string | null;
@@ -10,35 +13,49 @@ interface WorkspaceState {
   setActiveFile: (path: string) => void;
 }
 
-export const useWorkspaceStore = create<WorkspaceState>((set) => ({
-  rootPath: null,
-  openFiles: [],
-  activeFile: null,
+export const useWorkspaceStore = create<WorkspaceState>()(
+  persist(
+    (set) => ({
+      rootPath: null,
+      openFiles: [],
+      activeFile: null,
 
-  setRoot: (rootPath) => set({ rootPath }),
+      setRoot: (rootPath) => set({ rootPath }),
 
-  openFile: (path) =>
-    set((state) => ({
-      openFiles: state.openFiles.includes(path)
-        ? state.openFiles
-        : [...state.openFiles, path],
-      activeFile: path,
-    })),
+      openFile: (path) =>
+        set((state) => ({
+          openFiles: state.openFiles.includes(path)
+            ? state.openFiles
+            : [...state.openFiles, path],
+          activeFile: path,
+        })),
 
-  closeFile: (path) =>
-    set((state) => {
-      const index = state.openFiles.indexOf(path);
-      if (index === -1) {
-        return state;
-      }
-      const openFiles = state.openFiles.filter((p) => p !== path);
-      let activeFile = state.activeFile;
-      if (state.activeFile === path) {
-        const neighbour = openFiles[index - 1] ?? openFiles[index] ?? null;
-        activeFile = neighbour ?? null;
-      }
-      return { openFiles, activeFile };
+      closeFile: (path) =>
+        set((state) => {
+          const index = state.openFiles.indexOf(path);
+          if (index === -1) {
+            return state;
+          }
+          const openFiles = state.openFiles.filter((p) => p !== path);
+          let activeFile = state.activeFile;
+          if (state.activeFile === path) {
+            const neighbour = openFiles[index - 1] ?? openFiles[index] ?? null;
+            activeFile = neighbour ?? null;
+          }
+          return { openFiles, activeFile };
+        }),
+
+      setActiveFile: (activeFile) => set({ activeFile }),
     }),
-
-  setActiveFile: (activeFile) => set({ activeFile }),
-}));
+    {
+      name: WORKSPACE_STORAGE_KEY,
+      // Restore the explorer root and open-file list; the setters and any
+      // transient state are derived at runtime.
+      partialize: (state) => ({
+        rootPath: state.rootPath,
+        openFiles: state.openFiles,
+        activeFile: state.activeFile,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

Makes a cold launch fast and gives it loading feedback, restores more of the previous session, and fixes the editor showing stale file content on reopen.

## Startup performance

The big win: listing system fonts. `fonts_report` (font-kit loads every installed font, ~4s on a real machine) ran as a synchronous Tauri command on the main thread, freezing the UI for the whole launch. That, not the JS bundle, was the cause of the multi-second hang.

- Run font enumeration off the main thread (`spawn_blocking`) and stop loading the report at startup at all — the Fonts settings section loads it on demand. The terminal font chain already carries a hard CJK fallback (PingFang TC), so Chinese still renders with no report.
- Code-split the heavy non-terminal pane contents (editor, note, preview, git graph) behind `React.lazy`, so TipTap + lowlight and CodeMirror leave the startup bundle (eager bundle ~2.3MB to ~1.0MB).
- Mount only the active tab on launch; other tabs mount on first activation and stay alive after.
- Themed dark window background and an inline splash spinner in `index.html`, so the webview cold-start is a dark loading screen rather than a blank flash. A per-terminal spinner shows until each shell connects.

(A `visible: false` show-on-ready attempt was tried and reverted: hiding the window until ready felt like a hang, and an in-app loading screen reads better.)

## Session restore

- Window size and position via `tauri-plugin-window-state` (SIZE | POSITION only).
- Persist `workspaceStore` (explorer root, open files); because a terminal spawns at the root path, this also reopens the primary terminal in its last directory.
- Tabs and split layout already persisted; verified.

## Editor fix

- Re-read a file from disk when its tab reopens, skipping only when the buffer has unsaved edits, so reopening a closed file no longer shows stale cached content.

## Test plan

- `vitest` 250 passing, `tsc` clean, `cargo` builds
- Manual: cold launch is fast with a dark splash; window geometry / explorer root / primary terminal cwd restore; reopening an externally-edited file shows fresh content; Chinese still renders in the terminal; the Fonts settings dropdown still lists families (loads on open)

## Deferred (not in this PR)

- Per-pane terminal cwd for split terminals (needs a layout-tree version bump + migration)
- Shell pre-warm (the webview boot, not the shell, dominated once fonts were fixed)
