### PR TITLE
fix: prevent launcher panel from overflowing when narrow

### DIFF
--- a/src/components/LauncherPanel.tsx
+++ b/src/components/LauncherPanel.tsx
@@ -182,9 +182,9 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
   ];
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-6 bg-bg text-fg-subtle">
-      <p className="text-sm">{t("workspace.launcherHint")}</p>
-      <div className="flex w-72 flex-col gap-5">
+    <div className="flex h-full flex-col items-center justify-center gap-6 px-4 bg-bg text-fg-subtle">
+      <p className="text-center text-sm">{t("workspace.launcherHint")}</p>
+      <div className="flex w-full max-w-72 flex-col gap-5">
         {groups.map((group) => (
           <div key={group.key}>
             <h3 className="mb-1 text-xs font-medium uppercase tracking-wide text-fg-subtle">


### PR DESCRIPTION
The launcher's content block used a fixed w-72 (288px) width inside a horizontally-centered flex container. When the pane shrank below 288px the block could not shrink and, being centered, overflowed equally to both sides. The left overflow was clipped by the neighbouring pane, so content looked shoved to the right and the list dividers stuck out and got cut off.

Make the block fluid (w-full max-w-72) so it shrinks to fit narrow panes while keeping the 288px cap on wide ones, add horizontal padding for breathing room, and centre the hint text for clean wrapping.