### PR TITLE
feat: track Codex CLI session status and progress

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1571,7 +1571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3209,11 +3209,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
 ]
 
@@ -4703,6 +4702,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
+ "toml_edit 0.22.27",
  "trash",
 ]
 
@@ -4856,7 +4856,7 @@ checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "toml_edit 0.20.2",
 ]
 
@@ -4892,9 +4892,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
@@ -4924,7 +4924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
@@ -4937,8 +4937,20 @@ dependencies = [
  "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4961,6 +4973,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -6113,6 +6131,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,8 +494,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -4682,6 +4684,7 @@ dependencies = [
 name = "tempo-term"
 version = "0.0.6"
 dependencies = [
+ "chrono",
  "font-kit",
  "git2",
  "grep-matcher",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-process = "2"
 tauri-plugin-window-state = "2"
 trash = "5"
 notify = "6"
+toml_edit = "0.22"
 
 # keyring 3.x ships no credential store by default; each platform must opt into
 # its native backend or every keychain operation fails silently.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ tauri-plugin-window-state = "2"
 trash = "5"
 notify = "6"
 toml_edit = "0.22"
+chrono = "0.4"
 
 # keyring 3.x ships no credential store by default; each platform must opt into
 # its native backend or every keychain operation fails silently.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ use modules::claude_progress::{
     claude_progress_unwatch, claude_progress_watch, claude_session_title, ClaudeProgressState,
 };
 use modules::claude_status_hook::{claude_status_hook_install, claude_status_hook_uninstall};
+use modules::codex_status_hook::{codex_status_hook_install, codex_status_hook_uninstall};
 use modules::notes::{notes_unwatch, notes_watch, NotesWatchState};
 use modules::clipboard::{
     terminal_clipboard_image_paths, terminal_clipboard_paths, terminal_clipboard_text,
@@ -161,6 +162,8 @@ pub fn run() {
             claude_session_title,
             claude_status_hook_install,
             claude_status_hook_uninstall,
+            codex_status_hook_install,
+            codex_status_hook_uninstall,
             notes_watch,
             notes_unwatch
         ])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ use modules::ai::ai_chat;
 use modules::claude_progress::{
     claude_progress_unwatch, claude_progress_watch, claude_session_title, ClaudeProgressState,
 };
+use modules::codex_progress::CodexProgressState;
 use modules::claude_status_hook::{claude_status_hook_install, claude_status_hook_uninstall};
 use modules::codex_status_hook::{codex_status_hook_install, codex_status_hook_uninstall};
 use modules::notes::{notes_unwatch, notes_watch, NotesWatchState};
@@ -73,6 +74,7 @@ pub fn run() {
         )
         .manage(PtyState::new())
         .manage(ClaudeProgressState::new())
+        .manage(CodexProgressState::new())
         .manage(NotesWatchState::new())
         .setup(|app| {
             // window-state restores the last size/position, but it can persist a

--- a/src-tauri/src/modules/claude_progress/mod.rs
+++ b/src-tauri/src/modules/claude_progress/mod.rs
@@ -85,6 +85,7 @@ const PROGRESS_EVENT: &str = "claude-progress:lines";
 #[derive(Clone, serde::Serialize)]
 struct ProgressBatch {
     cwd: String,
+    agent: String,
     lines: Vec<String>,
     /// True for the first batch of a newly started session, telling the frontend
     /// to clear this cwd's accumulated progress before applying these lines.
@@ -291,6 +292,7 @@ fn build_watcher(app: &AppHandle, dir: &Path, cwd: String) -> Result<Recommended
                 PROGRESS_EVENT,
                 ProgressBatch {
                     cwd: cwd.clone(),
+                    agent: "claude".into(),
                     lines,
                     reset,
                 },
@@ -328,16 +330,21 @@ impl Default for ClaudeProgressState {
 /// Sync the set of watched project directories to exactly `cwds`: keep existing
 /// watchers, drop ones no longer present, and start watching new ones. Directories
 /// with no transcript yet are simply skipped (no watcher until a session exists).
+/// Also (re)points the Codex watcher at the same cwd set.
 #[tauri::command]
 pub fn claude_progress_watch(
     app: AppHandle,
     state: State<ClaudeProgressState>,
+    codex: State<crate::modules::codex_progress::CodexProgressState>,
     cwds: Vec<String>,
 ) -> Result<(), String> {
     let home = app.path().home_dir().map_err(|e| e.to_string())?;
     let env_value = std::env::var("CLAUDE_CONFIG_DIR").ok();
     let base = config_base_dir(&home, env_value.as_deref());
     let mut watchers = state.watchers.lock().unwrap();
+
+    // Drive the Codex watcher before the loop consumes `cwds`.
+    crate::modules::codex_progress::set_watched_cwds(&app, &codex, &cwds);
 
     watchers.retain(|cwd, _| cwds.contains(cwd));
 

--- a/src-tauri/src/modules/claude_progress/mod.rs
+++ b/src-tauri/src/modules/claude_progress/mod.rs
@@ -122,7 +122,7 @@ pub fn split_new_lines(contents: &str, from_offset: usize) -> (Vec<String>, usiz
 /// untouched. If the offset is past the end (the file shrank or was rewritten),
 /// or the tail isn't valid UTF-8 (the seek landed mid-character), we fall back to
 /// reading the whole file from the start, matching `split_new_lines`'s recovery.
-fn read_new_lines(path: &Path, from_offset: usize) -> Option<(Vec<String>, usize)> {
+pub(crate) fn read_new_lines(path: &Path, from_offset: usize) -> Option<(Vec<String>, usize)> {
     let len = match std::fs::metadata(path) {
         Ok(meta) => meta.len() as usize,
         // The tracked file is gone (deleted/rotated): signal so the caller can
@@ -167,7 +167,7 @@ fn read_from_start(path: &Path, from_offset: usize) -> (Vec<String>, usize) {
 /// Byte length of a file, or 0 if it cannot be read. Used to start tailing at the
 /// end of an existing transcript so old history is never replayed. Reads only the
 /// metadata, never the file contents.
-fn byte_len(path: &Path) -> usize {
+pub(crate) fn byte_len(path: &Path) -> usize {
     std::fs::metadata(path).map_or(0, |meta| meta.len() as usize)
 }
 

--- a/src-tauri/src/modules/claude_status_hook/mod.rs
+++ b/src-tauri/src/modules/claude_status_hook/mod.rs
@@ -37,7 +37,7 @@ fn our_command(script_path: &str, state: &str) -> String {
 
 /// Add our hook entry to each event without disturbing the user's own hooks.
 /// Idempotent: re-running never duplicates our entries.
-pub fn merge_hook_settings(mut existing: Value, script_path: &str) -> Value {
+pub fn merge_hook_settings(mut existing: Value, script_path: &str, events: &[(&str, &str)]) -> Value {
     if !existing.is_object() {
         existing = json!({});
     }
@@ -47,7 +47,7 @@ pub fn merge_hook_settings(mut existing: Value, script_path: &str) -> Value {
         *hooks = json!({});
     }
     let hooks = hooks.as_object_mut().unwrap();
-    for (event, state) in EVENTS {
+    for (event, state) in events {
         let cmd = our_command(script_path, state);
         let arr = hooks.entry(*event).or_insert_with(|| json!([]));
         if !arr.is_array() {
@@ -68,11 +68,11 @@ pub fn merge_hook_settings(mut existing: Value, script_path: &str) -> Value {
 
 /// Remove only the entries whose command points at our script, then drop any
 /// event array we left empty. The user's other hooks are untouched.
-pub fn remove_hook_settings(mut existing: Value, script_path: &str) -> Value {
+pub fn remove_hook_settings(mut existing: Value, script_path: &str, events: &[(&str, &str)]) -> Value {
     let Some(hooks) = existing.get_mut("hooks").and_then(Value::as_object_mut) else {
         return existing;
     };
-    for (event, _) in EVENTS {
+    for (event, _) in events {
         if let Some(arr) = hooks.get_mut(*event).and_then(Value::as_array_mut) {
             arr.retain(|e| {
                 e["hooks"].as_array().is_none_or(|hs| {
@@ -162,8 +162,8 @@ pub fn claude_status_hook_install(app: AppHandle) -> Result<(), String> {
     // from older versions whose command arguments differed (e.g. Notification
     // used to pass "waiting-approval"); a plain merge would leave those stale
     // entries behind alongside the new ones.
-    let cleaned = remove_hook_settings(read_settings(&settings_path)?, script_str);
-    let merged = merge_hook_settings(cleaned, script_str);
+    let cleaned = remove_hook_settings(read_settings(&settings_path)?, script_str, EVENTS);
+    let merged = merge_hook_settings(cleaned, script_str, EVENTS);
     write_settings(&settings_path, &merged)
 }
 
@@ -175,7 +175,7 @@ pub fn claude_status_hook_uninstall(app: AppHandle) -> Result<(), String> {
     // Only rewrite settings.json if it already exists, so uninstalling never
     // creates an empty `{}` file for a user who has no settings.
     if settings_path.exists() {
-        let cleaned = remove_hook_settings(read_settings(&settings_path)?, script_str);
+        let cleaned = remove_hook_settings(read_settings(&settings_path)?, script_str, EVENTS);
         write_settings(&settings_path, &cleaned)?;
     }
     let _ = std::fs::remove_file(&script_path);
@@ -194,7 +194,7 @@ mod tests {
         let existing = json!({
             "hooks": { "PreToolUse": [{ "hooks": [{ "type": "command", "command": "user-thing" }] }] }
         });
-        let merged = merge_hook_settings(existing, "/p/status-hook.sh");
+        let merged = merge_hook_settings(existing, "/p/status-hook.sh", EVENTS);
         let pre = merged["hooks"]["PreToolUse"].as_array().unwrap();
         assert!(pre.iter().any(|e| e["hooks"][0]["command"] == "user-thing"));
         assert!(pre
@@ -212,8 +212,9 @@ mod tests {
                 "hooks": { "PreToolUse": [{ "hooks": [{ "type": "command", "command": "user-thing" }] }] }
             }),
             "/p/status-hook.sh",
+            EVENTS,
         );
-        let cleaned = remove_hook_settings(merged, "/p/status-hook.sh");
+        let cleaned = remove_hook_settings(merged, "/p/status-hook.sh", EVENTS);
         let pre = cleaned["hooks"]["PreToolUse"].as_array().unwrap();
         assert!(pre.iter().any(|e| e["hooks"][0]["command"] == "user-thing"));
         assert!(!pre.iter().any(|e| e["hooks"][0]["command"]
@@ -225,8 +226,8 @@ mod tests {
 
     #[test]
     fn merge_is_idempotent() {
-        let once = merge_hook_settings(json!({}), "/p/status-hook.sh");
-        let twice = merge_hook_settings(once.clone(), "/p/status-hook.sh");
+        let once = merge_hook_settings(json!({}), "/p/status-hook.sh", EVENTS);
+        let twice = merge_hook_settings(once.clone(), "/p/status-hook.sh", EVENTS);
         assert_eq!(once, twice);
     }
 
@@ -234,21 +235,21 @@ mod tests {
     fn remove_drops_the_hooks_key_when_it_becomes_empty() {
         // Settings whose only hooks are ours: after removal nothing is left, so
         // the whole "hooks" key should be gone rather than left as "hooks": {}.
-        let merged = merge_hook_settings(json!({}), "/p/status-hook.sh");
-        let cleaned = remove_hook_settings(merged, "/p/status-hook.sh");
+        let merged = merge_hook_settings(json!({}), "/p/status-hook.sh", EVENTS);
+        let cleaned = remove_hook_settings(merged, "/p/status-hook.sh", EVENTS);
         assert!(cleaned.get("hooks").is_none());
     }
 
     #[test]
     fn remove_on_settings_without_our_hooks_is_safe() {
         let other = json!({ "hooks": { "PreToolUse": [{ "hooks": [{ "type": "command", "command": "user" }] }] } });
-        let cleaned = remove_hook_settings(other.clone(), "/p/status-hook.sh");
+        let cleaned = remove_hook_settings(other.clone(), "/p/status-hook.sh", EVENTS);
         assert_eq!(cleaned, other);
     }
 
     #[test]
     fn merge_installs_notification_and_posttooluse_entries() {
-        let merged = merge_hook_settings(json!({}), "/p/status-hook.sh");
+        let merged = merge_hook_settings(json!({}), "/p/status-hook.sh", EVENTS);
         // Notification forwards its type via the "notification" sentinel, not a
         // hard-coded waiting-approval.
         let notif = merged["hooks"]["Notification"].as_array().unwrap();
@@ -275,7 +276,7 @@ mod tests {
             }
         });
         let migrated =
-            merge_hook_settings(remove_hook_settings(stale, "/p/status-hook.sh"), "/p/status-hook.sh");
+            merge_hook_settings(remove_hook_settings(stale, "/p/status-hook.sh", EVENTS), "/p/status-hook.sh", EVENTS);
         let notif = migrated["hooks"]["Notification"].as_array().unwrap();
         let commands: Vec<&str> = notif
             .iter()

--- a/src-tauri/src/modules/codex_progress/mod.rs
+++ b/src-tauri/src/modules/codex_progress/mod.rs
@@ -4,6 +4,25 @@
 //! cwd is read from each file's first `session_meta` line.
 
 use serde_json::Value;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+/// A discovered Codex rollout file: its path, last-modified time, and the cwd
+/// read from its session_meta line.
+pub struct RolloutCandidate {
+    pub path: PathBuf,
+    pub modified: SystemTime,
+    pub cwd: String,
+}
+
+/// The newest candidate whose cwd equals `target_cwd`, or None.
+pub fn select_newest_for_cwd(candidates: &[RolloutCandidate], target_cwd: &str) -> Option<PathBuf> {
+    candidates
+        .iter()
+        .filter(|c| c.cwd == target_cwd)
+        .max_by_key(|c| c.modified)
+        .map(|c| c.path.clone())
+}
 
 /// The cwd recorded in a Codex rollout's first line. Returns None when the line
 /// is not a `session_meta` record or has no cwd.
@@ -22,6 +41,8 @@ pub fn parse_session_meta_cwd(first_line: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+    use std::time::{Duration, SystemTime};
 
     #[test]
     fn reads_cwd_from_a_session_meta_line() {
@@ -34,5 +55,17 @@ mod tests {
         assert_eq!(parse_session_meta_cwd(r#"{"type":"event_msg","payload":{}}"#), None);
         assert_eq!(parse_session_meta_cwd("not json"), None);
         assert_eq!(parse_session_meta_cwd(r#"{"type":"session_meta","payload":{}}"#), None);
+    }
+
+    #[test]
+    fn picks_the_newest_candidate_whose_cwd_matches() {
+        let base = SystemTime::UNIX_EPOCH;
+        let candidates = vec![
+            RolloutCandidate { path: PathBuf::from("/a/old.jsonl"), modified: base, cwd: "/proj".into() },
+            RolloutCandidate { path: PathBuf::from("/a/new.jsonl"), modified: base + Duration::from_secs(10), cwd: "/proj".into() },
+            RolloutCandidate { path: PathBuf::from("/a/other.jsonl"), modified: base + Duration::from_secs(20), cwd: "/elsewhere".into() },
+        ];
+        assert_eq!(select_newest_for_cwd(&candidates, "/proj"), Some(PathBuf::from("/a/new.jsonl")));
+        assert_eq!(select_newest_for_cwd(&candidates, "/missing"), None);
     }
 }

--- a/src-tauri/src/modules/codex_progress/mod.rs
+++ b/src-tauri/src/modules/codex_progress/mod.rs
@@ -4,7 +4,9 @@
 //! cwd is read from each file's first `session_meta` line.
 
 use serde_json::Value;
-use std::path::PathBuf;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 /// A discovered Codex rollout file: its path, last-modified time, and the cwd
@@ -38,11 +40,83 @@ pub fn parse_session_meta_cwd(first_line: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+/// `~/.codex/sessions` (or under the CODEX_HOME override).
+pub fn codex_sessions_base(home: &Path) -> PathBuf {
+    match std::env::var("CODEX_HOME") {
+        Ok(v) if !v.trim().is_empty() => {
+            let p = Path::new(&v);
+            p.strip_prefix("~").map(|r| home.join(r)).unwrap_or_else(|_| p.to_path_buf()).join("sessions")
+        }
+        _ => home.join(".codex").join("sessions"),
+    }
+}
+
+/// Read just the first line of a file (the session_meta), cheaply.
+fn first_line(path: &Path) -> Option<String> {
+    let file = File::open(path).ok()?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    reader.read_line(&mut line).ok()?;
+    Some(line)
+}
+
+/// Collect rollout candidates from the given (year, month, day) directories only.
+pub fn scan_recent_rollouts(base: &Path, days: &[(i32, u32, u32)]) -> Vec<RolloutCandidate> {
+    let mut out = Vec::new();
+    for (y, m, d) in days {
+        let dir = base.join(format!("{y:04}")).join(format!("{m:02}")).join(format!("{d:02}"));
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let modified = match entry.metadata().and_then(|m| m.modified()) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            if let Some(cwd) = first_line(&path).as_deref().and_then(parse_session_meta_cwd) {
+                out.push(RolloutCandidate { path, modified, cwd });
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
     use std::time::{Duration, SystemTime};
+
+    fn write_rollout(dir: &PathBuf, name: &str, cwd: &str) -> PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        let path = dir.join(name);
+        let line = format!(r#"{{"type":"session_meta","payload":{{"cwd":"{cwd}"}}}}"#);
+        std::fs::write(&path, line + "\n").unwrap();
+        path
+    }
+
+    #[test]
+    fn scans_only_the_given_day_dirs_and_reads_each_cwd() {
+        let base = std::env::temp_dir().join(format!("tempoterm-codex-scan-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let day = base.join("2026").join("06").join("22");
+        write_rollout(&day, "rollout-a.jsonl", "/proj/x");
+        // A file in a day we do not scan must be ignored.
+        let other = base.join("2026").join("06").join("01");
+        write_rollout(&other, "rollout-b.jsonl", "/proj/y");
+
+        let found = scan_recent_rollouts(&base, &[(2026, 6, 22)]);
+        let cwds: Vec<&str> = found.iter().map(|c| c.cwd.as_str()).collect();
+        assert!(cwds.contains(&"/proj/x"));
+        assert!(!cwds.contains(&"/proj/y"));
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
 
     #[test]
     fn reads_cwd_from_a_session_meta_line() {

--- a/src-tauri/src/modules/codex_progress/mod.rs
+++ b/src-tauri/src/modules/codex_progress/mod.rs
@@ -181,10 +181,9 @@ pub fn set_watched_cwds(app: &AppHandle, state: &CodexProgressState, cwds: &[Str
     let base_cb = base.clone();
     let route_cb = Arc::clone(&state.route);
     let watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
-        if res.is_err() {
-            return;
+        if let Ok(event) = res {
+            route_event(&app_cb, &base_cb, &route_cb, Some(event));
         }
-        route_event(&app_cb, &base_cb, &route_cb);
     });
     if let Ok(mut w) = watcher {
         if w.watch(&base, RecursiveMode::Recursive).is_ok() {
@@ -193,15 +192,36 @@ pub fn set_watched_cwds(app: &AppHandle, state: &CodexProgressState, cwds: &[Str
     }
 }
 
-/// On any change under the sessions base: for each watched cwd, find its newest
-/// current rollout, switch (reset) if it changed, then tail appended lines and
-/// emit them tagged with agent "codex".
-fn route_event(app: &AppHandle, base: &Path, route: &Arc<Mutex<RouteState>>) {
-    let candidates = scan_recent_rollouts(base, &recent_days());
+/// On a change under the sessions base: for each watched cwd, find its current
+/// rollout, switch (reset) if it changed, then tail appended lines and emit them
+/// tagged with agent "codex".
+///
+/// Scanning the sessions tree (one first-line read per rollout) is only needed
+/// when a new file might have appeared: a Create / rename, or a cwd that has no
+/// tracked file yet. Plain appends (`Modify(Data)`) just tail the already-tracked
+/// file, mirroring how the Claude watcher avoids rescanning on every write.
+fn route_event(app: &AppHandle, base: &Path, route: &Arc<Mutex<RouteState>>, event: Option<notify::Event>) {
     let mut route = route.lock().unwrap();
     let watched = route.watched.clone();
+    let needs_scan = event.as_ref().map_or(true, |e| {
+        matches!(
+            e.kind,
+            notify::EventKind::Create(_) | notify::EventKind::Modify(notify::event::ModifyKind::Name(_))
+        )
+    }) || watched
+        .iter()
+        .any(|cwd| route.cursors.get(cwd).and_then(|c| c.current.as_ref()).is_none());
+    let candidates = if needs_scan {
+        scan_recent_rollouts(base, &recent_days())
+    } else {
+        Vec::new()
+    };
     for cwd in watched {
-        let newest = select_newest_for_cwd(&candidates, &cwd);
+        let newest = if needs_scan {
+            select_newest_for_cwd(&candidates, &cwd)
+        } else {
+            route.cursors.get(&cwd).and_then(|c| c.current.clone())
+        };
         let cursor = route.cursors.entry(cwd.clone()).or_insert_with(|| CwdCursor {
             current: None,
             offset: 0,

--- a/src-tauri/src/modules/codex_progress/mod.rs
+++ b/src-tauri/src/modules/codex_progress/mod.rs
@@ -1,0 +1,38 @@
+//! Watches Codex rollout transcripts and streams newly appended lines to the
+//! frontend, tagged with the cwd they belong to. Codex stores sessions under
+//! `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`, keyed by date not cwd, so the
+//! cwd is read from each file's first `session_meta` line.
+
+use serde_json::Value;
+
+/// The cwd recorded in a Codex rollout's first line. Returns None when the line
+/// is not a `session_meta` record or has no cwd.
+pub fn parse_session_meta_cwd(first_line: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(first_line).ok()?;
+    if value.get("type").and_then(Value::as_str) != Some("session_meta") {
+        return None;
+    }
+    value
+        .get("payload")?
+        .get("cwd")?
+        .as_str()
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_cwd_from_a_session_meta_line() {
+        let line = r#"{"type":"session_meta","payload":{"id":"x","cwd":"/Users/me/proj","cli_version":"0.140.0"}}"#;
+        assert_eq!(parse_session_meta_cwd(line).as_deref(), Some("/Users/me/proj"));
+    }
+
+    #[test]
+    fn returns_none_for_non_session_meta_or_malformed() {
+        assert_eq!(parse_session_meta_cwd(r#"{"type":"event_msg","payload":{}}"#), None);
+        assert_eq!(parse_session_meta_cwd("not json"), None);
+        assert_eq!(parse_session_meta_cwd(r#"{"type":"session_meta","payload":{}}"#), None);
+    }
+}

--- a/src-tauri/src/modules/codex_progress/mod.rs
+++ b/src-tauri/src/modules/codex_progress/mod.rs
@@ -4,10 +4,18 @@
 //! cwd is read from each file's first `session_meta` line.
 
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
+
+use chrono::{Datelike, Duration as ChronoDuration, Local};
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::modules::claude_progress::{byte_len, read_new_lines};
 
 /// A discovered Codex rollout file: its path, last-modified time, and the cwd
 /// read from its session_meta line.
@@ -84,6 +92,146 @@ pub fn scan_recent_rollouts(base: &Path, days: &[(i32, u32, u32)]) -> Vec<Rollou
         }
     }
     out
+}
+
+const PROGRESS_EVENT: &str = "claude-progress:lines";
+
+#[derive(Clone, serde::Serialize)]
+struct ProgressBatch {
+    cwd: String,
+    agent: String,
+    lines: Vec<String>,
+    reset: bool,
+}
+
+struct CwdCursor {
+    current: Option<PathBuf>,
+    offset: usize,
+    pending_reset: bool,
+}
+
+struct RouteState {
+    watched: Vec<String>,
+    cursors: HashMap<String, CwdCursor>,
+}
+
+pub struct CodexProgressState {
+    route: Arc<Mutex<RouteState>>,
+    watcher: Mutex<Option<RecommendedWatcher>>,
+}
+
+impl CodexProgressState {
+    pub fn new() -> Self {
+        Self {
+            route: Arc::new(Mutex::new(RouteState { watched: Vec::new(), cursors: HashMap::new() })),
+            watcher: Mutex::new(None),
+        }
+    }
+}
+
+impl Default for CodexProgressState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Today and yesterday as (year, month, day) in local time. Both days are
+/// returned so an overnight session started yesterday is still found. Codex
+/// names its date directories in local time, so this must be local, not UTC.
+fn recent_days() -> Vec<(i32, u32, u32)> {
+    let today = Local::now().date_naive();
+    let yesterday = today - ChronoDuration::days(1);
+    vec![
+        (today.year(), today.month(), today.day()),
+        (yesterday.year(), yesterday.month(), yesterday.day()),
+    ]
+}
+
+/// (Re)point each watched cwd at its newest current rollout, then rebuild the
+/// single recursive watcher on the sessions base. Called whenever the watched
+/// set changes.
+pub fn set_watched_cwds(app: &AppHandle, state: &CodexProgressState, cwds: &[String]) {
+    let home = match app.path().home_dir() {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+    let base = codex_sessions_base(&home);
+    let candidates = scan_recent_rollouts(&base, &recent_days());
+
+    {
+        let mut route = state.route.lock().unwrap();
+        route.watched = cwds.to_vec();
+        route.cursors.retain(|cwd, _| cwds.contains(cwd));
+        // Seed a cursor at the end of each new cwd's newest rollout so history is
+        // not replayed. Existing cursors keep their offset.
+        for cwd in cwds {
+            if !route.cursors.contains_key(cwd) {
+                let newest = select_newest_for_cwd(&candidates, cwd);
+                let offset = newest.as_deref().map(byte_len).unwrap_or(0);
+                route.cursors.insert(
+                    cwd.clone(),
+                    CwdCursor { current: newest, offset, pending_reset: false },
+                );
+            }
+        }
+    }
+
+    // One recursive watcher on the sessions base; the callback reroutes on each event.
+    let app_cb = app.clone();
+    let base_cb = base.clone();
+    let route_cb = Arc::clone(&state.route);
+    let watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        if res.is_err() {
+            return;
+        }
+        route_event(&app_cb, &base_cb, &route_cb);
+    });
+    if let Ok(mut w) = watcher {
+        if w.watch(&base, RecursiveMode::Recursive).is_ok() {
+            *state.watcher.lock().unwrap() = Some(w);
+        }
+    }
+}
+
+/// On any change under the sessions base: for each watched cwd, find its newest
+/// current rollout, switch (reset) if it changed, then tail appended lines and
+/// emit them tagged with agent "codex".
+fn route_event(app: &AppHandle, base: &Path, route: &Arc<Mutex<RouteState>>) {
+    let candidates = scan_recent_rollouts(base, &recent_days());
+    let mut route = route.lock().unwrap();
+    let watched = route.watched.clone();
+    for cwd in watched {
+        let newest = select_newest_for_cwd(&candidates, &cwd);
+        let cursor = route.cursors.entry(cwd.clone()).or_insert_with(|| CwdCursor {
+            current: None,
+            offset: 0,
+            pending_reset: false,
+        });
+        if newest.is_some() && cursor.current != newest {
+            cursor.current = newest.clone();
+            cursor.offset = 0;
+            cursor.pending_reset = true;
+        }
+        let Some(path) = cursor.current.clone() else {
+            continue;
+        };
+        let (lines, new_offset) = match read_new_lines(&path, cursor.offset) {
+            Some(r) => r,
+            None => {
+                cursor.current = None;
+                continue;
+            }
+        };
+        cursor.offset = new_offset;
+        if !lines.is_empty() {
+            let reset = cursor.pending_reset;
+            cursor.pending_reset = false;
+            let _ = app.emit(
+                PROGRESS_EVENT,
+                ProgressBatch { cwd: cwd.clone(), agent: "codex".into(), lines, reset },
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/modules/codex_status_hook/mod.rs
+++ b/src-tauri/src/modules/codex_status_hook/mod.rs
@@ -2,7 +2,113 @@
 //! report live state as OSC, mirroring the Claude installer. Reuses the shared
 //! pure merge over hooks.json and ensures Codex's hooks feature flag is on.
 
+use std::path::{Path, PathBuf};
+
+use tauri::{AppHandle, Manager};
 use toml_edit::{DocumentMut, Item, Table, value};
+
+use crate::modules::claude_status_hook::{merge_hook_settings, remove_hook_settings, HOOK_SCRIPT};
+
+/// Codex hook event to status argument. No `Notification` catch-all: Codex signals
+/// approval directly via `PermissionRequest`.
+const CODEX_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "idle"),
+    ("UserPromptSubmit", "thinking"),
+    ("PreToolUse", "active"),
+    ("PostToolUse", "active"),
+    ("PermissionRequest", "waiting-approval"),
+    ("Stop", "idle"),
+    ("SessionEnd", "end"),
+];
+
+/// `~/.codex` (or the `CODEX_HOME` override). Returns the script path, the
+/// hooks.json path, and the config.toml path.
+fn codex_paths(app: &AppHandle) -> Result<(PathBuf, PathBuf, PathBuf), String> {
+    let home = app.path().home_dir().map_err(|e| e.to_string())?;
+    let base = match std::env::var("CODEX_HOME") {
+        Ok(v) if !v.trim().is_empty() => {
+            let p = Path::new(&v);
+            p.strip_prefix("~").map(|rest| home.join(rest)).unwrap_or_else(|_| p.to_path_buf())
+        }
+        _ => home.join(".codex"),
+    };
+    Ok((
+        base.join("tempoterm").join("status-hook.sh"),
+        base.join("hooks.json"),
+        base.join("config.toml"),
+    ))
+}
+
+fn read_json(path: &Path) -> Result<serde_json::Value, String> {
+    match std::fs::read_to_string(path) {
+        Ok(text) if text.trim().is_empty() => Ok(serde_json::json!({})),
+        Ok(text) => serde_json::from_str(&text).map_err(|e| format!("hooks.json is not valid JSON: {e}")),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(serde_json::json!({})),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn write_atomic(path: &Path, text: &str) -> Result<(), String> {
+    let tmp = path.with_extension("tmp");
+    if let Err(err) = std::fs::write(&tmp, text) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(err.to_string());
+    }
+    std::fs::rename(&tmp, path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        e.to_string()
+    })
+}
+
+#[tauri::command]
+pub fn codex_status_hook_install(app: AppHandle) -> Result<(), String> {
+    let (script_path, hooks_path, config_path) = codex_paths(&app)?;
+    if let Some(dir) = script_path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(&script_path, HOOK_SCRIPT).map_err(|e| e.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| e.to_string())?;
+    }
+    let script_str = script_path.to_str().ok_or("script path is not valid UTF-8")?;
+
+    // Ensure Codex's hooks feature is on, without clobbering the user's config.
+    let existing_toml = match std::fs::read_to_string(&config_path) {
+        Ok(t) => t,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => return Err(err.to_string()),
+    };
+    if let Some(dir) = config_path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    write_atomic(&config_path, &ensure_hooks_feature(&existing_toml)?)?;
+
+    let cleaned = remove_hook_settings(read_json(&hooks_path)?, script_str, CODEX_EVENTS);
+    let merged = merge_hook_settings(cleaned, script_str, CODEX_EVENTS);
+    let text = serde_json::to_string_pretty(&merged).map_err(|e| e.to_string())? + "\n";
+    write_atomic(&hooks_path, &text)
+}
+
+#[tauri::command]
+pub fn codex_status_hook_uninstall(app: AppHandle) -> Result<(), String> {
+    let (script_path, hooks_path, _config_path) = codex_paths(&app)?;
+    let script_str = script_path.to_str().ok_or("script path is not valid UTF-8")?;
+    // Leave `[features] hooks = true` in config.toml: it is shared infra other
+    // tools (e.g. CodeIsland) rely on. Only remove our hooks.json entries + script.
+    if hooks_path.exists() {
+        let cleaned = remove_hook_settings(read_json(&hooks_path)?, script_str, CODEX_EVENTS);
+        let text = serde_json::to_string_pretty(&cleaned).map_err(|e| e.to_string())? + "\n";
+        write_atomic(&hooks_path, &text)?;
+    }
+    let _ = std::fs::remove_file(&script_path);
+    if let Some(dir) = script_path.parent() {
+        let _ = std::fs::remove_dir(dir);
+    }
+    Ok(())
+}
 
 /// Ensure `[features] hooks = true` in the given config.toml text, preserving all
 /// other keys, tables, and comments. Returns the updated text. A blank input
@@ -22,6 +128,31 @@ pub fn ensure_hooks_feature(existing_toml: &str) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use crate::modules::claude_status_hook::{merge_hook_settings, remove_hook_settings};
+
+    #[test]
+    fn codex_merge_keeps_codeisland_entries_and_adds_ours() {
+        let existing = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "hooks": [{ "type": "command", "command": "/Users/u/.codeisland/codeisland-bridge --source codex" }] }
+                ]
+            }
+        });
+        let merged = merge_hook_settings(existing, "/c/status-hook.sh", CODEX_EVENTS);
+        let pre = merged["hooks"]["PreToolUse"].as_array().unwrap();
+        assert!(pre.iter().any(|e| e["hooks"][0]["command"]
+            .as_str()
+            .is_some_and(|c| c.contains("codeisland-bridge"))));
+        assert!(pre.iter().any(|e| e["hooks"][0]["command"] == "/c/status-hook.sh active"));
+        // No Notification event for Codex.
+        assert!(merged["hooks"].get("Notification").is_none());
+        let cleaned = remove_hook_settings(merged, "/c/status-hook.sh", CODEX_EVENTS);
+        let pre = cleaned["hooks"]["PreToolUse"].as_array().unwrap();
+        assert!(pre.iter().any(|e| e["hooks"][0]["command"].as_str().is_some_and(|c| c.contains("codeisland-bridge"))));
+        assert!(!pre.iter().any(|e| e["hooks"][0]["command"].as_str().is_some_and(|c| c.contains("status-hook.sh"))));
+    }
 
     #[test]
     fn ensure_hooks_feature_preserves_existing_keys_and_comments() {

--- a/src-tauri/src/modules/codex_status_hook/mod.rs
+++ b/src-tauri/src/modules/codex_status_hook/mod.rs
@@ -49,7 +49,10 @@ fn read_json(path: &Path) -> Result<serde_json::Value, String> {
 }
 
 fn write_atomic(path: &Path, text: &str) -> Result<(), String> {
-    let tmp = path.with_extension("tmp");
+    let tmp = path.with_file_name(format!(
+        "{}.tmp",
+        path.file_name().unwrap_or_default().to_string_lossy()
+    ));
     if let Err(err) = std::fs::write(&tmp, text) {
         let _ = std::fs::remove_file(&tmp);
         return Err(err.to_string());

--- a/src-tauri/src/modules/codex_status_hook/mod.rs
+++ b/src-tauri/src/modules/codex_status_hook/mod.rs
@@ -1,0 +1,49 @@
+//! Installs tempo-term's status hook into Codex's config so Codex sessions
+//! report live state as OSC, mirroring the Claude installer. Reuses the shared
+//! pure merge over hooks.json and ensures Codex's hooks feature flag is on.
+
+use toml_edit::{DocumentMut, Item, Table, value};
+
+/// Ensure `[features] hooks = true` in the given config.toml text, preserving all
+/// other keys, tables, and comments. Returns the updated text. A blank input
+/// yields a document containing just the features table.
+pub fn ensure_hooks_feature(existing_toml: &str) -> Result<String, String> {
+    let mut doc = existing_toml
+        .parse::<DocumentMut>()
+        .map_err(|e| format!("config.toml is not valid TOML: {e}"))?;
+    // Ensure [features] exists as an explicit table header, not a dotted key
+    if !doc.contains_table("features") {
+        doc["features"] = Item::Table(Table::new());
+    }
+    doc["features"]["hooks"] = value(true);
+    Ok(doc.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_hooks_feature_preserves_existing_keys_and_comments() {
+        let input = "model = \"gpt-5.5\"\n# keep me\n[features]\nmulti_agent = true\n";
+        let out = ensure_hooks_feature(input).unwrap();
+        assert!(out.contains("model = \"gpt-5.5\""));
+        assert!(out.contains("# keep me"));
+        assert!(out.contains("multi_agent = true"));
+        assert!(out.contains("hooks = true"));
+    }
+
+    #[test]
+    fn ensure_hooks_feature_is_noop_when_already_true() {
+        let input = "[features]\nhooks = true\n";
+        let out = ensure_hooks_feature(input).unwrap();
+        assert_eq!(out.matches("hooks = true").count(), 1);
+    }
+
+    #[test]
+    fn ensure_hooks_feature_creates_features_table_when_absent() {
+        let out = ensure_hooks_feature("model = \"x\"\n").unwrap();
+        assert!(out.contains("[features]"));
+        assert!(out.contains("hooks = true"));
+    }
+}

--- a/src-tauri/src/modules/codex_status_hook/mod.rs
+++ b/src-tauri/src/modules/codex_status_hook/mod.rs
@@ -46,4 +46,22 @@ mod tests {
         assert!(out.contains("[features]"));
         assert!(out.contains("hooks = true"));
     }
+
+    #[test]
+    fn ensure_hooks_feature_flips_false_to_true_keeping_other_keys() {
+        let input = "[features]\nmulti_agent = true\nhooks = false\n";
+        let out = ensure_hooks_feature(input).unwrap();
+        assert!(out.contains("hooks = true"));
+        assert!(!out.contains("hooks = false"));
+        assert!(out.contains("multi_agent = true"));
+    }
+
+    #[test]
+    fn ensure_hooks_feature_preserves_a_comment_inside_features() {
+        let input = "[features]\n# flag for multi-agent\nmulti_agent = true\n";
+        let out = ensure_hooks_feature(input).unwrap();
+        assert!(out.contains("# flag for multi-agent"));
+        assert!(out.contains("multi_agent = true"));
+        assert!(out.contains("hooks = true"));
+    }
 }

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,6 +1,7 @@
 pub mod ai;
 pub mod claude_progress;
 pub mod claude_status_hook;
+pub mod codex_status_hook;
 pub mod clipboard;
 pub mod fonts;
 pub mod fs;

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,6 +1,7 @@
 pub mod ai;
 pub mod claude_progress;
 pub mod claude_status_hook;
+pub mod codex_progress;
 pub mod codex_status_hook;
 pub mod clipboard;
 pub mod fonts;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import { applyTheme, getTheme } from "@/themes/themes";
 import { listen } from "@tauri-apps/api/event";
 import { useProgressStore } from "@/modules/claude-progress/lib/progressStore";
 import { useWatchSessions } from "@/modules/claude-progress/lib/useWatchSessions";
-import { installStatusHook } from "@/modules/claude-progress/lib/statusHookBridge";
+import { installStatusHook, installCodexStatusHook } from "@/modules/claude-progress/lib/statusHookBridge";
 import { useWatchNotes } from "@/modules/notes/lib/useWatchNotes";
 
 const MIN_SIDEBAR = 180;
@@ -56,6 +56,7 @@ function App() {
   useEffect(() => {
     if (useSettingsStore.getState().claudeStatusTracking) {
       void installStatusHook().catch(() => {});
+      void installCodexStatusHook().catch(() => {});
     }
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,11 +74,11 @@ function App() {
   useEffect(() => {
     // listen() rejects when there is no Tauri runtime (unit tests, web preview);
     // swallow it so it never surfaces as an unhandled rejection.
-    const unlisten = listen<{ cwd: string; lines: string[]; reset: boolean }>(
+    const unlisten = listen<{ cwd: string; agent: "claude" | "codex"; lines: string[]; reset: boolean }>(
       "claude-progress:lines",
       (event) => {
-        const { cwd, lines, reset } = event.payload;
-        useProgressStore.getState().pushLines(cwd, "claude", lines, reset);
+        const { cwd, agent, lines, reset } = event.payload;
+        useProgressStore.getState().pushLines(cwd, agent, lines, reset);
       },
     ).catch(() => undefined);
     return () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,7 @@ function App() {
       "claude-progress:lines",
       (event) => {
         const { cwd, lines, reset } = event.payload;
-        useProgressStore.getState().pushLines(cwd, lines, reset);
+        useProgressStore.getState().pushLines(cwd, "claude", lines, reset);
       },
     ).catch(() => undefined);
     return () => {

--- a/src/modules/claude-progress/lib/codexNormalize.test.ts
+++ b/src/modules/claude-progress/lib/codexNormalize.test.ts
@@ -47,6 +47,22 @@ describe("createCodexNormalizer", () => {
     ]);
   });
 
+  it("maps custom_tool_call update_plan to a todo event", () => {
+    const n = createCodexNormalizer();
+    const events = n.push(
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          name: "update_plan",
+          call_id: "p2",
+          input: JSON.stringify({ plan: [{ step: "Deploy", status: "pending" }] }),
+        },
+      }),
+    );
+    expect(events).toEqual([{ kind: "todo", items: [{ text: "Deploy", status: "pending" }] }]);
+  });
+
   it("treats apply_patch custom_tool_call as a tool with a friendly name", () => {
     const n = createCodexNormalizer();
     const start = n.push(

--- a/src/modules/claude-progress/lib/codexNormalize.test.ts
+++ b/src/modules/claude-progress/lib/codexNormalize.test.ts
@@ -95,4 +95,32 @@ describe("createCodexNormalizer", () => {
     expect(n.push("not json")).toEqual([]);
     expect(n.push("")).toEqual([]);
   });
+
+  it("does not crash on a JSON null line", () => {
+    // JSON.parse("null") yields null, not a throw, so the payload access must be
+    // null-safe or it would TypeError outside the parse try/catch.
+    const n = createCodexNormalizer();
+    expect(n.push("null")).toEqual([]);
+  });
+
+  it("tolerates a null element in an update_plan plan array", () => {
+    const n = createCodexNormalizer();
+    const events = n.push(
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "update_plan",
+          call_id: "p",
+          arguments: JSON.stringify({ plan: [{ step: "A", status: "x" }, null] }),
+        },
+      }),
+    );
+    expect(events).toEqual([
+      { kind: "todo", items: [
+        { text: "A", status: "x" },
+        { text: "", status: "" },
+      ] },
+    ]);
+  });
 });

--- a/src/modules/claude-progress/lib/codexNormalize.test.ts
+++ b/src/modules/claude-progress/lib/codexNormalize.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { createCodexNormalizer } from "./codexNormalize";
+
+describe("createCodexNormalizer", () => {
+  it("pairs a function_call with its function_call_output by call_id", () => {
+    const n = createCodexNormalizer();
+    const start = n.push(
+      JSON.stringify({
+        type: "response_item",
+        payload: { type: "function_call", name: "exec_command", call_id: "c1", arguments: "{}" },
+      }),
+    );
+    expect(start).toEqual([{ kind: "tool:start", id: "c1", name: "Shell" }]);
+
+    const end = n.push(
+      JSON.stringify({
+        type: "response_item",
+        payload: { type: "function_call_output", call_id: "c1", output: "Process exited with code 0" },
+      }),
+    );
+    expect(end).toEqual([{ kind: "tool:end", id: "c1", name: "Shell", ok: true }]);
+  });
+
+  it("maps update_plan to a todo event", () => {
+    const n = createCodexNormalizer();
+    const events = n.push(
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "update_plan",
+          call_id: "p1",
+          arguments: JSON.stringify({
+            plan: [
+              { step: "Audit", status: "in_progress" },
+              { step: "Implement", status: "pending" },
+            ],
+          }),
+        },
+      }),
+    );
+    expect(events).toEqual([
+      { kind: "todo", items: [
+        { text: "Audit", status: "in_progress" },
+        { text: "Implement", status: "pending" },
+      ] },
+    ]);
+  });
+
+  it("treats apply_patch custom_tool_call as a tool with a friendly name", () => {
+    const n = createCodexNormalizer();
+    const start = n.push(
+      JSON.stringify({
+        type: "response_item",
+        payload: { type: "custom_tool_call", name: "apply_patch", call_id: "a1", status: "completed", input: "*** Begin Patch" },
+      }),
+    );
+    expect(start).toEqual([{ kind: "tool:start", id: "a1", name: "Edit" }]);
+    const end = n.push(
+      JSON.stringify({
+        type: "response_item",
+        payload: { type: "custom_tool_call_output", call_id: "a1", status: "completed" },
+      }),
+    );
+    expect(end).toEqual([{ kind: "tool:end", id: "a1", name: "Edit", ok: true }]);
+  });
+
+  it("emits idle on task_complete", () => {
+    const n = createCodexNormalizer();
+    expect(
+      n.push(JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } })),
+    ).toEqual([{ kind: "idle" }]);
+  });
+
+  it("ignores reasoning, token_count, messages, and malformed lines", () => {
+    const n = createCodexNormalizer();
+    expect(n.push(JSON.stringify({ type: "response_item", payload: { type: "reasoning" } }))).toEqual([]);
+    expect(n.push(JSON.stringify({ type: "event_msg", payload: { type: "token_count" } }))).toEqual([]);
+    expect(n.push("not json")).toEqual([]);
+    expect(n.push("")).toEqual([]);
+  });
+});

--- a/src/modules/claude-progress/lib/codexNormalize.ts
+++ b/src/modules/claude-progress/lib/codexNormalize.ts
@@ -1,0 +1,100 @@
+import type { Normalizer, ProgressEvent, TodoItem } from "./normalize";
+
+export type AgentKind = "claude" | "codex";
+
+interface CodexPayload {
+  type?: string;
+  name?: string;
+  call_id?: string;
+  arguments?: string;
+  input?: string;
+  status?: string;
+}
+
+interface CodexLine {
+  type?: string;
+  payload?: CodexPayload;
+}
+
+/** Codex internal tool names mapped to panel-friendly labels. Unknown names pass through. */
+const FRIENDLY_TOOL_NAMES: Record<string, string> = {
+  exec_command: "Shell",
+  apply_patch: "Edit",
+  view_image: "Read",
+  write_stdin: "Input",
+  web_search: "Web search",
+};
+
+function friendly(name: string): string {
+  return FRIENDLY_TOOL_NAMES[name] ?? name;
+}
+
+/** Codex `update_plan` arguments: { plan: [{ step, status }] } -> TodoItem[]. */
+function parsePlan(argsJson: string | undefined): TodoItem[] {
+  if (!argsJson) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(argsJson) as { plan?: { step?: string; status?: string }[] };
+    return (parsed.plan ?? []).map((s) => ({ text: s.step ?? "", status: s.status ?? "" }));
+  } catch {
+    return [];
+  }
+}
+
+/** Codex outputs carry no explicit success flag; treat a present non-completed status
+ * as failure, otherwise assume success. Refined later (see plan open questions). */
+function isOk(payload: CodexPayload): boolean {
+  if (!payload.status) {
+    return true;
+  }
+  return payload.status === "completed" || payload.status === "success";
+}
+
+/**
+ * Normalizes Codex rollout JSONL into the same ProgressEvent stream the Claude
+ * normalizer emits, so the existing reducer, store, and panel render it unchanged.
+ * One raw line in, zero or more events out. Stateful: pairs tool calls with their
+ * outputs by call_id, like the Claude normalizer pairs tool_use ids.
+ */
+export function createCodexNormalizer(): Normalizer {
+  const toolNames = new Map<string, string>();
+
+  return {
+    push(rawLine: string): ProgressEvent[] {
+      let record: CodexLine;
+      try {
+        record = JSON.parse(rawLine) as CodexLine;
+      } catch {
+        return [];
+      }
+      const payload = record.payload;
+      if (!payload) {
+        return [];
+      }
+      const events: ProgressEvent[] = [];
+
+      if (record.type === "response_item") {
+        const isCall = payload.type === "function_call" || payload.type === "custom_tool_call";
+        const isOutput =
+          payload.type === "function_call_output" || payload.type === "custom_tool_call_output";
+        if (isCall && payload.call_id && payload.name) {
+          if (payload.name === "update_plan") {
+            events.push({ kind: "todo", items: parsePlan(payload.arguments ?? payload.input) });
+          } else {
+            toolNames.set(payload.call_id, friendly(payload.name));
+            events.push({ kind: "tool:start", id: payload.call_id, name: friendly(payload.name) });
+          }
+        } else if (isOutput && payload.call_id) {
+          const name = toolNames.get(payload.call_id) ?? "";
+          toolNames.delete(payload.call_id);
+          events.push({ kind: "tool:end", id: payload.call_id, name, ok: isOk(payload) });
+        }
+      } else if (record.type === "event_msg" && payload.type === "task_complete") {
+        events.push({ kind: "idle" });
+      }
+
+      return events;
+    },
+  };
+}

--- a/src/modules/claude-progress/lib/codexNormalize.ts
+++ b/src/modules/claude-progress/lib/codexNormalize.ts
@@ -35,8 +35,8 @@ function parsePlan(argsJson: string | undefined): TodoItem[] {
     return [];
   }
   try {
-    const parsed = JSON.parse(argsJson) as { plan?: { step?: string; status?: string }[] };
-    return (parsed.plan ?? []).map((s) => ({ text: s.step ?? "", status: s.status ?? "" }));
+    const parsed = JSON.parse(argsJson) as { plan?: ({ step?: string; status?: string } | null)[] };
+    return (parsed.plan ?? []).map((s) => ({ text: s?.step ?? "", status: s?.status ?? "" }));
   } catch {
     return [];
   }
@@ -68,7 +68,7 @@ export function createCodexNormalizer(): Normalizer {
       } catch {
         return [];
       }
-      const payload = record.payload;
+      const payload = record?.payload;
       if (!payload) {
         return [];
       }

--- a/src/modules/claude-progress/lib/progressStore.test.ts
+++ b/src/modules/claude-progress/lib/progressStore.test.ts
@@ -18,15 +18,35 @@ describe("isEmptyProgress", () => {
 describe("sessionEpochs", () => {
   it("increments a cwd's epoch each time its session resets", () => {
     useProgressStore.setState({ sessions: {}, sessionEpochs: {} });
-    useProgressStore.getState().pushLines("/a", [], true);
+    useProgressStore.getState().pushLines("/a", "claude", [], true);
     expect(useProgressStore.getState().sessionEpochs["/a"]).toBe(1);
-    useProgressStore.getState().pushLines("/a", [], true);
+    useProgressStore.getState().pushLines("/a", "claude", [], true);
     expect(useProgressStore.getState().sessionEpochs["/a"]).toBe(2);
   });
 
   it("does not bump the epoch on a non-reset append", () => {
     useProgressStore.setState({ sessions: {}, sessionEpochs: { "/a": 1 } });
-    useProgressStore.getState().pushLines("/a", [], false);
+    useProgressStore.getState().pushLines("/a", "claude", [], false);
     expect(useProgressStore.getState().sessionEpochs["/a"]).toBe(1);
+  });
+});
+
+describe("per-agent normalizer selection", () => {
+  it("rebuilds the normalizer when the agent changes for a cwd", () => {
+    useProgressStore.setState({ sessions: {}, sessionEpochs: {} });
+    const store = useProgressStore.getState();
+    // A Codex tool starts under codex.
+    store.pushLines("/p", "codex", [
+      JSON.stringify({ type: "response_item", payload: { type: "function_call", name: "exec_command", call_id: "c1", arguments: "{}" } }),
+    ], false);
+    expect(useProgressStore.getState().sessions["/p"].activities).toHaveLength(1);
+
+    // Switching the same cwd to claude starts fresh (no leftover codex activity).
+    store.pushLines("/p", "claude", [
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", id: "t1", name: "Bash" }] } }),
+    ], false);
+    const activities = useProgressStore.getState().sessions["/p"].activities;
+    expect(activities).toHaveLength(1);
+    expect(activities[0].id).toBe("t1");
   });
 });

--- a/src/modules/claude-progress/lib/progressStore.ts
+++ b/src/modules/claude-progress/lib/progressStore.ts
@@ -12,6 +12,8 @@ interface ProgressStoreState {
    * session title.
    */
   sessionEpochs: Record<string, number>;
+  /** The agent currently feeding each cwd (keyed by cwd). */
+  agents: Record<string, AgentKind>;
   /**
    * Feed raw transcript lines (from the backend watcher) for one cwd. `reset`
    * marks the first batch of a newly started session, clearing prior progress.
@@ -44,6 +46,7 @@ function normalizerFor(cwd: string, agent: AgentKind): Normalizer {
 export const useProgressStore = create<ProgressStoreState>((set) => ({
   sessions: {},
   sessionEpochs: {},
+  agents: {},
 
   pushLines: (cwd, agent, lines, reset) =>
     set((state) => {
@@ -66,14 +69,15 @@ export const useProgressStore = create<ProgressStoreState>((set) => ({
           next = reduceProgress(next, event);
         }
       }
+      const agents = state.agents[cwd] === agent ? state.agents : { ...state.agents, [cwd]: agent };
       if (next === previous) {
-        return { sessionEpochs };
+        return { sessionEpochs, agents };
       }
       // Don't materialize an empty session for a cwd whose lines produced nothing.
       if (!fresh && previous === undefined && isEmptyProgress(next)) {
-        return { sessionEpochs };
+        return { sessionEpochs, agents };
       }
-      return { sessions: { ...state.sessions, [cwd]: next }, sessionEpochs };
+      return { sessions: { ...state.sessions, [cwd]: next }, sessionEpochs, agents };
     }),
 
   syncSessions: (cwds) =>
@@ -91,7 +95,13 @@ export const useProgressStore = create<ProgressStoreState>((set) => ({
           sessions[cwd] = progress;
         }
       }
-      return { sessions };
+      const agents: Record<string, AgentKind> = {};
+      for (const [cwd, kind] of Object.entries(state.agents)) {
+        if (keep.has(cwd)) {
+          agents[cwd] = kind;
+        }
+      }
+      return { sessions, agents };
     }),
 }));
 

--- a/src/modules/claude-progress/lib/progressStore.ts
+++ b/src/modules/claude-progress/lib/progressStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { createNormalizer, type Normalizer } from "./normalize";
+import { createCodexNormalizer, type AgentKind } from "./codexNormalize";
 import { emptyProgressState, reduceProgress, type ProgressState } from "./progressState";
 
 interface ProgressStoreState {
@@ -14,8 +15,9 @@ interface ProgressStoreState {
   /**
    * Feed raw transcript lines (from the backend watcher) for one cwd. `reset`
    * marks the first batch of a newly started session, clearing prior progress.
+   * `agent` selects the normalizer; switching agent for a cwd rebuilds it fresh.
    */
-  pushLines: (cwd: string, lines: string[], reset: boolean) => void;
+  pushLines: (cwd: string, agent: AgentKind, lines: string[], reset: boolean) => void;
   /** Keep only the sessions for `cwds`; drop progress for directories no longer watched. */
   syncSessions: (cwds: string[]) => void;
 }
@@ -23,12 +25,18 @@ interface ProgressStoreState {
 // Each cwd's normalizer is stateful (it pairs tool calls with their results), so
 // the normalizers live alongside the store, one per watched directory.
 const normalizers = new Map<string, Normalizer>();
+const normalizerAgents = new Map<string, AgentKind>();
 
-function normalizerFor(cwd: string): Normalizer {
+function makeNormalizer(agent: AgentKind): Normalizer {
+  return agent === "codex" ? createCodexNormalizer() : createNormalizer();
+}
+
+function normalizerFor(cwd: string, agent: AgentKind): Normalizer {
   let normalizer = normalizers.get(cwd);
-  if (!normalizer) {
-    normalizer = createNormalizer();
+  if (!normalizer || normalizerAgents.get(cwd) !== agent) {
+    normalizer = makeNormalizer(agent);
     normalizers.set(cwd, normalizer);
+    normalizerAgents.set(cwd, agent);
   }
   return normalizer;
 }
@@ -37,20 +45,21 @@ export const useProgressStore = create<ProgressStoreState>((set) => ({
   sessions: {},
   sessionEpochs: {},
 
-  pushLines: (cwd, lines, reset) =>
+  pushLines: (cwd, agent, lines, reset) =>
     set((state) => {
-      // A reset means the backend switched this cwd to a new session: start its
-      // normalizer and accumulated state fresh so the old session's leftovers
-      // (e.g. a tool that never finished) can't linger forever.
-      if (reset) {
-        normalizers.set(cwd, createNormalizer());
+      // A reset (new session) or an agent switch for this cwd starts fresh so the
+      // old session's or other agent's leftovers can't linger.
+      const fresh = reset || normalizerAgents.get(cwd) !== agent;
+      if (fresh) {
+        normalizers.set(cwd, makeNormalizer(agent));
+        normalizerAgents.set(cwd, agent);
       }
       // A new session for this cwd: bump its epoch so title consumers refetch.
-      const sessionEpochs = reset
+      const sessionEpochs = fresh
         ? { ...state.sessionEpochs, [cwd]: (state.sessionEpochs[cwd] ?? 0) + 1 }
         : state.sessionEpochs;
-      const normalizer = normalizerFor(cwd);
-      const previous = reset ? undefined : state.sessions[cwd];
+      const normalizer = normalizerFor(cwd, agent);
+      const previous = fresh ? undefined : state.sessions[cwd];
       let next = previous ?? emptyProgressState();
       for (const line of lines) {
         for (const event of normalizer.push(line)) {
@@ -61,7 +70,7 @@ export const useProgressStore = create<ProgressStoreState>((set) => ({
         return { sessionEpochs };
       }
       // Don't materialize an empty session for a cwd whose lines produced nothing.
-      if (!reset && previous === undefined && isEmptyProgress(next)) {
+      if (!fresh && previous === undefined && isEmptyProgress(next)) {
         return { sessionEpochs };
       }
       return { sessions: { ...state.sessions, [cwd]: next }, sessionEpochs };
@@ -73,6 +82,7 @@ export const useProgressStore = create<ProgressStoreState>((set) => ({
       for (const cwd of normalizers.keys()) {
         if (!keep.has(cwd)) {
           normalizers.delete(cwd);
+          normalizerAgents.delete(cwd);
         }
       }
       const sessions: Record<string, ProgressState> = {};

--- a/src/modules/claude-progress/lib/sessionStatus.test.ts
+++ b/src/modules/claude-progress/lib/sessionStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isClaudeForeground, parseStatusOsc } from "./sessionStatus";
+import { isClaudeForeground, isCodexForeground, isTrackedAgentForeground, parseStatusOsc } from "./sessionStatus";
 
 describe("parseStatusOsc", () => {
   it("parses a status payload", () => {
@@ -80,5 +80,27 @@ describe("isClaudeForeground", () => {
   it("does not match claude only appearing as an argument", () => {
     expect(isClaudeForeground("vim claude.md")).toBe(false);
     expect(isClaudeForeground("cat claude.log")).toBe(false);
+  });
+});
+
+describe("isCodexForeground", () => {
+  it("matches the codex binary by name, path, and prefix runners", () => {
+    expect(isCodexForeground("codex")).toBe(true);
+    expect(isCodexForeground("/Users/me/.nvm/versions/node/v22.15.1/bin/codex")).toBe(true);
+    expect(isCodexForeground("node /opt/homebrew/lib/node_modules/@openai/codex/cli.js")).toBe(true);
+    expect(isCodexForeground("npx codex")).toBe(true);
+  });
+  it("does not match a shell or codex as a mere argument", () => {
+    expect(isCodexForeground("zsh")).toBe(false);
+    expect(isCodexForeground("vim codex.md")).toBe(false);
+    expect(isCodexForeground(null)).toBe(false);
+  });
+});
+
+describe("isTrackedAgentForeground", () => {
+  it("is true for either claude or codex", () => {
+    expect(isTrackedAgentForeground("claude")).toBe(true);
+    expect(isTrackedAgentForeground("codex")).toBe(true);
+    expect(isTrackedAgentForeground("zsh")).toBe(false);
   });
 });

--- a/src/modules/claude-progress/lib/sessionStatus.test.ts
+++ b/src/modules/claude-progress/lib/sessionStatus.test.ts
@@ -88,6 +88,7 @@ describe("isCodexForeground", () => {
     expect(isCodexForeground("codex")).toBe(true);
     expect(isCodexForeground("/Users/me/.nvm/versions/node/v22.15.1/bin/codex")).toBe(true);
     expect(isCodexForeground("node /opt/homebrew/lib/node_modules/@openai/codex/cli.js")).toBe(true);
+    expect(isCodexForeground("node /usr/local/lib/node_modules/openai-codex/cli.js")).toBe(true);
     expect(isCodexForeground("npx codex")).toBe(true);
   });
   it("does not match a shell or codex as a mere argument", () => {

--- a/src/modules/claude-progress/lib/sessionStatus.ts
+++ b/src/modules/claude-progress/lib/sessionStatus.ts
@@ -75,3 +75,26 @@ export function isClaudeForeground(cmd: string | null): boolean {
     /@anthropic-ai\/claude/i.test(trimmed)
   );
 }
+
+/**
+ * Whether a terminal's foreground command looks like Codex, used for the same
+ * crash backstop and to label which agent a pane runs. Matches the `codex`
+ * binary by name or path, behind a prefix runner, or the npm package's node
+ * command, but not codex appearing only as an argument.
+ */
+export function isCodexForeground(cmd: string | null): boolean {
+  if (!cmd) {
+    return false;
+  }
+  const trimmed = cmd.trim();
+  return (
+    /^(?:(?:sudo|npx|bunx|yarn\s+run)\s+)?(?:.*\/)?codex(?:\s|$)/i.test(trimmed) ||
+    /@openai\/codex\b/i.test(trimmed) ||
+    /\bopenai-codex\b/i.test(trimmed)
+  );
+}
+
+/** True when any agent tempo-term tracks is the foreground process. */
+export function isTrackedAgentForeground(cmd: string | null): boolean {
+  return isClaudeForeground(cmd) || isCodexForeground(cmd);
+}

--- a/src/modules/claude-progress/lib/statusHookBridge.ts
+++ b/src/modules/claude-progress/lib/statusHookBridge.ts
@@ -9,3 +9,13 @@ export async function installStatusHook(): Promise<void> {
 export async function uninstallStatusHook(): Promise<void> {
   await invoke("claude_status_hook_uninstall");
 }
+
+/** Write the status hook into Codex's hooks.json and config.toml. */
+export async function installCodexStatusHook(): Promise<void> {
+  await invoke("codex_status_hook_install");
+}
+
+/** Remove our Codex hook entries and delete the script. */
+export async function uninstallCodexStatusHook(): Promise<void> {
+  await invoke("codex_status_hook_uninstall");
+}

--- a/src/modules/settings/WorkspaceSettingsSection.tsx
+++ b/src/modules/settings/WorkspaceSettingsSection.tsx
@@ -8,7 +8,12 @@ import {
 } from "@/stores/settingsStore";
 import { ghAvailable } from "@/modules/workspace/lib/prBridge";
 import { secretsDeleteKey, secretsHasKey, secretsSetKey } from "@/modules/ai/lib/aiBridge";
-import { installStatusHook, uninstallStatusHook } from "@/modules/claude-progress/lib/statusHookBridge";
+import {
+  installStatusHook,
+  uninstallStatusHook,
+  installCodexStatusHook,
+  uninstallCodexStatusHook,
+} from "@/modules/claude-progress/lib/statusHookBridge";
 
 /** Keychain account the GitHub API token is stored under (matches the backend). */
 const GITHUB_PROVIDER = "github";
@@ -100,7 +105,13 @@ export function WorkspaceSettingsSection() {
   async function toggleStatusTracking(checked: boolean) {
     setStatusTracking(checked);
     try {
-      await (checked ? installStatusHook() : uninstallStatusHook());
+      if (checked) {
+        await installStatusHook();
+        await installCodexStatusHook();
+      } else {
+        await uninstallStatusHook();
+        await uninstallCodexStatusHook();
+      }
     } catch {
       // Keep the toggle in sync with the real system state: if install or
       // uninstall failed, the hook is in the opposite state from what we set.

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -42,7 +42,7 @@ import { fsHomeDir, fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import { getDraggedEntry } from "@/modules/explorer/lib/dragEntry";
 import {
   STATUS_OSC_CODE,
-  isClaudeForeground,
+  isTrackedAgentForeground,
   parseStatusOsc,
 } from "@/modules/claude-progress/lib/sessionStatus";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
@@ -613,7 +613,7 @@ export function TerminalView({
         const leaf = leafIdRef.current;
         if (leaf && useSessionStatusStore.getState().statuses[leaf]) {
           const command = await session.foregroundCommand().catch(() => null);
-          if (!cancelled && !isClaudeForeground(command)) {
+          if (!cancelled && !isTrackedAgentForeground(command)) {
             useSessionStatusStore.getState().clear(leaf);
           }
         }

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -607,9 +607,9 @@ export function TerminalView({
           last = dir;
           useWorkspaceStore.getState().setRoot(dir);
         }
-        // Crash backstop: if this pane still shows a Claude status but Claude is
-        // no longer the foreground process, SessionEnd never arrived (e.g. a
-        // hard kill), so the OSC never cleared it. Clear it here.
+        // Crash backstop: if this pane still shows a status but no tracked agent
+        // (Claude or Codex) is the foreground process, SessionEnd never arrived
+        // (e.g. a hard kill), so the OSC never cleared it. Clear it here.
         const leaf = leafIdRef.current;
         if (leaf && useSessionStatusStore.getState().statuses[leaf]) {
           const command = await session.foregroundCommand().catch(() => null);

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -31,6 +31,8 @@ import { usePrStore } from "./lib/prStore";
 import { useWorkspacePrs } from "./lib/useWorkspacePrs";
 import type { WorktreeInfo } from "./lib/worktreeBridge";
 import type { PrInfo } from "./lib/prBridge";
+import { useProgressStore } from "@/modules/claude-progress/lib/progressStore";
+import { agentLabel } from "./lib/agentLabel";
 
 function tabIcon(kind: TabKind): LucideIcon {
   switch (kind) {
@@ -176,6 +178,7 @@ function TabCard({ tab }: { tab: Tab }) {
   const titles = useTitlesStore((s) => s.titles);
   const prs = usePrStore((s) => s.prs);
   const card = useSettingsStore((s) => s.workspaceCard);
+  const progressAgents = useProgressStore((s) => s.agents);
   const active = tab.id === activeId;
   const cwd = deriveTabCwd(tab);
   const status = tabSessionStatus(tab, statuses);
@@ -183,6 +186,7 @@ function TabCard({ tab }: { tab: Tab }) {
   const title = selectCardTitle(tab, titles);
   const pr = cwd ? prs[cwd] : undefined;
   const Icon = tabIcon(tab.kind);
+  const label = agentLabel(cwd ? progressAgents[cwd] : undefined);
 
   return (
     <button
@@ -199,6 +203,9 @@ function TabCard({ tab }: { tab: Tab }) {
         <span className="flex items-center gap-1.5">
           <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">{title}</span>
           {card.status && status && <StatusBadge status={status} />}
+          {card.status && status && label && (
+            <span className="shrink-0 text-[11px] text-fg-subtle">{label}</span>
+          )}
         </span>
         <BranchBlock info={info} cwd={cwd} showBranch={card.branch} showCwd={card.cwd} />
         {card.pr && pr && (

--- a/src/modules/workspace/lib/agentLabel.test.ts
+++ b/src/modules/workspace/lib/agentLabel.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { agentLabel } from "./agentLabel";
+
+describe("agentLabel", () => {
+  it('returns "Codex" for codex agent', () => {
+    expect(agentLabel("codex")).toBe("Codex");
+  });
+
+  it('returns "Claude" for claude agent', () => {
+    expect(agentLabel("claude")).toBe("Claude");
+  });
+
+  it("returns null for undefined", () => {
+    expect(agentLabel(undefined)).toBeNull();
+  });
+});

--- a/src/modules/workspace/lib/agentLabel.ts
+++ b/src/modules/workspace/lib/agentLabel.ts
@@ -1,0 +1,8 @@
+import type { AgentKind } from "@/modules/claude-progress/lib/codexNormalize";
+
+/** Display label for the agent feeding a workspace card, or null when unknown. */
+export function agentLabel(agent: AgentKind | undefined): "Claude" | "Codex" | null {
+  if (agent === "codex") return "Codex";
+  if (agent === "claude") return "Claude";
+  return null;
+}


### PR DESCRIPTION
## Summary

Adds live session tracking for **Codex CLI**, at parity with the existing Claude Code tracking: a status badge (執行中 / 思考中 / 等待批准 / 等待輸入) and the full progress panel (tool activities + plan todos). Built on the insight that the existing pipeline is already agent-agnostic over a `ProgressEvent` stream, so Codex lights up the same reducer, store, and panel once its data is normalized into that shape.

Approach C from the design: a shared core with three thin per-agent seams, leaving Claude behavior unchanged.

## What changed

**Badge layer (hook → OSC, reuses the existing mechanism)**
- The existing `status-hook.sh` is now installed into Codex's config too. New Rust commands `codex_status_hook_install` / `codex_status_hook_uninstall` merge our entries into `~/.codex/hooks.json` and ensure `[features] hooks = true` in `~/.codex/config.toml`.
- The hook merge was parameterized by event list so Claude and Codex share the same pure merge/remove functions with different event maps (Codex has no `Notification` event).
- The crash backstop and foreground detection learned about Codex (`isCodexForeground` / `isTrackedAgentForeground`), so a Codex badge clears correctly when no tracked agent is foreground.

**Progress layer (file watcher → normalizer → existing panel)**
- New `codex_progress` module: a single recursive `notify` watcher over `~/.codex/sessions/`, which locates each watched cwd's newest rollout by reading the `session_meta` line (Codex stores by date, not by cwd), tails appended lines via the shared tail core, and emits `ProgressBatch { cwd, agent: "codex", lines, reset }`.
- New `createCodexNormalizer` maps Codex rollout JSONL (`function_call` / `custom_tool_call` / `*_output` / `update_plan` / `task_complete`) into the same `ProgressEvent` union the Claude normalizer produces.
- `progressStore.pushLines` now selects the normalizer per agent and rebuilds it on an agent switch; `App.tsx` routes each batch by its `agent` tag.
- Workspace cards show a small `Claude` / `Codex` label next to the badge, sourced from the agent feeding the panel.

## Coexistence & safety

- **Never clobbers CodeIsland**: our hook entries are identified by our script path, so a pre-existing `codeisland-bridge --source codex` entry survives both install and uninstall (covered by a test).
- **Preserves the user's config**: `config.toml` is edited with `toml_edit` (comments, keys, and formatting preserved) and written atomically (temp-then-rename). Uninstall leaves the shared `hooks` flag in place.

## Out of scope (deferred by design)

- Codex subagents in the panel (Codex stores child agents as separate threads; structurally different from Claude's inline model).
- Antigravity and Gemini.

## Known follow-up (not a blocker)

- `codex_progress::route_event` rescans the today+yesterday rollout dirs on every filesystem event. The Claude watcher gates rescans on `Create`/`Rename` event kinds; Codex should do the same (or cache the cwd→path map) before this scales to heavy users. Tracked as a follow-up.

## Test plan

**Automated (passing):**
- [x] Rust: `cargo test` — 123 passed (incl. Codex normalizer-adjacent hook/merge/toml/parse/scan/select tests)
- [x] Frontend: `pnpm test` — 512 passed; `pnpm run typecheck` clean
- [x] Per-task reviews + a final whole-branch review (verdict: ready to merge, 0 Critical / 0 Important)

**Manual verification (TODO before merge):**
- [ ] Run the app with tracking on; confirm `~/.codex/hooks.json` still contains CodeIsland's entries **and** ours, and `~/.codex/config.toml` keeps all prior keys with `[features] hooks = true`
- [ ] Launch `codex` in a pane; badge transitions through thinking / active / waiting-approval / idle; a plain shell shows no badge
- [ ] During a Codex turn, the panel shows tool activities (Shell, Edit, Read) and, on `update_plan`, the todo list
- [ ] Switching a directory between Codex and Claude sessions resets the panel cleanly
- [ ] Claude sessions behave exactly as before
- [ ] CPU stays reasonable under a busy Codex session (watch the full-tree-rescan follow-up above)
