### PR TITLE
fix: 窗格分隔線 hover 不變粗、拖曳終端不再被洗版

### DIFF
--- a/src/lib/debounce.test.ts
+++ b/src/lib/debounce.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { debounce } from "./debounce";
+
+describe("debounce", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("runs the callback only after the delay elapses", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces rapid calls into a single trailing run with the last args", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced("a");
+    vi.advanceTimersByTime(50);
+    debounced("b");
+    vi.advanceTimersByTime(50); // 100ms since "a", but only 50ms since "b"
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(50); // now 100ms since the last call
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("b");
+  });
+
+  it("cancel() stops a pending run from firing", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    debounced.cancel();
+    vi.advanceTimersByTime(100);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,0 +1,31 @@
+/**
+ * Wrap `fn` so rapid-fire calls collapse into a single trailing run, delayMs
+ * after the calls stop, using the most recent arguments. `cancel()` drops any
+ * pending run — call it on teardown so a late callback can't touch a disposed
+ * resource.
+ */
+export function debounce<A extends unknown[]>(
+  fn: (...args: A) => void,
+  delayMs: number,
+): ((...args: A) => void) & { cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const debounced = (...args: A) => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      timer = undefined;
+      fn(...args);
+    }, delayMs);
+  };
+
+  debounced.cancel = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  return debounced;
+}

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef, type MouseEvent as ReactMouseEvent } from "react";
+import { lazy, Suspense, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2, X } from "lucide-react";
 import { TerminalView } from "./TerminalView";
@@ -59,6 +59,13 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   const closePane = useTabsStore((s) => s.closePane);
   const isActiveTab = useTabsStore((s) => s.activeId === tab.id);
   const paneAreaRef = useRef<HTMLDivElement>(null);
+  // Which splitter is currently being dragged, so its hairline keeps its
+  // highlight color even when the pointer slips off the thin hit area mid-drag.
+  const [draggingSplitterId, setDraggingSplitterId] = useState<string | null>(null);
+  // Which splitter the pointer is hovering. Tracked in state (not CSS
+  // group-hover) because the hairline lives in a child element and group-hover
+  // doesn't reach it reliably in the app's WebView.
+  const [hoveredSplitterId, setHoveredSplitterId] = useState<string | null>(null);
   // Pointer-drag state lives in the explorer drag store (see dragEntry.ts): the
   // entry being dragged, which pane it's over, and a resolved drop to consume.
   const dragging = useEntryDragStore((s) => s.dragging);
@@ -154,6 +161,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
 
     document.body.style.cursor = isRow ? "col-resize" : "row-resize";
     document.body.style.userSelect = "none";
+    setDraggingSplitterId(splitter.id);
 
     function onMove(ev: MouseEvent) {
       const box = container!.getBoundingClientRect();
@@ -167,6 +175,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
     function onUp() {
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
+      setDraggingSplitterId(null);
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     }
@@ -268,10 +277,14 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
           const dividerPct = isRow
             ? splitter.rect.left + splitter.rect.width * splitter.fraction
             : splitter.rect.top + splitter.rect.height * splitter.fraction;
+          const isLit =
+            draggingSplitterId === splitter.id || hoveredSplitterId === splitter.id;
           return (
             <div
               key={splitter.id}
               onMouseDown={(e) => startDrag(e, splitter)}
+              onMouseEnter={() => setHoveredSplitterId(splitter.id)}
+              onMouseLeave={() => setHoveredSplitterId(null)}
               style={
                 isRow
                   ? {
@@ -291,10 +304,26 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                       transform: "translateY(-50%)",
                     }
               }
-              className={`z-20 transition-colors hover:bg-accent/40 ${
+              className={`z-20 ${
                 isRow ? "cursor-col-resize" : "cursor-row-resize"
               }`}
-            />
+            >
+              {/*
+               * The hit area stays 8px so the divider is easy to grab, but only
+               * this centered 1px hairline is visible. Hover / drag just recolors
+               * the hairline instead of flooding the whole strip, so the divider
+               * never looks like it got thicker.
+               */}
+              <div
+                className={`pointer-events-none absolute transition-colors ${
+                  isLit ? "bg-accent" : "bg-transparent"
+                } ${
+                  isRow
+                    ? "inset-y-0 left-1/2 w-px -translate-x-1/2"
+                    : "inset-x-0 top-1/2 h-px -translate-y-1/2"
+                }`}
+              />
+            </div>
           );
         })}
       </div>

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -34,6 +34,7 @@ import { findFilePaths, resolveFilePath } from "./lib/fileLinks";
 import { buildCellPositions, type TerminalRow } from "./lib/cellPositions";
 import { terminalKeySequence } from "./lib/terminalKeymap";
 import { shouldCdToRoot } from "./lib/cwdSync";
+import { debounce } from "@/lib/debounce";
 import { dropOverlayClassName } from "@/components/EntryDropOverlay";
 import { fsHomeDir, fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import { getDraggedEntry } from "@/modules/explorer/lib/dragEntry";
@@ -475,12 +476,20 @@ export function TerminalView({
     };
     const snapshotTimer = setInterval(snapshot, 5000);
 
-    const observer = new ResizeObserver(() => {
-      safeFit();
+    // Telling the PTY its new size sends SIGWINCH, which makes the shell repaint
+    // its prompt. A divider drag fires this observer dozens of times a second, so
+    // pushing every intermediate size spams the shell with reprinted prompts.
+    // safeFit stays immediate (xterm reflows in step with the pane), but the PTY
+    // resize is debounced to the size the drag settles on.
+    const pushPtySize = debounce(() => {
       const session = sessionRef.current;
       if (session) {
         void session.resize(term.cols, term.rows);
       }
+    }, 80);
+    const observer = new ResizeObserver(() => {
+      safeFit();
+      pushPtySize();
     });
     observer.observe(container);
 
@@ -489,6 +498,7 @@ export function TerminalView({
       clearInterval(snapshotTimer);
       writeListener.dispose();
       observer.disconnect();
+      pushPtySize.cancel();
       document.removeEventListener("keydown", onKeyDownCapture, true);
       document.removeEventListener("paste", onPasteCapture, true);
       if (leafIdRef.current) {


### PR DESCRIPTION
## 摘要

修兩個窗格分隔線相關的問題：

- **hover/拖曳分隔線會變粗**：左右窗格分隔線原本是 8px 的拖曳區，hover 時整塊上色，細框看起來變很粗。改成「8px 透明拖曳區 + 置中 1px 細線」，hover / 拖曳只讓那條 1px 線變色。線的顏色改用 React 狀態（hover + drag）控制，因為這個 WebView 下 `group-hover` 打不到子元素。
- **拖曳時另一側終端被 prompt 洗版**：拖分隔線時 `ResizeObserver` 每秒觸發幾十次，每次都通知 PTY 新尺寸（SIGWINCH），shell 被迫反覆重畫提示字串把終端洗版。新增一個可複用的 `debounce` 工具，把送給 PTY 的尺寸通知防抖到拖曳停下才送一次；xterm 的 fit 維持即時，畫面照樣跟手。

## 測試

- `debounce` 工具：3 個單元測試（延遲後才執行、連續呼叫只跑最後一次、`cancel` 取消待執行）
- `npm run typecheck` 通過
- 既有 310 個測試全綠
- 實機驗證（macOS WKWebView）：hover / 拖曳分隔線只變色不變粗、放開後回灰；拖曳時終端不再被 prompt 洗版

🤖 Generated with [Claude Code](https://claude.com/claude-code)