### PR TITLE
feat: list every agent session per pane in the workspace sidebar

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ use modules::ai::ai_chat;
 use modules::claude_progress::{
     claude_progress_unwatch, claude_progress_watch, claude_session_title, ClaudeProgressState,
 };
-use modules::codex_progress::CodexProgressState;
+use modules::codex_progress::{codex_session_title, CodexProgressState};
 use modules::claude_status_hook::{claude_status_hook_install, claude_status_hook_uninstall};
 use modules::codex_status_hook::{codex_status_hook_install, codex_status_hook_uninstall};
 use modules::notes::{notes_unwatch, notes_watch, NotesWatchState};
@@ -163,6 +163,7 @@ pub fn run() {
             claude_progress_watch,
             claude_progress_unwatch,
             claude_session_title,
+            codex_session_title,
             claude_status_hook_install,
             claude_status_hook_uninstall,
             codex_status_hook_install,

--- a/src-tauri/src/modules/codex_progress/mod.rs
+++ b/src-tauri/src/modules/codex_progress/mod.rs
@@ -48,6 +48,44 @@ pub fn parse_session_meta_cwd(first_line: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Longest session title we keep; longer text is truncated for display.
+const MAX_TITLE_CHARS: usize = 80;
+
+/// Derive a title for a Codex session from its rollout JSONL: the first
+/// `user_message` event's text, trimmed and truncated. The session opens with
+/// injected `response_item` context (environment, instructions); the user's own
+/// first turn arrives as an `event_msg`/`user_message`, so that is what we use.
+/// Returns None when the rollout has no user message yet.
+pub fn extract_codex_title(contents: &str) -> Option<String> {
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        if value.get("type").and_then(Value::as_str) != Some("event_msg") {
+            continue;
+        }
+        let payload = match value.get("payload") {
+            Some(payload) => payload,
+            None => continue,
+        };
+        if payload.get("type").and_then(Value::as_str) != Some("user_message") {
+            continue;
+        }
+        if let Some(text) = payload.get("message").and_then(Value::as_str) {
+            let trimmed = text.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.chars().take(MAX_TITLE_CHARS).collect());
+            }
+        }
+    }
+    None
+}
+
 /// `~/.codex/sessions` (or under the CODEX_HOME override).
 pub fn codex_sessions_base(home: &Path) -> PathBuf {
     match std::env::var("CODEX_HOME") {
@@ -254,6 +292,18 @@ fn route_event(app: &AppHandle, base: &Path, route: &Arc<Mutex<RouteState>>, eve
     }
 }
 
+/// The title of the newest Codex session for `cwd`, read from its rollout.
+/// Returns None when no recent rollout exists for that directory.
+#[tauri::command]
+pub fn codex_session_title(app: AppHandle, cwd: String) -> Option<String> {
+    let home = app.path().home_dir().ok()?;
+    let base = codex_sessions_base(&home);
+    let candidates = scan_recent_rollouts(&base, &recent_days());
+    let path = select_newest_for_cwd(&candidates, &cwd)?;
+    let contents = std::fs::read_to_string(path).ok()?;
+    extract_codex_title(&contents)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -309,5 +359,31 @@ mod tests {
         ];
         assert_eq!(select_newest_for_cwd(&candidates, "/proj"), Some(PathBuf::from("/a/new.jsonl")));
         assert_eq!(select_newest_for_cwd(&candidates, "/missing"), None);
+    }
+
+    #[test]
+    fn title_is_the_first_user_message_text() {
+        // A real rollout opens with session_meta and injected context lines; the
+        // first thing the user actually typed arrives as an event_msg/user_message.
+        let contents = concat!(
+            r#"{"type":"session_meta","payload":{"cwd":"/proj"}}"#,
+            "\n",
+            r#"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>noise</environment_context>"}]}}"#,
+            "\n",
+            r#"{"type":"event_msg","payload":{"type":"user_message","message":"Fix the flaky test"}}"#,
+            "\n",
+            r#"{"type":"event_msg","payload":{"type":"user_message","message":"a later message"}}"#,
+        );
+        assert_eq!(extract_codex_title(contents).as_deref(), Some("Fix the flaky test"));
+    }
+
+    #[test]
+    fn title_is_none_without_a_user_message() {
+        let contents = concat!(
+            r#"{"type":"session_meta","payload":{"cwd":"/proj"}}"#,
+            "\n",
+            r#"{"type":"event_msg","payload":{"type":"task_started"}}"#,
+        );
+        assert_eq!(extract_codex_title(contents), None);
     }
 }

--- a/src-tauri/src/modules/codex_progress/mod.rs
+++ b/src-tauri/src/modules/codex_progress/mod.rs
@@ -51,13 +51,18 @@ pub fn parse_session_meta_cwd(first_line: &str) -> Option<String> {
 /// Longest session title we keep; longer text is truncated for display.
 const MAX_TITLE_CHARS: usize = 80;
 
-/// Derive a title for a Codex session from its rollout JSONL: the first
-/// `user_message` event's text, trimmed and truncated. The session opens with
-/// injected `response_item` context (environment, instructions); the user's own
-/// first turn arrives as an `event_msg`/`user_message`, so that is what we use.
-/// Returns None when the rollout has no user message yet.
-pub fn extract_codex_title(contents: &str) -> Option<String> {
-    for line in contents.lines() {
+/// Derive a title for a Codex session from a reader over its rollout JSONL: the
+/// first `user_message` event's text, trimmed and truncated. The session opens
+/// with injected `response_item` context (environment, instructions); the user's
+/// own first turn arrives as an `event_msg`/`user_message`, so that is what we
+/// use. Reads lazily and stops at the first match, so a long rollout is not fully
+/// loaded. Returns None when the rollout has no user message yet.
+pub fn extract_codex_title<R: BufRead>(reader: R) -> Option<String> {
+    for line in reader.lines() {
+        let line = match line {
+            Ok(line) => line,
+            Err(_) => continue,
+        };
         let line = line.trim();
         if line.is_empty() {
             continue;
@@ -300,8 +305,8 @@ pub fn codex_session_title(app: AppHandle, cwd: String) -> Option<String> {
     let base = codex_sessions_base(&home);
     let candidates = scan_recent_rollouts(&base, &recent_days());
     let path = select_newest_for_cwd(&candidates, &cwd)?;
-    let contents = std::fs::read_to_string(path).ok()?;
-    extract_codex_title(&contents)
+    let file = File::open(path).ok()?;
+    extract_codex_title(BufReader::new(file))
 }
 
 #[cfg(test)]
@@ -374,7 +379,7 @@ mod tests {
             "\n",
             r#"{"type":"event_msg","payload":{"type":"user_message","message":"a later message"}}"#,
         );
-        assert_eq!(extract_codex_title(contents).as_deref(), Some("Fix the flaky test"));
+        assert_eq!(extract_codex_title(contents.as_bytes()).as_deref(), Some("Fix the flaky test"));
     }
 
     #[test]
@@ -384,6 +389,6 @@ mod tests {
             "\n",
             r#"{"type":"event_msg","payload":{"type":"task_started"}}"#,
         );
-        assert_eq!(extract_codex_title(contents), None);
+        assert_eq!(extract_codex_title(contents.as_bytes()), None);
     }
 }

--- a/src/modules/claude-progress/lib/progressStore.test.ts
+++ b/src/modules/claude-progress/lib/progressStore.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { isEmptyProgress, useProgressStore } from "./progressStore";
+import { isEmptyProgress, progressKey, useProgressStore } from "./progressStore";
 import { emptyProgressState, reduceProgress } from "./progressState";
+
+const CODEX_EXEC_LINE = JSON.stringify({
+  type: "response_item",
+  payload: { type: "function_call", name: "exec_command", call_id: "c1", arguments: "{}" },
+});
+const CLAUDE_TOOL_LINE = JSON.stringify({
+  type: "assistant",
+  message: { content: [{ type: "tool_use", id: "t1", name: "Bash" }] },
+});
 
 describe("isEmptyProgress", () => {
   it("is true for a fresh empty state", () => {
@@ -16,37 +25,37 @@ describe("isEmptyProgress", () => {
 });
 
 describe("sessionEpochs", () => {
-  it("increments a cwd's epoch each time its session resets", () => {
+  it("increments a session's epoch each time it resets", () => {
     useProgressStore.setState({ sessions: {}, sessionEpochs: {} });
+    const key = progressKey("/a", "claude");
     useProgressStore.getState().pushLines("/a", "claude", [], true);
-    expect(useProgressStore.getState().sessionEpochs["/a"]).toBe(1);
+    expect(useProgressStore.getState().sessionEpochs[key]).toBe(1);
     useProgressStore.getState().pushLines("/a", "claude", [], true);
-    expect(useProgressStore.getState().sessionEpochs["/a"]).toBe(2);
+    expect(useProgressStore.getState().sessionEpochs[key]).toBe(2);
   });
 
   it("does not bump the epoch on a non-reset append", () => {
-    useProgressStore.setState({ sessions: {}, sessionEpochs: { "/a": 1 } });
+    const key = progressKey("/a", "claude");
+    useProgressStore.setState({ sessions: {}, sessionEpochs: { [key]: 1 } });
     useProgressStore.getState().pushLines("/a", "claude", [], false);
-    expect(useProgressStore.getState().sessionEpochs["/a"]).toBe(1);
+    expect(useProgressStore.getState().sessionEpochs[key]).toBe(1);
   });
 });
 
-describe("per-agent normalizer selection", () => {
-  it("rebuilds the normalizer when the agent changes for a cwd", () => {
+describe("per-(cwd, agent) sessions", () => {
+  it("keeps a cwd's codex and claude sessions independent", () => {
     useProgressStore.setState({ sessions: {}, sessionEpochs: {} });
     const store = useProgressStore.getState();
-    // A Codex tool starts under codex.
-    store.pushLines("/p", "codex", [
-      JSON.stringify({ type: "response_item", payload: { type: "function_call", name: "exec_command", call_id: "c1", arguments: "{}" } }),
-    ], false);
-    expect(useProgressStore.getState().sessions["/p"].activities).toHaveLength(1);
+    // The same directory runs Codex in one pane and Claude in another. Both
+    // streams arrive tagged with the same cwd but must not clobber each other.
+    store.pushLines("/p", "codex", [CODEX_EXEC_LINE], false);
+    store.pushLines("/p", "claude", [CLAUDE_TOOL_LINE], false);
 
-    // Switching the same cwd to claude starts fresh (no leftover codex activity).
-    store.pushLines("/p", "claude", [
-      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", id: "t1", name: "Bash" }] } }),
-    ], false);
-    const activities = useProgressStore.getState().sessions["/p"].activities;
-    expect(activities).toHaveLength(1);
-    expect(activities[0].id).toBe("t1");
+    const sessions = useProgressStore.getState().sessions;
+    const codex = sessions[progressKey("/p", "codex")];
+    const claude = sessions[progressKey("/p", "claude")];
+    expect(codex.activities).toHaveLength(1);
+    expect(claude.activities).toHaveLength(1);
+    expect(claude.activities[0].id).toBe("t1");
   });
 });

--- a/src/modules/claude-progress/lib/progressStore.ts
+++ b/src/modules/claude-progress/lib/progressStore.ts
@@ -3,42 +3,55 @@ import { createNormalizer, type Normalizer } from "./normalize";
 import { createCodexNormalizer, type AgentKind } from "./codexNormalize";
 import { emptyProgressState, reduceProgress, type ProgressState } from "./progressState";
 
+/**
+ * The store key for one tracked session: a directory plus the agent running in
+ * it. Keying by cwd alone collides when the same directory runs Claude in one
+ * pane and Codex in another, so each agent gets its own slot. The agent name has
+ * no colon, so splitting on the first colon recovers the full cwd.
+ */
+export function progressKey(cwd: string, agent: AgentKind): string {
+  return `${agent}:${cwd}`;
+}
+
+/** Split a progress key back into its agent and cwd. */
+export function parseProgressKey(key: string): { agent: AgentKind; cwd: string } {
+  const sep = key.indexOf(":");
+  return { agent: key.slice(0, sep) as AgentKind, cwd: key.slice(sep + 1) };
+}
+
 interface ProgressStoreState {
-  /** Accumulated progress per watched project directory (keyed by cwd). */
+  /** Accumulated progress per tracked session, keyed by `progressKey(cwd, agent)`. */
   sessions: Record<string, ProgressState>;
   /**
-   * A per-cwd counter bumped whenever that directory switches to a new session
-   * (a reset). Consumers watch it to know when to refetch derived data like the
-   * session title.
+   * A per-session counter bumped whenever that session resets (a new session in
+   * the same cwd+agent slot). Consumers watch it to know when to refetch derived
+   * data like the session title. Keyed by `progressKey(cwd, agent)`.
    */
   sessionEpochs: Record<string, number>;
-  /** The agent currently feeding each cwd (keyed by cwd). */
-  agents: Record<string, AgentKind>;
   /**
    * Feed raw transcript lines (from the backend watcher) for one cwd. `reset`
    * marks the first batch of a newly started session, clearing prior progress.
-   * `agent` selects the normalizer; switching agent for a cwd rebuilds it fresh.
+   * `agent` selects both the normalizer and which session slot the lines land in,
+   * so Claude and Codex in the same directory stay independent.
    */
   pushLines: (cwd: string, agent: AgentKind, lines: string[], reset: boolean) => void;
-  /** Keep only the sessions for `cwds`; drop progress for directories no longer watched. */
+  /** Keep only the sessions whose cwd is in `cwds`; drop the rest. */
   syncSessions: (cwds: string[]) => void;
 }
 
-// Each cwd's normalizer is stateful (it pairs tool calls with their results), so
-// the normalizers live alongside the store, one per watched directory.
+// Each session's normalizer is stateful (it pairs tool calls with their
+// results), so the normalizers live alongside the store, one per session slot.
 const normalizers = new Map<string, Normalizer>();
-const normalizerAgents = new Map<string, AgentKind>();
 
 function makeNormalizer(agent: AgentKind): Normalizer {
   return agent === "codex" ? createCodexNormalizer() : createNormalizer();
 }
 
-function normalizerFor(cwd: string, agent: AgentKind): Normalizer {
-  let normalizer = normalizers.get(cwd);
-  if (!normalizer || normalizerAgents.get(cwd) !== agent) {
+function normalizerFor(key: string, agent: AgentKind): Normalizer {
+  let normalizer = normalizers.get(key);
+  if (!normalizer) {
     normalizer = makeNormalizer(agent);
-    normalizers.set(cwd, normalizer);
-    normalizerAgents.set(cwd, agent);
+    normalizers.set(key, normalizer);
   }
   return normalizer;
 }
@@ -46,62 +59,52 @@ function normalizerFor(cwd: string, agent: AgentKind): Normalizer {
 export const useProgressStore = create<ProgressStoreState>((set) => ({
   sessions: {},
   sessionEpochs: {},
-  agents: {},
 
   pushLines: (cwd, agent, lines, reset) =>
     set((state) => {
-      // A reset (new session) or an agent switch for this cwd starts fresh so the
-      // old session's or other agent's leftovers can't linger.
-      const fresh = reset || normalizerAgents.get(cwd) !== agent;
-      if (fresh) {
-        normalizers.set(cwd, makeNormalizer(agent));
-        normalizerAgents.set(cwd, agent);
+      const key = progressKey(cwd, agent);
+      // A reset (new session) starts fresh so the old session's leftovers can't
+      // linger. Each agent has its own slot, so there is no cross-agent reset.
+      if (reset) {
+        normalizers.set(key, makeNormalizer(agent));
       }
-      // A new session for this cwd: bump its epoch so title consumers refetch.
-      const sessionEpochs = fresh
-        ? { ...state.sessionEpochs, [cwd]: (state.sessionEpochs[cwd] ?? 0) + 1 }
+      const sessionEpochs = reset
+        ? { ...state.sessionEpochs, [key]: (state.sessionEpochs[key] ?? 0) + 1 }
         : state.sessionEpochs;
-      const normalizer = normalizerFor(cwd, agent);
-      const previous = fresh ? undefined : state.sessions[cwd];
+      const normalizer = normalizerFor(key, agent);
+      const previous = reset ? undefined : state.sessions[key];
       let next = previous ?? emptyProgressState();
       for (const line of lines) {
         for (const event of normalizer.push(line)) {
           next = reduceProgress(next, event);
         }
       }
-      const agents = state.agents[cwd] === agent ? state.agents : { ...state.agents, [cwd]: agent };
       if (next === previous) {
-        return { sessionEpochs, agents };
+        return { sessionEpochs };
       }
-      // Don't materialize an empty session for a cwd whose lines produced nothing.
-      if (!fresh && previous === undefined && isEmptyProgress(next)) {
-        return { sessionEpochs, agents };
+      // Don't materialize an empty session for a slot whose lines produced nothing.
+      if (!reset && previous === undefined && isEmptyProgress(next)) {
+        return { sessionEpochs };
       }
-      return { sessions: { ...state.sessions, [cwd]: next }, sessionEpochs, agents };
+      return { sessions: { ...state.sessions, [key]: next }, sessionEpochs };
     }),
 
   syncSessions: (cwds) =>
     set((state) => {
       const keep = new Set(cwds);
-      for (const cwd of normalizers.keys()) {
-        if (!keep.has(cwd)) {
-          normalizers.delete(cwd);
-          normalizerAgents.delete(cwd);
+      const kept = (key: string) => keep.has(parseProgressKey(key).cwd);
+      for (const key of normalizers.keys()) {
+        if (!kept(key)) {
+          normalizers.delete(key);
         }
       }
       const sessions: Record<string, ProgressState> = {};
-      for (const [cwd, progress] of Object.entries(state.sessions)) {
-        if (keep.has(cwd)) {
-          sessions[cwd] = progress;
+      for (const [key, progress] of Object.entries(state.sessions)) {
+        if (kept(key)) {
+          sessions[key] = progress;
         }
       }
-      const agents: Record<string, AgentKind> = {};
-      for (const [cwd, kind] of Object.entries(state.agents)) {
-        if (keep.has(cwd)) {
-          agents[cwd] = kind;
-        }
-      }
-      return { sessions, agents };
+      return { sessions };
     }),
 }));
 

--- a/src/modules/claude-progress/lib/sessionStatusStore.test.ts
+++ b/src/modules/claude-progress/lib/sessionStatusStore.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { useSessionStatusStore } from "./sessionStatusStore";
 
-beforeEach(() => useSessionStatusStore.setState({ statuses: {} }));
+beforeEach(() => useSessionStatusStore.setState({ statuses: {}, agents: {} }));
 
 describe("sessionStatusStore", () => {
   it("sets and overwrites a leaf's status", () => {
@@ -21,5 +21,24 @@ describe("sessionStatusStore", () => {
     const before = useSessionStatusStore.getState().statuses;
     useSessionStatusStore.getState().clear("missing");
     expect(useSessionStatusStore.getState().statuses).toBe(before);
+  });
+});
+
+describe("sessionStatusStore agents", () => {
+  it("records the agent running in a leaf", () => {
+    useSessionStatusStore.getState().setAgent("leaf-1", "codex");
+    expect(useSessionStatusStore.getState().agents["leaf-1"]).toBe("codex");
+  });
+
+  it("clears a leaf's status and agent together when the session ends", () => {
+    const store = useSessionStatusStore.getState();
+    store.setStatus("leaf-1", "thinking");
+    store.setAgent("leaf-1", "claude");
+
+    store.clear("leaf-1");
+
+    const state = useSessionStatusStore.getState();
+    expect(state.statuses["leaf-1"]).toBeUndefined();
+    expect(state.agents["leaf-1"]).toBeUndefined();
   });
 });

--- a/src/modules/claude-progress/lib/sessionStatusStore.ts
+++ b/src/modules/claude-progress/lib/sessionStatusStore.ts
@@ -1,24 +1,39 @@
 import { create } from "zustand";
 import type { SessionStatus } from "./sessionStatus";
+import type { AgentKind } from "./codexNormalize";
 
 interface SessionStatusState {
-  /** Live Claude status per terminal leaf id; absence means no badge. */
+  /** Live agent status per terminal leaf id; absence means no badge. */
   statuses: Record<string, SessionStatus>;
+  /**
+   * Which agent (Claude or Codex) is running in each terminal leaf, derived from
+   * the pane's foreground process. Lets a card label each pane's session even
+   * when two panes share one directory.
+   */
+  agents: Record<string, AgentKind>;
   setStatus: (leafId: string, status: SessionStatus) => void;
+  setAgent: (leafId: string, agent: AgentKind) => void;
   clear: (leafId: string) => void;
 }
 
 export const useSessionStatusStore = create<SessionStatusState>((set) => ({
   statuses: {},
+  agents: {},
   setStatus: (leafId, status) =>
     set((s) => ({ statuses: { ...s.statuses, [leafId]: status } })),
+  setAgent: (leafId, agent) =>
+    set((s) =>
+      s.agents[leafId] === agent ? s : { agents: { ...s.agents, [leafId]: agent } },
+    ),
   clear: (leafId) =>
     set((s) => {
-      if (!(leafId in s.statuses)) {
+      if (!(leafId in s.statuses) && !(leafId in s.agents)) {
         return s;
       }
-      const next = { ...s.statuses };
-      delete next[leafId];
-      return { statuses: next };
+      const statuses = { ...s.statuses };
+      delete statuses[leafId];
+      const agents = { ...s.agents };
+      delete agents[leafId];
+      return { statuses, agents };
     }),
 }));

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -42,7 +42,8 @@ import { fsHomeDir, fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import { getDraggedEntry } from "@/modules/explorer/lib/dragEntry";
 import {
   STATUS_OSC_CODE,
-  isTrackedAgentForeground,
+  isClaudeForeground,
+  isCodexForeground,
   parseStatusOsc,
 } from "@/modules/claude-progress/lib/sessionStatus";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
@@ -607,14 +608,22 @@ export function TerminalView({
           last = dir;
           useWorkspaceStore.getState().setRoot(dir);
         }
-        // Crash backstop: if this pane still shows a status but no tracked agent
-        // (Claude or Codex) is the foreground process, SessionEnd never arrived
-        // (e.g. a hard kill), so the OSC never cleared it. Clear it here.
+        // While a pane shows a status, read its foreground process to (a) label
+        // which agent is running, so a card can tell Claude from Codex even when
+        // two panes share a directory, and (b) act as a crash backstop: if no
+        // tracked agent is foreground, SessionEnd never arrived (e.g. a hard
+        // kill) so the OSC never cleared it — clear the stale status here.
         const leaf = leafIdRef.current;
         if (leaf && useSessionStatusStore.getState().statuses[leaf]) {
           const command = await session.foregroundCommand().catch(() => null);
-          if (!cancelled && !isTrackedAgentForeground(command)) {
-            useSessionStatusStore.getState().clear(leaf);
+          if (!cancelled) {
+            if (isClaudeForeground(command)) {
+              useSessionStatusStore.getState().setAgent(leaf, "claude");
+            } else if (isCodexForeground(command)) {
+              useSessionStatusStore.getState().setAgent(leaf, "codex");
+            } else {
+              useSessionStatusStore.getState().clear(leaf);
+            }
           }
         }
       } catch {

--- a/src/modules/workspace/WorkspacePanel.test.tsx
+++ b/src/modules/workspace/WorkspacePanel.test.tsx
@@ -5,13 +5,14 @@ import { WorkspacePanel } from "./WorkspacePanel";
 import { useTabsStore } from "@/stores/tabsStore";
 import { leaf } from "@/modules/terminal/lib/terminalLayout";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
+import { progressKey } from "@/modules/claude-progress/lib/progressStore";
 import { useWorktreeStore } from "./lib/worktreeStore";
 import { useTitlesStore } from "./lib/titlesStore";
 import { usePrStore } from "./lib/prStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 
 beforeEach(() => {
-  useSessionStatusStore.setState({ statuses: {} });
+  useSessionStatusStore.setState({ statuses: {}, agents: {} });
   useWorktreeStore.setState({ infos: {} });
   useTitlesStore.setState({ titles: {} });
   usePrStore.setState({ prs: {}, fetchedAt: {} });
@@ -141,10 +142,53 @@ describe("WorkspacePanel", () => {
   });
 
   it("shows the auto session title instead of the tab title", () => {
-    useTitlesStore.setState({ titles: { "/a": "Auto Alpha" } });
+    useSessionStatusStore.setState({ statuses: { p1: "active" }, agents: { p1: "claude" } });
+    useTitlesStore.setState({ titles: { [progressKey("/a", "claude")]: "Auto Alpha" } });
     render(<WorkspacePanel />);
     expect(screen.getByText("Auto Alpha")).toBeInTheDocument();
     expect(screen.queryByText("alpha")).toBeNull();
+  });
+
+  it("lists every agent session when a tab is split across two panes", () => {
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Salon" }],
+      activeSpaceId: "s1",
+      activeId: "t1",
+      tabs: [
+        {
+          id: "t1",
+          spaceId: "s1",
+          title: "split",
+          kind: "terminal",
+          paneTree: {
+            kind: "split",
+            direction: "row",
+            sizes: [0.5, 0.5],
+            children: [
+              { kind: "leaf", id: "p1", pane: { kind: "terminal", cwd: "/a" } },
+              { kind: "leaf", id: "p2", pane: { kind: "terminal", cwd: "/a" } },
+            ],
+          },
+          activeLeafId: "p1",
+        },
+      ],
+    });
+    useSessionStatusStore.setState({
+      statuses: { p1: "active", p2: "thinking" },
+      agents: { p1: "codex", p2: "claude" },
+    });
+    useTitlesStore.setState({
+      titles: {
+        [progressKey("/a", "codex")]: "Codex task",
+        [progressKey("/a", "claude")]: "Claude task",
+      },
+    });
+    render(<WorkspacePanel />);
+    const card = screen.getByRole("button", { name: /split/ });
+    expect(within(card).getByText("Codex")).toBeInTheDocument();
+    expect(within(card).getByText("Claude")).toBeInTheDocument();
+    expect(within(card).getByText("Codex task")).toBeInTheDocument();
+    expect(within(card).getByText("Claude task")).toBeInTheDocument();
   });
 
   it("shows a PR badge on a card whose cwd has a tracked PR", () => {

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -23,6 +23,7 @@ import type { SessionStatus } from "@/modules/claude-progress/lib/sessionStatus"
 import { tabSessionStatus } from "./lib/tabSessionStatus";
 import { deriveTabCwd } from "./lib/tabCwd";
 import { selectCardTitle } from "./lib/cardTitle";
+import { collectTabSessions, type TabSession } from "./lib/tabSessions";
 import { useWorktreeStore } from "./lib/worktreeStore";
 import { useWorktreeInfos } from "./lib/useWorktreeInfos";
 import { useTitlesStore } from "./lib/titlesStore";
@@ -31,7 +32,7 @@ import { usePrStore } from "./lib/prStore";
 import { useWorkspacePrs } from "./lib/useWorkspacePrs";
 import type { WorktreeInfo } from "./lib/worktreeBridge";
 import type { PrInfo } from "./lib/prBridge";
-import { useProgressStore } from "@/modules/claude-progress/lib/progressStore";
+import { progressKey } from "@/modules/claude-progress/lib/progressStore";
 import { agentLabel } from "./lib/agentLabel";
 
 function tabIcon(kind: TabKind): LucideIcon {
@@ -170,23 +171,74 @@ function PrBadge({ pr }: { pr: PrInfo }) {
   );
 }
 
+/** The last path segment of a cwd, used when a session has no transcript title yet. */
+function basename(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}
+
+/** A session's display title: its transcript title, else its directory name. */
+function sessionTitle(session: TabSession, titles: Record<string, string>): string {
+  if (session.agent && session.cwd) {
+    const auto = titles[progressKey(session.cwd, session.agent)];
+    if (auto) {
+      return auto;
+    }
+  }
+  return session.cwd ? basename(session.cwd) : "";
+}
+
+/**
+ * One session line inside a card that runs more than one agent: its status, the
+ * agent label, and its own title. The status badge follows the card setting.
+ */
+function SessionRow({
+  session,
+  titles,
+  showStatus,
+}: {
+  session: TabSession;
+  titles: Record<string, string>;
+  showStatus: boolean;
+}) {
+  const label = agentLabel(session.agent);
+  return (
+    <span className="flex items-center gap-1.5">
+      {showStatus && <StatusBadge status={session.status} />}
+      {label && <span className="shrink-0 text-[11px] text-fg-subtle">{label}</span>}
+      <span className="min-w-0 flex-1 truncate text-[11px] text-fg-muted">
+        {sessionTitle(session, titles)}
+      </span>
+    </span>
+  );
+}
+
 function TabCard({ tab }: { tab: Tab }) {
   const activeId = useTabsStore((s) => s.activeId);
   const setActive = useTabsStore((s) => s.setActive);
   const statuses = useSessionStatusStore((s) => s.statuses);
+  const leafAgents = useSessionStatusStore((s) => s.agents);
   const infos = useWorktreeStore((s) => s.infos);
   const titles = useTitlesStore((s) => s.titles);
   const prs = usePrStore((s) => s.prs);
   const card = useSettingsStore((s) => s.workspaceCard);
-  const progressAgents = useProgressStore((s) => s.agents);
   const active = tab.id === activeId;
   const cwd = deriveTabCwd(tab);
+  // Each pane running an agent is its own session. With two or more, the header
+  // becomes the tab's identity and every session gets its own line below.
+  const sessions = collectTabSessions(tab, statuses, leafAgents);
+  const multi = sessions.length >= 2;
+  const primary = sessions[0];
   const status = tabSessionStatus(tab, statuses);
   const info = cwd ? infos[cwd] : undefined;
-  const title = selectCardTitle(tab, titles);
+  const autoTitle =
+    !multi && primary?.cwd && primary?.agent
+      ? titles[progressKey(primary.cwd, primary.agent)]
+      : undefined;
+  const title = selectCardTitle(tab, autoTitle);
   const pr = cwd ? prs[cwd] : undefined;
   const Icon = tabIcon(tab.kind);
-  const label = agentLabel(cwd ? progressAgents[cwd] : undefined);
+  const label = agentLabel(primary?.agent);
 
   return (
     <button
@@ -202,11 +254,23 @@ function TabCard({ tab }: { tab: Tab }) {
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-1.5">
           <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">{title}</span>
-          {card.status && status && <StatusBadge status={status} />}
-          {card.status && status && label && (
+          {!multi && card.status && status && <StatusBadge status={status} />}
+          {!multi && card.status && status && label && (
             <span className="shrink-0 text-[11px] text-fg-subtle">{label}</span>
           )}
         </span>
+        {multi && (
+          <span className="mt-1 block space-y-0.5">
+            {sessions.map((session) => (
+              <SessionRow
+                key={session.leafId}
+                session={session}
+                titles={titles}
+                showStatus={card.status}
+              />
+            ))}
+          </span>
+        )}
         <BranchBlock info={info} cwd={cwd} showBranch={card.branch} showCwd={card.cwd} />
         {card.pr && pr && (
           <span className="mt-0.5 block">
@@ -329,6 +393,8 @@ export function WorkspacePanel() {
   const infos = useWorktreeStore((s) => s.infos);
   const showPr = useSettingsStore((s) => s.workspaceCard.pr);
   const prSource = useSettingsStore((s) => s.prSource);
+  const statuses = useSessionStatusStore((s) => s.statuses);
+  const leafAgents = useSessionStatusStore((s) => s.agents);
   // Dedupe so multiple tabs in the same directory don't trigger redundant IPC
   // and network lookups for that directory.
   const cwds = Array.from(
@@ -337,7 +403,14 @@ export function WorkspacePanel() {
     ),
   );
   useWorktreeInfos(cwds);
-  useWorkspaceTitles(cwds);
+  // Titles are per session (cwd + agent), so a directory running both Claude and
+  // Codex gets each one's own title fetched.
+  const titleTargets = tabs.flatMap((tab) =>
+    collectTabSessions(tab, statuses, leafAgents).flatMap((session) =>
+      session.cwd && session.agent ? [{ cwd: session.cwd, agent: session.agent }] : [],
+    ),
+  );
+  useWorkspaceTitles(titleTargets);
 
   // PR lookups need a branch, which comes from the worktree info fetched above.
   // Skip fetching entirely when the PR block is hidden.

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -173,7 +173,8 @@ function PrBadge({ pr }: { pr: PrInfo }) {
 
 /** The last path segment of a cwd, used when a session has no transcript title yet. */
 function basename(path: string): string {
-  const parts = path.split("/").filter(Boolean);
+  // Split on both separators so Windows paths (C:\...) basename correctly too.
+  const parts = path.split(/[/\\]/).filter(Boolean);
   return parts[parts.length - 1] ?? path;
 }
 

--- a/src/modules/workspace/lib/cardTitle.test.ts
+++ b/src/modules/workspace/lib/cardTitle.test.ts
@@ -20,16 +20,16 @@ describe("selectCardTitle", () => {
       activeLeafId: "p1",
       renamed: true,
     });
-    expect(selectCardTitle(t, { "/a": "auto title" })).toBe("tab-title");
+    expect(selectCardTitle(t, "auto title")).toBe("tab-title");
   });
 
   it("uses the auto session title when not renamed", () => {
     const t = tab({ paneTree: leaf("p1", { kind: "terminal", cwd: "/a" }), activeLeafId: "p1" });
-    expect(selectCardTitle(t, { "/a": "auto title" })).toBe("auto title");
+    expect(selectCardTitle(t, "auto title")).toBe("auto title");
   });
 
   it("falls back to the tab title when there is no auto title", () => {
     const t = tab({ paneTree: leaf("p1", { kind: "terminal", cwd: "/a" }), activeLeafId: "p1" });
-    expect(selectCardTitle(t, {})).toBe("tab-title");
+    expect(selectCardTitle(t, undefined)).toBe("tab-title");
   });
 });

--- a/src/modules/workspace/lib/cardTitle.ts
+++ b/src/modules/workspace/lib/cardTitle.ts
@@ -1,16 +1,13 @@
 import type { Tab } from "@/stores/tabsStore";
-import { deriveTabCwd } from "./tabCwd";
 
 /**
- * The title shown on a workspace card. A manual rename always wins; otherwise
- * the auto title derived from the tab's Claude session is used, falling back to
- * the tab's own title (cwd basename or default name).
+ * The title shown on a workspace card's header. A manual rename always wins;
+ * otherwise the resolved auto title (a session's transcript title, picked by the
+ * caller) is used, falling back to the tab's own title (cwd basename or default).
  */
-export function selectCardTitle(tab: Tab, titles: Record<string, string>): string {
+export function selectCardTitle(tab: Tab, autoTitle: string | undefined): string {
   if (tab.renamed) {
     return tab.title;
   }
-  const cwd = deriveTabCwd(tab);
-  const auto = cwd ? titles[cwd] : undefined;
-  return auto ?? tab.title;
+  return autoTitle ?? tab.title;
 }

--- a/src/modules/workspace/lib/tabSessions.test.ts
+++ b/src/modules/workspace/lib/tabSessions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { Tab } from "@/stores/tabsStore";
+import type { LayoutNode } from "@/modules/terminal/lib/terminalLayout";
+import { collectTabSessions } from "./tabSessions";
+
+function tabWith(paneTree: LayoutNode, cwd?: string): Tab {
+  return {
+    id: "tab-1",
+    spaceId: "space-1",
+    title: "Tab 1",
+    kind: "terminal",
+    paneTree,
+    activeLeafId: "L1",
+    cwd,
+  };
+}
+
+const splitTree: LayoutNode = {
+  kind: "split",
+  direction: "row",
+  sizes: [0.5, 0.5],
+  children: [
+    { kind: "leaf", id: "L1", pane: { kind: "terminal", cwd: "/p" } },
+    { kind: "leaf", id: "L2", pane: { kind: "terminal", cwd: "/p" } },
+  ],
+};
+
+describe("collectTabSessions", () => {
+  it("returns one row per terminal pane that has a live status", () => {
+    const rows = collectTabSessions(
+      tabWith(splitTree),
+      { L1: "thinking", L2: "active" },
+      { L1: "claude", L2: "codex" },
+    );
+
+    expect(rows).toEqual([
+      { leafId: "L1", cwd: "/p", agent: "claude", status: "thinking" },
+      { leafId: "L2", cwd: "/p", agent: "codex", status: "active" },
+    ]);
+  });
+
+  it("skips panes that have no live status", () => {
+    const rows = collectTabSessions(tabWith(splitTree), { L2: "active" }, {});
+    expect(rows.map((r) => r.leafId)).toEqual(["L2"]);
+  });
+
+  it("ignores non-terminal panes even if a status is keyed under their id", () => {
+    const tree: LayoutNode = {
+      kind: "split",
+      direction: "row",
+      sizes: [0.5, 0.5],
+      children: [
+        { kind: "leaf", id: "L1", pane: { kind: "terminal", cwd: "/p" } },
+        { kind: "leaf", id: "E1", pane: { kind: "editor", path: "/p/a.ts" } },
+      ],
+    };
+    const rows = collectTabSessions(tabWith(tree), { L1: "thinking", E1: "active" }, {});
+    expect(rows.map((r) => r.leafId)).toEqual(["L1"]);
+  });
+
+  it("falls back to the tab cwd when the pane has not reported one", () => {
+    const tree: LayoutNode = { kind: "leaf", id: "L1", pane: { kind: "terminal" } };
+    const rows = collectTabSessions(tabWith(tree, "/tab-cwd"), { L1: "idle" }, { L1: "claude" });
+    expect(rows[0].cwd).toBe("/tab-cwd");
+  });
+});

--- a/src/modules/workspace/lib/tabSessions.ts
+++ b/src/modules/workspace/lib/tabSessions.ts
@@ -1,0 +1,42 @@
+import type { Tab } from "@/stores/tabsStore";
+import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
+import type { SessionStatus } from "@/modules/claude-progress/lib/sessionStatus";
+import type { AgentKind } from "@/modules/claude-progress/lib/codexNormalize";
+
+/** One running agent session inside a tab, tied to the pane it lives in. */
+export interface TabSession {
+  leafId: string;
+  cwd: string | null;
+  agent: AgentKind | undefined;
+  status: SessionStatus;
+}
+
+/**
+ * The live agent sessions in a tab, one per terminal pane that currently has a
+ * status. A pane's own cwd wins, falling back to the tab's starting cwd. The
+ * agent comes from the per-leaf agent map; it may be undefined until the
+ * foreground poll classifies the pane. Panes are returned in layout order.
+ */
+export function collectTabSessions(
+  tab: Tab,
+  statuses: Record<string, SessionStatus>,
+  agents: Record<string, AgentKind>,
+): TabSession[] {
+  const sessions: TabSession[] = [];
+  for (const pane of computeLayout(tab.paneTree)) {
+    if (pane.content.kind !== "terminal") {
+      continue;
+    }
+    const status = statuses[pane.id];
+    if (!status) {
+      continue;
+    }
+    sessions.push({
+      leafId: pane.id,
+      cwd: pane.content.cwd ?? tab.cwd ?? null,
+      agent: agents[pane.id],
+      status,
+    });
+  }
+  return sessions;
+}

--- a/src/modules/workspace/lib/titlesBridge.ts
+++ b/src/modules/workspace/lib/titlesBridge.ts
@@ -4,3 +4,8 @@ import { invoke } from "@tauri-apps/api/core";
 export function claudeSessionTitle(cwd: string): Promise<string | null> {
   return invoke<string | null>("claude_session_title", { cwd });
 }
+
+/** The auto title for a directory's newest Codex session, or null if none. */
+export function codexSessionTitle(cwd: string): Promise<string | null> {
+  return invoke<string | null>("codex_session_title", { cwd });
+}

--- a/src/modules/workspace/lib/titlesStore.test.ts
+++ b/src/modules/workspace/lib/titlesStore.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { progressKey } from "@/modules/claude-progress/lib/progressStore";
+
+vi.mock("./titlesBridge", () => ({
+  claudeSessionTitle: vi.fn(async () => "Claude title"),
+  codexSessionTitle: vi.fn(async () => "Codex title"),
+}));
+
+import { useTitlesStore } from "./titlesStore";
+
+beforeEach(() => useTitlesStore.setState({ titles: {} }));
+
+describe("titlesStore", () => {
+  it("keys a Claude and a Codex title for the same cwd separately", async () => {
+    await useTitlesStore.getState().refresh("/p", "claude");
+    await useTitlesStore.getState().refresh("/p", "codex");
+
+    const titles = useTitlesStore.getState().titles;
+    expect(titles[progressKey("/p", "claude")]).toBe("Claude title");
+    expect(titles[progressKey("/p", "codex")]).toBe("Codex title");
+  });
+});

--- a/src/modules/workspace/lib/titlesStore.ts
+++ b/src/modules/workspace/lib/titlesStore.ts
@@ -1,21 +1,27 @@
 import { create } from "zustand";
-import { claudeSessionTitle } from "./titlesBridge";
+import { progressKey } from "@/modules/claude-progress/lib/progressStore";
+import type { AgentKind } from "@/modules/claude-progress/lib/codexNormalize";
+import { claudeSessionTitle, codexSessionTitle } from "./titlesBridge";
 
 interface TitlesStoreState {
-  /** Auto session title per directory (keyed by cwd). */
+  /** Auto session title per session, keyed by `progressKey(cwd, agent)`. */
   titles: Record<string, string>;
-  /** Fetch and cache the title for a cwd; a missing title or error is ignored. */
-  refresh: (cwd: string) => Promise<void>;
+  /**
+   * Fetch and cache the title for one cwd+agent session. The agent picks the
+   * source (Claude vs Codex transcripts); a missing title or error is ignored.
+   */
+  refresh: (cwd: string, agent: AgentKind) => Promise<void>;
 }
 
 export const useTitlesStore = create<TitlesStoreState>((set) => ({
   titles: {},
 
-  refresh: async (cwd) => {
+  refresh: async (cwd, agent) => {
     try {
-      const title = await claudeSessionTitle(cwd);
+      const title =
+        agent === "codex" ? await codexSessionTitle(cwd) : await claudeSessionTitle(cwd);
       if (title) {
-        set((state) => ({ titles: { ...state.titles, [cwd]: title } }));
+        set((state) => ({ titles: { ...state.titles, [progressKey(cwd, agent)]: title } }));
       }
     } catch {
       // No transcript yet, or no backend in tests/web preview; keep last value.

--- a/src/modules/workspace/lib/useWorkspaceTitles.ts
+++ b/src/modules/workspace/lib/useWorkspaceTitles.ts
@@ -1,29 +1,39 @@
 import { useEffect } from "react";
-import { useProgressStore } from "@/modules/claude-progress/lib/progressStore";
+import {
+  parseProgressKey,
+  progressKey,
+  useProgressStore,
+} from "@/modules/claude-progress/lib/progressStore";
+import type { AgentKind } from "@/modules/claude-progress/lib/codexNormalize";
 import { useTitlesStore } from "./titlesStore";
 
+/** One session whose auto title we want kept fresh. */
+export interface TitleTarget {
+  cwd: string;
+  agent: AgentKind;
+}
+
 /**
- * Fetches the auto session title for each visible card's cwd, and refetches a
- * cwd when its session epoch changes (a new session starts), so titles track
- * the latest transcript. Failures are swallowed by the store.
+ * Fetches the auto session title for each visible session (cwd + agent), and
+ * refetches one when its session epoch changes (a new session starts), so titles
+ * track the latest transcript. Failures are swallowed by the store.
  */
-export function useWorkspaceTitles(cwds: string[]): void {
+export function useWorkspaceTitles(targets: TitleTarget[]): void {
   const epochs = useProgressStore((s) => s.sessionEpochs);
   const refresh = useTitlesStore((s) => s.refresh);
-  // The key folds in each cwd's epoch so a reset triggers a refetch for it.
-  const key = cwds
-    .slice()
-    .sort()
-    .map((cwd) => `${cwd}@${epochs[cwd] ?? 0}`)
-    .join("\n");
+  // Dedupe to one entry per session and fold in each session's epoch, so a reset
+  // triggers exactly one refetch for it.
+  const keys = [...new Set(targets.map((t) => progressKey(t.cwd, t.agent)))].sort();
+  const key = keys.map((k) => `${k}@${epochs[k] ?? 0}`).join("\n");
 
   useEffect(() => {
     if (!key) {
       return;
     }
     for (const entry of key.split("\n")) {
-      const cwd = entry.slice(0, entry.lastIndexOf("@"));
-      void refresh(cwd);
+      const sessionKey = entry.slice(0, entry.lastIndexOf("@"));
+      const { cwd, agent } = parseProgressKey(sessionKey);
+      void refresh(cwd, agent);
     }
   }, [key, refresh]);
 }


### PR DESCRIPTION
## Problem

A tab split across two panes (e.g. Codex CLI in one pane, Claude Code in another) only showed a single session in the Workspace sidebar. Two causes stacked up:

- The card rendered one row per tab, keyed to a single derived cwd (`deriveTabCwd`), so only the active pane's session was shown.
- Progress, agent label, and title were all tracked per-cwd, so two agents running in the **same** directory clobbered each other (every agent switch reset the other's normalizer and overwrote its label).

## Changes

- **Per-(cwd, agent) progress** — `progressStore` keys `sessions`, `sessionEpochs` (and the normalizers) by `progressKey(cwd, agent)`, so Claude and Codex in the same directory stay independent. No backend change needed; the watcher already emits both streams tagged with their agent.
- **Per-pane agent** — each terminal pane's agent is classified from its foreground process (reusing the existing 1.2s poll) and stored per leaf in `sessionStatusStore` next to the live status.
- **Multi-session card** — a tab running 2+ agents shows the tab name as the header and one row per pane, each with its own status badge, agent label, and title. Single-session cards are unchanged.
- **Codex titles** — new `codex_session_title` Tauri command reads the newest Codex rollout's first `user_message` (skipping injected `environment_context`), mirroring `claude_session_title`. `titlesStore` is keyed by `(cwd, agent)` and dispatches to the right source.

## Test plan

- [x] `pnpm test` — 534 passing, including a new WorkspacePanel acceptance test that renders a split tab and asserts both Claude and Codex rows appear
- [x] `pnpm typecheck` clean
- [x] `cargo build` + `cargo test` for `codex_session_title` / `extract_codex_title`
- [x] Local signed `pnpm tauri build` succeeds
- [ ] Manual: split a tab, run `codex` in one pane and `claude` in the other (same dir and different dirs), confirm both sessions list in the sidebar with correct labels/titles

## Known limitations

- Two panes running the **same** agent in the **same** directory share one title/progress slot.
- A multi-session card still shows branch/path for the primary pane only (per-row branch not yet rendered).
- The agent label appears after the foreground poll classifies the pane (up to ~1.2s).