### PR TITLE
fix: decode non-ASCII terminal cwd from lsof (#7)

### DIFF
--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -199,6 +199,37 @@ pub fn cwd(state: &PtyState, id: u32) -> Result<Option<String>, String> {
     Ok(pid.and_then(read_process_cwd))
 }
 
+/// lsof `-Fn` escapes non-printable/non-ASCII bytes as literal `\xHH` text (and
+/// `\` as `\\`). Decode those back to the original bytes so a non-ASCII path
+/// (e.g. a Chinese folder name) is real UTF-8 rather than a literal `\xe6...`.
+#[cfg(target_os = "macos")]
+fn decode_lsof_name(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            if bytes[i + 1] == b'x' && i + 3 < bytes.len() {
+                let hi = (bytes[i + 2] as char).to_digit(16);
+                let lo = (bytes[i + 3] as char).to_digit(16);
+                if let (Some(hi), Some(lo)) = (hi, lo) {
+                    out.push((hi * 16 + lo) as u8);
+                    i += 4;
+                    continue;
+                }
+            }
+            if bytes[i + 1] == b'\\' {
+                out.push(b'\\');
+                i += 2;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 #[cfg(target_os = "macos")]
 fn read_process_cwd(pid: i32) -> Option<String> {
     let output = std::process::Command::new("lsof")
@@ -207,7 +238,7 @@ fn read_process_cwd(pid: i32) -> Option<String> {
         .ok()?;
     String::from_utf8_lossy(&output.stdout)
         .lines()
-        .find_map(|line| line.strip_prefix('n').map(|p| p.to_string()))
+        .find_map(|line| line.strip_prefix('n').map(|p| decode_lsof_name(p)))
 }
 
 #[cfg(target_os = "linux")]
@@ -319,5 +350,15 @@ mod tests {
         let id = spawn_with_sinks(&state, 80, 24, cmd, "echo".to_string(), |_| true, |_| {})
             .expect("spawn should succeed");
         assert!(state.get(id).is_ok());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn decodes_lsof_escaped_non_ascii_back_to_utf8() {
+        // lsof -Fn prints non-ASCII bytes as literal \xHH; decode them back.
+        assert_eq!(decode_lsof_name("/a/\\xe6\\x96\\x87"), "/a/文");
+        // Plain ASCII paths are unchanged; an escaped backslash becomes one.
+        assert_eq!(decode_lsof_name("/Users/muki/Documents"), "/Users/muki/Documents");
+        assert_eq!(decode_lsof_name("/a/b\\\\c"), "/a/b\\c");
     }
 }

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -218,8 +218,20 @@ fn decode_lsof_name(raw: &str) -> String {
                     continue;
                 }
             }
-            if bytes[i + 1] == b'\\' {
-                out.push(b'\\');
+            // lsof also uses standard C escapes for control characters.
+            let escaped = match bytes[i + 1] {
+                b'\\' => Some(b'\\'),
+                b'a' => Some(0x07),
+                b'b' => Some(0x08),
+                b'f' => Some(0x0c),
+                b'n' => Some(b'\n'),
+                b'r' => Some(b'\r'),
+                b't' => Some(b'\t'),
+                b'v' => Some(0x0b),
+                _ => None,
+            };
+            if let Some(byte) = escaped {
+                out.push(byte);
                 i += 2;
                 continue;
             }
@@ -227,7 +239,9 @@ fn decode_lsof_name(raw: &str) -> String {
         out.push(bytes[i]);
         i += 1;
     }
-    String::from_utf8_lossy(&out).into_owned()
+    // Reuse the buffer when it is already valid UTF-8 (the normal case); only
+    // fall back to lossy replacement for genuinely invalid bytes.
+    String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
 }
 
 #[cfg(target_os = "macos")]
@@ -360,5 +374,7 @@ mod tests {
         // Plain ASCII paths are unchanged; an escaped backslash becomes one.
         assert_eq!(decode_lsof_name("/Users/muki/Documents"), "/Users/muki/Documents");
         assert_eq!(decode_lsof_name("/a/b\\\\c"), "/a/b\\c");
+        // Standard C escapes for control characters are decoded too.
+        assert_eq!(decode_lsof_name("/a/b\\tc"), "/a/b\tc");
     }
 }


### PR DESCRIPTION
Fixes #7.

## Problem

When a terminal's cwd contains non-ASCII characters (e.g. a Chinese folder name), `lsof -Fn` prints those bytes as literal `\xHH` text. That escaped string became the per-pane cwd, so:
- the tab name showed garbled residue instead of the folder name
- the file explorer opened a path that does not exist and showed an empty folder

## Fix

Decode lsof's `\xHH` (and `\\`) escapes back to the original bytes before UTF-8 decoding, in `read_process_cwd` (macOS). The path is then real UTF-8, so the tab name and the explorer both get a valid directory. Linux uses `/proc/<pid>/cwd` and is unaffected.

## Test plan

- `cargo test` 69 passing, incl. a new `decode_lsof_name` unit test (`\xe6\x96\x87` -> 文, plain ASCII unchanged, `\\` -> `\`)
- `vitest` 263 passing, `tsc` clean
- Manual (macOS): `cd` into a folder with a Chinese name — the tab shows the real name and the explorer lists the directory
