### PR TITLE
perf: collect session cwds in a single tree pass

### DIFF
--- a/src/modules/claude-progress/lib/collectSessionCwds.ts
+++ b/src/modules/claude-progress/lib/collectSessionCwds.ts
@@ -1,5 +1,28 @@
 import type { Tab } from "@/stores/tabsStore";
-import { findPaneContent, leafIds } from "@/modules/terminal/lib/terminalLayout";
+import { type LayoutNode, paneOf } from "@/modules/terminal/lib/terminalLayout";
+
+/**
+ * Add every terminal pane's session cwd under `node` to `cwds`, in a single
+ * pass over the layout tree.
+ */
+function collectCwdsFromNode(
+  node: LayoutNode,
+  tabCwd: string | undefined,
+  cwds: Set<string>,
+): void {
+  if (node.kind === "leaf") {
+    const pane = paneOf(node);
+    if (pane.kind === "terminal") {
+      const cwd = pane.cwd || tabCwd;
+      if (cwd) {
+        cwds.add(cwd);
+      }
+    }
+    return;
+  }
+  collectCwdsFromNode(node.children[0], tabCwd, cwds);
+  collectCwdsFromNode(node.children[1], tabCwd, cwds);
+}
 
 /**
  * Every distinct directory a Claude session could be running in, one per open
@@ -10,20 +33,14 @@ import { findPaneContent, leafIds } from "@/modules/terminal/lib/terminalLayout"
  * tab's starting directory. A pane that hasn't reported its cwd yet (freshly
  * spawned, or an inactive split that never polled) falls back to the tab's
  * initial cwd so its session is still found. Empty results are skipped.
+ *
+ * Runs as a selector on every relevant store update, so it walks each tab's
+ * pane tree once (O(panes)) instead of re-finding each leaf from the root.
  */
 export function collectSessionCwds(tabs: Tab[]): string[] {
   const cwds = new Set<string>();
   for (const tab of tabs) {
-    for (const id of leafIds(tab.paneTree)) {
-      const pane = findPaneContent(tab.paneTree, id);
-      if (pane?.kind !== "terminal") {
-        continue;
-      }
-      const cwd = pane.cwd || tab.cwd;
-      if (cwd) {
-        cwds.add(cwd);
-      }
-    }
+    collectCwdsFromNode(tab.paneTree, tab.cwd, cwds);
   }
   return [...cwds];
 }


### PR DESCRIPTION
## Summary

Follow-up to the Gemini review on #25. `collectSessionCwds` called `leafIds()` then `findPaneContent()` for each leaf, re-walking the pane tree from the root per leaf (O(n²)). It now recurses once over the layout tree (O(n)).

Behavior is unchanged — the existing `collectSessionCwds` tests (live-cwd-wins, fallback-to-tab.cwd, multi-pane, dedup, ignore non-terminal, skip unresolved) stay green.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — `collectSessionCwds` tests pass, full suite green
- [x] `npm run build`

Refs #17
