### PR TITLE
feat: redesign Claude progress panel to show activity history and status

### DIFF
--- a/src-tauri/src/modules/claude_progress/mod.rs
+++ b/src-tauri/src/modules/claude_progress/mod.rs
@@ -118,9 +118,17 @@ fn mangle_cwd(cwd: &str) -> String {
 
 /// The base config directory Claude Code writes transcripts under: the
 /// `CLAUDE_CONFIG_DIR` override when set and non-empty, otherwise `~/.claude`.
+/// A leading `~` in the override is expanded against `home`; shells usually
+/// expand it first, but a literal `~` can still reach us from a config file.
 fn config_base_dir(home: &Path, env_value: Option<&str>) -> PathBuf {
     match env_value {
-        Some(value) if !value.trim().is_empty() => PathBuf::from(value),
+        Some(value) if !value.trim().is_empty() => {
+            let path = Path::new(value);
+            match path.strip_prefix("~") {
+                Ok(rest) => home.join(rest),
+                Err(_) => path.to_path_buf(),
+            }
+        }
         _ => home.join(".claude"),
     }
 }
@@ -455,5 +463,14 @@ mod tests {
         let home = Path::new("/home/u");
         assert_eq!(config_base_dir(home, None), PathBuf::from("/home/u/.claude"));
         assert_eq!(config_base_dir(home, Some("  ")), PathBuf::from("/home/u/.claude"));
+    }
+
+    #[test]
+    fn config_base_dir_expands_a_leading_tilde_against_home() {
+        let home = Path::new("/home/u");
+        assert_eq!(
+            config_base_dir(home, Some("~/.claude_custom")),
+            PathBuf::from("/home/u/.claude_custom")
+        );
     }
 }

--- a/src-tauri/src/modules/claude_progress/mod.rs
+++ b/src-tauri/src/modules/claude_progress/mod.rs
@@ -116,6 +116,15 @@ fn mangle_cwd(cwd: &str) -> String {
         .collect()
 }
 
+/// The base config directory Claude Code writes transcripts under: the
+/// `CLAUDE_CONFIG_DIR` override when set and non-empty, otherwise `~/.claude`.
+fn config_base_dir(home: &Path, env_value: Option<&str>) -> PathBuf {
+    match env_value {
+        Some(value) if !value.trim().is_empty() => PathBuf::from(value),
+        _ => home.join(".claude"),
+    }
+}
+
 /// The most recently modified `.jsonl` transcript in `dir`, if any.
 fn latest_transcript(dir: &Path) -> Option<PathBuf> {
     let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
@@ -254,6 +263,8 @@ pub fn claude_progress_watch(
     cwds: Vec<String>,
 ) -> Result<(), String> {
     let home = app.path().home_dir().map_err(|e| e.to_string())?;
+    let env_value = std::env::var("CLAUDE_CONFIG_DIR").ok();
+    let base = config_base_dir(&home, env_value.as_deref());
     let mut watchers = state.watchers.lock().unwrap();
 
     watchers.retain(|cwd, _| cwds.contains(cwd));
@@ -262,7 +273,7 @@ pub fn claude_progress_watch(
         if watchers.contains_key(&cwd) {
             continue;
         }
-        let dir = home.join(".claude").join("projects").join(mangle_cwd(&cwd));
+        let dir = base.join("projects").join(mangle_cwd(&cwd));
         if !dir.is_dir() {
             continue;
         }
@@ -428,5 +439,21 @@ mod tests {
         assert_eq!(byte_len(&dir.join("missing.jsonl")), 0);
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn config_base_dir_uses_env_override_when_set() {
+        let home = Path::new("/home/u");
+        assert_eq!(
+            config_base_dir(home, Some("/custom/cc")),
+            PathBuf::from("/custom/cc")
+        );
+    }
+
+    #[test]
+    fn config_base_dir_falls_back_to_dot_claude_when_unset_or_blank() {
+        let home = Path::new("/home/u");
+        assert_eq!(config_base_dir(home, None), PathBuf::from("/home/u/.claude"));
+        assert_eq!(config_base_dir(home, Some("  ")), PathBuf::from("/home/u/.claude"));
     }
 }

--- a/src/modules/claude-progress/ClaudeProgressPanel.tsx
+++ b/src/modules/claude-progress/ClaudeProgressPanel.tsx
@@ -2,8 +2,15 @@ import { useState } from "react";
 import { Check, ChevronDown, ChevronRight, CircleDot, Loader2, Square, X } from "lucide-react";
 import { activeCount, isEmptyProgress, useProgressStore } from "./lib/progressStore";
 import type { ProgressState, SubagentProgress } from "./lib/progressState";
+import { deriveStatus } from "./lib/progressState";
 import type { TodoItem } from "./lib/normalize";
 import { basename } from "@/modules/explorer/lib/paths";
+
+const STATUS_LABEL: Record<ReturnType<typeof deriveStatus>, string> = {
+  active: "正在執行",
+  thinking: "思考中",
+  idle: "等待輸入",
+};
 
 function Subagent({ sub }: { sub: SubagentProgress }) {
   const running = sub.status === "running";
@@ -48,7 +55,7 @@ function TodoRow({ item }: { item: TodoItem }) {
 }
 
 function SessionBody({ progress }: { progress: ProgressState }) {
-  const { runningTools, subagents, todos } = progress;
+  const { activities, subagents, todos } = progress;
   return (
     <div className="space-y-3 px-2.5 pb-2.5 pt-1 text-xs">
       {subagents.length > 0 && (
@@ -62,15 +69,27 @@ function SessionBody({ progress }: { progress: ProgressState }) {
         </section>
       )}
 
-      {runningTools.length > 0 && (
+      {activities.length > 0 && (
         <section className="space-y-1">
           <h4 className="text-[11px] font-medium uppercase tracking-wide text-fg-subtle">
-            進行中的工具
+            活動
           </h4>
-          {runningTools.map((tool) => (
-            <div key={tool.id} className="flex items-center gap-2 text-fg-muted">
-              <Loader2 size={12} className="shrink-0 animate-spin text-accent" />
-              <span className="truncate">{tool.name}</span>
+          {activities.map((activity) => (
+            <div key={activity.id} className="flex items-center gap-2 text-fg-muted">
+              {activity.status === "running" ? (
+                <Loader2 size={12} className="shrink-0 animate-spin text-accent" />
+              ) : activity.status === "error" ? (
+                <X size={12} className="shrink-0 text-fg-subtle" />
+              ) : (
+                <Check size={12} className="shrink-0 text-success" />
+              )}
+              <span
+                className={
+                  activity.status === "running" ? "truncate" : "truncate text-fg-subtle"
+                }
+              >
+                {activity.name}
+              </span>
             </div>
           ))}
         </section>
@@ -99,6 +118,7 @@ interface SessionSectionProps {
 
 function SessionSection({ cwd, progress, collapsed, onToggle }: SessionSectionProps) {
   const running = activeCount(progress);
+  const status = deriveStatus(progress);
   return (
     <section className="overflow-hidden rounded-lg border border-border bg-bg-inset">
       <button
@@ -114,6 +134,7 @@ function SessionSection({ cwd, progress, collapsed, onToggle }: SessionSectionPr
         <span className="min-w-0 flex-1 truncate text-xs font-semibold text-fg" title={cwd}>
           {basename(cwd)}
         </span>
+        <span className="shrink-0 text-[10px] text-fg-subtle">{STATUS_LABEL[status]}</span>
         {running > 0 && (
           <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[9px] font-bold leading-none text-bg">
             {running}

--- a/src/modules/claude-progress/lib/progressState.test.ts
+++ b/src/modules/claude-progress/lib/progressState.test.ts
@@ -1,27 +1,51 @@
 import { describe, expect, it } from "vitest";
-import { emptyProgressState, reduceProgress } from "./progressState";
+import { emptyProgressState, MAX_ACTIVITIES, reduceProgress } from "./progressState";
 
 describe("reduceProgress", () => {
-  it("adds a started tool to the running list", () => {
+  it("adds a started tool to activities as running", () => {
     const state = reduceProgress(emptyProgressState(), {
       kind: "tool:start",
       id: "t1",
       name: "Bash",
     });
 
-    expect(state.runningTools).toEqual([{ id: "t1", name: "Bash" }]);
+    expect(state.activities).toEqual([{ id: "t1", name: "Bash", status: "running" }]);
   });
 
-  it("removes a tool from the running list when it ends", () => {
-    let state = reduceProgress(emptyProgressState(), {
-      kind: "tool:start",
-      id: "t1",
-      name: "Bash",
-    });
+  it("marks a tool done on end and keeps it in activities", () => {
+    let state = reduceProgress(emptyProgressState(), { kind: "tool:start", id: "t1", name: "Bash" });
     state = reduceProgress(state, { kind: "tool:start", id: "t2", name: "Read" });
     state = reduceProgress(state, { kind: "tool:end", id: "t1", name: "Bash", ok: true });
 
-    expect(state.runningTools).toEqual([{ id: "t2", name: "Read" }]);
+    expect(state.activities).toEqual([
+      { id: "t1", name: "Bash", status: "done" },
+      { id: "t2", name: "Read", status: "running" },
+    ]);
+  });
+
+  it("marks a tool error when it ends with ok=false", () => {
+    let state = reduceProgress(emptyProgressState(), { kind: "tool:start", id: "t1", name: "Bash" });
+    state = reduceProgress(state, { kind: "tool:end", id: "t1", name: "Bash", ok: false });
+
+    expect(state.activities).toEqual([{ id: "t1", name: "Bash", status: "error" }]);
+  });
+
+  it("ignores tool:end for an unknown id", () => {
+    const start = reduceProgress(emptyProgressState(), { kind: "tool:start", id: "t1", name: "Bash" });
+    const next = reduceProgress(start, { kind: "tool:end", id: "nope", name: "X", ok: true });
+
+    expect(next).toBe(start);
+  });
+
+  it("caps activities at MAX_ACTIVITIES, dropping the oldest", () => {
+    let state = emptyProgressState();
+    for (let i = 0; i < MAX_ACTIVITIES + 5; i++) {
+      state = reduceProgress(state, { kind: "tool:start", id: `t${i}`, name: "Bash" });
+    }
+
+    expect(state.activities).toHaveLength(MAX_ACTIVITIES);
+    expect(state.activities[0].id).toBe("t5");
+    expect(state.activities[MAX_ACTIVITIES - 1].id).toBe(`t${MAX_ACTIVITIES + 4}`);
   });
 
   it("adds a started subagent as running", () => {

--- a/src/modules/claude-progress/lib/progressState.test.ts
+++ b/src/modules/claude-progress/lib/progressState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { emptyProgressState, MAX_ACTIVITIES, reduceProgress } from "./progressState";
+import { deriveStatus, emptyProgressState, MAX_ACTIVITIES, reduceProgress } from "./progressState";
 
 describe("reduceProgress", () => {
   it("adds a started tool to activities as running", () => {
@@ -144,5 +144,23 @@ describe("reduceProgress", () => {
     const next = reduceProgress(state, { kind: "idle" });
 
     expect(next).toBe(state);
+  });
+
+  it("derives active when a tool or subagent is running", () => {
+    const state = reduceProgress(emptyProgressState(), { kind: "tool:start", id: "t1", name: "Bash" });
+    expect(deriveStatus(state)).toBe("active");
+  });
+
+  it("derives idle when idle and nothing is running", () => {
+    let state = reduceProgress(emptyProgressState(), { kind: "tool:start", id: "t1", name: "Bash" });
+    state = reduceProgress(state, { kind: "tool:end", id: "t1", name: "Bash", ok: true });
+    state = reduceProgress(state, { kind: "idle" });
+    expect(deriveStatus(state)).toBe("idle");
+  });
+
+  it("derives thinking when there is history but nothing running and not idle", () => {
+    let state = reduceProgress(emptyProgressState(), { kind: "tool:start", id: "t1", name: "Bash" });
+    state = reduceProgress(state, { kind: "tool:end", id: "t1", name: "Bash", ok: true });
+    expect(deriveStatus(state)).toBe("thinking");
   });
 });

--- a/src/modules/claude-progress/lib/progressState.ts
+++ b/src/modules/claude-progress/lib/progressState.ts
@@ -1,9 +1,14 @@
 import type { ProgressEvent, TodoItem } from "./normalize";
 
-export interface RunningTool {
+export type ActivityStatus = "running" | "done" | "error";
+
+export interface ToolActivity {
   id: string;
   name: string;
+  status: ActivityStatus;
 }
+
+export const MAX_ACTIVITIES = 30;
 
 export interface SubagentProgress {
   id: string;
@@ -16,14 +21,14 @@ export interface SubagentProgress {
 }
 
 export interface ProgressState {
-  runningTools: RunningTool[];
+  activities: ToolActivity[];
   subagents: SubagentProgress[];
   todos: TodoItem[];
   idle: boolean;
 }
 
 export function emptyProgressState(): ProgressState {
-  return { runningTools: [], subagents: [], todos: [], idle: false };
+  return { activities: [], subagents: [], todos: [], idle: false };
 }
 
 /**
@@ -34,17 +39,25 @@ export function emptyProgressState(): ProgressState {
  */
 export function reduceProgress(state: ProgressState, event: ProgressEvent): ProgressState {
   switch (event.kind) {
-    case "tool:start":
-      return {
-        ...state,
-        idle: false,
-        runningTools: [...state.runningTools, { id: event.id, name: event.name }],
-      };
-    case "tool:end":
-      return {
-        ...state,
-        runningTools: state.runningTools.filter((tool) => tool.id !== event.id),
-      };
+    case "tool:start": {
+      const next = [
+        ...state.activities,
+        { id: event.id, name: event.name, status: "running" as const },
+      ];
+      const activities = next.length > MAX_ACTIVITIES ? next.slice(next.length - MAX_ACTIVITIES) : next;
+      return { ...state, idle: false, activities };
+    }
+    case "tool:end": {
+      const index = state.activities.findIndex(
+        (activity) => activity.id === event.id && activity.status === "running",
+      );
+      if (index === -1) {
+        return state;
+      }
+      const activities = state.activities.slice();
+      activities[index] = { ...activities[index], status: event.ok ? "done" : "error" };
+      return { ...state, activities };
+    }
     case "subagent:start":
       return {
         ...state,

--- a/src/modules/claude-progress/lib/progressState.ts
+++ b/src/modules/claude-progress/lib/progressState.ts
@@ -114,4 +114,21 @@ function todosEqual(a: TodoItem[], b: TodoItem[]): boolean {
   return a.every((item, index) => item.text === b[index].text && item.status === b[index].status);
 }
 
+/**
+ * The session's coarse state for the panel header: actively running a tool or
+ * subagent, finished and waiting for input (idle), or thinking between actions.
+ */
+export function deriveStatus(progress: ProgressState): "active" | "thinking" | "idle" {
+  const running =
+    progress.activities.some((activity) => activity.status === "running") ||
+    progress.subagents.some((subagent) => subagent.status === "running");
+  if (running) {
+    return "active";
+  }
+  if (progress.idle) {
+    return "idle";
+  }
+  return "thinking";
+}
+
 export type { TodoItem };

--- a/src/modules/claude-progress/lib/progressStore.test.ts
+++ b/src/modules/claude-progress/lib/progressStore.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { activeCount, isEmptyProgress } from "./progressStore";
+import { emptyProgressState, reduceProgress } from "./progressState";
+
+describe("isEmptyProgress", () => {
+  it("is true for a fresh empty state", () => {
+    expect(isEmptyProgress(emptyProgressState())).toBe(true);
+  });
+
+  it("is false once a tool has run, even after it finished", () => {
+    let state = reduceProgress(emptyProgressState(), { kind: "tool:start", id: "t1", name: "Bash" });
+    state = reduceProgress(state, { kind: "tool:end", id: "t1", name: "Bash", ok: true });
+
+    expect(isEmptyProgress(state)).toBe(false);
+  });
+});
+
+describe("activeCount", () => {
+  it("counts only running activities and subagents, not finished ones", () => {
+    let state = reduceProgress(emptyProgressState(), { kind: "tool:start", id: "t1", name: "Bash" });
+    state = reduceProgress(state, { kind: "tool:start", id: "t2", name: "Read" });
+    state = reduceProgress(state, { kind: "tool:end", id: "t1", name: "Bash", ok: true });
+    state = reduceProgress(state, {
+      kind: "subagent:start",
+      id: "a1",
+      agentType: "explorer",
+      description: "x",
+    });
+
+    expect(activeCount(state)).toBe(2);
+  });
+});

--- a/src/modules/claude-progress/lib/progressStore.ts
+++ b/src/modules/claude-progress/lib/progressStore.ts
@@ -84,8 +84,9 @@ export const useProgressStore = create<ProgressStoreState>((set) => ({
 
 /** In-flight work for one session, used to badge the panel section. */
 export function activeCount(progress: ProgressState): number {
-  const runningSubagents = progress.subagents.filter((s) => s.status === "running").length;
-  return progress.runningTools.length + runningSubagents;
+  const runningTools = progress.activities.filter((activity) => activity.status === "running").length;
+  const runningSubagents = progress.subagents.filter((sub) => sub.status === "running").length;
+  return runningTools + runningSubagents;
 }
 
 /** Total in-flight work across all sessions, used to badge the status-bar icon. */
@@ -93,10 +94,10 @@ export function totalActiveCount(sessions: Record<string, ProgressState>): numbe
   return Object.values(sessions).reduce((sum, progress) => sum + activeCount(progress), 0);
 }
 
-/** True when a session has nothing worth showing (no tools, subagents, or todos). */
+/** True when a session has nothing worth showing (no activities, subagents, or todos). */
 export function isEmptyProgress(progress: ProgressState): boolean {
   return (
-    progress.runningTools.length === 0 &&
+    progress.activities.length === 0 &&
     progress.subagents.length === 0 &&
     progress.todos.length === 0
   );


### PR DESCRIPTION
## Summary

Redesigns the right-hand "Claude 進度" panel so it stays useful during normal Claude sessions instead of showing "目前沒有 Claude 活動" almost all the time.

### Root cause

The panel only tracked `runningTools`, which were dropped the instant a tool finished. A typical session (tools that run and complete, no sub-agent, no TodoWrite) left the panel empty, and Opus' long thinking periods kept it empty even longer. A second, independent cause is also fixed: the backend hardcoded `~/.claude/projects/` and ignored `CLAUDE_CONFIG_DIR`.

### Changes

- **Activity history**: `runningTools` becomes a persistent `activities` list. Finished tools stay, marked done/error, capped at 30, so the panel shows recent work even while Claude is thinking. True emptiness now only means the session never ran a tool.
- **Status indicator**: each session header shows a derived status (正在執行 / 思考中 / 等待輸入).
- **CLAUDE_CONFIG_DIR**: the backend honors the env var when locating transcripts, falling back to `~/.claude` (decision extracted into a pure, unit-tested function).
- normalizer, sub-agent detection, and todo logic are intentionally unchanged.

### Out of scope

- workflow / background-worktree agents (they run in directories with no terminal pane; tracked separately)
- parsing background sub-agent completion notifications (background agents stay shown as in-progress)

## Test plan

- [x] Frontend unit tests: 383 passing (51 files), including new activity-history reducer, `deriveStatus`, and store selector tests
- [x] `tsc --noEmit` clean
- [x] Backend `cargo test`: 86 passing, including new `config_base_dir` tests
- [ ] Manual in-app: run interactive `claude` in a pane under the default `~/.claude` config, have it use several tools, and confirm the panel lists the activity history, keeps finished tools, persists through thinking, and shows the correct header status