### PR TITLE
feat: dismiss settings modal with Esc/backdrop and reorder terminal preview

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -28,10 +28,9 @@ describe("SettingsModal", () => {
   });
 
   it("closes when the backdrop behind the panel is clicked", () => {
-    const { container } = render(<SettingsModal />);
+    render(<SettingsModal />);
 
-    // The outermost element is the dimmed backdrop.
-    fireEvent.click(container.firstChild as HTMLElement);
+    fireEvent.click(screen.getByTestId("settings-modal-backdrop"));
 
     expect(useUiStore.getState().settingsOpen).toBe(false);
   });

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@/i18n";
+import { SettingsModal } from "./SettingsModal";
+import { useUiStore } from "@/stores/uiStore";
+
+// The settings body is a separate concern (and pulls in the whole settings UI);
+// stub it so this test stays focused on the modal chrome's close behavior.
+vi.mock("@/modules/settings/SettingsView", () => ({
+  SettingsView: () => <div data-testid="settings-body">settings</div>,
+}));
+
+describe("SettingsModal", () => {
+  beforeEach(() => {
+    useUiStore.setState({ settingsOpen: true });
+  });
+
+  afterEach(() => {
+    useUiStore.setState({ settingsOpen: false });
+  });
+
+  it("closes when Escape is pressed", () => {
+    render(<SettingsModal />);
+
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    expect(useUiStore.getState().settingsOpen).toBe(false);
+  });
+
+  it("closes when the backdrop behind the panel is clicked", () => {
+    const { container } = render(<SettingsModal />);
+
+    // The outermost element is the dimmed backdrop.
+    fireEvent.click(container.firstChild as HTMLElement);
+
+    expect(useUiStore.getState().settingsOpen).toBe(false);
+  });
+
+  it("stays open when a click lands inside the panel", () => {
+    render(<SettingsModal />);
+
+    fireEvent.click(screen.getByTestId("settings-body"));
+
+    expect(useUiStore.getState().settingsOpen).toBe(true);
+  });
+});

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -9,17 +9,17 @@ export function SettingsModal() {
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
   const close = () => setSettingsOpen(false);
 
-  // Esc closes the modal, matching the other dialogs in the app.
+  // Esc closes the modal, matching the other dialogs in the app. The Zustand
+  // setter is a stable reference, so the listener binds once.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        close();
+        setSettingsOpen(false);
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [setSettingsOpen]);
 
   return (
     <div
@@ -31,6 +31,7 @@ export function SettingsModal() {
           close();
         }
       }}
+      data-testid="settings-modal-backdrop"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"
     >
       <div className="relative flex h-[80vh] w-full max-w-4xl overflow-hidden rounded-xl border border-border-strong bg-bg shadow-2xl">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { X } from "lucide-react";
 import { SettingsView } from "@/modules/settings/SettingsView";
@@ -6,13 +7,37 @@ import { useUiStore } from "@/stores/uiStore";
 export function SettingsModal() {
   const { t } = useTranslation();
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
+  const close = () => setSettingsOpen(false);
+
+  // Esc closes the modal, matching the other dialogs in the app.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        close();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6">
+    <div
+      // Clicking the dimmed area beside the panel dismisses it; clicks that
+      // originate inside the panel bubble up here with a different target, so
+      // guard on currentTarget to leave those alone.
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          close();
+        }
+      }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"
+    >
       <div className="relative flex h-[80vh] w-full max-w-4xl overflow-hidden rounded-xl border border-border-strong bg-bg shadow-2xl">
         <button
           type="button"
           aria-label={t("actions.cancel")}
-          onClick={() => setSettingsOpen(false)}
+          onClick={close}
           className="absolute right-3 top-3 z-10 rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
         >
           <X size={18} />

--- a/src/modules/settings/TerminalSettingsSection.tsx
+++ b/src/modules/settings/TerminalSettingsSection.tsx
@@ -41,6 +41,23 @@ export function TerminalSettingsSection() {
         />
       </div>
 
+      {/* Live preview: an inner box inset by the chosen padding, in terminal
+          colours. Sits right under the slider it previews. */}
+      <div className="mb-6">
+        <div className="mb-2 text-xs text-fg-subtle">{t("terminalSettings.preview")}</div>
+        <div
+          className="overflow-hidden rounded-lg border border-border"
+          style={{ backgroundColor: terminal.background, padding: terminalPadding }}
+        >
+          <pre
+            className="m-0 font-mono text-xs leading-relaxed"
+            style={{ color: terminal.foreground }}
+          >
+            {t("terminalSettings.previewText")}
+          </pre>
+        </div>
+      </div>
+
       <div className="mb-6">
         <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg">
           <input
@@ -64,22 +81,6 @@ export function TerminalSettingsSection() {
         >
           {cleared ? t("terminalSettings.historyCleared") : t("terminalSettings.clearHistory")}
         </button>
-      </div>
-
-      {/* Live preview: an inner box inset by the chosen padding, in terminal colours */}
-      <div>
-        <div className="mb-2 text-xs text-fg-subtle">{t("terminalSettings.preview")}</div>
-        <div
-          className="overflow-hidden rounded-lg border border-border"
-          style={{ backgroundColor: terminal.background, padding: terminalPadding }}
-        >
-          <pre
-            className="m-0 font-mono text-xs leading-relaxed"
-            style={{ color: terminal.foreground }}
-          >
-            {t("terminalSettings.previewText")}
-          </pre>
-        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

Two small settings UX improvements:

- **Dismiss the settings modal with Esc or a backdrop click.** Previously only the X button closed it. Added an Esc keydown handler (matching the app's other dialogs) and a click handler on the dimmed backdrop, guarded on `currentTarget` so clicks inside the panel are left alone.
- **Move the terminal padding preview next to its slider.** The live preview previews the padding slider, so it now sits directly under the slider, above the unrelated "restore terminal history" toggle, instead of at the bottom of the section.

## Test plan

- [x] New `SettingsModal` tests: closes on Esc, closes on backdrop click, stays open on a click inside the panel
- [x] `pnpm test` full suite green (495)
- [x] `tsc --noEmit` clean
- [ ] Manual: open Settings, confirm Esc and clicking outside the panel both close it, and that the terminal preview renders above the restore-history toggle