### PR TITLE
perf: render the terminal with the WebGL (GPU) renderer

### DIFF
--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -2,7 +2,7 @@ import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
-import { createTerminal, type TerminalHandle } from "./lib/createTerminal";
+import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/createTerminal";
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import {
   deleteTerminalHistory,
@@ -137,6 +137,10 @@ export function TerminalView({
     handleRef.current = handle;
     const { term, fit } = handle;
     term.open(container);
+    // Opt into GPU rendering now that the canvas is mounted. Falls back to the
+    // DOM renderer on its own if WebGL is unavailable; term.dispose() (cleanup
+    // below) tears the addon down with the terminal.
+    enableWebglRenderer(term);
 
     // The session-status hook (see claude_status_hook) emits OSC 6973 on this
     // pane's tty when Claude changes state. Capture it here, where we know the

--- a/src/modules/terminal/lib/createTerminal.test.ts
+++ b/src/modules/terminal/lib/createTerminal.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createTerminal, enableWebglRenderer } from "./createTerminal";
+
+describe("enableWebglRenderer", () => {
+  const containers: HTMLDivElement[] = [];
+
+  afterEach(() => {
+    for (const el of containers) el.remove();
+    containers.length = 0;
+  });
+
+  function openTerminal() {
+    const { term } = createTerminal();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+    term.open(container);
+    return term;
+  }
+
+  it("falls back without throwing when the environment has no WebGL context", () => {
+    const term = openTerminal();
+
+    // jsdom provides no real WebGL2 context, so the GPU renderer cannot start.
+    // The terminal must stay usable rather than crash the whole pane.
+    expect(() => enableWebglRenderer(term)).not.toThrow();
+    expect(enableWebglRenderer(term)).toBeNull();
+    expect(() => term.write("hello")).not.toThrow();
+
+    term.dispose();
+  });
+});

--- a/src/modules/terminal/lib/createTerminal.ts
+++ b/src/modules/terminal/lib/createTerminal.ts
@@ -2,6 +2,7 @@ import { Terminal, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { WebglAddon } from "@xterm/addon-webgl";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { buildTerminalFontFamily } from "@/modules/fonts/lib/fontChain";
 import { isWebUrl } from "@/lib/url";
@@ -75,4 +76,27 @@ export function createTerminal(options: CreateTerminalOptions = {}): TerminalHan
   term.unicode.activeVersion = "11";
 
   return { term, fit };
+}
+
+/**
+ * Switch the terminal to the WebGL (GPU-accelerated) renderer. Must run after
+ * `term.open()`, because the addon needs the terminal's mounted canvas.
+ *
+ * WebGL can be unavailable or fail mid-session: no GPU / headless environment,
+ * a blocked context, or the OS reclaiming the context on sleep/wake. In every
+ * failure case we drop back to xterm's default DOM renderer so the terminal
+ * keeps working rather than going blank. Returns the addon while it is active
+ * (so the caller may dispose it), or `null` when we fell back to DOM.
+ */
+export function enableWebglRenderer(term: Terminal): WebglAddon | null {
+  try {
+    const addon = new WebglAddon();
+    // A lost GPU context leaves a blank canvas; dispose the addon so xterm
+    // reattaches its DOM renderer.
+    addon.onContextLoss(() => addon.dispose());
+    term.loadAddon(addon);
+    return addon;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

Wire up the WebGL (GPU-accelerated) renderer for the terminal. `@xterm/addon-webgl` was already a dependency but nothing imported it, so the terminal rendered through xterm's default DOM renderer.

- Add `enableWebglRenderer(term)` in `createTerminal.ts`: loads the WebGL addon, falls back to the DOM renderer on any activation failure (no GPU / headless / blocked context), and disposes the addon on GPU context loss (sleep/wake, driver reset) so xterm reattaches its DOM renderer.
- Call it from `TerminalView` right after `term.open()`, since the addon needs the mounted canvas. Teardown is covered by the existing `term.dispose()`.

## Test plan

- [x] `enableWebglRenderer` leaves the terminal usable (no throw, returns `null`) when WebGL is unavailable, verified against jsdom's null WebGL context with the real addon
- [x] `pnpm test` full suite green (492)
- [x] `tsc --noEmit` clean
- [x] Manual: `document.querySelector('.xterm-screen canvas')` is present in the running app (`true`), confirming the WebGL renderer is active (the DOM renderer uses no canvas)