### PR TITLE
feat: git graph 加入 commit 排序選項與分支配色

### DIFF
--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -82,6 +82,16 @@ pub struct CommitDetails {
 }
 
 /// 線圖的顯示選項，來自前端工具列。branch 空字串或 None 代表 Show All。
+/// 線圖 commit 的排序方式。`Date` 依時間交錯（VSCode 預設，分支線並排展開），
+/// `Topo` 依拓樸把同一分支的 commit 收攏（線較少）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CommitOrder {
+    #[default]
+    Date,
+    Topo,
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct GraphOptions {
@@ -89,6 +99,15 @@ pub struct GraphOptions {
     pub include_remotes: bool,
     pub include_tags: bool,
     pub include_stashes: bool,
+    pub order: CommitOrder,
+}
+
+/// 把排序選項翻成 git log 旗標。純函式方便測試。
+fn order_flag(order: CommitOrder) -> &'static str {
+    match order {
+        CommitOrder::Date => "--date-order",
+        CommitOrder::Topo => "--topo-order",
+    }
 }
 
 /// 把顯示選項翻成 git log 的 ref 範圍參數。純函式方便測試。
@@ -488,7 +507,7 @@ pub fn graph_log(
     let ref_args = build_log_refs(options);
     let mut args: Vec<&str> = vec![
         "log",
-        "--topo-order",
+        order_flag(options.order),
         "--decorate=full",
         "--pretty=format:%h|%p|%an|%ad|%d|%s",
         "--date=format-local:%Y-%m-%d %H:%M",
@@ -1224,6 +1243,7 @@ mod tests {
             include_remotes: true,
             include_tags: true,
             include_stashes: true,
+            order: CommitOrder::Date,
         };
         assert_eq!(
             build_log_refs(&options),
@@ -1243,6 +1263,17 @@ mod tests {
             ..GraphOptions::default()
         };
         assert_eq!(build_log_refs(&options), vec!["--branches".to_string()]);
+    }
+
+    #[test]
+    fn order_flag_maps_each_commit_order() {
+        assert_eq!(order_flag(CommitOrder::Date), "--date-order");
+        assert_eq!(order_flag(CommitOrder::Topo), "--topo-order");
+    }
+
+    #[test]
+    fn graph_options_default_order_is_date() {
+        assert_eq!(GraphOptions::default().order, CommitOrder::Date);
     }
 
     #[test]

--- a/src/i18n/locales/en/gitGraph.json
+++ b/src/i18n/locales/en/gitGraph.json
@@ -21,7 +21,10 @@
     "fetching": "Fetching…",
     "matches": "{{count}} matches",
     "head": "HEAD",
-    "more": "More"
+    "more": "More",
+    "commitOrder": "Commit order",
+    "orderDate": "Date order",
+    "orderTopo": "Topological order"
   },
   "details": {
     "author": "Author",

--- a/src/i18n/locales/zh-Hant/gitGraph.json
+++ b/src/i18n/locales/zh-Hant/gitGraph.json
@@ -21,7 +21,10 @@
     "fetching": "抓取中…",
     "matches": "{{count}} 筆符合",
     "head": "HEAD",
-    "more": "更多"
+    "more": "更多",
+    "commitOrder": "排序方式",
+    "orderDate": "日期順序",
+    "orderTopo": "拓樸順序"
   },
   "details": {
     "author": "作者",

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -25,14 +25,21 @@ interface GitGraphProps {
   labels: GitGraphLabels;
 }
 
-// Lane colours cycle through the semantic accent tokens so the graph reads well
-// in either theme (the tokens are remapped per theme, unlike hardcoded hex).
-const LANE_COLORS = [
-  "var(--color-accent)",
-  "var(--color-purple-500)",
-  "var(--color-warning)",
-  "var(--color-success)",
-  "var(--color-danger)",
+// Branch colours cycle per branch line (see CommitLayout.colorIndex), not per
+// lane index, so concurrent lanes never share a colour. This is a fixed rainbow
+// (red→violet), deliberately NOT theme tokens: branch colours are identifiers,
+// not UI surfaces, so they stay constant across themes — and the theme's colour
+// scales aren't remapped per theme anyway, so a token palette would wash out on
+// the light themes. Hues are mid-lightness so each reads on both dark (#222) and
+// light (#fff) backgrounds, and evenly spaced so adjacent lanes stay distinct.
+const BRANCH_COLORS = [
+  "#e0555f", // red
+  "#e08a3c", // orange
+  "#d6a82c", // yellow (deepened so it reads on light themes)
+  "#46a758", // green
+  "#3b8ee0", // blue
+  "#6366d6", // indigo
+  "#a857c4", // violet
 ];
 
 // Decoration chip styles per ref kind, built from semantic tokens.
@@ -131,7 +138,7 @@ export function GitGraph({
                 if (edge.parentIndex < visibleStart || edge.childIndex > visibleEnd) {
                   return null;
                 }
-                const color = LANE_COLORS[edge.lane % LANE_COLORS.length];
+                const color = BRANCH_COLORS[edge.colorIndex % BRANCH_COLORS.length];
                 return (
                   <path
                     key={`edge-${idx}`}
@@ -151,7 +158,7 @@ export function GitGraph({
               if (!layout) {
                 return null;
               }
-              const color = LANE_COLORS[layout.lane % LANE_COLORS.length];
+              const color = BRANCH_COLORS[layout.colorIndex % BRANCH_COLORS.length];
               const isSelected = selectedCommit?.hash === commit.hash;
               return (
                 <button

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -31,7 +31,7 @@ import { filterCommits } from "./lib/filterCommits";
 import { buildCommitMenu, buildRefMenu } from "./lib/contextMenuItems";
 import { splitRemoteRef } from "./lib/remoteRef";
 import { withMinDuration } from "@/lib/withMinDuration";
-import type { Branch, CommitNode, CommitRef, GraphOptions } from "./types";
+import type { Branch, CommitNode, CommitRef, CommitOrder, GraphOptions } from "./types";
 
 const PAGE_SIZE = 200;
 // Local git reloads finish almost instantly; keep the busy spinner up at least
@@ -86,6 +86,9 @@ export function GitGraphTabContent() {
   const [includeRemotes, setIncludeRemotes] = useState(true);
   const [includeTags, setIncludeTags] = useState(true);
   const [includeStashes, setIncludeStashes] = useState(false);
+  const [commitOrder, setCommitOrder] = useState<CommitOrder>(() =>
+    localStorage.getItem("tempoterm-gitgraph-commit-order") === "topo" ? "topo" : "date",
+  );
   const [searchQuery, setSearchQuery] = useState("");
   const [fetching, setFetching] = useState(false);
   // Any action that reloads the graph (refresh button + context-menu git ops)
@@ -97,6 +100,7 @@ export function GitGraphTabContent() {
     includeRemotes,
     includeTags,
     includeStashes,
+    order: commitOrder,
   };
 
   const visibleCommits = filterCommits(commits, searchQuery);
@@ -162,8 +166,9 @@ export function GitGraphTabContent() {
       includeRemotes,
       includeTags,
       includeStashes,
+      order: commitOrder,
     });
-  }, [repo, selectedBranch, includeRemotes, includeTags, includeStashes, reload]);
+  }, [repo, selectedBranch, includeRemotes, includeTags, includeStashes, commitOrder, reload]);
 
   // Run an action then refresh the graph; surface any failure inline.
   const runAction = useCallback(
@@ -187,7 +192,7 @@ export function GitGraphTabContent() {
         setBusy(false);
       }
     },
-    [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes],
+    [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes, options.order],
   );
 
   const loadMore = useCallback(() => {
@@ -197,7 +202,7 @@ export function GitGraphTabContent() {
     const next = limit + PAGE_SIZE;
     setLimit(next);
     void reload(repo, next, options);
-  }, [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes]);
+  }, [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes, options.order]);
 
   // Turning remotes off hides remote branches; if one was selected, fall back
   // to Show All so the dropdown value and selectedBranch stay in sync.
@@ -214,6 +219,12 @@ export function GitGraphTabContent() {
     [branches, selectedBranch],
   );
 
+  // Remember the chosen order so it survives reopening the graph tab.
+  const handleChangeOrder = useCallback((order: CommitOrder) => {
+    setCommitOrder(order);
+    localStorage.setItem("tempoterm-gitgraph-commit-order", order);
+  }, []);
+
   const handleFetch = useCallback(async () => {
     if (!repo) {
       return;
@@ -228,7 +239,7 @@ export function GitGraphTabContent() {
     } finally {
       setFetching(false);
     }
-  }, [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes]);
+  }, [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes, options.order]);
 
   const toolbarLabels: GitGraphToolbarLabels = {
     branches: t("toolbar.branches"),
@@ -245,6 +256,9 @@ export function GitGraphTabContent() {
     matches: t("toolbar.matches"),
     head: t("toolbar.head"),
     more: t("toolbar.more"),
+    commitOrder: t("toolbar.commitOrder"),
+    orderDate: t("toolbar.orderDate"),
+    orderTopo: t("toolbar.orderTopo"),
   };
 
   const persistDetailsHeight = useCallback(() => {
@@ -440,6 +454,8 @@ export function GitGraphTabContent() {
           onToggleTags={setIncludeTags}
           includeStashes={includeStashes}
           onToggleStashes={setIncludeStashes}
+          commitOrder={commitOrder}
+          onChangeOrder={handleChangeOrder}
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
           matchCount={visibleCommits.length}

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GitGraphToolbar, type GitGraphToolbarLabels } from "./GitGraphToolbar";
 import type { Branch } from "./types";
@@ -193,6 +193,15 @@ describe("GitGraphToolbar commit ordering", () => {
 
     expect(screen.getByRole("radio", { name: labels.orderTopo })).toBeChecked();
     expect(screen.getByRole("radio", { name: labels.orderDate })).not.toBeChecked();
+  });
+
+  it("groups the order options as a labelled radiogroup for screen readers", () => {
+    renderToolbar({ commitOrder: "date" });
+
+    fireEvent.click(screen.getByTitle(labels.displayOptions));
+
+    const group = screen.getByRole("radiogroup", { name: labels.commitOrder });
+    expect(within(group).getAllByRole("radio")).toHaveLength(2);
   });
 
   it("changes the order from the overflow menu (compact)", () => {

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -53,6 +53,9 @@ const labels: GitGraphToolbarLabels = {
   matches: "{{count}} matches",
   head: "HEAD",
   more: "More",
+  commitOrder: "Commit order",
+  orderDate: "Date order",
+  orderTopo: "Topological order",
 };
 
 const branches: Branch[] = [
@@ -71,6 +74,8 @@ function renderToolbar(overrides: Partial<Parameters<typeof GitGraphToolbar>[0]>
     onToggleTags: vi.fn(),
     includeStashes: false,
     onToggleStashes: vi.fn(),
+    commitOrder: "date" as const,
+    onChangeOrder: vi.fn(),
     searchQuery: "",
     onSearchChange: vi.fn(),
     matchCount: 0,
@@ -167,5 +172,35 @@ describe("GitGraphToolbar responsive layout", () => {
     const row = screen.getByText(labels.refresh).closest("button");
     expect(row).toBeDisabled();
     expect(row?.querySelector(".animate-spin")).not.toBeNull();
+  });
+});
+
+describe("GitGraphToolbar commit ordering", () => {
+  it("changes the order from the display-options popover (roomy)", () => {
+    const props = renderToolbar({ commitOrder: "date" });
+
+    fireEvent.click(screen.getByTitle(labels.displayOptions));
+
+    expect(screen.getByText(labels.orderDate)).toBeInTheDocument();
+    fireEvent.click(screen.getByText(labels.orderTopo));
+    expect(props.onChangeOrder).toHaveBeenCalledWith("topo");
+  });
+
+  it("marks the active order so the current choice is visible", () => {
+    renderToolbar({ commitOrder: "topo" });
+
+    fireEvent.click(screen.getByTitle(labels.displayOptions));
+
+    expect(screen.getByRole("radio", { name: labels.orderTopo })).toBeChecked();
+    expect(screen.getByRole("radio", { name: labels.orderDate })).not.toBeChecked();
+  });
+
+  it("changes the order from the overflow menu (compact)", () => {
+    const props = renderToolbar({ commitOrder: "date" });
+    setToolbarWidth(360);
+    fireEvent.click(screen.getByTitle(labels.more));
+
+    fireEvent.click(screen.getByText(labels.orderTopo));
+    expect(props.onChangeOrder).toHaveBeenCalledWith("topo");
   });
 });

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -132,17 +132,22 @@ export function GitGraphToolbar({
   const orderSection = (
     <>
       <div className="my-1 border-t border-border" />
-      <div className="px-2 py-1 font-mono text-[11px] text-fg-subtle">
+      <div
+        className="px-2 py-1 font-mono text-[11px] text-fg-subtle"
+        aria-hidden="true"
+      >
         {labels.commitOrder}
       </div>
-      {orderOptions.map((o) => (
-        <OrderRow
-          key={o.value}
-          label={o.label}
-          checked={commitOrder === o.value}
-          onSelect={() => onChangeOrder(o.value)}
-        />
-      ))}
+      <div role="radiogroup" aria-label={labels.commitOrder}>
+        {orderOptions.map((o) => (
+          <OrderRow
+            key={o.value}
+            label={o.label}
+            checked={commitOrder === o.value}
+            onSelect={() => onChangeOrder(o.value)}
+          />
+        ))}
+      </div>
     </>
   );
 

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -9,7 +9,7 @@ import {
   X,
 } from "lucide-react";
 import { Combobox } from "@/components/Combobox";
-import type { Branch } from "./types";
+import type { Branch, CommitOrder } from "./types";
 
 // Below this measured toolbar width the layout switches to compact: the action
 // icons fold into a single overflow menu. Sized to the point where the roomy
@@ -32,6 +32,9 @@ export interface GitGraphToolbarLabels {
   matches: string;
   head: string;
   more: string;
+  commitOrder: string;
+  orderDate: string;
+  orderTopo: string;
 }
 
 interface GitGraphToolbarProps {
@@ -44,6 +47,8 @@ interface GitGraphToolbarProps {
   onToggleTags: (value: boolean) => void;
   includeStashes: boolean;
   onToggleStashes: (value: boolean) => void;
+  commitOrder: CommitOrder;
+  onChangeOrder: (order: CommitOrder) => void;
   searchQuery: string;
   onSearchChange: (query: string) => void;
   matchCount: number;
@@ -65,6 +70,8 @@ export function GitGraphToolbar({
   onToggleTags,
   includeStashes,
   onToggleStashes,
+  commitOrder,
+  onChangeOrder,
   searchQuery,
   onSearchChange,
   matchCount,
@@ -117,6 +124,27 @@ export function GitGraphToolbar({
     { label: labels.showTags, checked: includeTags, onChange: onToggleTags },
     { label: labels.showStashes, checked: includeStashes, onChange: onToggleStashes },
   ];
+
+  const orderOptions: { value: CommitOrder; label: string }[] = [
+    { value: "date", label: labels.orderDate },
+    { value: "topo", label: labels.orderTopo },
+  ];
+  const orderSection = (
+    <>
+      <div className="my-1 border-t border-border" />
+      <div className="px-2 py-1 font-mono text-[11px] text-fg-subtle">
+        {labels.commitOrder}
+      </div>
+      {orderOptions.map((o) => (
+        <OrderRow
+          key={o.value}
+          label={o.label}
+          checked={commitOrder === o.value}
+          onSelect={() => onChangeOrder(o.value)}
+        />
+      ))}
+    </>
+  );
 
   // In compact mode an open search input needs the whole row, so the branch
   // combobox steps aside until search closes.
@@ -252,6 +280,7 @@ export function GitGraphToolbar({
                   {toggles.map((t) => (
                     <ToggleRow key={t.label} {...t} />
                   ))}
+                  {orderSection}
                 </div>
               </>
             )}
@@ -274,10 +303,11 @@ export function GitGraphToolbar({
                     onClick={() => setOptionsOpen(false)}
                     aria-hidden="true"
                   />
-                  <div className="absolute right-0 z-30 mt-1 w-44 rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg">
+                  <div className="absolute right-0 z-30 mt-1 w-48 rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg">
                     {toggles.map((t) => (
                       <ToggleRow key={t.label} {...t} />
                     ))}
+                    {orderSection}
                   </div>
                 </>
               )}
@@ -326,6 +356,27 @@ function ToggleRow({ label, checked, onChange }: ToggleRowProps) {
       role="checkbox"
       aria-checked={checked}
       onClick={() => onChange(!checked)}
+      className="flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs text-fg-muted hover:bg-bg-inset hover:text-fg"
+    >
+      <span>{label}</span>
+      {checked && <Check className="h-3.5 w-3.5 text-accent" />}
+    </button>
+  );
+}
+
+interface OrderRowProps {
+  label: string;
+  checked: boolean;
+  onSelect: () => void;
+}
+
+function OrderRow({ label, checked, onSelect }: OrderRowProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={checked}
+      onClick={onSelect}
       className="flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs text-fg-muted hover:bg-bg-inset hover:text-fg"
     >
       <span>{label}</span>

--- a/src/modules/git-graph/lib/graphLayout.test.ts
+++ b/src/modules/git-graph/lib/graphLayout.test.ts
@@ -90,6 +90,48 @@ describe("computeGraphLayout", () => {
   });
 });
 
+describe("computeGraphLayout colouring", () => {
+  it("keeps a single branch on one colour", () => {
+    const commits = [commit("c", ["b"]), commit("b", ["a"]), commit("a", [])];
+    const { layouts } = computeGraphLayout(commits);
+
+    expect(layouts["c"].colorIndex).toBe(0);
+    expect(layouts["b"].colorIndex).toBe(0);
+    expect(layouts["a"].colorIndex).toBe(0);
+  });
+
+  it("gives a merge's second-parent branch a different colour from the trunk", () => {
+    const commits = [commit("m", ["a", "b"]), commit("b", ["a"]), commit("a", [])];
+    const { layouts } = computeGraphLayout(commits);
+
+    expect(layouts["m"].colorIndex).toBe(0);
+    expect(layouts["b"].colorIndex).not.toBe(layouts["m"].colorIndex);
+  });
+
+  it("gives a reused lane a fresh colour so it does not repeat the previous branch", () => {
+    const commits = [
+      commit("x", ["root"]),
+      commit("y", ["root"]),
+      commit("root", []),
+      commit("z", []),
+    ];
+    const { layouts } = computeGraphLayout(commits);
+
+    // z reuses lane 0 (geometry) but is a new branch line, so its colour must
+    // not collide with the earlier occupant of lane 0.
+    expect(layouts["z"].lane).toBe(0);
+    expect(layouts["z"].colorIndex).not.toBe(layouts["x"].colorIndex);
+  });
+
+  it("colours a merge bend by the merged branch, not the trunk", () => {
+    const commits = [commit("m", ["a", "b"]), commit("b", ["a"]), commit("a", [])];
+    const { layouts, edges } = computeGraphLayout(commits);
+
+    const mergeBend = edges.find((e) => e.childIndex === 0 && e.parentIndex === 1);
+    expect(mergeBend?.colorIndex).toBe(layouts["b"].colorIndex);
+  });
+});
+
 describe("laneX", () => {
   it("clamps lanes past maxLane onto the last column", () => {
     const beyond = laneX(DEFAULT_GEOMETRY.maxLane + 3, DEFAULT_GEOMETRY);
@@ -108,6 +150,7 @@ describe("edgePath", () => {
       lane: 0,
       childIndex: 0,
       parentIndex: 1,
+      colorIndex: 0,
     };
     expect(edgePath(edge, 36)).toBe("M 20 20 L 20 56");
   });
@@ -121,6 +164,7 @@ describe("edgePath", () => {
       lane: 0,
       childIndex: 0,
       parentIndex: 2,
+      colorIndex: 0,
     };
     const path = edgePath(edge, 36);
     expect(path.startsWith("M 20 20 C")).toBe(true);

--- a/src/modules/git-graph/lib/graphLayout.ts
+++ b/src/modules/git-graph/lib/graphLayout.ts
@@ -24,6 +24,8 @@ export interface CommitLayout {
   y: number;
   lane: number;
   index: number;
+  /** Branch colour id — cycles per branch line, not per lane index. */
+  colorIndex: number;
 }
 
 /** A parent→child link resolved to concrete coordinates for drawing. */
@@ -35,6 +37,8 @@ export interface GraphEdge {
   lane: number;
   childIndex: number;
   parentIndex: number;
+  /** Branch colour id of the line (the branch side of a merge/branch bend). */
+  colorIndex: number;
 }
 
 export interface GraphLayout {
@@ -68,12 +72,19 @@ export function computeGraphLayout(
   // Each slot holds the hash a lane is currently waiting for. An empty string
   // marks a freed lane that a new branch can reuse.
   const activeLanes: string[] = [];
+  // Colour id per lane slot. A new branch line (every claim, including reusing a
+  // freed slot) takes the next colour so concurrent lanes never share a colour
+  // and adjacent branches stay visually distinct, independent of lane index.
+  const laneColors: number[] = [];
+  let nextColor = 0;
   const claimLane = (): number => {
     const free = activeLanes.indexOf("");
     if (free !== -1) {
+      laneColors[free] = nextColor++;
       return free;
     }
     activeLanes.push("");
+    laneColors.push(nextColor++);
     return activeLanes.length - 1;
   };
 
@@ -101,7 +112,13 @@ export function computeGraphLayout(
       activeLanes[lane] = "";
     }
 
-    layouts[commit.hash] = { x: laneX(lane, geometry), y, lane, index };
+    layouts[commit.hash] = {
+      x: laneX(lane, geometry),
+      y,
+      lane,
+      index,
+      colorIndex: laneColors[lane] ?? 0,
+    };
   });
 
   // Parents may be referenced by a hash of a different length than the keys in
@@ -128,6 +145,12 @@ export function computeGraphLayout(
       if (!parent) {
         return;
       }
+      // Colour the line by its branch side: the endpoint on the higher lane.
+      // For a merge bend that is the merged-in branch (parent); for a branch's
+      // tail merging back to the trunk it is the branch commit (child). Keeps
+      // merge lines off the trunk colour so the graph reads as multiple colours.
+      const colorIndex =
+        child.lane >= parent.lane ? child.colorIndex : parent.colorIndex;
       edges.push({
         cx: child.x,
         cy: child.y,
@@ -136,6 +159,7 @@ export function computeGraphLayout(
         lane: child.lane,
         childIndex: index,
         parentIndex: parent.index,
+        colorIndex,
       });
     });
   });

--- a/src/modules/git-graph/types.ts
+++ b/src/modules/git-graph/types.ts
@@ -28,12 +28,20 @@ export interface Branch {
   isRemote: boolean;
 }
 
+/**
+ * Commit ordering for the graph. "date" interleaves branches chronologically
+ * (more parallel lanes, matches VSCode's default); "topo" groups each branch's
+ * commits together (fewer lanes).
+ */
+export type CommitOrder = "date" | "topo";
+
 /** Display options sent to the backend graph log. `branch` null means Show All. */
 export interface GraphOptions {
   branch: string | null;
   includeRemotes: boolean;
   includeTags: boolean;
   includeStashes: boolean;
+  order: CommitOrder;
 }
 
 /** One file changed by a commit. */


### PR DESCRIPTION
## 這個 PR 做了什麼

幫 git graph 線圖加上兩個視覺強化，都是在工具列就能操作或直接看到的改進。

### 1. Commit 排序選項（日期 / 拓樸）

工具列的設定選單多了一組排序選擇：

- **日期順序**（預設）：依時間交錯，分支線並排展開，跟 VSCode 預設一樣
- **拓樸順序**：把同一分支的 commit 收攏在一起，線比較少

選擇會記到 localStorage，切走再切回來、重開分頁都還在。後端把這個選項翻成 `git log` 的 `--date-order` / `--topo-order`。

### 2. 分支配色改成依分支線上色

原本是依 lane 索引循環上色，相鄰的線容易撞到同一個顏色。改成每條分支線取調色盤裡的下一個顏色，同時存在的線就不會同色。

調色盤用固定的彩虹色（紅→紫），刻意不用主題 token，因為分支顏色是識別用的，不該隨主題變動；色值也都調過，在亮色和暗色背景下都讀得清楚。

## 測試

- 前端 `vitest`：362 個測試全過（含工具列排序 UI 與 `graphLayout` 配色的新測試）
- `tsc --noEmit` typecheck 通過
- 後端 `cargo test`：git module 23 個測試全過（含 `order_flag` 對應與預設排序的新測試）

## Test plan

- [x] 開 git graph，切換日期 / 拓樸排序，確認線圖重畫且選擇有被記住
- [x] 多分支的 repo 看相鄰分支線顏色不重疊
- [ ] 切到亮色主題確認分支顏色仍清楚