### PR TITLE
feat: highlight the current commit in the git graph

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -275,3 +275,30 @@ button:disabled {
 .note-md .hljs-variable, .note-md .hljs-template-variable,
 .note-md .hljs-property, .note-md .hljs-params { color: var(--color-fg); }
 .note-md .hljs-meta, .note-md .hljs-comment { color: var(--color-fg-subtle); }
+
+/*
+ * Git graph: the current (HEAD) commit's node. Filled with the accent — a colour
+ * the branch lanes never use — with a soft glow that gently breathes, so "you are
+ * here" is unmistakable without disturbing the calm commit rows.
+ */
+.git-head-node {
+  box-shadow:
+    0 0 0 1.5px var(--color-accent),
+    0 0 11px 2px color-mix(in srgb, var(--color-accent) 60%, transparent);
+  animation: git-head-pulse 2.6s ease-in-out infinite;
+}
+@keyframes git-head-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 0 1.5px var(--color-accent),
+      0 0 8px 1px color-mix(in srgb, var(--color-accent) 45%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 0 1.5px var(--color-accent),
+      0 0 14px 3px color-mix(in srgb, var(--color-accent) 72%, transparent);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .git-head-node { animation: none; }
+}

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -6,6 +6,7 @@ import {
   DEFAULT_GEOMETRY,
   edgePath,
 } from "./lib/graphLayout";
+import { isCurrentCommit } from "./lib/currentCommit";
 
 export interface GitGraphLabels {
   emptyTitle: string;
@@ -34,8 +35,8 @@ interface GitGraphProps {
 // light (#fff) backgrounds, and evenly spaced so adjacent lanes stay distinct.
 const BRANCH_COLORS = [
   "#e0555f", // red
-  "#e08a3c", // orange
-  "#d6a82c", // yellow (deepened so it reads on light themes)
+  "#e3712f", // orange (shifted redder to separate from yellow)
+  "#e8c139", // yellow (brighter gold so it never reads like orange)
   "#46a758", // green
   "#3b8ee0", // blue
   "#6366d6", // indigo
@@ -160,6 +161,7 @@ export function GitGraph({
               }
               const color = BRANCH_COLORS[layout.colorIndex % BRANCH_COLORS.length];
               const isSelected = selectedCommit?.hash === commit.hash;
+              const isCurrent = isCurrentCommit(commit);
               return (
                 <button
                   key={commit.hash}
@@ -180,9 +182,14 @@ export function GitGraph({
                     isSelected ? "scale-125 ring-4 ring-accent/30" : "hover:scale-110"
                   }`}
                 >
+                  {/* The current (HEAD) node is filled with the accent — a colour
+                      the branch lanes never use — and glows, so it reads as "you
+                      are here" without touching the calm commit rows. */}
                   <span
-                    className="h-3 w-3 rounded-full border-2 border-bg shadow-md"
-                    style={{ backgroundColor: color }}
+                    className={`h-3 w-3 rounded-full border-2 border-bg ${
+                      isCurrent ? "git-head-node" : "shadow-md"
+                    }`}
+                    style={{ backgroundColor: isCurrent ? "var(--color-accent)" : color }}
                   />
                 </button>
               );
@@ -197,6 +204,15 @@ export function GitGraph({
                 return null;
               }
               const isSelected = selectedCommit?.hash === commit.hash;
+              const isCurrent = isCurrentCommit(commit);
+              // The HEAD commit is marked at its graph node (filled accent + glow);
+              // its row stays calm and only brightens to full foreground, so the
+              // list reads uniformly. Selection keeps its own filled style.
+              const rowState = isSelected
+                ? "border-border-strong bg-bg-elevated text-fg shadow-sm"
+                : isCurrent
+                  ? "border-transparent text-fg hover:bg-bg-elevated/50"
+                  : "border-transparent text-fg-muted hover:bg-bg-elevated/50 hover:text-fg";
               return (
                 <div
                   key={commit.hash}
@@ -209,11 +225,7 @@ export function GitGraph({
                     height: `${ROW_HEIGHT}px`,
                     top: `${layout.y - ROW_HEIGHT / 2}px`,
                   }}
-                  className={`absolute left-[100px] right-4 flex cursor-pointer items-center justify-between rounded border px-3 py-1 transition-all ${
-                    isSelected
-                      ? "border-border-strong bg-bg-elevated text-fg shadow-sm"
-                      : "border-transparent text-fg-muted hover:bg-bg-elevated/50 hover:text-fg"
-                  }`}
+                  className={`absolute left-[100px] right-4 flex cursor-pointer items-center justify-between rounded border px-3 py-1 transition-all ${rowState}`}
                 >
                   <div className="flex items-center space-x-3 overflow-hidden pr-2">
                     <span className="select-all font-mono text-xs font-semibold text-accent">

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -187,9 +187,9 @@ export function GitGraph({
                       are here" without touching the calm commit rows. */}
                   <span
                     className={`h-3 w-3 rounded-full border-2 border-bg ${
-                      isCurrent ? "git-head-node" : "shadow-md"
+                      isCurrent ? "git-head-node bg-accent" : "shadow-md"
                     }`}
-                    style={{ backgroundColor: isCurrent ? "var(--color-accent)" : color }}
+                    style={isCurrent ? undefined : { backgroundColor: color }}
                   />
                 </button>
               );

--- a/src/modules/git-graph/lib/currentCommit.test.ts
+++ b/src/modules/git-graph/lib/currentCommit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { isCurrentCommit } from "./currentCommit";
+import type { CommitNode, CommitRef } from "../types";
+
+function commit(refs: CommitRef[]): CommitNode {
+  return { hash: "abc1234", parents: [], author: "a", date: "d", message: "m", refs };
+}
+
+describe("isCurrentCommit", () => {
+  it("is true when a checked-out branch head points at the commit", () => {
+    expect(isCurrentCommit(commit([{ name: "master", kind: "head" }]))).toBe(true);
+  });
+
+  it("is true on a detached HEAD", () => {
+    expect(isCurrentCommit(commit([{ name: "HEAD", kind: "head" }]))).toBe(true);
+  });
+
+  it("is false for a commit carrying only branch, tag, or remote refs", () => {
+    expect(
+      isCurrentCommit(
+        commit([
+          { name: "origin/master", kind: "remote" },
+          { name: "v1.0", kind: "tag" },
+          { name: "feature", kind: "branch" },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false when the commit has no refs", () => {
+    expect(isCurrentCommit(commit([]))).toBe(false);
+  });
+});

--- a/src/modules/git-graph/lib/currentCommit.ts
+++ b/src/modules/git-graph/lib/currentCommit.ts
@@ -1,0 +1,10 @@
+import type { CommitNode } from "../types";
+
+/**
+ * Whether HEAD currently points at this commit, i.e. it is the checked-out
+ * commit. The backend tags such a commit with a `head` ref for both an attached
+ * HEAD (`HEAD -> branch`) and a detached HEAD (a bare `HEAD`).
+ */
+export function isCurrentCommit(commit: CommitNode): boolean {
+  return commit.refs.some((ref) => ref.kind === "head");
+}


### PR DESCRIPTION
## What

The git graph had no persistent cue for which commit `HEAD` points at — only the small green head-ref chip. This marks the current commit and tidies two lane colours.

- **Current commit highlight (Variation B — node halo)**: the HEAD commit's graph node is filled with `--color-accent` (a colour the branch lanes never use) and given a soft, reduced-motion-aware breathing glow. The commit rows stay calm — the current row only brightens to full foreground — so the list still reads uniformly and the cue doesn't fight row selection.
- **`isCurrentCommit()`**: a pure helper — a commit is current when it carries a `head` ref. Covers both an attached HEAD (`HEAD -> branch`) and a detached HEAD (bare `HEAD`).
- **orange / yellow separation**: the two warm lane colours were only ~12° of hue apart (and the yellow had been deepened toward gold), so adjacent lanes looked alike. orange `#e08a3c` → `#e3712f` (redder), yellow `#d6a82c` → `#e8c139` (brighter gold).

## Test plan

- [x] `pnpm test` — 538 passing, incl. new `isCurrentCommit` tests (attached HEAD, detached HEAD, non-head refs, no refs)
- [x] `pnpm typecheck` clean
- [x] Local signed `pnpm tauri build` succeeds
- [ ] Manual: open the git graph, confirm the HEAD node glows in accent and rows stay calm; check orange vs yellow lanes are distinct on both dark and light themes

## Notes

- The glow honours `prefers-reduced-motion: reduce` (animation disabled).
- Styles were chosen via standalone HTML previews (Variation A/B/C, then HEAD-node colour, then the orange/yellow pair) to avoid repeated app rebuilds.