### PR TITLE
feat: restore each terminal pane's working directory

### DIFF
--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtyPair, PtySize};
 use tauri::ipc::{Channel, Response};
 
-use super::shell::{login_args, resolve_shell, terminal_env};
+use super::shell::{login_args, resolve_shell, terminal_env, usable_cwd};
 
 /// A single live terminal session.
 pub struct Session {
@@ -64,7 +64,7 @@ fn build_shell_command(cwd: Option<String>) -> (CommandBuilder, String) {
     for arg in login_args(&shell) {
         cmd.arg(arg);
     }
-    if let Some(dir) = cwd.filter(|d| !d.trim().is_empty()) {
+    if let Some(dir) = usable_cwd(cwd) {
         cmd.cwd(dir);
     }
     let locale_env = terminal_env(

--- a/src-tauri/src/modules/pty/shell.rs
+++ b/src-tauri/src/modules/pty/shell.rs
@@ -99,6 +99,14 @@ pub fn login_args(shell: &str) -> Vec<String> {
     }
 }
 
+/// Keep a start directory only when it is a real, existing directory. A restored
+/// session may point at a folder that has since been deleted; spawning there
+/// would fail, so fall back (the caller drops to the default) instead.
+pub fn usable_cwd(cwd: Option<String>) -> Option<String> {
+    cwd.filter(|d| !d.trim().is_empty())
+        .filter(|d| std::path::Path::new(d).is_dir())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,5 +183,13 @@ mod tests {
         // LC_ALL outranks LC_CTYPE, so patching LC_CTYPE alone would not win.
         let env = terminal_env(Some("C".to_string()), None, Some("zh_TW.UTF-8".to_string()));
         assert!(has_utf8(&env, "LC_ALL"));
+    }
+
+    #[test]
+    fn usable_cwd_keeps_existing_dirs_and_drops_the_rest() {
+        assert_eq!(usable_cwd(Some("/".to_string())), Some("/".to_string()));
+        assert_eq!(usable_cwd(Some("/no/such/dir/zzz_tempoterm".to_string())), None);
+        assert_eq!(usable_cwd(Some("   ".to_string())), None);
+        assert_eq!(usable_cwd(None), None);
     }
 }

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -6,6 +6,7 @@ import { dropPathsIntoTerminal, writeToTerminal } from "./lib/terminalBus";
 import {
   computeLayout,
   computeSplitters,
+  resolveTerminalCwd,
   type PaneContent,
   type SplitterInfo,
 } from "./lib/terminalLayout";
@@ -53,6 +54,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   const resizePane = useTabsStore((s) => s.resizePane);
   const splitPaneWith = useTabsStore((s) => s.splitPaneWith);
   const setPaneContent = useTabsStore((s) => s.setPaneContent);
+  const setTerminalCwd = useTabsStore((s) => s.setTerminalCwd);
   const closePane = useTabsStore((s) => s.closePane);
   const isActiveTab = useTabsStore((s) => s.activeId === tab.id);
   const paneAreaRef = useRef<HTMLDivElement>(null);
@@ -228,9 +230,14 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                   <TerminalView
                     active={active}
                     cwdTracking={active && isActiveTab}
-                    cwd={rootPath ?? tab.cwd}
+                    cwd={resolveTerminalCwd(
+                      pane.content.kind === "terminal" ? pane.content.cwd : undefined,
+                      rootPath,
+                      tab.cwd,
+                    )}
                     leafId={pane.id}
                     onExit={() => closePane(tab.id, pane.id)}
+                    onCwdChange={(dir) => setTerminalCwd(tab.id, pane.id, dir)}
                     onOpenFile={(absolutePath) =>
                       splitPaneWith(tab.id, pane.id, { kind: "editor", path: absolutePath }, "row")
                     }

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -60,6 +60,8 @@ interface TerminalViewProps {
   /** Pane id, so notes/workflows can run commands into this terminal. */
   leafId?: string;
   onExit?: () => void;
+  /** Report the shell's current directory so it can be restored next launch. */
+  onCwdChange?: (cwd: string) => void;
   /** Alt+click on a file path in the output opens it (with the resolved abs path). */
   onOpenFile?: (absolutePath: string) => void;
 }
@@ -70,6 +72,7 @@ export function TerminalView({
   cwd,
   leafId,
   onExit,
+  onCwdChange,
   onOpenFile,
 }: TerminalViewProps) {
   const leafIdRef = useRef(leafId);
@@ -83,6 +86,8 @@ export function TerminalView({
   const sessionRef = useRef<PtySession | null>(null);
   const onExitRef = useRef(onExit);
   onExitRef.current = onExit;
+  const onCwdChangeRef = useRef(onCwdChange);
+  onCwdChangeRef.current = onCwdChange;
   const onOpenFileRef = useRef(onOpenFile);
   onOpenFileRef.current = onOpenFile;
   const { t } = useTranslation();
@@ -504,7 +509,12 @@ export function TerminalView({
       }
       try {
         const dir = await session.cwd();
-        if (!cancelled && dir && dir !== last) {
+        if (cancelled || !dir) {
+          return;
+        }
+        // Remember this pane's own cwd for session restore (store dedupes).
+        onCwdChangeRef.current?.(dir);
+        if (dir !== last) {
           last = dir;
           useWorkspaceStore.getState().setRoot(dir);
         }
@@ -542,6 +552,26 @@ export function TerminalView({
       unsubscribe();
     };
   }, [cwdTracking]);
+
+  // Snapshot the cwd when this pane stops being active (e.g. switching tabs), so
+  // its last directory is saved between polls. Event-driven, no extra polling.
+  useEffect(() => {
+    if (active) {
+      return;
+    }
+    const session = sessionRef.current;
+    if (!session) {
+      return;
+    }
+    void session
+      .cwd()
+      .then((dir) => {
+        if (dir) {
+          onCwdChangeRef.current?.(dir);
+        }
+      })
+      .catch(() => {});
+  }, [active]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/src/modules/terminal/lib/terminalLayout.test.ts
+++ b/src/modules/terminal/lib/terminalLayout.test.ts
@@ -2,16 +2,42 @@ import { describe, expect, it } from "vitest";
 import {
   computeLayout,
   computeSplitters,
+  findPaneContent,
   firstLeafId,
   leaf,
   leafIds,
   paneIdAt,
   removeLeaf,
+  resolveTerminalCwd,
   setSizesById,
   splitId,
   splitLeaf,
   type LayoutNode,
 } from "./terminalLayout";
+
+describe("resolveTerminalCwd", () => {
+  it("prefers the pane's own saved cwd over the explorer root and tab cwd", () => {
+    expect(resolveTerminalCwd("/pane/dir", "/root/dir", "/tab/dir")).toBe("/pane/dir");
+  });
+
+  it("falls back to the explorer root, then the tab cwd", () => {
+    expect(resolveTerminalCwd(undefined, "/root/dir", "/tab/dir")).toBe("/root/dir");
+    expect(resolveTerminalCwd(undefined, null, "/tab/dir")).toBe("/tab/dir");
+  });
+
+  it("returns undefined when nothing is set", () => {
+    expect(resolveTerminalCwd(undefined, null, undefined)).toBeUndefined();
+    expect(resolveTerminalCwd("", null, "")).toBeUndefined();
+  });
+});
+
+describe("findPaneContent", () => {
+  it("returns a leaf's content by id, or undefined when absent", () => {
+    const tree = splitLeaf(leaf("a", { kind: "terminal", cwd: "/x" }), "a", "row", "b");
+    expect(findPaneContent(tree, "a")).toEqual({ kind: "terminal", cwd: "/x" });
+    expect(findPaneContent(tree, "missing")).toBeUndefined();
+  });
+});
 
 describe("terminalLayout", () => {
   it("splits a leaf into a two-pane split", () => {

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -12,7 +12,7 @@ export type SplitDirection = "row" | "col";
  * graph, or the launcher (a freshly split pane that hasn't been chosen yet).
  */
 export type PaneContent =
-  | { kind: "terminal" }
+  | { kind: "terminal"; cwd?: string }
   | { kind: "editor"; path: string }
   | { kind: "note"; noteId: string }
   | { kind: "preview"; url: string }
@@ -20,6 +20,19 @@ export type PaneContent =
   | { kind: "launcher" };
 
 export const TERMINAL_PANE: PaneContent = { kind: "terminal" };
+
+/**
+ * Where a terminal pane should spawn. A pane's own saved cwd (restored from a
+ * previous session) wins, then the explorer root, then the tab's initial cwd.
+ * Empty values are skipped; returns undefined when nothing is set.
+ */
+export function resolveTerminalCwd(
+  paneCwd: string | undefined,
+  rootPath: string | null | undefined,
+  tabCwd: string | undefined,
+): string | undefined {
+  return paneCwd || rootPath || tabCwd || undefined;
+}
 
 export type LayoutNode =
   | { kind: "leaf"; id: string; pane?: PaneContent }
@@ -38,6 +51,14 @@ export function leaf(id: string, pane: PaneContent = TERMINAL_PANE): LayoutNode 
  * A leaf's content, defaulting to a terminal — trees persisted before mixed
  * panes existed have no `pane` field.
  */
+/** Find a leaf's content by id anywhere in the tree, or undefined if absent. */
+export function findPaneContent(node: LayoutNode, leafId: string): PaneContent | undefined {
+  if (node.kind === "leaf") {
+    return node.id === leafId ? paneOf(node) : undefined;
+  }
+  return findPaneContent(node.children[0], leafId) ?? findPaneContent(node.children[1], leafId);
+}
+
 export function paneOf(node: Extract<LayoutNode, { kind: "leaf" }>): PaneContent {
   return node.pane ?? TERMINAL_PANE;
 }

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -265,6 +265,29 @@ describe("tabsStore", () => {
     useTabsStore.getState().closePaneOrTab();
     expect(useTabsStore.getState().tabs.find((t) => t.id === id)).toBeUndefined();
   });
+
+  it("saves a terminal pane's cwd into its layout leaf", () => {
+    const id = useTabsStore.getState().newTerminalTab();
+    const leafId = activeTab().activeLeafId;
+    useTabsStore.getState().setTerminalCwd(id, leafId, "/work/dir");
+    expect(firstLeafContent(activeTab())).toEqual({ kind: "terminal", cwd: "/work/dir" });
+  });
+
+  it("leaves a non-terminal pane untouched", () => {
+    const id = useTabsStore.getState().openEditorTab("/a/b.ts");
+    const leafId = activeTab().activeLeafId;
+    useTabsStore.getState().setTerminalCwd(id, leafId, "/work/dir");
+    expect(firstLeafContent(activeTab())).toEqual({ kind: "editor", path: "/a/b.ts" });
+  });
+
+  it("does not rewrite state when the cwd is unchanged", () => {
+    const id = useTabsStore.getState().newTerminalTab();
+    const leafId = activeTab().activeLeafId;
+    useTabsStore.getState().setTerminalCwd(id, leafId, "/work/dir");
+    const before = useTabsStore.getState().tabs;
+    useTabsStore.getState().setTerminalCwd(id, leafId, "/work/dir");
+    expect(useTabsStore.getState().tabs).toBe(before);
+  });
 });
 
 describe("migratePersistedTabs", () => {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -3,6 +3,7 @@ import { persist } from "zustand/middleware";
 import { uid } from "@/lib/id";
 import {
   computeLayout,
+  findPaneContent,
   firstLeafId,
   leaf,
   paneOf,
@@ -86,6 +87,8 @@ interface TabsState {
   ) => void;
   /** Replace a pane's content in place (used when dropping a file onto it). */
   setPaneContent: (tabId: string, leafId: string, content: PaneContent) => void;
+  /** Remember a terminal pane's current working directory for session restore. */
+  setTerminalCwd: (tabId: string, leafId: string, cwd: string) => void;
   closePane: (tabId: string, leafId: string) => void;
 }
 
@@ -498,6 +501,27 @@ export const useTabsStore = create<TabsState>()(
           : tab,
       ),
     })),
+
+  setTerminalCwd: (tabId, leafId, cwd) =>
+    set((state) => {
+      const tab = state.tabs.find((t) => t.id === tabId);
+      if (!tab) {
+        return state;
+      }
+      const current = findPaneContent(tab.paneTree, leafId);
+      // Only terminal panes carry a cwd; skip a no-op write so persistence is
+      // not churned on every snapshot.
+      if (!current || current.kind !== "terminal" || current.cwd === cwd) {
+        return state;
+      }
+      return {
+        tabs: state.tabs.map((t) =>
+          t.id === tabId
+            ? { ...t, paneTree: setLeafPane(t.paneTree, leafId, { kind: "terminal", cwd }) }
+            : t,
+        ),
+      };
+    }),
 
   closePane: (tabId, leafId) =>
     set((state) => {


### PR DESCRIPTION
## Summary

Each terminal pane now reopens in the directory it was last in. Previously the layout and tabs were restored, but every terminal spawned at the shared explorer root, so split or multiple terminals all lost their individual directories.

## Changes

- Add an optional `cwd` to the terminal pane content in the layout tree. It is additive, so existing persisted sessions load unchanged (no migration).
- `resolveTerminalCwd(paneCwd, rootPath, tabCwd)`: spawn priority is the pane's own saved cwd, then the explorer root, then the tab's initial cwd. New panes are unaffected (they still follow the explorer root).
- `setTerminalCwd` store action + `findPaneContent` helper: write a pane's cwd back into its leaf, skipping non-terminal panes and no-op writes so persistence is not churned.
- Capture cwd off the existing explorer poll (no new polling), plus a one-shot event snapshot when a pane is switched away from, so a pane's last directory is saved without continuous per-pane polling.
- Backend `usable_cwd`: ignore a saved directory that no longer exists, so a stale cwd can never stop the shell from spawning (falls back to the default).

## Test plan

- `vitest` 261 passing, `cargo test` 67 passing, `tsc` clean
- New unit tests: `resolveTerminalCwd` priority/fallbacks, `findPaneContent`, `setTerminalCwd` (terminal-only + no-op dedupe), `usable_cwd` (drops missing dirs)
- Manual: open two terminals (tabs or a split) in different directories, fully quit and relaunch, each reopens in its own directory; a terminal whose saved dir was deleted still opens (falls back)
