### PR TITLE
chore: 把 .claude/ 加入 .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ docs/
 # ~/.tempoterm). These patterns are a safety net if one is ever copied in.
 *.key
 updater-key*.json
+
+# Claude Code local state (settings, worktrees, transcripts, etc.)
+.claude/


### PR DESCRIPTION
把 `.claude/` 整個目錄加入 `.gitignore`。

Claude Code 在 `.claude/` 底下放的是本機專屬狀態（設定、worktrees、transcripts 等），都不該進 repo。實際上建立在 `.claude/worktrees/` 的 worktree 目錄還會以未追蹤項目出現在原始碼控制清單裡。

目前 `.claude/` 底下沒有任何被追蹤的檔案，所以只加 ignore 規則即可，不需要 `git rm --cached`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)