### PR TITLE
fix: restore changelog notes in latest.json after Windows CI

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -75,6 +75,24 @@ jobs:
           prerelease: false
           args: "--target x86_64-pc-windows-msvc"
 
+      - name: Restore changelog notes in latest.json
+        # tauri-action above merges the Windows platforms into the release's
+        # latest.json, but it rewrites the file and drops the `notes` the macOS
+        # release embedded from the changelog. The in-app updater renders `notes`,
+        # so put it back from this tag's CHANGELOG-NEXT.md (still populated at the
+        # tagged commit; it's only reset in a later commit).
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass the ref through env (not inline ${{ }}) so a crafted tag name
+          # can't inject into the shell command.
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release download "$TAG" -p latest.json -O latest.json --clobber
+          node scripts/patchManifestNotes.mjs latest.json CHANGELOG-NEXT.md
+          gh release upload "$TAG" latest.json --clobber
+
       - name: Upload installers as workflow artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/scripts/patchManifestNotes.mjs
+++ b/scripts/patchManifestNotes.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 /**
@@ -32,7 +32,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-  const notes = readFileSync(changelogPath, "utf8");
+  // A missing changelog is treated like a blank one (no-op), so it can't crash
+  // the release step — patchManifestNotes then leaves the existing notes intact.
+  const notes = existsSync(changelogPath) ? readFileSync(changelogPath, "utf8") : "";
   const patched = patchManifestNotes(manifest, notes);
   writeFileSync(manifestPath, `${JSON.stringify(patched, null, 2)}\n`);
 }

--- a/scripts/patchManifestNotes.mjs
+++ b/scripts/patchManifestNotes.mjs
@@ -1,0 +1,38 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Re-inject the changelog into an updater manifest's `notes`.
+ *
+ * The Windows CI's tauri-action regenerates latest.json to add the Windows
+ * platforms, but in doing so it wipes the `notes` field that the macOS release
+ * embedded from the changelog. The in-app updater renders `notes`, so this
+ * restores it after that step. A blank changelog leaves the existing notes
+ * untouched (so a missing file can't blank a good manifest).
+ *
+ * @param {Record<string, unknown>} manifest
+ * @param {string} notes
+ * @returns {Record<string, unknown>}
+ */
+export function patchManifestNotes(manifest, notes) {
+  const trimmed = notes.trim();
+  if (!trimmed) {
+    return manifest;
+  }
+  return { ...manifest, notes: trimmed };
+}
+
+// CLI: node scripts/patchManifestNotes.mjs <manifestPath> <changelogPath>
+// Rewrites the manifest in place with the changelog folded into `notes`.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [manifestPath, changelogPath] = process.argv.slice(2);
+  if (!manifestPath || !changelogPath) {
+    process.stderr.write("usage: patchManifestNotes.mjs <manifestPath> <changelogPath>\n");
+    process.exit(1);
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const notes = readFileSync(changelogPath, "utf8");
+  const patched = patchManifestNotes(manifest, notes);
+  writeFileSync(manifestPath, `${JSON.stringify(patched, null, 2)}\n`);
+}

--- a/scripts/patchManifestNotes.test.ts
+++ b/scripts/patchManifestNotes.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error - plain .mjs release helper, no type declarations
+import { patchManifestNotes } from "./patchManifestNotes.mjs";
+
+const MERGED_MANIFEST = {
+  version: "0.0.7",
+  notes: "",
+  pub_date: "2026-06-22T17:03:26.650Z",
+  platforms: {
+    "darwin-aarch64": { signature: "mac-sig", url: "https://example.com/mac.tar.gz" },
+    "windows-x86_64": { signature: "win-sig", url: "https://example.com/win.exe" },
+  },
+};
+
+describe("patchManifestNotes", () => {
+  it("restores the changelog into notes while keeping the merged platforms", () => {
+    const result = patchManifestNotes(MERGED_MANIFEST, "## What's new\n- feat: a thing\n");
+
+    expect(result.notes).toBe("## What's new\n- feat: a thing");
+    expect(result.platforms).toEqual(MERGED_MANIFEST.platforms);
+    expect(result.version).toBe("0.0.7");
+  });
+
+  it("leaves existing notes untouched when the changelog is blank", () => {
+    const manifest = { ...MERGED_MANIFEST, notes: "keep me" };
+    expect(patchManifestNotes(manifest, "   \n  ").notes).toBe("keep me");
+  });
+});


### PR DESCRIPTION
## Bug

The in-app updater's "更新內容" dialog showed up **empty** for v0.0.7 (just a dash).

## Root cause

The updater renders the `notes` field of `latest.json` (not the GitHub release body). The release flow is: the macOS `release.sh` builds `latest.json` with `notes` embedded from `CHANGELOG-NEXT.md`, then the `v*` tag push triggers `windows-build.yml`, whose `tauri-action` **rewrites** `latest.json` to add the Windows platforms — merging the platform entries correctly but wiping `notes` to an empty string.

Evidence on the v0.0.7 release: `release.sh`'s local manifest had `notes` of 1267 chars (pub_date 16:58); the published manifest had `notes: ""` with pub_date 17:03, exactly during the Windows CI run.

(The live v0.0.7 `latest.json` has already been repaired out-of-band by re-uploading it with `notes` restored.)

## Fix

Add a post-build step in `windows-build.yml` (tag pushes only) that, after `tauri-action`, downloads `latest.json`, re-injects `notes` from this tag's `CHANGELOG-NEXT.md` (still populated at the tagged commit — it's only reset in a later commit), and re-uploads it. The JSON patching is a small `scripts/patchManifestNotes.mjs` helper.

- A blank changelog leaves existing notes untouched (a missing file can't blank a good manifest).
- The ref is passed via an `env:` var and quoted in the `run:` block to avoid shell injection from a crafted tag name.

## Test plan

- [x] `pnpm test` — new `patchManifestNotes` tests (restore notes + keep platforms; blank changelog is a no-op)
- [x] Workflow YAML parses
- [ ] Next release: confirm the published `latest.json` keeps both the merged platforms and the changelog `notes`