### PR TITLE
fix: session status accuracy, gh detection, and workspace card branch/path display

### DIFF
--- a/src-tauri/src/modules/claude_status_hook/mod.rs
+++ b/src-tauri/src/modules/claude_status_hook/mod.rs
@@ -13,15 +13,20 @@ use crate::modules::claude_progress::config_base_dir;
 /// The hook script body, embedded so install can write it to disk.
 pub const HOOK_SCRIPT: &str = include_str!("status-hook.sh");
 
-/// (Claude Code hook event, status argument) pairs we install. Both
-/// `PermissionRequest` and `Notification` map to waiting-approval so whichever
-/// the installed Claude Code fires lights the badge.
+/// (Claude Code hook event, status argument) pairs we install. The argument is
+/// the state passed to the hook script, except `Notification` passes the
+/// sentinel `notification`: that event is a catch-all (permission prompt, idle
+/// prompt, auth, elicitation, …), so the script reads its `notification_type`
+/// off stdin and forwards it for the app to resolve. `PermissionRequest` is the
+/// precise approval signal; `PostToolUse` returns to active so the badge
+/// recovers right after a tool (e.g. one that needed approval) finishes.
 const EVENTS: &[(&str, &str)] = &[
     ("SessionStart", "idle"),
     ("UserPromptSubmit", "thinking"),
     ("PreToolUse", "active"),
+    ("PostToolUse", "active"),
     ("PermissionRequest", "waiting-approval"),
-    ("Notification", "waiting-approval"),
+    ("Notification", "notification"),
     ("Stop", "idle"),
     ("SessionEnd", "end"),
 ];
@@ -153,7 +158,12 @@ pub fn claude_status_hook_install(app: AppHandle) -> Result<(), String> {
             .map_err(|e| e.to_string())?;
     }
     let script_str = script_path.to_str().ok_or("script path is not valid UTF-8")?;
-    let merged = merge_hook_settings(read_settings(&settings_path)?, script_str);
+    // Remove our existing entries first, then merge fresh. This migrates installs
+    // from older versions whose command arguments differed (e.g. Notification
+    // used to pass "waiting-approval"); a plain merge would leave those stale
+    // entries behind alongside the new ones.
+    let cleaned = remove_hook_settings(read_settings(&settings_path)?, script_str);
+    let merged = merge_hook_settings(cleaned, script_str);
     write_settings(&settings_path, &merged)
 }
 
@@ -234,5 +244,44 @@ mod tests {
         let other = json!({ "hooks": { "PreToolUse": [{ "hooks": [{ "type": "command", "command": "user" }] }] } });
         let cleaned = remove_hook_settings(other.clone(), "/p/status-hook.sh");
         assert_eq!(cleaned, other);
+    }
+
+    #[test]
+    fn merge_installs_notification_and_posttooluse_entries() {
+        let merged = merge_hook_settings(json!({}), "/p/status-hook.sh");
+        // Notification forwards its type via the "notification" sentinel, not a
+        // hard-coded waiting-approval.
+        let notif = merged["hooks"]["Notification"].as_array().unwrap();
+        assert!(notif
+            .iter()
+            .any(|e| e["hooks"][0]["command"] == "/p/status-hook.sh notification"));
+        // PostToolUse returns to active.
+        let post = merged["hooks"]["PostToolUse"].as_array().unwrap();
+        assert!(post
+            .iter()
+            .any(|e| e["hooks"][0]["command"] == "/p/status-hook.sh active"));
+    }
+
+    #[test]
+    fn reinstall_migrates_stale_argument_entries() {
+        // An older install left Notification pointing at "waiting-approval".
+        // The install sequence (remove then merge) must replace it, not stack a
+        // second entry, so idle prompts stop lighting waiting-approval.
+        let stale = json!({
+            "hooks": {
+                "Notification": [
+                    { "hooks": [{ "type": "command", "command": "/p/status-hook.sh waiting-approval" }] }
+                ]
+            }
+        });
+        let migrated =
+            merge_hook_settings(remove_hook_settings(stale, "/p/status-hook.sh"), "/p/status-hook.sh");
+        let notif = migrated["hooks"]["Notification"].as_array().unwrap();
+        let commands: Vec<&str> = notif
+            .iter()
+            .filter_map(|e| e["hooks"][0]["command"].as_str())
+            .collect();
+        assert!(commands.contains(&"/p/status-hook.sh notification"));
+        assert!(!commands.contains(&"/p/status-hook.sh waiting-approval"));
     }
 }

--- a/src-tauri/src/modules/claude_status_hook/status-hook.sh
+++ b/src-tauri/src/modules/claude_status_hook/status-hook.sh
@@ -4,6 +4,21 @@
 # slave) and write an OSC status sequence there. tempo-term's xterm parses it.
 # Only acts inside tempo-term, where the shell carries TEMPOTERM=1.
 [ -n "$TEMPOTERM" ] || exit 0
+
+# Most events pass their state directly as $1 (active/thinking/idle/...). The
+# Notification event is a catch-all keyed by notification_type, so it passes
+# "notification" and we read that type off the JSON on stdin and forward it; the
+# app decides what it means (a permission prompt is waiting-approval, an idle
+# prompt is just idle). An unknown or missing type emits nothing.
+state=$1
+if [ "$state" = "notification" ]; then
+  ntype=$(sed -n 's/.*"notification_type"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  [ -n "$ntype" ] || exit 0
+  payload="tempoterm;notify;$ntype"
+else
+  payload="tempoterm;status;$state"
+fi
+
 p=$PPID
 tty=""
 for _ in 1 2 3 4 5 6 7 8; do
@@ -17,5 +32,5 @@ for _ in 1 2 3 4 5 6 7 8; do
   p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')
 done
 [ -n "$tty" ] || exit 0
-printf '\033]6973;tempoterm;status;%s\007' "$1" > "/dev/$tty" 2>/dev/null
+printf '\033]6973;%s\007' "$payload" > "/dev/$tty" 2>/dev/null
 exit 0

--- a/src-tauri/src/modules/claude_status_hook/status-hook.sh
+++ b/src-tauri/src/modules/claude_status_hook/status-hook.sh
@@ -12,7 +12,7 @@
 # prompt is just idle). An unknown or missing type emits nothing.
 state=$1
 if [ "$state" = "notification" ]; then
-  ntype=$(sed -n 's/.*"notification_type"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  ntype=$(sed -n 's/.*"notification_type"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
   [ -n "$ntype" ] || exit 0
   payload="tempoterm;notify;$ntype"
 else

--- a/src-tauri/src/modules/pr/mod.rs
+++ b/src-tauri/src/modules/pr/mod.rs
@@ -3,6 +3,7 @@
 //! OS keychain. Either may be unavailable; callers treat a None result as
 //! "nothing to show" and degrade gracefully.
 
+use std::path::PathBuf;
 use std::process::Command;
 
 use serde::Serialize;
@@ -101,10 +102,41 @@ fn remote_origin_url(cwd: &str) -> Option<String> {
     remote.url().map(str::to_string)
 }
 
-/// Whether the `gh` CLI is available on PATH.
+/// Directories to search for a CLI binary. A GUI launch (Finder/Dock) hands the
+/// app a minimal PATH that omits Homebrew and other user install dirs, so we
+/// append the usual locations. Pure so it can be tested without the real env.
+fn cli_search_dirs(path_env: Option<&str>, home: Option<&str>) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = match path_env {
+        Some(path) => std::env::split_paths(path).collect(),
+        None => Vec::new(),
+    };
+    for extra in ["/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin"] {
+        dirs.push(PathBuf::from(extra));
+    }
+    if let Some(home) = home {
+        dirs.push(PathBuf::from(home).join(".local").join("bin"));
+    }
+    dirs
+}
+
+/// Absolute path to the `gh` binary, searching PATH plus the common install
+/// dirs a GUI launch drops, or None when it isn't installed.
+fn find_gh() -> Option<PathBuf> {
+    let path_env = std::env::var("PATH").ok();
+    let home = std::env::var("HOME").ok();
+    cli_search_dirs(path_env.as_deref(), home.as_deref())
+        .into_iter()
+        .map(|dir| dir.join("gh"))
+        .find(|candidate| candidate.is_file())
+}
+
+/// Whether the `gh` CLI is available.
 #[tauri::command]
 pub fn gh_available() -> bool {
-    Command::new("gh")
+    let Some(gh) = find_gh() else {
+        return false;
+    };
+    Command::new(gh)
         .arg("--version")
         .output()
         .map(|o| o.status.success())
@@ -127,9 +159,12 @@ pub fn pr_via_gh(cwd: String, branch: Option<String>) -> Result<Option<PrInfo>, 
         args.push(&branch);
     }
     args.extend(["--json", "number,state,isDraft,url,title"]);
-    let output = match Command::new("gh").args(&args).current_dir(&cwd).output() {
+    // gh not installed: not an error, just nothing to show.
+    let Some(gh) = find_gh() else {
+        return Ok(None);
+    };
+    let output = match Command::new(gh).args(&args).current_dir(&cwd).output() {
         Ok(output) => output,
-        // gh not installed: not an error, just nothing to show.
         Err(_) => return Ok(None),
     };
     if !output.status.success() {
@@ -248,5 +283,24 @@ mod tests {
         assert_eq!(pr.number, 7);
         assert_eq!(pr.state, "merged");
         assert_eq!(pr.url, "https://github.com/o/r/pull/7");
+    }
+
+    #[test]
+    fn cli_search_dirs_adds_common_install_locations_to_a_minimal_path() {
+        // A GUI launch (Finder/Dock) hands the app a minimal PATH without
+        // Homebrew, so gh "isn't found" even when installed. The search must
+        // still cover the usual install dirs.
+        let dirs = cli_search_dirs(Some("/usr/bin:/bin"), Some("/Users/me"));
+        assert!(dirs.contains(&PathBuf::from("/usr/bin"))); // PATH entries kept
+        assert!(dirs.contains(&PathBuf::from("/opt/homebrew/bin"))); // Apple Silicon brew
+        assert!(dirs.contains(&PathBuf::from("/usr/local/bin"))); // Intel brew
+        assert!(dirs.contains(&PathBuf::from("/Users/me/.local/bin"))); // home bin
+    }
+
+    #[test]
+    fn cli_search_dirs_works_without_a_path_or_home() {
+        let dirs = cli_search_dirs(None, None);
+        assert!(dirs.contains(&PathBuf::from("/opt/homebrew/bin")));
+        assert!(!dirs.iter().any(|d| d.ends_with(".local/bin")));
     }
 }

--- a/src/modules/claude-progress/lib/sessionStatus.test.ts
+++ b/src/modules/claude-progress/lib/sessionStatus.test.ts
@@ -24,6 +24,28 @@ describe("parseStatusOsc", () => {
   it("ignores unknown states", () => {
     expect(parseStatusOsc("tempoterm;status;bogus")).toBeNull();
   });
+
+  it("maps a permission notification to waiting-approval", () => {
+    expect(parseStatusOsc("tempoterm;notify;permission_prompt")).toEqual({
+      kind: "status",
+      status: "waiting-approval",
+    });
+  });
+
+  it("maps an idle notification to idle, not waiting-approval", () => {
+    // The idle prompt means Claude is just waiting for the user's next message;
+    // it must not light the "waiting for approval" badge.
+    expect(parseStatusOsc("tempoterm;notify;idle_prompt")).toEqual({
+      kind: "status",
+      status: "idle",
+    });
+  });
+
+  it("ignores notification types that don't map to a session state", () => {
+    // e.g. auth_success / elicitation — these should never clobber the status.
+    expect(parseStatusOsc("tempoterm;notify;auth_success")).toBeNull();
+    expect(parseStatusOsc("tempoterm;notify;")).toBeNull();
+  });
 });
 
 describe("isClaudeForeground", () => {

--- a/src/modules/claude-progress/lib/sessionStatus.test.ts
+++ b/src/modules/claude-progress/lib/sessionStatus.test.ts
@@ -46,6 +46,13 @@ describe("parseStatusOsc", () => {
     expect(parseStatusOsc("tempoterm;notify;auth_success")).toBeNull();
     expect(parseStatusOsc("tempoterm;notify;")).toBeNull();
   });
+
+  it("ignores prototype keys that resolve to inherited Object members", () => {
+    // A stray OSC must not look up "toString"/"constructor" and return an
+    // inherited function as the status.
+    expect(parseStatusOsc("tempoterm;notify;toString")).toBeNull();
+    expect(parseStatusOsc("tempoterm;notify;constructor")).toBeNull();
+  });
 });
 
 describe("isClaudeForeground", () => {

--- a/src/modules/claude-progress/lib/sessionStatus.ts
+++ b/src/modules/claude-progress/lib/sessionStatus.ts
@@ -6,15 +6,37 @@ export const STATUS_OSC_CODE = 6973;
 const STATES: readonly SessionStatus[] = ["active", "thinking", "waiting-approval", "idle"];
 
 /**
- * Parse a `tempoterm;status;<state>` OSC payload emitted by the session-status
- * hook. Returns the parsed status, an end signal, or null for anything that
- * isn't ours or isn't a known state.
+ * Claude Code's `Notification` hook is a catch-all keyed by `notification_type`,
+ * so the hook forwards that type and we resolve it here. Only the types that map
+ * to a real session state are listed; anything else (auth_success, elicitation,
+ * …) is ignored so a stray notification never clobbers the live status. In
+ * particular `idle_prompt` is "waiting for the user's next message", which is
+ * idle, NOT waiting-for-approval.
+ */
+const NOTIFICATION_STATUS: Record<string, SessionStatus> = {
+  permission_prompt: "waiting-approval",
+  idle_prompt: "idle",
+};
+
+/**
+ * Parse an OSC payload emitted by the session-status hook. Two shapes:
+ * `tempoterm;status;<state>` for direct state events, and
+ * `tempoterm;notify;<notification_type>` for the Notification catch-all.
+ * Returns the parsed status, an end signal, or null for anything that isn't
+ * ours or doesn't map to a known state.
  */
 export function parseStatusOsc(
   payload: string,
 ): { kind: "status"; status: SessionStatus } | { kind: "end" } | null {
   const parts = payload.split(";");
-  if (parts[0] !== "tempoterm" || parts[1] !== "status") {
+  if (parts[0] !== "tempoterm") {
+    return null;
+  }
+  if (parts[1] === "notify") {
+    const status = NOTIFICATION_STATUS[parts[2]];
+    return status ? { kind: "status", status } : null;
+  }
+  if (parts[1] !== "status") {
     return null;
   }
   const value = parts[2];

--- a/src/modules/claude-progress/lib/sessionStatus.ts
+++ b/src/modules/claude-progress/lib/sessionStatus.ts
@@ -33,8 +33,13 @@ export function parseStatusOsc(
     return null;
   }
   if (parts[1] === "notify") {
+    // Validate the resolved value is a real state: bracket access on an
+    // attacker-controlled key could otherwise surface an inherited member
+    // (e.g. "toString" → Object.prototype.toString).
     const status = NOTIFICATION_STATUS[parts[2]];
-    return status ? { kind: "status", status } : null;
+    return status && (STATES as readonly string[]).includes(status)
+      ? { kind: "status", status }
+      : null;
   }
   if (parts[1] !== "status") {
     return null;

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -88,9 +88,9 @@ function BranchLine({
     return null;
   }
   return (
-    <span className="flex items-center gap-1 text-[11px] text-fg-subtle">
+    <span className="flex min-w-0 items-center gap-1 text-[11px] text-fg-subtle">
       <GitBranch size={11} className="shrink-0" />
-      {shownBranch && <span className="shrink-0 text-fg-muted">{shownBranch}</span>}
+      {shownBranch && <span className="min-w-0 truncate text-fg-muted">{shownBranch}</span>}
       {shownPath && <span className="min-w-0 truncate">{shownPath}</span>}
     </span>
   );

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -87,11 +87,21 @@ function BranchLine({
   if (!shownBranch && !shownPath) {
     return null;
   }
+  // Branch name and path each get their own line and wrap in full (no
+  // truncation) so a long repo or path is always readable. The path is indented
+  // to sit under the branch text, so it stays visually paired with its repo when
+  // a card lists more than one (e.g. a worktree's main repo plus the worktree).
   return (
-    <span className="flex min-w-0 items-center gap-1 text-[11px] text-fg-subtle">
-      <GitBranch size={11} className="shrink-0" />
-      {shownBranch && <span className="min-w-0 truncate text-fg-muted">{shownBranch}</span>}
-      {shownPath && <span className="min-w-0 truncate">{shownPath}</span>}
+    <span className="block text-[11px] leading-snug text-fg-subtle">
+      {shownBranch && (
+        <span className="flex items-start gap-1 text-fg-muted">
+          <GitBranch size={11} className="mt-[3px] shrink-0" />
+          <span className="min-w-0 break-all">{shownBranch}</span>
+        </span>
+      )}
+      {shownPath && (
+        <span className={`block break-all ${shownBranch ? "pl-[15px]" : ""}`}>{shownPath}</span>
+      )}
     </span>
   );
 }
@@ -112,12 +122,14 @@ function BranchBlock({
   }
   if (!info) {
     return showCwd && cwd ? (
-      <span className="block truncate text-[11px] text-fg-subtle">{cwd}</span>
+      <span className="block break-all text-[11px] leading-snug text-fg-subtle">{cwd}</span>
     ) : null;
   }
   if (info.isWorktree) {
+    // Extra space between the two repo groups so each branch stays visually
+    // paired with its own path.
     return (
-      <span className="block space-y-0.5">
+      <span className="block space-y-1.5">
         <BranchLine
           branch={info.mainBranch}
           path={info.mainPath}


### PR DESCRIPTION
Three workspace/session fixes surfaced while testing the workspace cards.

## 1. Session status: tell waiting-for-input apart from waiting-for-approval

Cards showed **等待批准 (waiting for approval)** for sessions that were simply idle.

Claude Code's `Notification` hook is a catch-all keyed by `notification_type` (`permission_prompt`, `idle_prompt`, `auth_success`, `elicitation_*`, …), but the hook hard-wired every `Notification` to `waiting-approval` and never read the payload. So the idle prompt lit the approval badge.

- `status-hook.sh`: for `Notification`, read `notification_type` off stdin and forward it (`tempoterm;notify;<type>`).
- `parseStatusOsc`: map `permission_prompt → waiting-approval`, `idle_prompt → idle`, ignore types with no session state.
- Hook install: keep the precise `PermissionRequest → waiting-approval`, add `PostToolUse → active` so the badge recovers after an approved tool, and remove-then-merge on install to migrate stale entries from older versions.

## 2. Workspace card: wrap long branch names and paths

A long branch name overflowed the card border. Branch and path now each wrap in full (branch first, path indented under it) instead of truncating, and worktree cards space the two repo groups apart so each branch stays paired with its path.

## 3. gh CLI detection: search common install dirs, not just PATH

A GUI launch (Finder/Dock) hands the app a minimal PATH without Homebrew, so gh detection and PR lookups reported "not found" even when gh was installed at `/opt/homebrew/bin`. We now search PATH plus the usual install dirs (`/opt/homebrew/bin`, `/usr/local/bin`, `/opt/local/bin`, `~/.local/bin`) and run the resolved absolute path.

## Test plan

- [x] `parseStatusOsc` notify mapping (permission/idle/ignored) — vitest
- [x] Rust: `Notification → notification` + `PostToolUse → active` installed; reinstall migrates a stale `waiting-approval` entry; `cli_search_dirs` adds Homebrew dirs to a minimal PATH
- [x] `pnpm test` + `cargo test` green, `tsc --noEmit` clean
- [x] Manual (local build): session status no longer stuck on 等待批准 when idle; gh shows "已偵測到 gh CLI" and PR status loads; long branch/path wrap cleanly within the card