### PR TITLE
feat: restore terminal scrollback across restarts

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,10 @@ use modules::pty::{
     pty_close, pty_close_all, pty_cwd, pty_foreground_command, pty_open, pty_resize,
     pty_shell_name, pty_write, PtyState,
 };
+use modules::terminal_history::{
+    terminal_history_clear, terminal_history_delete, terminal_history_load,
+    terminal_history_prune, terminal_history_save,
+};
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -108,7 +112,12 @@ pub fn run() {
             secrets_set_key,
             secrets_delete_key,
             secrets_has_key,
-            ai_chat
+            ai_chat,
+            terminal_history_save,
+            terminal_history_load,
+            terminal_history_delete,
+            terminal_history_clear,
+            terminal_history_prune
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -5,3 +5,4 @@ pub mod fs;
 pub mod git;
 pub mod pty;
 pub mod secrets;
+pub mod terminal_history;

--- a/src-tauri/src/modules/terminal_history/mod.rs
+++ b/src-tauri/src/modules/terminal_history/mod.rs
@@ -75,15 +75,12 @@ pub fn terminal_history_clear(app: AppHandle) -> Result<(), String> {
 #[tauri::command]
 pub fn terminal_history_prune(app: AppHandle, keep: Vec<String>) -> Result<(), String> {
     let dir = history_dir(&app)?;
+    let keep: std::collections::HashSet<String> = keep.into_iter().collect();
     for entry in fs::read_dir(&dir).map_err(|e| e.to_string())?.flatten() {
-        let stem = entry
-            .path()
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .map(String::from);
-        if let Some(stem) = stem {
-            if !keep.contains(&stem) {
-                let _ = fs::remove_file(entry.path());
+        let path = entry.path();
+        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+            if !keep.contains(stem) {
+                let _ = fs::remove_file(&path);
             }
         }
     }

--- a/src-tauri/src/modules/terminal_history/mod.rs
+++ b/src-tauri/src/modules/terminal_history/mod.rs
@@ -1,0 +1,105 @@
+//! Persisted terminal scrollback. Each pane's serialized buffer is stored as a
+//! single file named by its (stable) UI leaf id, overwritten on each snapshot,
+//! and deleted when the pane is closed or its shell exits. On next launch the
+//! saved buffer is shown as read-only history above a fresh shell.
+
+use std::fs;
+use std::path::PathBuf;
+
+use tauri::{AppHandle, Manager};
+
+const DIR_NAME: &str = "terminal-history";
+
+/// Leaf ids come from our own `uid()` generator, but treat them as untrusted
+/// since they become file names: only allow characters that cannot escape the
+/// history directory.
+fn is_safe_leaf_id(id: &str) -> bool {
+    !id.is_empty() && id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+fn history_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join(DIR_NAME);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    Ok(dir)
+}
+
+fn history_file(app: &AppHandle, leaf_id: &str) -> Result<PathBuf, String> {
+    if !is_safe_leaf_id(leaf_id) {
+        return Err("invalid leaf id".to_string());
+    }
+    Ok(history_dir(app)?.join(format!("{leaf_id}.txt")))
+}
+
+#[tauri::command]
+pub fn terminal_history_save(app: AppHandle, leaf_id: String, contents: String) -> Result<(), String> {
+    let path = history_file(&app, &leaf_id)?;
+    fs::write(path, contents).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn terminal_history_load(app: AppHandle, leaf_id: String) -> Result<Option<String>, String> {
+    let path = history_file(&app, &leaf_id)?;
+    match fs::read_to_string(&path) {
+        Ok(s) => Ok(Some(s)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn terminal_history_delete(app: AppHandle, leaf_id: String) -> Result<(), String> {
+    let path = history_file(&app, &leaf_id)?;
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Remove every saved history file (the manual "clear" action in settings).
+#[tauri::command]
+pub fn terminal_history_clear(app: AppHandle) -> Result<(), String> {
+    let dir = history_dir(&app)?;
+    for entry in fs::read_dir(&dir).map_err(|e| e.to_string())?.flatten() {
+        let _ = fs::remove_file(entry.path());
+    }
+    Ok(())
+}
+
+/// Delete saved files for panes that no longer exist (orphans), keeping only the
+/// given leaf ids. Called on startup with the panes still in the layout tree.
+#[tauri::command]
+pub fn terminal_history_prune(app: AppHandle, keep: Vec<String>) -> Result<(), String> {
+    let dir = history_dir(&app)?;
+    for entry in fs::read_dir(&dir).map_err(|e| e.to_string())?.flatten() {
+        let stem = entry
+            .path()
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(String::from);
+        if let Some(stem) = stem {
+            if !keep.contains(&stem) {
+                let _ = fs::remove_file(entry.path());
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_safe_leaf_id;
+
+    #[test]
+    fn accepts_generated_ids_and_rejects_path_escapes() {
+        assert!(is_safe_leaf_id("pane-1a2b3c"));
+        assert!(is_safe_leaf_id("pane_42"));
+        assert!(!is_safe_leaf_id("../secret"));
+        assert!(!is_safe_leaf_id("a/b"));
+        assert!(!is_safe_leaf_id(""));
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import { useUpdaterStore } from "@/stores/updaterStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { pruneTerminalHistory } from "@/modules/terminal/lib/terminalHistory";
+import { leafIds } from "@/modules/terminal/lib/terminalLayout";
 import { applyTheme, getTheme } from "@/themes/themes";
 
 const MIN_SIDEBAR = 180;
@@ -33,6 +35,13 @@ function App() {
   // The font report (enumerating every installed family) is loaded lazily by
   // the Fonts settings section when it opens, not at startup — the terminal's
   // default font chain already covers CJK, so a cold launch does no font work.
+
+  // Drop saved terminal scrollback for panes that no longer exist (orphans
+  // left by closed tabs/panes), keeping only the panes still in the layout.
+  useEffect(() => {
+    const keep = useTabsStore.getState().tabs.flatMap((t) => leafIds(t.paneTree));
+    void pruneTerminalHistory(keep).catch(() => {});
+  }, []);
 
   // Quietly check for a new release a few seconds after launch; the prompt only
   // appears if one actually exists, so a normal start stays uninterrupted.

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -56,7 +56,11 @@
     "description": "Adjust the gap between the terminal content and its pane edges",
     "padding": "Inner padding",
     "preview": "Preview",
-    "previewText": "$ tempo --version\nTempoTerm terminal padding preview"
+    "previewText": "$ tempo --version\nTempoTerm terminal padding preview",
+    "restoreHistory": "Restore terminal history on relaunch",
+    "restoreHistoryHint": "Reopen each terminal with its previous output (read-only), unless its shell was exited or the pane was closed",
+    "clearHistory": "Clear saved history",
+    "historyCleared": "Cleared"
   },
   "aiModel": {
     "label": "Default model",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -56,7 +56,11 @@
     "description": "調整終端機畫面與面板邊緣之間的間距",
     "padding": "內距",
     "preview": "預覽",
-    "previewText": "$ tempo --version\nTempoTerm 終端機間距預覽"
+    "previewText": "$ tempo --version\nTempoTerm 終端機間距預覽",
+    "restoreHistory": "重新啟動時還原終端機歷史",
+    "restoreHistoryHint": "重開時把每個終端機的上次輸出以唯讀方式還原,除非該 shell 已結束或分頁已關閉",
+    "clearHistory": "清除已儲存的歷史",
+    "historyCleared": "已清除"
   },
   "aiModel": {
     "label": "預設模型",

--- a/src/modules/settings/TerminalSettingsSection.tsx
+++ b/src/modules/settings/TerminalSettingsSection.tsx
@@ -1,17 +1,22 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   MAX_TERMINAL_PADDING,
   MIN_TERMINAL_PADDING,
   useSettingsStore,
 } from "@/stores/settingsStore";
+import { clearTerminalHistory } from "@/modules/terminal/lib/terminalHistory";
 import { getTheme } from "@/themes/themes";
 
 export function TerminalSettingsSection() {
   const { t } = useTranslation("settings");
   const terminalPadding = useSettingsStore((s) => s.terminalPadding);
   const setTerminalPadding = useSettingsStore((s) => s.setTerminalPadding);
+  const restoreTerminalHistory = useSettingsStore((s) => s.restoreTerminalHistory);
+  const setRestoreTerminalHistory = useSettingsStore((s) => s.setRestoreTerminalHistory);
   const themeId = useSettingsStore((s) => s.themeId);
   const terminal = getTheme(themeId).terminal;
+  const [cleared, setCleared] = useState(false);
 
   return (
     <section>
@@ -34,6 +39,31 @@ export function TerminalSettingsSection() {
           onChange={(e) => setTerminalPadding(Number(e.target.value))}
           className="w-64 accent-accent"
         />
+      </div>
+
+      <div className="mb-6">
+        <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg">
+          <input
+            type="checkbox"
+            checked={restoreTerminalHistory}
+            onChange={(e) => setRestoreTerminalHistory(e.target.checked)}
+            className="accent-accent"
+          />
+          {t("terminalSettings.restoreHistory")}
+        </label>
+        <p className="mt-1 text-xs text-fg-muted">{t("terminalSettings.restoreHistoryHint")}</p>
+        <button
+          type="button"
+          onClick={() => {
+            void clearTerminalHistory().then(() => {
+              setCleared(true);
+              setTimeout(() => setCleared(false), 1500);
+            });
+          }}
+          className="mt-3 rounded-md border border-border px-3 py-1.5 text-xs text-fg-muted transition-colors hover:bg-bg-elevated hover:text-fg"
+        >
+          {cleared ? t("terminalSettings.historyCleared") : t("terminalSettings.clearHistory")}
+        </button>
       </div>
 
       {/* Live preview: an inner box inset by the chosen padding, in terminal colours */}

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -37,6 +37,7 @@ import {
   type DraggedEntry,
 } from "@/modules/explorer/lib/dragEntry";
 import { insertLinkIntoNote } from "@/modules/notes/lib/noteBus";
+import { deleteTerminalHistory } from "./lib/terminalHistory";
 import { useTabsStore, type Tab } from "@/stores/tabsStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
@@ -200,6 +201,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                   title={t("workspace.closePane")}
                   onClick={(e) => {
                     e.stopPropagation();
+                    void deleteTerminalHistory(pane.id);
                     closePane(tab.id, pane.id);
                   }}
                   className="absolute right-1.5 top-1.5 z-10 rounded bg-bg-inset/80 p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -439,13 +439,25 @@ export function TerminalView({
 
     // Snapshot the scrollback periodically so a crash/quit loses at most a few
     // seconds. Overwrites the same per-pane file; gated on the user setting.
+    // Only writes when the buffer actually changed since the last snapshot, so
+    // an idle terminal does no work.
+    let dirty = false;
+    const writeListener = term.onWriteParsed(() => {
+      dirty = true;
+    });
     const snapshot = () => {
       const leafId = leafIdRef.current;
-      if (!leafId || !useSettingsStore.getState().restoreTerminalHistory) {
+      if (!leafId || !dirty || !useSettingsStore.getState().restoreTerminalHistory) {
         return;
       }
-      const data = trimScrollback(serializeBufferText(term), MAX_SCROLLBACK_LINES);
-      void saveTerminalHistory(leafId, data).catch(() => {});
+      dirty = false;
+      const data = trimScrollback(
+        serializeBufferText(term, MAX_SCROLLBACK_LINES),
+        MAX_SCROLLBACK_LINES,
+      );
+      void saveTerminalHistory(leafId, data).catch(() => {
+        dirty = true;
+      });
     };
     const snapshotTimer = setInterval(snapshot, 5000);
 
@@ -461,6 +473,7 @@ export function TerminalView({
     return () => {
       disposed = true;
       clearInterval(snapshotTimer);
+      writeListener.dispose();
       observer.disconnect();
       document.removeEventListener("keydown", onKeyDownCapture, true);
       document.removeEventListener("paste", onPasteCapture, true);

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -5,6 +5,14 @@ import { Loader2 } from "lucide-react";
 import { createTerminal, type TerminalHandle } from "./lib/createTerminal";
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import {
+  deleteTerminalHistory,
+  loadTerminalHistory,
+  saveTerminalHistory,
+  serializeBufferText,
+  trimScrollback,
+  MAX_SCROLLBACK_LINES,
+} from "./lib/terminalHistory";
+import {
   registerTerminal,
   registerTerminalPathDrop,
   unregisterTerminal,
@@ -357,7 +365,29 @@ export function TerminalView({
     safeFit();
 
     let disposed = false;
-    void openPty({
+
+    // Restore the saved scrollback (read-only history) before the shell starts,
+    // so it appears above a fresh prompt. Gated on the user setting.
+    const restoreHistory = async () => {
+      const leafId = leafIdRef.current;
+      if (!leafId || !useSettingsStore.getState().restoreTerminalHistory) {
+        return;
+      }
+      const saved = await loadTerminalHistory(leafId).catch(() => null);
+      if (disposed || !saved) {
+        return;
+      }
+      // Plain logical lines; dim the whole block grey so it reads as history,
+      // and convert "\n" to "\r\n" for the terminal.
+      term.write(`\x1b[90m${saved.replace(/\n/g, "\r\n")}\x1b[0m\r\n`);
+      term.write("\x1b[90m── previous session ──\x1b[0m\r\n");
+    };
+
+    void restoreHistory().then(() => {
+      if (disposed) {
+        return;
+      }
+      void openPty({
       cols: term.cols,
       rows: term.rows,
       cwd: cwdRef.current,
@@ -367,6 +397,12 @@ export function TerminalView({
       onExit: () => {
         if (!disposed) {
           onExitRef.current?.();
+          // The shell ended while the app is running (e.g. the user typed
+          // `exit`), so its history is no longer wanted. An app teardown sets
+          // `disposed` first, so that path keeps the history for next launch.
+          if (leafIdRef.current) {
+            void deleteTerminalHistory(leafIdRef.current);
+          }
         }
       },
     })
@@ -399,6 +435,19 @@ export function TerminalView({
         term.write(`\r\n\x1b[31mFailed to open shell: ${message}\x1b[0m\r\n`);
         setConnecting(false);
       });
+    });
+
+    // Snapshot the scrollback periodically so a crash/quit loses at most a few
+    // seconds. Overwrites the same per-pane file; gated on the user setting.
+    const snapshot = () => {
+      const leafId = leafIdRef.current;
+      if (!leafId || !useSettingsStore.getState().restoreTerminalHistory) {
+        return;
+      }
+      const data = trimScrollback(serializeBufferText(term), MAX_SCROLLBACK_LINES);
+      void saveTerminalHistory(leafId, data).catch(() => {});
+    };
+    const snapshotTimer = setInterval(snapshot, 5000);
 
     const observer = new ResizeObserver(() => {
       safeFit();
@@ -411,6 +460,7 @@ export function TerminalView({
 
     return () => {
       disposed = true;
+      clearInterval(snapshotTimer);
       observer.disconnect();
       document.removeEventListener("keydown", onKeyDownCapture, true);
       document.removeEventListener("paste", onPasteCapture, true);

--- a/src/modules/terminal/lib/terminalHistory.test.ts
+++ b/src/modules/terminal/lib/terminalHistory.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { trimScrollback } from "./terminalHistory";
+
+describe("trimScrollback", () => {
+  it("keeps only the last N lines when the text is longer", () => {
+    const text = ["a", "b", "c", "d", "e"].join("\n");
+    expect(trimScrollback(text, 3)).toBe("c\nd\ne");
+  });
+
+  it("returns the text unchanged when it has at most N lines", () => {
+    expect(trimScrollback("a\nb", 5)).toBe("a\nb");
+    expect(trimScrollback("", 5)).toBe("");
+  });
+});

--- a/src/modules/terminal/lib/terminalHistory.ts
+++ b/src/modules/terminal/lib/terminalHistory.ts
@@ -10,11 +10,25 @@ export const MAX_SCROLLBACK_LINES = 1000;
  * it reflows cleanly when restored into a pane of any width, so resizing never
  * truncates the history. Lines are separated by "\n".
  */
-export function serializeBufferText(term: Terminal): string {
+export function serializeBufferText(term: Terminal, maxLines?: number): string {
   const buffer = term.buffer.active;
   const lines: string[] = [];
   let current = "";
-  for (let y = 0; y < buffer.length; y++) {
+  // Start near the end when capped, then back up to a non-wrapped row so the
+  // first kept logical line is whole — avoids scanning thousands of rows only
+  // to trim them away.
+  let startY = 0;
+  if (maxLines !== undefined) {
+    startY = Math.max(0, buffer.length - maxLines);
+    while (startY > 0) {
+      const line = buffer.getLine(startY);
+      if (line && !line.isWrapped) {
+        break;
+      }
+      startY--;
+    }
+  }
+  for (let y = startY; y < buffer.length; y++) {
     const line = buffer.getLine(y);
     if (!line) {
       continue;

--- a/src/modules/terminal/lib/terminalHistory.ts
+++ b/src/modules/terminal/lib/terminalHistory.ts
@@ -1,0 +1,70 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { Terminal } from "@xterm/xterm";
+
+/** Cap on retained scrollback lines per pane (bounds file size + restore time). */
+export const MAX_SCROLLBACK_LINES = 1000;
+
+/**
+ * Read the terminal buffer as plain logical lines (soft-wrapped rows joined back
+ * into one line). Unlike a cell-exact serialization this carries no colour, but
+ * it reflows cleanly when restored into a pane of any width, so resizing never
+ * truncates the history. Lines are separated by "\n".
+ */
+export function serializeBufferText(term: Terminal): string {
+  const buffer = term.buffer.active;
+  const lines: string[] = [];
+  let current = "";
+  for (let y = 0; y < buffer.length; y++) {
+    const line = buffer.getLine(y);
+    if (!line) {
+      continue;
+    }
+    current += line.translateToString(false);
+    const next = buffer.getLine(y + 1);
+    if (!next || !next.isWrapped) {
+      lines.push(current.replace(/\s+$/u, ""));
+      current = "";
+    }
+  }
+  while (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Keep only the last `maxLines` lines of a serialized terminal buffer, so a
+ * persisted scrollback file stays bounded in size and quick to restore.
+ */
+export function trimScrollback(text: string, maxLines: number): string {
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) {
+    return text;
+  }
+  return lines.slice(lines.length - maxLines).join("\n");
+}
+
+/** Overwrite a pane's saved scrollback (keyed by its stable leaf id). */
+export function saveTerminalHistory(leafId: string, contents: string): Promise<void> {
+  return invoke("terminal_history_save", { leafId, contents });
+}
+
+/** Load a pane's saved scrollback, or null if none was saved. */
+export function loadTerminalHistory(leafId: string): Promise<string | null> {
+  return invoke<string | null>("terminal_history_load", { leafId });
+}
+
+/** Drop a pane's saved scrollback (shell exited or pane closed). */
+export function deleteTerminalHistory(leafId: string): Promise<void> {
+  return invoke("terminal_history_delete", { leafId });
+}
+
+/** Remove every saved scrollback file (manual clear in settings). */
+export function clearTerminalHistory(): Promise<void> {
+  return invoke("terminal_history_clear");
+}
+
+/** Delete saved files for panes no longer present, keeping `keep` leaf ids. */
+export function pruneTerminalHistory(keep: string[]): Promise<void> {
+  return invoke("terminal_history_prune", { keep });
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -13,10 +13,13 @@ interface SettingsState {
   /** Inner padding (px) between the terminal content and its pane edges. */
   terminalPadding: number;
   wordWrap: boolean;
+  /** Persist each terminal's scrollback and restore it on next launch. */
+  restoreTerminalHistory: boolean;
   setLanguage: (language: SupportedLanguage) => void;
   setThemeId: (themeId: string) => void;
   setTerminalPadding: (padding: number) => void;
   toggleWordWrap: () => void;
+  setRestoreTerminalHistory: (value: boolean) => void;
 }
 
 export const SETTINGS_STORAGE_KEY = "tempoterm-settings";
@@ -35,10 +38,12 @@ export const useSettingsStore = create<SettingsState>()(
       themeId: DEFAULT_THEME_ID,
       terminalPadding: DEFAULT_TERMINAL_PADDING,
       wordWrap: false,
+      restoreTerminalHistory: true,
       setLanguage: (language) => set({ language }),
       setThemeId: (themeId) => set({ themeId }),
       setTerminalPadding: (padding) => set({ terminalPadding: clampPadding(padding) }),
       toggleWordWrap: () => set((s) => ({ wordWrap: !s.wordWrap })),
+      setRestoreTerminalHistory: (value) => set({ restoreTerminalHistory: value }),
     }),
     {
       name: SETTINGS_STORAGE_KEY,


### PR DESCRIPTION
## Summary

Persist each terminal pane's output so a crash or restart no longer loses the on-screen conversation (for example a Claude Code session). On relaunch the saved output is shown as dimmed, read-only history above a fresh shell, so you can re-read it and copy a resume command. Opt-out in settings.

## Behaviour

- Restored history is read-only text above a brand-new shell (the process itself cannot be revived once the app closed).
- A pane's history is kept only if you did not intentionally end it: it is discarded when the shell exits (e.g. you typed `exit`) or you close the pane, and kept when the app is quit/crashes with the shell still alive.

## Changes

- New `terminal_history` Rust module: `save` / `load` / `delete` / `clear` / `prune` commands storing one file per pane in the app data dir, keyed by the stable UI leaf id. Leaf ids are sanitized so they cannot escape the directory.
- Snapshot the buffer as **plain logical-line text** on a throttled timer, overwriting the same per-pane file. Plain logical lines reflow at any width, so resizing a pane never truncates restored history (a cell-exact serialization is width-dependent and broke on resize). Capped at 1000 lines.
- Restore writes the saved text dimmed, with a `── previous session ──` separator, before the shell starts.
- Discard rules: delete on shell exit and on pane close; prune orphaned files (panes no longer in the layout) on startup. App quit keeps the files (the throttled snapshot means at most a few seconds are lost).
- Settings: a `restoreTerminalHistory` toggle (default on) and a separate "Clear saved history" button, kept independent so disabling does not delete and clearing does not disable.

## Test plan

- `vitest` 263 passing, `cargo test` 68 passing (incl. `trimScrollback`, leaf-id sanitization), `tsc` clean
- Manual: type in a terminal, quit the app (no `exit`), relaunch — output is restored as dimmed history above a fresh prompt; resizing the pane reflows without truncation; typing `exit` or closing a pane drops that history; toggling the setting off stops restore; the clear button removes saved files
