### PR TITLE
feat(terminal): platform-aware link open modifier, file-link tooltips, and wrapped-path clicks

### DIFF
--- a/src/components/LauncherPanel.tsx
+++ b/src/components/LauncherPanel.tsx
@@ -15,12 +15,11 @@ import { useNotesStore } from "@/stores/notesStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { pickNotesFolder } from "@/modules/notes/lib/pickNotesFolder";
 import { pickFile, pickFolder } from "@/lib/dialog";
+import { IS_MAC } from "@/lib/platform";
 import type { PaneContent } from "@/modules/terminal/lib/terminalLayout";
 
 const DEFAULT_PREVIEW_URL = "http://localhost:3000";
 
-const IS_MAC =
-  typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac");
 const MOD = IS_MAC ? "⌘" : "Ctrl";
 const SHIFT = IS_MAC ? "⇧" : "Shift";
 const TERMINAL_SHORTCUT = `${MOD} ${SHIFT} T`;

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -2,7 +2,7 @@
   "appName": "TempoTerm",
   "tagline": "AI-powered terminal workspace",
   "terminalConnecting": "Starting shell…",
-  "openLinkHint": "Cmd / Ctrl-click to open",
+  "openLinkHint": "{{mods}}-click to open",
   "nav": {
     "terminal": "Terminal",
     "explorer": "Explorer",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -2,7 +2,7 @@
   "appName": "TempoTerm",
   "tagline": "AI 驅動的終端機工作區",
   "terminalConnecting": "啟動中…",
-  "openLinkHint": "Cmd / Ctrl + 點擊開啟",
+  "openLinkHint": "{{mods}} + 點擊開啟",
   "nav": {
     "terminal": "終端機",
     "explorer": "檔案總管",

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { matchesOpenModifier, openModifierLabel } from "./platform";
+
+type Mods = { altKey?: boolean; metaKey?: boolean; ctrlKey?: boolean };
+const ev = (m: Mods) => ({ altKey: false, metaKey: false, ctrlKey: false, ...m });
+
+describe("matchesOpenModifier", () => {
+  it("mac: Cmd matches", () => {
+    expect(matchesOpenModifier(ev({ metaKey: true }), true)).toBe(true);
+  });
+  it("mac: Alt matches", () => {
+    expect(matchesOpenModifier(ev({ altKey: true }), true)).toBe(true);
+  });
+  it("mac: Ctrl alone does not match", () => {
+    expect(matchesOpenModifier(ev({ ctrlKey: true }), true)).toBe(false);
+  });
+  it("mac: no modifier does not match", () => {
+    expect(matchesOpenModifier(ev({}), true)).toBe(false);
+  });
+  it("non-mac: Ctrl matches", () => {
+    expect(matchesOpenModifier(ev({ ctrlKey: true }), false)).toBe(true);
+  });
+  it("non-mac: Alt matches", () => {
+    expect(matchesOpenModifier(ev({ altKey: true }), false)).toBe(true);
+  });
+  it("non-mac: Cmd alone does not match", () => {
+    expect(matchesOpenModifier(ev({ metaKey: true }), false)).toBe(false);
+  });
+});
+
+describe("openModifierLabel", () => {
+  it("mac label", () => expect(openModifierLabel(true)).toBe("Alt / Cmd"));
+  it("non-mac label", () => expect(openModifierLabel(false)).toBe("Alt / Ctrl"));
+});

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { matchesOpenModifier, openModifierLabel } from "./platform";
 
 type Mods = { altKey?: boolean; metaKey?: boolean; ctrlKey?: boolean };
@@ -31,4 +31,36 @@ describe("matchesOpenModifier", () => {
 describe("openModifierLabel", () => {
   it("mac label", () => expect(openModifierLabel(true)).toBe("Alt / Cmd"));
   it("non-mac label", () => expect(openModifierLabel(false)).toBe("Alt / Ctrl"));
+});
+
+// IS_MAC is evaluated at module load, so each case stubs navigator, resets the
+// module registry, and re-imports to observe a fresh evaluation.
+describe("IS_MAC platform detection", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  async function loadIsMac(nav: unknown): Promise<boolean> {
+    vi.stubGlobal("navigator", nav);
+    vi.resetModules();
+    const mod = await import("./platform");
+    return mod.IS_MAC;
+  }
+
+  it("does not throw and falls back to userAgent when platform is undefined", async () => {
+    await expect(
+      loadIsMac({ userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X)", platform: undefined }),
+    ).resolves.toBe(true);
+  });
+
+  it("detects mac via platform when userAgent is missing", async () => {
+    await expect(loadIsMac({ platform: "MacIntel" })).resolves.toBe(true);
+  });
+
+  it("is false on a non-mac platform", async () => {
+    await expect(
+      loadIsMac({ userAgent: "Mozilla/5.0 (Windows NT 10.0)", platform: "Win32" }),
+    ).resolves.toBe(false);
+  });
 });

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,24 @@
+/**
+ * Single source of truth for platform detection and the link-open gesture.
+ * Mac opens links on Alt or Cmd; Windows and other non-mac on Alt or Ctrl.
+ */
+export const IS_MAC =
+  typeof navigator !== "undefined" &&
+  navigator.platform.toLowerCase().includes("mac");
+
+type ModifierEvent = Pick<MouseEvent, "altKey" | "metaKey" | "ctrlKey">;
+
+/** Whether a click carries the platform's open-link modifier. */
+export function matchesOpenModifier(
+  event: ModifierEvent,
+  isMac: boolean = IS_MAC,
+): boolean {
+  return isMac
+    ? event.altKey || event.metaKey
+    : event.altKey || event.ctrlKey;
+}
+
+/** Modifier-key label shown in the link hover tooltip. */
+export function openModifierLabel(isMac: boolean = IS_MAC): string {
+  return isMac ? "Alt / Cmd" : "Alt / Ctrl";
+}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,10 +1,16 @@
 /**
  * Single source of truth for platform detection and the link-open gesture.
  * Mac opens links on Alt or Cmd; Windows and other non-mac on Alt or Ctrl.
+ *
+ * navigator.platform is deprecated and may be undefined in some runtimes, so we
+ * guard it with optional chaining and fall back to userAgent to avoid throwing
+ * at module load.
  */
 export const IS_MAC =
   typeof navigator !== "undefined" &&
-  navigator.platform.toLowerCase().includes("mac");
+  (navigator.platform?.toLowerCase().includes("mac") ||
+    navigator.userAgent?.toLowerCase().includes("mac") ||
+    false);
 
 type ModifierEvent = Pick<MouseEvent, "altKey" | "metaKey" | "ctrlKey">;
 

--- a/src/modules/settings/ShortcutsSettingsSection.tsx
+++ b/src/modules/settings/ShortcutsSettingsSection.tsx
@@ -1,7 +1,5 @@
 import { useTranslation } from "react-i18next";
-
-const IS_MAC =
-  typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac");
+import { IS_MAC } from "@/lib/platform";
 const MOD = IS_MAC ? "⌘" : "Ctrl";
 const SHIFT = IS_MAC ? "⇧" : "Shift";
 const ENTER = IS_MAC ? "↵" : "Enter";

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -32,8 +32,8 @@ import {
   shouldAttachImage,
   shellQuotePath,
 } from "./lib/terminalClipboard";
-import { findFilePaths, resolveFilePath } from "./lib/fileLinks";
-import { buildCellPositions, type TerminalRow } from "./lib/cellPositions";
+import { buildFileLink, findFilePaths, resolveFilePath } from "./lib/fileLinks";
+import { buildCellPositions, gatherLogicalLine } from "./lib/cellPositions";
 import { terminalKeySequence } from "./lib/terminalKeymap";
 import { shouldCdToRoot } from "./lib/cwdSync";
 import { debounce } from "@/lib/debounce";
@@ -41,8 +41,7 @@ import { dropOverlayClassName } from "@/components/EntryDropOverlay";
 import { fsHomeDir, fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import { getDraggedEntry } from "@/modules/explorer/lib/dragEntry";
 
-const IS_MAC =
-  typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac");
+import { IS_MAC, openModifierLabel } from "@/lib/platform";
 import { selectTerminalFontFamily, useFontStore } from "@/stores/fontStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -103,8 +102,8 @@ export function TerminalView({
   const onOpenFileRef = useRef(onOpenFile);
   onOpenFileRef.current = onOpenFile;
   const { t } = useTranslation();
-  const linkHintRef = useRef(t("openLinkHint"));
-  linkHintRef.current = t("openLinkHint");
+  const linkHintRef = useRef(t("openLinkHint", { mods: openModifierLabel(IS_MAC) }));
+  linkHintRef.current = t("openLinkHint", { mods: openModifierLabel(IS_MAC) });
 
   const fontFamily = useFontStore(selectTerminalFontFamily);
   const fontSize = useFontStore((s) => s.fontSize);
@@ -301,42 +300,13 @@ export function TerminalView({
 
     term.registerLinkProvider({
       provideLinks(lineNumber, callback) {
-        const buffer = term.buffer.active;
-        const firstLine = buffer.getLine(lineNumber - 1);
-        // Only handle a logical line at its first row; wrapped continuation rows
-        // are covered by the multi-row range built below.
-        if (!firstLine || firstLine.isWrapped) {
+        // Resolve the logical line (handles wrapped paths) and read its cells.
+        const rows = gatherLogicalLine(term.buffer.active, lineNumber);
+        if (!rows) {
           callback(undefined);
           return;
         }
-        // Gather the logical line: this row plus any wrapped continuation rows,
-        // so a path that wraps across rows is still detected as one link. Read
-        // the actual buffer cells (not translateToString) so column math stays
-        // in sync with xterm's own widths for wide / CJK glyphs.
-        const cellRows: TerminalRow[] = [];
-        let y = lineNumber;
-        let line: typeof firstLine | undefined = firstLine;
-        while (line) {
-          const cells: TerminalRow["cells"] = [];
-          // Reuse one cell object across columns; xterm fills it in place to
-          // avoid allocating per cell.
-          let cell: ReturnType<typeof line.getCell>;
-          for (let col = 0; col < line.length; col += 1) {
-            cell = line.getCell(col, cell);
-            cells.push({
-              chars: cell?.getChars() ?? "",
-              width: cell?.getWidth() ?? 1,
-            });
-          }
-          cellRows.push({ y, cells });
-          const next = buffer.getLine(y);
-          if (!next || !next.isWrapped) {
-            break;
-          }
-          line = next;
-          y += 1;
-        }
-        const { text, spans } = buildCellPositions(cellRows);
+        const { text, spans } = buildCellPositions(rows);
         const matches = findFilePaths(text);
         if (matches.length === 0) {
           callback(undefined);
@@ -354,17 +324,15 @@ export function TerminalView({
           return { x: span?.endX ?? 1, y: span?.y ?? lineNumber };
         };
         callback(
-          matches.map((m) => ({
-            range: { start: startCell(m.start), end: endCell(m.end - 1) },
-            text: m.text,
-            activate: (event: MouseEvent) => {
-              // Alt+click is xterm's rectangular-select gesture and can be
-              // swallowed, so Cmd+click works too (matching VS Code's gesture).
-              if (event.altKey || event.metaKey) {
-                void openFromTerminal(m.text);
-              }
-            },
-          })),
+          matches.map((m) =>
+            buildFileLink({
+              text: m.text,
+              range: { start: startCell(m.start), end: endCell(m.end - 1) },
+              hint: linkHintRef.current,
+              isMac: IS_MAC,
+              onOpen: (raw) => void openFromTerminal(raw),
+            }),
+          ),
         );
       },
     });

--- a/src/modules/terminal/lib/cellPositions.test.ts
+++ b/src/modules/terminal/lib/cellPositions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildCellPositions, type TerminalRow } from "./cellPositions";
+import { gatherLogicalLine, type TerminalBufferLine } from "./cellPositions";
 
 /** Build a row of single-width ASCII cells from a plain string. */
 function asciiRow(y: number, text: string): TerminalRow {
@@ -61,5 +62,55 @@ describe("buildCellPositions", () => {
     // First char of the second row restarts at column 1 on line 5.
     expect(spans[2]).toEqual({ startX: 1, endX: 1, y: 5 });
     expect(spans[3]).toEqual({ startX: 2, endX: 2, y: 5 });
+  });
+});
+
+function fakeLine(text: string, isWrapped: boolean): TerminalBufferLine {
+  const chars = [...text];
+  return {
+    isWrapped,
+    length: chars.length,
+    getCell: (col: number) => ({
+      getChars: () => chars[col] ?? "",
+      getWidth: () => 1,
+    }),
+  };
+}
+
+function fakeBuffer(lines: TerminalBufferLine[]) {
+  return { getLine: (i: number) => lines[i] };
+}
+
+describe("gatherLogicalLine", () => {
+  it("returns a single row for a non-wrapped line", () => {
+    const buffer = fakeBuffer([fakeLine("abc", false)]);
+    const rows = gatherLogicalLine(buffer, 1);
+    expect(rows).not.toBeNull();
+    expect(rows).toHaveLength(1);
+    expect(rows?.[0].y).toBe(1);
+    expect(rows?.[0].cells.map((c) => c.chars).join("")).toBe("abc");
+  });
+
+  it("returns the whole logical line when asked for the first row", () => {
+    const buffer = fakeBuffer([
+      fakeLine("/long/", false),
+      fakeLine("end.md", true),
+    ]);
+    const rows = gatherLogicalLine(buffer, 1);
+    expect(rows?.map((r) => r.y)).toEqual([1, 2]);
+  });
+
+  it("returns the whole logical line when asked for a wrapped continuation row", () => {
+    const buffer = fakeBuffer([
+      fakeLine("/long/", false),
+      fakeLine("end.md", true),
+    ]);
+    const rows = gatherLogicalLine(buffer, 2);
+    expect(rows?.map((r) => r.y)).toEqual([1, 2]);
+  });
+
+  it("returns null when the row does not exist", () => {
+    const buffer = fakeBuffer([fakeLine("abc", false)]);
+    expect(gatherLogicalLine(buffer, 5)).toBeNull();
   });
 });

--- a/src/modules/terminal/lib/cellPositions.ts
+++ b/src/modules/terminal/lib/cellPositions.ts
@@ -64,3 +64,71 @@ export function buildCellPositions(rows: TerminalRow[]): CellPositions {
 
   return { text, spans };
 }
+
+/** Minimal structural view of the xterm buffer this module reads. */
+export interface TerminalBufferCell {
+  getChars(): string;
+  getWidth(): number;
+}
+
+export interface TerminalBufferLine {
+  isWrapped: boolean;
+  length: number;
+  getCell(column: number, cell?: TerminalBufferCell): TerminalBufferCell | undefined;
+}
+
+export interface TerminalBuffer {
+  /** 0-based line lookup, matching xterm's buffer.getLine. */
+  getLine(line: number): TerminalBufferLine | undefined;
+}
+
+/**
+ * Resolve the logical line that contains the given 1-based row and read its
+ * cells into rows. xterm queries link providers per viewport row, so a path
+ * that wraps must be found whether the click lands on its first row or a
+ * wrapped continuation row. We walk up to the logical start, then down through
+ * every wrapped continuation, so each row of the path returns the same rows.
+ */
+export function gatherLogicalLine(
+  buffer: TerminalBuffer,
+  lineNumber: number,
+): TerminalRow[] | null {
+  let startRow = lineNumber;
+  for (;;) {
+    const line = buffer.getLine(startRow - 1);
+    if (!line) {
+      return null;
+    }
+    if (!line.isWrapped || startRow <= 1) {
+      break;
+    }
+    startRow -= 1;
+  }
+
+  const rows: TerminalRow[] = [];
+  let y = startRow;
+  let line: TerminalBufferLine | undefined = buffer.getLine(startRow - 1);
+  while (line) {
+    const cells: TerminalCell[] = [];
+    // Reuse one cell object across columns; xterm fills it in place to avoid
+    // allocating per cell. We copy out chars/width immediately, so the reuse
+    // never aliases pushed entries.
+    let cell: TerminalBufferCell | undefined;
+    for (let col = 0; col < line.length; col += 1) {
+      cell = line.getCell(col, cell);
+      cells.push({
+        chars: cell?.getChars() ?? "",
+        width: cell?.getWidth() ?? 1,
+      });
+    }
+    rows.push({ y, cells });
+    const next = buffer.getLine(y);
+    if (!next || !next.isWrapped) {
+      break;
+    }
+    line = next;
+    y += 1;
+  }
+
+  return rows;
+}

--- a/src/modules/terminal/lib/createTerminal.ts
+++ b/src/modules/terminal/lib/createTerminal.ts
@@ -5,6 +5,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { buildTerminalFontFamily } from "@/modules/fonts/lib/fontChain";
 import { isWebUrl } from "@/lib/url";
+import { IS_MAC, matchesOpenModifier } from "@/lib/platform";
 import { hideLinkTooltip, showLinkTooltip } from "./linkTooltip";
 import "@xterm/xterm/css/xterm.css";
 
@@ -52,7 +53,7 @@ export function createTerminal(options: CreateTerminalOptions = {}): TerminalHan
   term.loadAddon(
     new WebLinksAddon(
       (event, uri) => {
-        if ((event.metaKey || event.ctrlKey || event.altKey) && isWebUrl(uri)) {
+        if (matchesOpenModifier(event, IS_MAC) && isWebUrl(uri)) {
           void openUrl(uri);
         }
       },

--- a/src/modules/terminal/lib/fileLinks.test.ts
+++ b/src/modules/terminal/lib/fileLinks.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { findFilePaths, resolveFilePath } from "./fileLinks";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { findFilePaths, resolveFilePath, buildFileLink } from "./fileLinks";
+import { showLinkTooltip, hideLinkTooltip } from "./linkTooltip";
+
+vi.mock("./linkTooltip", () => ({
+  showLinkTooltip: vi.fn(),
+  hideLinkTooltip: vi.fn(),
+}));
 
 describe("findFilePaths", () => {
   it("finds a relative path with a line number", () => {
@@ -76,5 +82,39 @@ describe("resolveFilePath", () => {
 
   it("expands a leading ~ when home is known", () => {
     expect(resolveFilePath("~/notes/a.md", null, "/Users/me")).toBe("/Users/me/notes/a.md");
+  });
+});
+
+const range = { start: { x: 1, y: 1 }, end: { x: 5, y: 1 } };
+const mouse = (m: Partial<MouseEvent>) =>
+  ({ altKey: false, metaKey: false, ctrlKey: false, clientX: 10, clientY: 20, ...m }) as MouseEvent;
+
+describe("buildFileLink", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("hover shows the tooltip with the hint and cursor position", () => {
+    const link = buildFileLink({ text: "a.ts", range, hint: "Alt / Cmd", isMac: true, onOpen: vi.fn() });
+    link.hover?.(mouse({ clientX: 30, clientY: 40 }), "a.ts");
+    expect(showLinkTooltip).toHaveBeenCalledWith("Alt / Cmd", 30, 40);
+  });
+
+  it("leave hides the tooltip", () => {
+    const link = buildFileLink({ text: "a.ts", range, hint: "Alt / Cmd", isMac: true, onOpen: vi.fn() });
+    link.leave?.(mouse({}), "a.ts");
+    expect(hideLinkTooltip).toHaveBeenCalled();
+  });
+
+  it("activate with the platform modifier opens the file", () => {
+    const onOpen = vi.fn();
+    const link = buildFileLink({ text: "a.ts", range, hint: "Alt / Cmd", isMac: true, onOpen });
+    link.activate(mouse({ metaKey: true }), "a.ts");
+    expect(onOpen).toHaveBeenCalledWith("a.ts");
+  });
+
+  it("activate without a modifier does not open", () => {
+    const onOpen = vi.fn();
+    const link = buildFileLink({ text: "a.ts", range, hint: "Alt / Cmd", isMac: true, onOpen });
+    link.activate(mouse({}), "a.ts");
+    expect(onOpen).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/terminal/lib/fileLinks.ts
+++ b/src/modules/terminal/lib/fileLinks.ts
@@ -5,6 +5,10 @@
  * out false positives like bare domains.
  */
 
+import type { ILink, IBufferRange } from "@xterm/xterm";
+import { hideLinkTooltip, showLinkTooltip } from "./linkTooltip";
+import { matchesOpenModifier } from "@/lib/platform";
+
 export interface FilePathMatch {
   /** The raw matched text, including any :line(:col) suffix. */
   text: string;
@@ -71,4 +75,41 @@ export function resolveFilePath(
   const base = (cwd ?? "").replace(/\/$/, "");
   const rel = path.replace(/^\.\//, "");
   return base ? `${base}/${rel}` : rel;
+}
+
+interface BuildFileLinkParams {
+  text: string;
+  range: IBufferRange;
+  hint: string;
+  isMac: boolean;
+  onOpen: (text: string) => void;
+}
+
+/**
+ * Build an xterm ILink for a detected file path. activate honours the
+ * platform open-modifier; hover/leave drive the shared link tooltip so file
+ * links get the same hover hint as web links.
+ */
+export function buildFileLink({
+  text,
+  range,
+  hint,
+  isMac,
+  onOpen,
+}: BuildFileLinkParams): ILink {
+  return {
+    range,
+    text,
+    activate: (event: MouseEvent) => {
+      if (matchesOpenModifier(event, isMac)) {
+        onOpen(text);
+      }
+    },
+    hover: (event: MouseEvent) => {
+      showLinkTooltip(hint, event.clientX, event.clientY);
+    },
+    leave: () => {
+      hideLinkTooltip();
+    },
+  };
 }


### PR DESCRIPTION
## Summary

Terminal file-path links now get a cross-platform hover tooltip and a consistent open-modifier gesture, and paths that wrap across two terminal rows are clickable on either row. Platform detection and the open-link modifier logic are consolidated into a single shared module so file links, web links, and the keyboard hint all agree.

Built task-by-task with a test-first (RED → GREEN) flow and per-task review; a final whole-branch review passed with no Critical or Important findings.

## What changed

**New shared platform module** (`src/lib/platform.ts`)
- `IS_MAC`, `matchesOpenModifier(event, isMac?)`, `openModifierLabel(isMac?)`
- Modifier semantics: Mac opens on Alt or Cmd, non-Mac on Alt or Ctrl
- Tooltip label: `Alt / Cmd` on Mac, `Alt / Ctrl` elsewhere

**Wrapped-path fix** (`gatherLogicalLine` in `cellPositions.ts`)
- Resolves the full logical line for a wrapped path regardless of which wrapped row the link provider is queried for, so the continuation row stays clickable

**File-link builder** (`buildFileLink` in `fileLinks.ts`)
- Builds an xterm `ILink` whose `activate` honours the platform modifier and whose `hover`/`leave` drive the shared link tooltip, matching web-link behaviour

**Integration** (`TerminalView.tsx`, `createTerminal.ts`, i18n)
- Web-link activate guard now routes through `matchesOpenModifier`
- File-link provider rewritten to use `gatherLogicalLine` + `buildFileLink`
- `openLinkHint` is now `{{mods}}`-interpolated in `en` and `zh-Hant`, fed by `openModifierLabel(IS_MAC)`

**De-duplication**
- `LauncherPanel.tsx`, `ShortcutsSettingsSection.tsx`, and `TerminalView.tsx` now import `IS_MAC` from the shared module instead of each redefining it

## Test plan

Automated (passing):
- [x] `pnpm typecheck` clean
- [x] `pnpm test` green (55 files, 415 tests)
- [x] New unit tests: `platform.test.ts`, `gatherLogicalLine` cases in `cellPositions.test.ts`, `buildFileLink` cases in `fileLinks.test.ts`

Manual smoke test (needs the Tauri GUI, not yet verified):
- [ ] Hover a file path in terminal output shows the tooltip with the interpolated modifier label (not a literal `{{mods}}`)
- [ ] Cmd-click (Mac) opens the file in a split in the same tab
- [ ] Print a path long enough to wrap two rows, then Cmd-click the part on the second row: it opens
- [ ] A web URL still opens in the browser on Cmd-click and still shows its hover tooltip
