### PR TITLE
feat: track per-pane live cwd in the claude progress panel

### DIFF
--- a/src/modules/claude-progress/lib/collectSessionCwds.test.ts
+++ b/src/modules/claude-progress/lib/collectSessionCwds.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { Tab } from "@/stores/tabsStore";
+import { leaf, splitLeaf } from "@/modules/terminal/lib/terminalLayout";
+import { collectSessionCwds } from "./collectSessionCwds";
+
+function terminalTab(overrides: Partial<Tab> = {}): Tab {
+  return {
+    id: "t1",
+    spaceId: "s1",
+    title: "Terminal",
+    kind: "terminal",
+    paneTree: leaf("a", { kind: "terminal" }),
+    activeLeafId: "a",
+    ...overrides,
+  };
+}
+
+describe("collectSessionCwds", () => {
+  it("watches a pane's live cwd, not just the tab's initial cwd", () => {
+    // The pane has cd'd to a new directory; its live cwd was saved on the pane.
+    const tab = terminalTab({
+      cwd: "/initial/tab/dir",
+      paneTree: leaf("a", { kind: "terminal", cwd: "/where/i/cded" }),
+    });
+    expect(collectSessionCwds([tab])).toEqual(["/where/i/cded"]);
+  });
+
+  it("falls back to the tab's initial cwd when a pane has no live cwd yet", () => {
+    // A freshly spawned pane has not polled its shell yet, so pane.cwd is unset.
+    const tab = terminalTab({
+      cwd: "/initial/tab/dir",
+      paneTree: leaf("a", { kind: "terminal" }),
+    });
+    expect(collectSessionCwds([tab])).toEqual(["/initial/tab/dir"]);
+  });
+
+  it("collects the live cwd of every terminal pane across a split", () => {
+    const tree = splitLeaf(
+      leaf("a", { kind: "terminal", cwd: "/pane/a" }),
+      "a",
+      "row",
+      "b",
+      { kind: "terminal", cwd: "/pane/b" },
+    );
+    const tab = terminalTab({ cwd: "/tab/dir", paneTree: tree });
+    expect(collectSessionCwds([tab]).sort()).toEqual(["/pane/a", "/pane/b"]);
+  });
+
+  it("dedupes directories shared by multiple panes", () => {
+    const tree = splitLeaf(
+      leaf("a", { kind: "terminal", cwd: "/same/dir" }),
+      "a",
+      "row",
+      "b",
+      { kind: "terminal", cwd: "/same/dir" },
+    );
+    const tab = terminalTab({ cwd: "/tab/dir", paneTree: tree });
+    expect(collectSessionCwds([tab])).toEqual(["/same/dir"]);
+  });
+
+  it("ignores non-terminal panes", () => {
+    const tab = terminalTab({
+      cwd: "/tab/dir",
+      paneTree: leaf("a", { kind: "editor", path: "/some/file.ts" }),
+    });
+    expect(collectSessionCwds([tab])).toEqual([]);
+  });
+
+  it("skips terminal panes with no resolvable cwd", () => {
+    const tab = terminalTab({ cwd: undefined, paneTree: leaf("a", { kind: "terminal" }) });
+    expect(collectSessionCwds([tab])).toEqual([]);
+  });
+});

--- a/src/modules/claude-progress/lib/collectSessionCwds.ts
+++ b/src/modules/claude-progress/lib/collectSessionCwds.ts
@@ -1,0 +1,29 @@
+import type { Tab } from "@/stores/tabsStore";
+import { findPaneContent, leafIds } from "@/modules/terminal/lib/terminalLayout";
+
+/**
+ * Every distinct directory a Claude session could be running in, one per open
+ * terminal pane.
+ *
+ * A pane's live cwd (saved to `pane.cwd` as the shell `cd`s around) wins, so the
+ * panel follows the directory the user actually ran `claude` in — not just the
+ * tab's starting directory. A pane that hasn't reported its cwd yet (freshly
+ * spawned, or an inactive split that never polled) falls back to the tab's
+ * initial cwd so its session is still found. Empty results are skipped.
+ */
+export function collectSessionCwds(tabs: Tab[]): string[] {
+  const cwds = new Set<string>();
+  for (const tab of tabs) {
+    for (const id of leafIds(tab.paneTree)) {
+      const pane = findPaneContent(tab.paneTree, id);
+      if (pane?.kind !== "terminal") {
+        continue;
+      }
+      const cwd = pane.cwd || tab.cwd;
+      if (cwd) {
+        cwds.add(cwd);
+      }
+    }
+  }
+  return [...cwds];
+}

--- a/src/modules/claude-progress/lib/useWatchSessions.ts
+++ b/src/modules/claude-progress/lib/useWatchSessions.ts
@@ -1,32 +1,21 @@
 import { useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { useTabsStore, type Tab } from "@/stores/tabsStore";
-import { findPaneContent, leafIds } from "@/modules/terminal/lib/terminalLayout";
+import { useTabsStore } from "@/stores/tabsStore";
 import { useProgressStore } from "./progressStore";
-
-/** Every distinct working directory that has an open terminal pane. */
-function collectTerminalCwds(tabs: Tab[]): string[] {
-  const cwds = new Set<string>();
-  for (const tab of tabs) {
-    for (const id of leafIds(tab.paneTree)) {
-      const pane = findPaneContent(tab.paneTree, id);
-      if (pane?.kind === "terminal" && pane.cwd) {
-        cwds.add(pane.cwd);
-      }
-    }
-  }
-  return [...cwds];
-}
+import { collectSessionCwds } from "./collectSessionCwds";
 
 /**
  * Streams Claude progress for every open terminal pane's directory. Whenever the
- * set of terminal cwds changes we drop progress for directories that are gone and
+ * set of pane cwds changes we drop progress for directories that are gone and
  * ask the backend to watch the current set; the backend follows each directory's
  * latest session and emits `claude-progress:lines` tagged with its cwd.
+ *
+ * The set comes from each pane's live cwd (see `collectSessionCwds`), so a
+ * session started after `cd`-ing inside a pane is still found.
  */
 export function useWatchSessions(): void {
   // A stable string key so the effect only re-runs when the cwd set changes.
-  const cwdKey = useTabsStore((s) => collectTerminalCwds(s.tabs).sort().join("\n"));
+  const cwdKey = useTabsStore((s) => collectSessionCwds(s.tabs).sort().join("\n"));
 
   useEffect(() => {
     const cwds = cwdKey ? cwdKey.split("\n") : [];


### PR DESCRIPTION
## Summary

Implements the **per-pane live cwd** part of #17 so the progress panel can locate a Claude session even when you `cd` into another directory inside a pane before running `claude`.

Previously `useWatchSessions` watched the tab's initial `cwd`. Now it collects the live cwd of each pane (`PaneContent.cwd`) so the session is found at its actual directory. The backend watcher and normalizer already support multiple cwds; this feeds them the correct per-pane values.

- New pure helper `collectSessionCwds` (unit-tested) builds the watched-cwd set from panes.
- `useWatchSessions` wired to the per-pane live cwds.

**Deferred (still open on #17, out of scope here):** `needs-input` detection and OSC 777 notifications — both depend on external Claude Code hooks and need design.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — pass (incl. new `collectSessionCwds` tests)
- [x] `npm run build`
- [ ] Manual: `cd` into a subdir in a pane, run `claude`, confirm the panel tracks that session

Refs #17
