### PR TITLE
feat: drag to reorder tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@lezer/highlight": "^1.2.3",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,12 @@ importers:
       '@codemirror/view':
         specifier: ^6.43.1
         version: 6.43.1
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
@@ -375,6 +381,28 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -2261,6 +2289,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -2712,6 +2743,31 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -4745,6 +4801,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  tslib@2.8.1: {}
 
   typescript@5.8.3: {}
 

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -33,6 +33,12 @@ import { useEditorStore } from "@/modules/editor/store/editorStore";
 import { useUiStore } from "@/stores/uiStore";
 import { SpaceDropdown } from "./SpaceDropdown";
 
+// Module-level so the reference stays stable across renders. Passing an inline
+// options object would make useSensor/useSensors return a new sensors array on
+// every render, re-initializing the sensor managers (a re-render is triggered
+// mid-drag when draggingId updates).
+const POINTER_SENSOR_OPTIONS = { activationConstraint: { distance: 5 } };
+
 function tabIcon(kind: Tab["kind"]): LucideIcon {
   switch (kind) {
     case "terminal":
@@ -163,9 +169,7 @@ export function TabBar() {
   const sidebarVisible = useUiStore((s) => s.sidebarVisible);
   const reorderTab = useTabsStore((s) => s.reorderTab);
   const [draggingId, setDraggingId] = useState<string | null>(null);
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-  );
+  const sensors = useSensors(useSensor(PointerSensor, POINTER_SENSOR_OPTIONS));
   const draggingTab = visibleTabs.find((tab) => tab.id === draggingId);
 
   function handleDragStart(event: DragStartEvent) {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -12,6 +12,21 @@ import {
   X,
   type LucideIcon,
 } from "lucide-react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
 import { useTabsStore, type Tab } from "@/stores/tabsStore";
 import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
 import { useEditorStore } from "@/modules/editor/store/editorStore";
@@ -42,6 +57,8 @@ function TabItem({ id }: { id: string }) {
   const setActive = useTabsStore((s) => s.setActive);
   const closeTab = useTabsStore((s) => s.closeTab);
   const setTabTitle = useTabsStore((s) => s.setTabTitle);
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id });
   // A tab is dirty when any of its editor panes has unsaved changes.
   const dirty = useEditorStore((s) => {
     if (!tab) {
@@ -72,6 +89,13 @@ function TabItem({ id }: { id: string }) {
 
   return (
     <div
+      ref={setNodeRef}
+      style={{
+        transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+        transition,
+      }}
+      {...attributes}
+      {...listeners}
       role="tab"
       aria-selected={active}
       onClick={() => setActive(tab.id)}
@@ -82,7 +106,7 @@ function TabItem({ id }: { id: string }) {
       title={tab.title}
       className={`group flex h-7 cursor-pointer items-center gap-2 rounded-md px-3 text-xs transition-colors ${
         active ? "bg-bg-elevated text-fg" : "text-fg-muted hover:bg-bg-elevated/60"
-      }`}
+      } ${isDragging ? "opacity-40" : ""}`}
     >
       <Icon size={13} className="shrink-0" />
       {editing ? (
@@ -92,6 +116,7 @@ function TabItem({ id }: { id: string }) {
           onChange={(e) => setDraft(e.target.value)}
           onBlur={commit}
           onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
           onKeyDown={(e) => {
             if (e.key === "Enter") commit();
             if (e.key === "Escape") setEditing(false);
@@ -105,6 +130,7 @@ function TabItem({ id }: { id: string }) {
       <button
         type="button"
         aria-label={t("actions.closeTab")}
+        onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.stopPropagation();
           closeTab(tab.id);
@@ -117,6 +143,16 @@ function TabItem({ id }: { id: string }) {
   );
 }
 
+function TabOverlay({ tab }: { tab: Tab }) {
+  const Icon = tabIcon(tab.kind);
+  return (
+    <div className="flex h-7 items-center gap-2 rounded-md bg-bg-elevated px-3 text-xs text-fg shadow-lg">
+      <Icon size={13} className="shrink-0" />
+      <span className="max-w-[160px] truncate">{tab.title}</span>
+    </div>
+  );
+}
+
 export function TabBar() {
   const { t } = useTranslation();
   const tabs = useTabsStore((s) => s.tabs);
@@ -125,6 +161,28 @@ export function TabBar() {
   const openLauncherTab = useTabsStore((s) => s.openLauncherTab);
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
   const sidebarVisible = useUiStore((s) => s.sidebarVisible);
+  const reorderTab = useTabsStore((s) => s.reorderTab);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+  const draggingTab = visibleTabs.find((tab) => tab.id === draggingId);
+
+  function handleDragStart(event: DragStartEvent) {
+    setDraggingId(String(event.active.id));
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setDraggingId(null);
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      reorderTab(String(active.id), String(over.id));
+    }
+  }
+
+  function handleDragCancel() {
+    setDraggingId(null);
+  }
 
   return (
     <header
@@ -145,14 +203,25 @@ export function TabBar() {
       </button>
       <SpaceDropdown />
       <div className="mx-1 h-4 w-px shrink-0 bg-border" />
-      <div
-        data-tauri-drag-region
-        className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
       >
-        {visibleTabs.map((tab) => (
-          <TabItem key={tab.id} id={tab.id} />
-        ))}
-      </div>
+        <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+          <SortableContext
+            items={visibleTabs.map((tab) => tab.id)}
+            strategy={horizontalListSortingStrategy}
+          >
+            {visibleTabs.map((tab) => (
+              <TabItem key={tab.id} id={tab.id} />
+            ))}
+          </SortableContext>
+        </div>
+        <DragOverlay>{draggingTab ? <TabOverlay tab={draggingTab} /> : null}</DragOverlay>
+      </DndContext>
 
       <button
         type="button"

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -288,6 +288,55 @@ describe("tabsStore", () => {
     useTabsStore.getState().setTerminalCwd(id, leafId, "/work/dir");
     expect(useTabsStore.getState().tabs).toBe(before);
   });
+
+  it("reorders tabs within the same space", () => {
+    const a = useTabsStore.getState().newTerminalTab();
+    const b = useTabsStore.getState().newTerminalTab();
+    const c = useTabsStore.getState().newTerminalTab();
+    // initial order in this space: [a, b, c]
+    useTabsStore.getState().reorderTab(c, a);
+    expect(useTabsStore.getState().tabs.map((t) => t.id)).toEqual([c, a, b]);
+  });
+
+  it("reordering one space leaves other spaces' tabs in place", () => {
+    const a1 = useTabsStore.getState().newTerminalTab();
+    const space1 = useTabsStore.getState().activeSpaceId!;
+    useTabsStore.getState().newSpace();
+    const b1 = useTabsStore.getState().newTerminalTab();
+    useTabsStore.getState().setActiveSpace(space1);
+    const a2 = useTabsStore.getState().newTerminalTab();
+    const a3 = useTabsStore.getState().newTerminalTab();
+    // Flat order is [a1, b1, a2, a3]; space1 subsequence is [a1, a2, a3].
+    useTabsStore.getState().reorderTab(a3, a1);
+    expect(useTabsStore.getState().tabs.map((t) => t.id)).toEqual([a3, b1, a1, a2]);
+  });
+
+  it("reordering does not change the active tab", () => {
+    const a = useTabsStore.getState().newTerminalTab();
+    const b = useTabsStore.getState().newTerminalTab();
+    useTabsStore.getState().setActive(a);
+    useTabsStore.getState().reorderTab(b, a);
+    expect(useTabsStore.getState().activeId).toBe(a);
+  });
+
+  it("is a no-op when dropping on itself or onto an unknown tab", () => {
+    const a = useTabsStore.getState().newTerminalTab();
+    useTabsStore.getState().newTerminalTab();
+    const before = useTabsStore.getState().tabs;
+    useTabsStore.getState().reorderTab(a, a);
+    expect(useTabsStore.getState().tabs).toBe(before);
+    useTabsStore.getState().reorderTab(a, "nope");
+    expect(useTabsStore.getState().tabs).toBe(before);
+  });
+
+  it("is a no-op when the two tabs are in different spaces", () => {
+    const a = useTabsStore.getState().newTerminalTab(); // space1
+    useTabsStore.getState().newSpace(); // space2 becomes active
+    const c = useTabsStore.getState().newTerminalTab(); // space2
+    const before = useTabsStore.getState().tabs;
+    useTabsStore.getState().reorderTab(a, c);
+    expect(useTabsStore.getState().tabs).toBe(before);
+  });
 });
 
 describe("migratePersistedTabs", () => {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -75,6 +75,8 @@ interface TabsState {
    */
   closePaneOrTab: () => void;
   setActive: (id: string) => void;
+  /** Move `activeId` to `overId`'s slot within the same space. No-op across spaces. */
+  reorderTab: (activeId: string, overId: string) => void;
   splitActivePane: (direction: SplitDirection) => void;
   setActiveLeaf: (tabId: string, leafId: string) => void;
   resizePane: (tabId: string, splitId: string, sizes: [number, number]) => void;
@@ -103,6 +105,14 @@ function basename(path: string): string {
 
 function neighbourId(tabs: Tab[], index: number): string | null {
   return tabs[index - 1]?.id ?? tabs[index]?.id ?? null;
+}
+
+/** Return a copy of `items` with the element at `from` moved to `to`. */
+function moveItem<T>(items: readonly T[], from: number, to: number): T[] {
+  const next = items.slice();
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
 }
 
 /** True when a tab is a single, unsplit leaf showing exactly `content`. */
@@ -442,6 +452,36 @@ export const useTabsStore = create<TabsState>()(
     set((state) => {
       const tab = state.tabs.find((t) => t.id === id);
       return tab ? { activeId: id, activeSpaceId: tab.spaceId } : { activeId: id };
+    }),
+
+  reorderTab: (activeId, overId) =>
+    set((state) => {
+      if (activeId === overId) {
+        return state;
+      }
+      const moving = state.tabs.find((t) => t.id === activeId);
+      const over = state.tabs.find((t) => t.id === overId);
+      if (!moving || !over || moving.spaceId !== over.spaceId) {
+        return state;
+      }
+      // Slots are the indices this space's tabs occupy in the flat array;
+      // we reorder only the subsequence and write it back into those slots,
+      // so tabs from other spaces never move.
+      const slots: number[] = [];
+      state.tabs.forEach((tab, index) => {
+        if (tab.spaceId === moving.spaceId) {
+          slots.push(index);
+        }
+      });
+      const subsequence = slots.map((index) => state.tabs[index]);
+      const from = subsequence.findIndex((t) => t.id === activeId);
+      const to = subsequence.findIndex((t) => t.id === overId);
+      const reordered = moveItem(subsequence, from, to);
+      const tabs = state.tabs.slice();
+      slots.forEach((slotIndex, k) => {
+        tabs[slotIndex] = reordered[k];
+      });
+      return { tabs };
     }),
 
   splitActivePane: (direction) =>


### PR DESCRIPTION
## Summary

Adds drag-to-reorder for tabs in the tab bar. Users can drag a tab left/right to reposition it within the active space, and the order persists across reloads.

## Changes

- **Store** (`src/stores/tabsStore.ts`): new `reorderTab(activeId, overId)` action that moves a tab to a target tab's slot within the same space, leaving other spaces' tabs in their original flat-array positions. No-op when the two tabs are in different spaces, when an id is unknown, or when dropping on itself. Does not change the active tab. Order lives in the existing flat `tabs` array (no new `order` field) and is persisted by the existing zustand persist middleware.
- **UI** (`src/components/TabBar.tsx`): wired dnd-kit (`@dnd-kit/core` + `@dnd-kit/sortable`). `TabItem` is now sortable; the tab list is wrapped in `DndContext` + `SortableContext` (horizontal strategy) with a `DragOverlay` ghost that follows the cursor while the in-place slot dims. A `PointerSensor` with a 5px activation distance keeps a plain click switching tabs and a double click entering rename; the close button and rename input no longer start a drag. Removed `data-tauri-drag-region` from the inner tab list so grabbing a tab no longer drags the OS window.

## Test plan

- [x] Store unit tests: reorder within space, cross-space isolation, active-id unchanged, no-op (self / unknown id / cross-space) — 34 tabsStore tests pass
- [x] Full suite green (403 tests), typecheck clean
- [x] Manual GUI: drag reorders and the order sticks; window does not drag when grabbing a tab; single click switches and double click renames; order intact after switching spaces and back; order persists after an app reload