### PR TITLE
fix: consistent thin terminal scrollbar across split panes (#8)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -95,6 +95,28 @@ body {
  */
 
 /*
+ * The terminal is different: xterm 6.0 ships its own VS Code-style scrollbar
+ * (.xterm-scrollable-element) instead of using the native overlay one, so the
+ * policy above never reaches it. Its width is JS-measured, and on macOS overlay
+ * scrollbars that measurement is 0, so split panes ended up with inconsistent
+ * (missing or overly thick) scrollbars. Force a consistent thin, rounded,
+ * semi-transparent overlay slider; xterm's own opacity transition still fades
+ * it out when idle.
+ */
+.xterm .xterm-scrollable-element > .scrollbar.vertical {
+  width: 11px !important;
+}
+.xterm .xterm-scrollable-element > .scrollbar.vertical .slider {
+  width: 6px !important;
+  left: 3px !important;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.22) !important;
+}
+.xterm .xterm-scrollable-element > .scrollbar.vertical .slider:hover {
+  background: rgba(255, 255, 255, 0.36) !important;
+}
+
+/*
  * Tailwind v4 / browsers render <button> with the default arrow cursor. Give
  * every interactive control a pointer cursor (disabled ones excepted).
  */

--- a/src/index.css
+++ b/src/index.css
@@ -112,7 +112,7 @@ body {
   border-radius: 6px;
   background: rgba(255, 255, 255, 0.22) !important;
 }
-.xterm .xterm-scrollable-element > .scrollbar.vertical .slider:hover {
+.xterm .xterm-scrollable-element > .scrollbar.vertical:hover .slider {
   background: rgba(255, 255, 255, 0.36) !important;
 }
 


### PR DESCRIPTION
Fixes #8.

## Problem

With two or more terminal panes split in a tab, scrollbars were inconsistent: some panes had none, some were too thick, and the bar overlapped the text. xterm 6.0 replaced the native viewport scrollbar with its own VS Code-style `.xterm-scrollable-element`, whose width is measured in JS. On macOS overlay scrollbars that measurement is 0, so each instance ended up sizing its scrollbar differently.

## Fix

CSS-only: force a consistent thin (6px), rounded, semi-transparent overlay slider for the terminal's custom scrollbar, scoped to `.xterm .xterm-scrollable-element`. xterm's own opacity transition still fades it out when idle, keeping the macOS overlay feel. The global no-custom-scrollbar policy for the rest of the app is untouched (the comment there is extended to explain why the terminal needs its own rule).

## Test plan

- `vitest` 263 passing, `tsc` clean (CSS-only change)
- Manual (macOS): split a tab into two+ terminals, produce scrollable output in each — every pane shows the same thin, rounded scrollbar that fades when idle

## Note

Kept the overlay model (no permanently reserved right padding), matching the app's existing macOS-overlay scrollbar philosophy; the thin fading slider only briefly overlaps the last column while scrolling. Reserving a fixed gutter can be a follow-up if preferred.
