### PR TITLE
fix: align terminal file links with wide/CJK characters

### DIFF
--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -315,8 +315,11 @@ export function TerminalView({
         let line: typeof firstLine | undefined = firstLine;
         while (line) {
           const cells: TerminalRow["cells"] = [];
+          // Reuse one cell object across columns; xterm fills it in place to
+          // avoid allocating per cell.
+          let cell: ReturnType<typeof line.getCell>;
           for (let col = 0; col < line.length; col += 1) {
-            const cell = line.getCell(col);
+            cell = line.getCell(col, cell);
             cells.push({
               chars: cell?.getChars() ?? "",
               width: cell?.getWidth() ?? 1,
@@ -341,11 +344,11 @@ export function TerminalView({
         // glyph's first column; end uses its last, so wide glyphs are covered.
         const startCell = (index: number): { x: number; y: number } => {
           const span = spans[index] ?? lastSpan;
-          return { x: span.startX, y: span.y };
+          return { x: span?.startX ?? 1, y: span?.y ?? lineNumber };
         };
         const endCell = (index: number): { x: number; y: number } => {
           const span = spans[index] ?? lastSpan;
-          return { x: span.endX, y: span.y };
+          return { x: span?.endX ?? 1, y: span?.y ?? lineNumber };
         };
         callback(
           matches.map((m) => ({

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -31,6 +31,7 @@ import {
   shellQuotePath,
 } from "./lib/terminalClipboard";
 import { findFilePaths, resolveFilePath } from "./lib/fileLinks";
+import { buildCellPositions, type TerminalRow } from "./lib/cellPositions";
 import { terminalKeySequence } from "./lib/terminalKeymap";
 import { shouldCdToRoot } from "./lib/cwdSync";
 import { dropOverlayClassName } from "@/components/EntryDropOverlay";
@@ -306,12 +307,22 @@ export function TerminalView({
           return;
         }
         // Gather the logical line: this row plus any wrapped continuation rows,
-        // so a path that wraps across rows is still detected as one link.
-        const rows: { y: number; text: string }[] = [];
+        // so a path that wraps across rows is still detected as one link. Read
+        // the actual buffer cells (not translateToString) so column math stays
+        // in sync with xterm's own widths for wide / CJK glyphs.
+        const cellRows: TerminalRow[] = [];
         let y = lineNumber;
         let line: typeof firstLine | undefined = firstLine;
         while (line) {
-          rows.push({ y, text: line.translateToString(false) });
+          const cells: TerminalRow["cells"] = [];
+          for (let col = 0; col < line.length; col += 1) {
+            const cell = line.getCell(col);
+            cells.push({
+              chars: cell?.getChars() ?? "",
+              width: cell?.getWidth() ?? 1,
+            });
+          }
+          cellRows.push({ y, cells });
           const next = buffer.getLine(y);
           if (!next || !next.isWrapped) {
             break;
@@ -319,26 +330,26 @@ export function TerminalView({
           line = next;
           y += 1;
         }
-        const matches = findFilePaths(rows.map((r) => r.text).join(""));
+        const { text, spans } = buildCellPositions(cellRows);
+        const matches = findFilePaths(text);
         if (matches.length === 0) {
           callback(undefined);
           return;
         }
-        // Map an index in the joined text back to a buffer cell (1-based x/y).
-        const locate = (index: number): { x: number; y: number } => {
-          let acc = 0;
-          for (const row of rows) {
-            if (index < acc + row.text.length) {
-              return { x: index - acc + 1, y: row.y };
-            }
-            acc += row.text.length;
-          }
-          const last = rows[rows.length - 1];
-          return { x: last.text.length, y: last.y };
+        const lastSpan = spans[spans.length - 1];
+        // Map a string index back to a buffer cell (1-based x/y). start uses the
+        // glyph's first column; end uses its last, so wide glyphs are covered.
+        const startCell = (index: number): { x: number; y: number } => {
+          const span = spans[index] ?? lastSpan;
+          return { x: span.startX, y: span.y };
+        };
+        const endCell = (index: number): { x: number; y: number } => {
+          const span = spans[index] ?? lastSpan;
+          return { x: span.endX, y: span.y };
         };
         callback(
           matches.map((m) => ({
-            range: { start: locate(m.start), end: locate(m.end - 1) },
+            range: { start: startCell(m.start), end: endCell(m.end - 1) },
             text: m.text,
             activate: (event: MouseEvent) => {
               // Alt+click is xterm's rectangular-select gesture and can be

--- a/src/modules/terminal/lib/cellPositions.test.ts
+++ b/src/modules/terminal/lib/cellPositions.test.ts
@@ -35,6 +35,23 @@ describe("buildCellPositions", () => {
     expect(spans[1]).toEqual({ startX: 3, endX: 3, y: 1 });
   });
 
+  it("renders a never-written cell as a space so adjacent paths stay separate", () => {
+    // A never-written cell is width 1 with empty chars (NULL_CELL_WIDTH = 1),
+    // not a width-0 spacer; it must become a space, not be dropped, or two
+    // paths either side of it would merge into one bogus token.
+    const row: TerminalRow = {
+      y: 1,
+      cells: [
+        { chars: "a", width: 1 },
+        { chars: "", width: 1 },
+        { chars: "b", width: 1 },
+      ],
+    };
+    const { text, spans } = buildCellPositions([row]);
+    expect(text).toBe("a b");
+    expect(spans[2]).toEqual({ startX: 3, endX: 3, y: 1 });
+  });
+
   it("continues onto a wrapped row with its own column origin", () => {
     const { text, spans } = buildCellPositions([
       asciiRow(4, "ab"),

--- a/src/modules/terminal/lib/cellPositions.test.ts
+++ b/src/modules/terminal/lib/cellPositions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildCellPositions, type TerminalRow } from "./cellPositions";
+
+/** Build a row of single-width ASCII cells from a plain string. */
+function asciiRow(y: number, text: string): TerminalRow {
+  return {
+    y,
+    cells: [...text].map((ch) => ({ chars: ch, width: 1 })),
+  };
+}
+
+describe("buildCellPositions", () => {
+  it("maps an ASCII string index to the same 1-based column", () => {
+    const { text, spans } = buildCellPositions([asciiRow(7, "abc")]);
+    expect(text).toBe("abc");
+    expect(spans[0]).toEqual({ startX: 1, endX: 1, y: 7 });
+    expect(spans[2]).toEqual({ startX: 3, endX: 3, y: 7 });
+  });
+
+  it("accounts for the two columns a wide glyph occupies", () => {
+    // xterm stores a wide glyph as a width-2 cell followed by a width-0 spacer.
+    const row: TerminalRow = {
+      y: 1,
+      cells: [
+        { chars: "文", width: 2 },
+        { chars: "", width: 0 },
+        { chars: "a", width: 1 },
+      ],
+    };
+    const { text, spans } = buildCellPositions([row]);
+    expect(text).toBe("文a");
+    // The wide glyph spans columns 1-2...
+    expect(spans[0]).toEqual({ startX: 1, endX: 2, y: 1 });
+    // ...so the ASCII char after it sits at column 3, not 2.
+    expect(spans[1]).toEqual({ startX: 3, endX: 3, y: 1 });
+  });
+
+  it("continues onto a wrapped row with its own column origin", () => {
+    const { text, spans } = buildCellPositions([
+      asciiRow(4, "ab"),
+      asciiRow(5, "cd"),
+    ]);
+    expect(text).toBe("abcd");
+    // First char of the second row restarts at column 1 on line 5.
+    expect(spans[2]).toEqual({ startX: 1, endX: 1, y: 5 });
+    expect(spans[3]).toEqual({ startX: 2, endX: 2, y: 5 });
+  });
+});

--- a/src/modules/terminal/lib/cellPositions.ts
+++ b/src/modules/terminal/lib/cellPositions.ts
@@ -44,11 +44,14 @@ export function buildCellPositions(rows: TerminalRow[]): CellPositions {
   for (const row of rows) {
     for (let col = 0; col < row.cells.length; col += 1) {
       const cell = row.cells[col];
-      // The spacer column after a wide glyph carries no text of its own.
+      // width 0 only ever marks the spacer column that follows a wide (width-2)
+      // glyph; it carries no text of its own, so skip it. Never-written cells
+      // are width 1 with empty chars and fall through to the space below.
       if (cell.width === 0) {
         continue;
       }
-      // Never-written cells translate to a single space, like xterm does.
+      // Empty cells translate to a single space, matching xterm's
+      // translateToString(false) so findFilePaths sees the same text.
       const chars = cell.chars === "" ? " " : cell.chars;
       const startX = col + 1;
       const endX = startX + Math.max(cell.width, 1) - 1;

--- a/src/modules/terminal/lib/cellPositions.ts
+++ b/src/modules/terminal/lib/cellPositions.ts
@@ -1,0 +1,63 @@
+/**
+ * Map string indices in a terminal line back to xterm buffer cell columns.
+ *
+ * xterm positions links by display column, not by JavaScript string length:
+ * a wide (CJK / fullwidth) glyph occupies two columns while counting as one
+ * code unit. Walking the buffer's own cells keeps our column math in sync with
+ * however xterm measured them, so link underlines and hit regions land on the
+ * actual text even when wide characters sit earlier on the line.
+ */
+
+export interface TerminalCell {
+  /** The cell's text. Empty for never-written cells and wide-char spacers. */
+  chars: string;
+  /** Display width in columns: 1 (normal), 2 (wide), or 0 (wide-char spacer). */
+  width: number;
+}
+
+export interface TerminalRow {
+  /** 1-based buffer line number, as used by xterm link ranges. */
+  y: number;
+  cells: TerminalCell[];
+}
+
+export interface CellSpan {
+  /** 1-based column where the character starts. */
+  startX: number;
+  /** 1-based column of the last cell the character occupies. */
+  endX: number;
+  /** 1-based buffer line number. */
+  y: number;
+}
+
+export interface CellPositions {
+  /** Text rebuilt from the cells, matching xterm's translateToString(false). */
+  text: string;
+  /** Cell span for each UTF-16 code unit in `text`. */
+  spans: CellSpan[];
+}
+
+export function buildCellPositions(rows: TerminalRow[]): CellPositions {
+  let text = "";
+  const spans: CellSpan[] = [];
+
+  for (const row of rows) {
+    for (let col = 0; col < row.cells.length; col += 1) {
+      const cell = row.cells[col];
+      // The spacer column after a wide glyph carries no text of its own.
+      if (cell.width === 0) {
+        continue;
+      }
+      // Never-written cells translate to a single space, like xterm does.
+      const chars = cell.chars === "" ? " " : cell.chars;
+      const startX = col + 1;
+      const endX = startX + Math.max(cell.width, 1) - 1;
+      for (let k = 0; k < chars.length; k += 1) {
+        spans.push({ startX, endX, y: row.y });
+      }
+      text += chars;
+    }
+  }
+
+  return { text, spans };
+}

--- a/src/modules/terminal/lib/fileLinks.test.ts
+++ b/src/modules/terminal/lib/fileLinks.test.ts
@@ -37,6 +37,21 @@ describe("findFilePaths", () => {
     ]);
   });
 
+  it("matches a space-delimited CJK filename cleanly", () => {
+    expect(findFilePaths("see 報告.md here").map((m) => m.text)).toEqual(["報告.md"]);
+  });
+
+  // Known limitation: CJK has no reliable word boundary, so prose written
+  // flush against an ASCII filename (no space) is swallowed into the token.
+  // Matching is deliberately broad and the click handler verifies the file
+  // exists, so the worst case is an underline that does nothing — documented
+  // here so the behaviour is intentional, not an accident.
+  it("over-matches CJK prose glued to a filename (documented limitation)", () => {
+    expect(findFilePaths("打開config.json").map((m) => m.text)).toEqual([
+      "打開config.json",
+    ]);
+  });
+
   it("ignores file-looking tokens inside a web URL but still finds real paths", () => {
     const matches = findFilePaths("see https://muki.tw/a.png and ./src/b.ts").map((m) => m.text);
     expect(matches).toContain("./src/b.ts");

--- a/src/modules/terminal/lib/fileLinks.test.ts
+++ b/src/modules/terminal/lib/fileLinks.test.ts
@@ -24,6 +24,19 @@ describe("findFilePaths", () => {
     expect(findFilePaths("just some regular words here")).toEqual([]);
   });
 
+  it("matches a path whose filename contains CJK characters", () => {
+    const line = "exists docs/specs/2026-06-19-新點首頁三新風格EFG-design.md, checked";
+    const matches = findFilePaths(line);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe("docs/specs/2026-06-19-新點首頁三新風格EFG-design.md");
+  });
+
+  it("matches a path with a CJK directory segment", () => {
+    expect(findFilePaths("open 專案/notes.md").map((m) => m.text)).toEqual([
+      "專案/notes.md",
+    ]);
+  });
+
   it("ignores file-looking tokens inside a web URL but still finds real paths", () => {
     const matches = findFilePaths("see https://muki.tw/a.png and ./src/b.ts").map((m) => m.text);
     expect(matches).toContain("./src/b.ts");

--- a/src/modules/terminal/lib/fileLinks.ts
+++ b/src/modules/terminal/lib/fileLinks.ts
@@ -15,9 +15,11 @@ export interface FilePathMatch {
 }
 
 // optional ~/ ./ ../ or / prefix, dir segments, a filename with an extension,
-// and an optional :line or :line:col suffix.
+// and an optional :line or :line:col suffix. Segment characters allow any
+// Unicode letter/number (via the u flag) so CJK file and directory names match,
+// not just ASCII; the extension itself stays ASCII.
 const FILE_PATH_RE =
-  /(?:~\/|\.{0,2}\/)?(?:[\w.\-]+\/)*[\w.\-]+\.[A-Za-z0-9]+(?::\d+(?::\d+)?)?/g;
+  /(?:~\/|\.{0,2}\/)?(?:[\p{L}\p{N}_.\-]+\/)*[\p{L}\p{N}_.\-]+\.[A-Za-z0-9]+(?::\d+(?::\d+)?)?/gu;
 
 // Web URLs are handled by the web-links addon; skip any file-looking token that
 // sits inside one so the two link providers don't fight over the same text.


### PR DESCRIPTION
## Summary

Fixes file-path links in the terminal that were misaligned and hard to click when a line contains CJK / wide characters (issue #11).

Two root causes:

1. **Wrong column math.** The link provider mapped a string index to an xterm buffer column using JavaScript string `.length`, but xterm positions cells by *display width*. A wide glyph (CJK / fullwidth) occupies 2 columns while counting as 1 code unit, so any wide character earlier on the line shifted the link range to the left of the real text, misplacing the underline and the hover/click hit region.
2. **ASCII-only detection.** The path regex (`[\w.\-]`) could not match CJK characters, so a path whose own name contains CJK (e.g. `2026-06-19-新點首頁三新風格EFG-design.md`) was only partially detected.

## Changes

- New pure module `cellPositions.ts` (`buildCellPositions`): walks the buffer's own cells to map each UTF-16 code unit to its 1-based start/end column and row, so column math stays in sync with however xterm measured each glyph. Link start uses the glyph's first column, end its last, so wide glyphs are fully covered. Handles wide-glyph spacers, never-written cells, surrogate pairs, and wrapped rows.
  - The public xterm API does not expose `translateToString`'s internal `outColumns`, so reading cells via `getCell().getWidth()` is the correct public-API way to get this mapping.
- `TerminalView.tsx`: the link provider now builds text + column spans from cells, replacing the old `.length`-based `locate()`.
- `fileLinks.ts`: `FILE_PATH_RE` now accepts Unicode letters/numbers (`\p{L}\p{N}` + `u` flag) so CJK file and directory names match; the extension stays ASCII.

## Known limitation

CJK has no reliable word boundary, so prose written flush against an ASCII filename with no separating space (e.g. `打開config.json`) is swallowed into the matched token. Matching is intentionally broad and the click handler verifies the file exists, so the worst case is an underline that does nothing. This is captured by a test (`over-matches CJK prose glued to a filename`). Flagging it in case we'd rather narrow it later, but a regex alone can't distinguish a CJK filename from CJK prose.

## Test plan

- [x] `cellPositions.test.ts` — ASCII mapping, wide-glyph 2-column span, never-written-cell-as-space (no path merge), wrapped-row column origin
- [x] `fileLinks.test.ts` — CJK filename, CJK directory segment, space-delimited CJK filename, documented over-match; existing ASCII / URL cases still pass
- [x] `npm test` — 271 passed
- [x] `npm run typecheck` — clean
- [ ] Manual: hover a path on a line containing CJK, confirm the underline aligns and Cmd/Ctrl+click opens the file

Closes #11
