### PR TITLE
feat: highlight leading shell command names in note code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "codemirror-theme-vitesse": "^0.3.0",
+    "highlight.js": "^11.11.1",
     "i18next": "^25.6.0",
     "i18next-browser-languagedetector": "^8.2.0",
     "lowlight": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       codemirror-theme-vitesse:
         specifier: ^0.3.0
         version: 0.3.0(@codemirror/language@6.12.3)(@codemirror/view@6.43.1)(codemirror@6.0.2)
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       i18next:
         specifier: ^25.6.0
         version: 25.10.10(typescript@5.8.3)
@@ -619,24 +622,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -697,66 +704,79 @@ packages:
     resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
     resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
     resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
     resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
     resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.0':
     resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.0':
     resolution: {integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==}
@@ -826,24 +846,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -904,30 +928,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.2':
     resolution: {integrity: sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
     resolution: {integrity: sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.2':
     resolution: {integrity: sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.2':
     resolution: {integrity: sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
     resolution: {integrity: sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==}
@@ -1705,24 +1734,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/src/modules/notes/NoteEditor.tsx
+++ b/src/modules/notes/NoteEditor.tsx
@@ -24,9 +24,13 @@ import { runCommandInTerminal } from "@/modules/terminal/lib/terminalBus";
 import { isWebUrl } from "@/lib/url";
 import { createSlashCommand } from "./slashCommand";
 import { registerNoteInserter, unregisterNoteInserter } from "./lib/noteBus";
+import { bashCommandHighlight } from "./lib/bashCommandHighlight";
 import { Combobox } from "@/components/Combobox";
 
 const lowlight = createLowlight(common);
+// Override the stock bash grammar so leading command names (ssh, git, custom
+// scripts) get colored too, not only highlight.js's built-in whitelist.
+lowlight.register("bash", bashCommandHighlight);
 const SHELL_LANGS = new Set(["", "sh", "bash", "zsh", "shell", "console", "terminal"]);
 
 const CODE_LANGS = [

--- a/src/modules/notes/lib/bashCommandHighlight.test.ts
+++ b/src/modules/notes/lib/bashCommandHighlight.test.ts
@@ -62,6 +62,18 @@ describe("bashCommandHighlight", () => {
     expect(scopeOf("FOO=bar sudo docker ps", "docker")).toBe("hljs-built_in");
   });
 
+  it("does not color a standalone env assignment as a command", () => {
+    expect(scopeOf("FOO=bar", "FOO")).toBeNull();
+    expect(scopeOf("FOO+=bar", "FOO")).toBeNull();
+  });
+
+  it("handles a quoted value in a leading env assignment", () => {
+    const code = 'COMMIT_MSG="feat: some message" git commit';
+    expect(scopeOf(code, "git")).toBe("hljs-built_in");
+    // text inside the quoted value must not leak out as a command
+    expect(scopeOf(code, "some")).toBeNull();
+  });
+
   it("preserves string highlighting", () => {
     expect(scopeOf('echo "hi"', '"hi"')).toBe("hljs-string");
   });

--- a/src/modules/notes/lib/bashCommandHighlight.test.ts
+++ b/src/modules/notes/lib/bashCommandHighlight.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { createLowlight } from "lowlight";
+import { bashCommandHighlight } from "./bashCommandHighlight";
+
+interface HastNode {
+  type: string;
+  value?: string;
+  properties?: { className?: string[] };
+  children?: HastNode[];
+}
+
+const lowlight = createLowlight();
+lowlight.register("bash", bashCommandHighlight);
+
+/** Flatten lowlight output to (scope, text) pairs; scope inherits from the nearest hljs-* span. */
+function tokens(code: string): Array<{ scope: string | null; text: string }> {
+  const tree = lowlight.highlight("bash", code) as unknown as HastNode;
+  const out: Array<{ scope: string | null; text: string }> = [];
+  const walk = (node: HastNode, scope: string | null): void => {
+    if (node.type === "text") {
+      out.push({ scope, text: node.value ?? "" });
+      return;
+    }
+    const className = node.properties?.className;
+    const next = className && className.length > 0 ? className.join(" ") : scope;
+    for (const child of node.children ?? []) {
+      walk(child, next);
+    }
+  };
+  walk(tree, null);
+  return out;
+}
+
+/** Scope of the first token whose trimmed text equals `word`. */
+function scopeOf(code: string, word: string): string | null {
+  const match = tokens(code).find((token) => token.text.trim() === word);
+  return match ? match.scope : null;
+}
+
+describe("bashCommandHighlight", () => {
+  it("colors an external command at the start of a line", () => {
+    expect(scopeOf("ssh alan@192.168.1.122", "ssh")).toBe("hljs-built_in");
+  });
+
+  it("colors git as a command", () => {
+    expect(scopeOf("git push origin main", "git")).toBe("hljs-built_in");
+  });
+
+  it("keeps coloring known builtins", () => {
+    expect(scopeOf("cd 文件/projects/", "cd")).toBe("hljs-built_in");
+  });
+
+  it("colors a custom script invocation", () => {
+    expect(scopeOf("./deploy.sh --prod", "./deploy.sh")).toBe("hljs-built_in");
+  });
+
+  it("colors the command after a pipe", () => {
+    expect(scopeOf("echo hi | grep h", "grep")).toBe("hljs-built_in");
+  });
+
+  it("skips env assignments and the sudo prefix", () => {
+    expect(scopeOf("FOO=bar sudo docker ps", "docker")).toBe("hljs-built_in");
+  });
+
+  it("preserves string highlighting", () => {
+    expect(scopeOf('echo "hi"', '"hi"')).toBe("hljs-string");
+  });
+
+  it("preserves variable highlighting", () => {
+    expect(scopeOf("echo $f", "$f")).toBe("hljs-variable");
+  });
+
+  it("does not misclassify shell keywords as commands", () => {
+    expect(scopeOf("if true; then echo hi; fi", "if")).toBe("hljs-keyword");
+    expect(scopeOf("for f in list; do echo x; done", "for")).toBe("hljs-keyword");
+    expect(scopeOf("while read l; do echo x; done", "while")).toBe("hljs-keyword");
+  });
+});

--- a/src/modules/notes/lib/bashCommandHighlight.ts
+++ b/src/modules/notes/lib/bashCommandHighlight.ts
@@ -18,13 +18,16 @@ export function bashCommandHighlight(hljs: HLJSApi): Language {
     begin: [
       // 1: statement boundary (start of block, newline, ; | & ( ) + trailing space
       /(?:^|[\n;&|(])\s*/,
-      // 2: optional leading env-var assignments, e.g. FOO=bar
-      /(?:\w+=\S*\s+)*/,
+      // 2: optional leading env-var assignments; the value may be quoted and
+      //    contain spaces, e.g. FOO=bar or MSG="hi there"
+      /(?:\w+=(?:"[^"]*"|'[^']*'|[^\s'"]+)*\s+)*/,
       // 3: optional command wrappers
       /(?:sudo\s+|command\s+|exec\s+)?/,
       // 4: the command name (only this group is scoped); excludes shell keywords,
-      //    allows ./ ../ / path prefixes for script invocations
-      new RegExp(`(?!(?:${SHELL_KEYWORDS})\\b)(?:\\.{0,2}/)?[A-Za-z_][\\w./-]*`),
+      //    allows ./ ../ / path prefixes for script invocations. The trailing
+      //    lookaheads pin the match to a whole word and reject assignment
+      //    prefixes (FOO=bar), so an env var alone is not read as a command.
+      new RegExp(`(?!(?:${SHELL_KEYWORDS})\\b)(?:\\.{0,2}/)?[A-Za-z_][\\w./-]*(?![\\w./-])(?!\\+?=)`),
     ],
     beginScope: { 4: "built_in" },
     relevance: 0,

--- a/src/modules/notes/lib/bashCommandHighlight.ts
+++ b/src/modules/notes/lib/bashCommandHighlight.ts
@@ -1,0 +1,34 @@
+import bash from "highlight.js/lib/languages/bash";
+import type { HLJSApi, Language, Mode } from "highlight.js";
+
+const SHELL_KEYWORDS = [
+  "if", "then", "else", "elif", "fi", "for", "while", "until",
+  "do", "done", "case", "esac", "function", "select", "in",
+  "time", "return", "coproc",
+].join("|");
+
+/**
+ * Bash grammar that also colors the leading command of each statement
+ * (ssh, git, custom scripts), not only highlight.js's built-in whitelist.
+ * Reuses the `built_in` scope so commands share the existing accent color.
+ */
+export function bashCommandHighlight(hljs: HLJSApi): Language {
+  const grammar = bash(hljs);
+  const commandMode: Mode = {
+    begin: [
+      // 1: statement boundary (start of block, newline, ; | & ( ) + trailing space
+      /(?:^|[\n;&|(])\s*/,
+      // 2: optional leading env-var assignments, e.g. FOO=bar
+      /(?:\w+=\S*\s+)*/,
+      // 3: optional command wrappers
+      /(?:sudo\s+|command\s+|exec\s+)?/,
+      // 4: the command name (only this group is scoped); excludes shell keywords,
+      //    allows ./ ../ / path prefixes for script invocations
+      new RegExp(`(?!(?:${SHELL_KEYWORDS})\\b)(?:\\.{0,2}/)?[A-Za-z_][\\w./-]*`),
+    ],
+    beginScope: { 4: "built_in" },
+    relevance: 0,
+  };
+  grammar.contains = [commandMode, ...grammar.contains];
+  return grammar;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare module "highlight.js/lib/languages/bash" {
+  const bash: import("highlight.js").LanguageFn;
+  export default bash;
+}


### PR DESCRIPTION
## Summary

In note code blocks, highlight.js only colors a fixed whitelist of shell built-ins, so common commands like `ssh`, `git`, or a custom `./deploy.sh` were left uncolored. This adds a thin bash grammar wrapper that also colors the **leading command name** of each statement, reusing the existing `built_in` scope so it shares the current accent color.

## Changes

- Add `highlight.js` as a direct dependency (it was already transitive via lowlight).
- `bashCommandHighlight`: wraps highlight.js's bash grammar with a leading-command rule. Handles statement boundaries (`;`, `|`, `&`, newlines), skips env assignments and `sudo`/`command`/`exec` prefixes, allows `./ ../ /` script paths, and avoids misclassifying shell keywords (`if`, `for`, `while`, …) as commands.
- Wire it into `NoteEditor`: register the custom grammar on the editor's lowlight instance so it overrides the bash language shipped in `common`.
- Add a type declaration for the `highlight.js/lib/languages/bash` deep import.

## Test plan

- [x] `bashCommandHighlight` unit tests (9 cases: external commands, git, builtins, script invocations, pipes, env+sudo prefixes, string/variable preservation, keyword guard)
- [x] `pnpm typecheck` clean
- [x] full suite green (364 tests)
- [x] verified the wiring overrides `common`'s built-in bash, the `sh` alias resolves to it, and sibling languages (e.g. javascript) are unaffected