### PR TITLE
feat: add SSH connection support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4825,7 +4825,19 @@ dependencies = [
  "mio 1.2.1",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "zeroize",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +91,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "argon2"
+version = "0.6.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.3.0",
+ "password-hash",
 ]
 
 [[package]]
@@ -223,6 +272,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +311,23 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144e573728da132683b9488acd528274c790e07fc06ff81ee29f9d8f8b1041e0"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2 0.11.0",
+]
 
 [[package]]
 name = "bit-set"
@@ -265,12 +360,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.11.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -293,6 +416,16 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -431,6 +564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +630,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +655,33 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"
@@ -519,6 +701,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cookie"
@@ -617,10 +805,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -669,13 +872,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -718,6 +959,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +1039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +1062,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
  "dbus",
+ "zeroize",
+]
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -814,13 +1129,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -984,6 +1320,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.17.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54fb064faabbee66e1fc8e5c5a9458d4269dc2d8b638fe86a425adb2510d1a96"
+dependencies = [
+ "der",
+ "digest 0.11.3",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.0-rc.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102d3643d30dd8b559613c5cced68317199597fffb278cdc88daa2ef7fafc935"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff",
+ "group",
+ "hkdf",
+ "hybrid-array",
+ "once_cell",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.10.1",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1426,18 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1110,6 +1522,22 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "field-offset"
@@ -1255,6 +1683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,12 +1698,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1337,6 +1787,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1457,6 +1908,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
+dependencies = [
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,10 +1952,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
 ]
 
 [[package]]
@@ -1658,6 +2132,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +2240,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +2317,18 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "ctutils",
+ "subtle",
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hyper"
@@ -2086,6 +2607,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
+name = "internal-russh-num-bigint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2797,26 @@ checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2457,6 +3020,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,6 +3095,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8",
+ "rand_core 0.10.1",
+ "sha3",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +3183,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+]
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,10 +3214,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2925,6 +3550,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.14.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41adc63effe99d48837a8cc0e6d7a77e32ae6a07f6000df466178dbc2193093e"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p384"
+version = "0.14.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd5333afa5ae0347f39e6a0f2c9c155da431583fd71fe5555bd0521b4ccaf02"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p521"
+version = "0.14.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a5297f53dc16d35909060ba3032cff7867e8809f01e273ff325579d5f0ceae"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "pageant"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3a5ae18f65a85c67a77d18d42d3606c07948e3c17c1e5f74852b26589e88a5"
+dependencies = [
+ "base16ct",
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "windows 0.62.2",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +3665,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
+dependencies = [
+ "phc",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,10 +3699,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
+]
 
 [[package]]
 name = "phf"
@@ -3080,6 +3804,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279a91971a1d8eb1260a30938eae3be9cb67b472dffecb222fbbbe2fd2dc1453"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "rand_core 0.10.1",
+ "scrypt",
+ "sha2 0.11.0",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core 0.10.1",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,6 +3901,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash",
+ "zeroize",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,7 +3935,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.28.0",
  "serial2",
  "shared_library",
  "shell-words",
@@ -3197,6 +3981,29 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8675564771a62f69a0af716b03e89b917b963c7b173b5855575e84fd4f605ca0"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2793f22b9b6fd11ef3ac1d59bf003c2573593e4968702341605c2748fd90bf"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3298,7 +4105,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3352,7 +4159,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3362,7 +4180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3373,6 +4191,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-window-handle"
@@ -3527,6 +4351,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5236ce872cac07e0fb3969b0cbf468c7d2f37d432f1b627dcb7b8d34563fb0c3"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3560,8 +4394,123 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
+dependencies = [
+ "const-oid",
+ "crypto-bigint",
+ "crypto-primes",
+ "digest 0.11.3",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "signature",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
+name = "russh"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf893f64684e58da8a68d56a5e84d1cf0440226274c515770fe267707a7d0b0"
+dependencies = [
+ "aes",
+ "aws-lc-rs",
+ "bitflags 2.13.0",
+ "block-padding",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "cipher",
+ "crypto-bigint",
+ "ctr",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der",
+ "digest 0.11.3",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array 1.4.3",
+ "getrandom 0.4.2",
+ "ghash",
+ "hex-literal",
+ "hmac",
+ "inout",
+ "internal-russh-num-bigint",
+ "keccak",
+ "log",
+ "md5",
+ "ml-kem",
+ "module-lattice",
+ "num-bigint",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8",
+ "polyval",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
+ "rsa",
+ "russh-cryptovec",
+ "russh-util",
+ "salsa20",
+ "scrypt",
+ "sec1",
+ "sha1",
+ "sha2 0.11.0",
+ "sha3",
+ "signature",
+ "spki",
+ "ssh-encoding",
+ "ssh-key",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "typenum",
+ "universal-hash",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443f6bbcfacb34a1aab2b12b99bf08e0c63abdc5a0db261901365df9d57fff51"
+dependencies = [
+ "log",
+ "nix 0.31.3",
+ "ssh-encoding",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3663,7 +4612,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3677,6 +4626,16 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -3752,6 +4711,32 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct",
+ "ctutils",
+ "der",
+ "hybrid-array",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -3958,6 +4943,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "serial2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4000,14 +4995,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
 ]
 
 [[package]]
@@ -4040,6 +5067,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4138,6 +5175,77 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.3.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10db6f219196a8528f9ec904d9d45cdad692d65b0e57e72be4dedd1c5fddce36"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20",
+ "cipher",
+ "ctr",
+ "ctutils",
+ "des",
+ "poly1305",
+ "ssh-encoding",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.3.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abf34aa716da5d5b4c496936d042ea282ab392092cd68a72ef6a8863ff8c96a"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "crypto-bigint",
+ "ctutils",
+ "digest 0.11.3",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.7.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45735ce3dea95690e4a9e414c4cfde7f79835063c3dcd35881df85a84118e74b"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "ctutils",
+ "ed25519-dalek",
+ "hex",
+ "hmac",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.10.1",
+ "rsa",
+ "sec1",
+ "sha1",
+ "sha2 0.11.0",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "zeroize",
 ]
 
 [[package]]
@@ -4405,7 +5513,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -4695,6 +5803,7 @@ dependencies = [
  "notify",
  "portable-pty",
  "reqwest 0.12.28",
+ "russh",
  "serde",
  "serde_json",
  "tauri",
@@ -5206,6 +6315,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5641,11 +6766,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -5655,6 +6792,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5703,7 +6849,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5770,6 +6927,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5941,6 +7108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6317,7 +7493,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ grep-searcher = "0.1"
 grep-matcher = "0.1"
 git2 = "0.19"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "rt"] }
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ grep-searcher = "0.1"
 grep-matcher = "0.1"
 git2 = "0.19"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "rt"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "rt", "io-util", "net", "time"] }
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
@@ -39,6 +39,7 @@ trash = "5"
 notify = "6"
 toml_edit = "0.22"
 chrono = "0.4"
+russh = "0.61.2"
 
 # keyring 3.x ships no credential store by default; each platform must opt into
 # its native backend or every keychain operation fails silently.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ use modules::pty::{
     pty_close, pty_close_all, pty_cwd, pty_foreground_command, pty_open, pty_resize,
     pty_shell_name, pty_write, PtyState,
 };
+use modules::ssh::{ssh_close, ssh_open, ssh_prompt_reply, ssh_resize, ssh_write, SshState};
 use modules::terminal_history::{
     terminal_history_clear, terminal_history_delete, terminal_history_load,
     terminal_history_prune, terminal_history_save,
@@ -73,6 +74,7 @@ pub fn run() {
                 .build(),
         )
         .manage(PtyState::new())
+        .manage(SshState::new())
         .manage(ClaudeProgressState::new())
         .manage(CodexProgressState::new())
         .manage(NotesWatchState::new())
@@ -169,7 +171,12 @@ pub fn run() {
             codex_status_hook_install,
             codex_status_hook_uninstall,
             notes_watch,
-            notes_unwatch
+            notes_unwatch,
+            ssh_open,
+            ssh_write,
+            ssh_resize,
+            ssh_close,
+            ssh_prompt_reply
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,9 @@ use modules::git::{
     git_unstage, git_worktree_info,
 };
 use modules::pr::{gh_available, pr_via_api, pr_via_gh};
-use modules::secrets::{secrets_delete_key, secrets_has_key, secrets_set_key};
+use modules::secrets::{
+    secrets_delete_key, secrets_has_key, secrets_set_key, ssh_secret_delete, ssh_secret_set,
+};
 use modules::pty::{
     pty_close, pty_close_all, pty_cwd, pty_foreground_command, pty_open, pty_resize,
     pty_shell_name, pty_write, PtyState,
@@ -176,7 +178,9 @@ pub fn run() {
             ssh_write,
             ssh_resize,
             ssh_close,
-            ssh_prompt_reply
+            ssh_prompt_reply,
+            ssh_secret_set,
+            ssh_secret_delete
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,4 +1,5 @@
 pub mod ai;
+pub mod ssh;
 pub mod claude_progress;
 pub mod claude_status_hook;
 pub mod codex_progress;

--- a/src-tauri/src/modules/secrets/mod.rs
+++ b/src-tauri/src/modules/secrets/mod.rs
@@ -5,6 +5,7 @@
 use keyring::Entry;
 
 const SERVICE: &str = "tempoterm-ai";
+const SSH_SERVICE: &str = "tempoterm-ssh";
 
 fn account_for(provider: &str) -> String {
     format!("provider:{provider}")
@@ -12,6 +13,14 @@ fn account_for(provider: &str) -> String {
 
 fn entry(provider: &str) -> Result<Entry, String> {
     Entry::new(SERVICE, &account_for(provider)).map_err(|e| e.to_string())
+}
+
+fn ssh_account_for(connection_id: &str) -> String {
+    format!("connection:{connection_id}")
+}
+
+fn ssh_entry(connection_id: &str) -> Result<Entry, String> {
+    Entry::new(SSH_SERVICE, &ssh_account_for(connection_id)).map_err(|e| e.to_string())
 }
 
 pub fn set_key(provider: &str, key: &str) -> Result<(), String> {
@@ -55,6 +64,42 @@ pub fn secrets_has_key(provider: String) -> bool {
     has_key(&provider)
 }
 
+// ---------------------------------------------------------------------------
+// SSH secrets — passwords / key passphrases keyed by connection id.
+//
+// Stored under a distinct `tempoterm-ssh` service so they never collide with
+// the AI provider keys. The value is read ONLY inside the backend (the ssh
+// auth dispatch) via `ssh_get_secret`, which is deliberately NOT a Tauri
+// command so a stored SSH secret can never travel back to the webview.
+// ---------------------------------------------------------------------------
+
+/// Read the stored SSH secret (password or key passphrase) for a connection.
+/// Backend-only: never exposed as a command so the secret stays in the backend.
+/// A missing entry is `Ok(None)`, not an error.
+pub fn ssh_get_secret(connection_id: &str) -> Result<Option<String>, String> {
+    match ssh_entry(connection_id)?.get_password() {
+        Ok(secret) => Ok(Some(secret)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn ssh_secret_set(connection_id: String, secret: String) -> Result<(), String> {
+    ssh_entry(&connection_id)?
+        .set_password(&secret)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn ssh_secret_delete(connection_id: String) -> Result<(), String> {
+    match ssh_entry(&connection_id)?.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +109,12 @@ mod tests {
         assert_eq!(account_for("openai"), "provider:openai");
         assert_eq!(account_for("anthropic"), "provider:anthropic");
         assert_ne!(account_for("openai"), account_for("anthropic"));
+    }
+
+    #[test]
+    fn ssh_account_name_is_namespaced_per_connection() {
+        assert_eq!(ssh_account_for("conn-1"), "connection:conn-1");
+        assert_eq!(ssh_account_for("conn-2"), "connection:conn-2");
+        assert_ne!(ssh_account_for("conn-1"), ssh_account_for("conn-2"));
     }
 }

--- a/src-tauri/src/modules/ssh/client.rs
+++ b/src-tauri/src/modules/ssh/client.rs
@@ -13,8 +13,12 @@ use std::time::Duration;
 
 use tauri::{AppHandle, Emitter};
 
-use super::known_hosts::{classify, known_hosts_line, HostKeyStatus};
+use super::known_hosts::{classify, host_token, known_hosts_line, rewrite_lines, HostKeyStatus};
 use super::prompt::{PromptKind, PromptRegistry, PromptReply, PromptRequest};
+
+/// Guards concurrent writes to the app-managed known_hosts file.
+/// Held only across the sync read+rewrite in `persist_host_key`.
+static KNOWN_HOSTS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Emit an `ssh-prompt` to the frontend, register the request id, and await the
 /// user's reply. This is the single emit+register+await primitive shared by the
@@ -131,7 +135,6 @@ impl russh::client::Handler for VerifyingClient {
                     // lines for the host token before appending the new one.
                     persist_host_key(
                         &self.known_hosts_path,
-                        &lines,
                         &self.host,
                         self.port,
                         &presented,
@@ -155,48 +158,24 @@ impl russh::client::Handler for VerifyingClient {
 /// created so the very first write succeeds.
 fn persist_host_key(
     path: &Path,
-    lines: &[String],
     host: &str,
     port: u16,
     key: &str,
 ) -> std::io::Result<()> {
-    let token = host_token(host, port);
-    let mut kept: Vec<String> = lines
-        .iter()
-        .filter(|raw| {
-            let trimmed = raw.trim();
-            // Keep comments / blanks untouched.
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                return true;
-            }
-            // Drop only entries whose first field is exactly this host token,
-            // matching how `classify` keys entries (avoids prefix false matches
-            // like "host" vs "host2").
-            let entry_host = trimmed
-                .split(char::is_whitespace)
-                .next()
-                .unwrap_or("");
-            entry_host != token
-        })
+    let _guard = KNOWN_HOSTS_LOCK.lock().unwrap();
+    let lines: Vec<String> = std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
         .map(|l| l.to_string())
         .collect();
-
-    kept.push(known_hosts_line(host, port, key));
+    let token = host_token(host, port);
+    let new_line = known_hosts_line(host, port, key);
+    let kept = rewrite_lines(lines.as_slice(), &token, &new_line);
 
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(path, kept.join("\n") + "\n")
-}
-
-/// The known_hosts token for a host: bare host on port 22, `[host]:port`
-/// otherwise (OpenSSH convention; mirrors `known_hosts::host_token`).
-fn host_token(host: &str, port: u16) -> String {
-    if port == 22 {
-        host.to_string()
-    } else {
-        format!("[{host}]:{port}")
-    }
 }
 
 /// Inputs needed to open a verified SSH connection.
@@ -293,6 +272,16 @@ pub struct AuthArgs {
     pub connection_id: String,
 }
 
+/// Validate that the requested auth method is one we support.
+/// Returns `Ok(())` for `"password"`, `"keyFile"`, `"agent"`, and
+/// `Err("unsupported auth method: {method}")` for anything else.
+fn validate_auth_method(method: &str) -> Result<(), String> {
+    match method {
+        "password" | "keyFile" | "agent" => Ok(()),
+        other => Err(format!("unsupported auth method: {other}")),
+    }
+}
+
 /// Authenticate the (already host-key-verified) connection using the method the
 /// user selected. Returns `Ok(true)` if the server accepted the credentials,
 /// `Ok(false)` if it rejected them, and `Err` on an operational failure (key
@@ -305,6 +294,7 @@ pub async fn authenticate(
     window_label: &str,
     session_id: u32,
 ) -> Result<bool, String> {
+    validate_auth_method(&args.auth_method)?;
     match args.auth_method.as_str() {
         "password" => {
             authenticate_password(handle, args, registry, app, window_label, session_id).await
@@ -658,5 +648,20 @@ mod tests {
             expand_tilde_with("~other/key.pem", "/Users/muki"),
             "~other/key.pem"
         );
+    }
+
+    #[test]
+    fn valid_auth_methods_return_ok() {
+        assert!(validate_auth_method("password").is_ok());
+        assert!(validate_auth_method("keyFile").is_ok());
+        assert!(validate_auth_method("agent").is_ok());
+    }
+
+    #[test]
+    fn unknown_auth_method_returns_err_with_unsupported() {
+        let result = validate_auth_method("ftp");
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("unsupported"), "expected 'unsupported' in: {msg}");
     }
 }

--- a/src-tauri/src/modules/ssh/client.rs
+++ b/src-tauri/src/modules/ssh/client.rs
@@ -1,3 +1,196 @@
 //! SSH client handler — implements `russh::client::Handler` for host-key
-//! verification, auth negotiation, and channel data forwarding.
-//! Implemented in Task 6.
+//! verification against an app-managed `known_hosts` file.
+//!
+//! `check_server_key` is the security-critical path: it classifies the
+//! presented key (Trusted / Unknown / Changed), prompts the user through the
+//! Tauri `ssh-prompt` event for anything not already trusted, awaits the reply,
+//! and only persists the key on explicit approval. A Changed key is never
+//! auto-accepted.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tauri::{AppHandle, Emitter};
+
+use super::known_hosts::{classify, known_hosts_line, HostKeyStatus};
+use super::prompt::{PromptKind, PromptRegistry, PromptRequest};
+
+/// The russh `Handler` that verifies the server's host key before the session
+/// is allowed to proceed. Carries everything `check_server_key` needs to read
+/// the known_hosts file, emit a prompt, and await the user's decision.
+pub struct VerifyingClient {
+    /// Used to emit the `ssh-prompt` Tauri event to the frontend.
+    pub app: AppHandle,
+    /// Shared registry that pairs a prompt id with the oneshot that the
+    /// `ssh_prompt_reply` command resolves.
+    pub registry: Arc<PromptRegistry>,
+    /// `app_data_dir()/ssh_known_hosts` — the app-managed known_hosts file.
+    pub known_hosts_path: PathBuf,
+    /// Host the user asked to connect to (used as the known_hosts token).
+    pub host: String,
+    /// Port (drives bare-host vs `[host]:port` token form).
+    pub port: u16,
+    /// Session id, used to make the prompt request id unique per session.
+    pub session_id: u32,
+}
+
+impl VerifyingClient {
+    /// A prompt id unique to this session's host-key check.
+    fn new_request_id(&self) -> String {
+        format!("{}-hostkey", self.session_id)
+    }
+}
+
+impl russh::client::Handler for VerifyingClient {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &russh::keys::ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        // Build the presented key string ("<algo> <base64>") from the openssh
+        // encoding. If the key cannot be encoded we refuse rather than risk
+        // trusting an empty/garbage entry.
+        let openssh = server_public_key
+            .to_openssh()
+            .map_err(|_| russh::Error::CouldNotReadKey)?;
+        let presented: String = openssh
+            .split_whitespace()
+            .take(2)
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        // SHA256 fingerprint for display in the prompt (renders as "SHA256:...").
+        let fingerprint = server_public_key
+            .fingerprint(russh::keys::HashAlg::Sha256)
+            .to_string();
+
+        // Missing file = empty list (first-ever connection).
+        let lines: Vec<String> = std::fs::read_to_string(&self.known_hosts_path)
+            .unwrap_or_default()
+            .lines()
+            .map(|l| l.to_string())
+            .collect();
+
+        match classify(&lines, &self.host, self.port, &presented) {
+            // Already pinned and matching — accept silently, no prompt.
+            HostKeyStatus::Trusted => Ok(true),
+            status => {
+                let kind = match status {
+                    HostKeyStatus::Changed => PromptKind::HostKeyChanged,
+                    // Unknown (Trusted handled above).
+                    _ => PromptKind::HostKeyUnknown,
+                };
+
+                let id = self.new_request_id();
+                let rx = self.registry.register(&id);
+                self.app
+                    .emit(
+                        "ssh-prompt",
+                        PromptRequest {
+                            id,
+                            kind,
+                            message: fingerprint,
+                        },
+                    )
+                    .map_err(|_| russh::Error::Disconnect)?;
+
+                // Await the user's decision. A dropped sender (registry gone /
+                // session torn down) aborts the connection.
+                let reply = rx.await.map_err(|_| russh::Error::Disconnect)?;
+
+                if reply.approved {
+                    // Unknown -> append; Changed -> replace this host's lines.
+                    // `persist_host_key` handles both by removing any existing
+                    // lines for the host token before appending the new one.
+                    persist_host_key(
+                        &self.known_hosts_path,
+                        &lines,
+                        &self.host,
+                        self.port,
+                        &presented,
+                    )
+                    .map_err(|_| russh::Error::Disconnect)?;
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+        }
+    }
+}
+
+/// Rewrite the known_hosts file so the host token has exactly one line: the
+/// newly-approved key.
+///
+/// Works for both the Unknown case (no existing line, so this is an append) and
+/// the Changed case (drops the host's stale line(s) first). Other hosts'
+/// entries, comments, and blank lines are preserved. Parent directories are
+/// created so the very first write succeeds.
+fn persist_host_key(
+    path: &Path,
+    lines: &[String],
+    host: &str,
+    port: u16,
+    key: &str,
+) -> std::io::Result<()> {
+    let token = host_token(host, port);
+    let mut kept: Vec<String> = lines
+        .iter()
+        .filter(|raw| {
+            let trimmed = raw.trim();
+            // Keep comments / blanks untouched.
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return true;
+            }
+            // Drop only entries whose first field is exactly this host token,
+            // matching how `classify` keys entries (avoids prefix false matches
+            // like "host" vs "host2").
+            let entry_host = trimmed
+                .split(char::is_whitespace)
+                .next()
+                .unwrap_or("");
+            entry_host != token
+        })
+        .map(|l| l.to_string())
+        .collect();
+
+    kept.push(known_hosts_line(host, port, key));
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, kept.join("\n") + "\n")
+}
+
+/// The known_hosts token for a host: bare host on port 22, `[host]:port`
+/// otherwise (OpenSSH convention; mirrors `known_hosts::host_token`).
+fn host_token(host: &str, port: u16) -> String {
+    if port == 22 {
+        host.to_string()
+    } else {
+        format!("[{host}]:{port}")
+    }
+}
+
+/// Inputs needed to open a verified SSH connection.
+pub struct ConnectArgs {
+    /// Pre-built handler carrying the host-key verification context.
+    pub handler: VerifyingClient,
+    /// Host to dial.
+    pub host: String,
+    /// Port to dial.
+    pub port: u16,
+}
+
+/// Open a TCP connection and run the SSH transport handshake, verifying the
+/// host key via `VerifyingClient::check_server_key`. Returns the connected
+/// handle (authentication is performed by the caller in a later task).
+pub async fn connect(
+    args: ConnectArgs,
+) -> Result<russh::client::Handle<VerifyingClient>, String> {
+    let config = Arc::new(russh::client::Config::default());
+    russh::client::connect(config, (args.host.as_str(), args.port), args.handler)
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/modules/ssh/client.rs
+++ b/src-tauri/src/modules/ssh/client.rs
@@ -1,0 +1,3 @@
+//! SSH client handler — implements `russh::client::Handler` for host-key
+//! verification, auth negotiation, and channel data forwarding.
+//! Implemented in Task 6.

--- a/src-tauri/src/modules/ssh/client.rs
+++ b/src-tauri/src/modules/ssh/client.rs
@@ -9,6 +9,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use tauri::{AppHandle, Emitter};
 
@@ -211,11 +212,37 @@ pub struct ConnectArgs {
 /// Open a TCP connection and run the SSH transport handshake, verifying the
 /// host key via `VerifyingClient::check_server_key`. Returns the connected
 /// handle (authentication is performed by the caller in a later task).
+/// How long to wait for the TCP connection before giving up. Only the TCP
+/// connect is bounded by this — the SSH handshake that follows includes the
+/// interactive host-key prompt, which legitimately waits on the user, so it must
+/// NOT be under a timeout. An unreachable host or a filtered port is exactly what
+/// would otherwise hang here (~75s on the OS SYN-retry timeout).
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
 pub async fn connect(
     args: ConnectArgs,
 ) -> Result<russh::client::Handle<VerifyingClient>, String> {
     let config = Arc::new(russh::client::Config::default());
-    russh::client::connect(config, (args.host.as_str(), args.port), args.handler)
+
+    // Do the TCP connect ourselves with a timeout, then hand the live stream to
+    // russh. Wrapping `russh::client::connect` directly would also time out the
+    // host-key prompt, which must be allowed to wait for the user.
+    let stream = tokio::time::timeout(
+        CONNECT_TIMEOUT,
+        tokio::net::TcpStream::connect((args.host.as_str(), args.port)),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "timed out after {}s connecting to {}:{}",
+            CONNECT_TIMEOUT.as_secs(),
+            args.host,
+            args.port
+        )
+    })?
+    .map_err(|e| format!("could not reach {}:{}: {e}", args.host, args.port))?;
+
+    russh::client::connect_stream(config, stream, args.handler)
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/modules/ssh/client.rs
+++ b/src-tauri/src/modules/ssh/client.rs
@@ -39,7 +39,25 @@ async fn request_prompt(
     kind: PromptKind,
     message: String,
 ) -> Result<PromptReply, String> {
+    // Ensure the pending entry is removed no matter how we leave this function —
+    // a failed emit, a dropped receiver, or the whole future being cancelled when
+    // the connection unwinds. Without this the id would linger in the registry.
+    struct CleanupGuard {
+        registry: Arc<PromptRegistry>,
+        id: String,
+    }
+    impl Drop for CleanupGuard {
+        fn drop(&mut self) {
+            self.registry.remove(&self.id);
+        }
+    }
+
     let rx = registry.register(&id);
+    let _guard = CleanupGuard {
+        registry: registry.clone(),
+        id: id.clone(),
+    };
+
     app.emit_to(window_label, "ssh-prompt", PromptRequest { id, kind, message })
         .map_err(|e| e.to_string())?;
     rx.await.map_err(|_| "prompt cancelled".to_string())
@@ -244,9 +262,14 @@ fn expand_tilde_with(path: &str, home: &str) -> String {
 /// an `ssh -i ~/...` command) arrives literal, so the backend must do it here.
 /// Mirrors the `$HOME` lookup used elsewhere (see `modules::fs::dir::home_dir`).
 fn expand_tilde(path: &str) -> String {
-    match std::env::var("HOME") {
-        Ok(home) if !home.is_empty() => expand_tilde_with(path, &home),
-        _ => path.to_string(),
+    // `HOME` on Unix; Windows sets `USERPROFILE` instead, so fall back to it.
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_default();
+    if home.is_empty() {
+        path.to_string()
+    } else {
+        expand_tilde_with(path, &home)
     }
 }
 

--- a/src-tauri/src/modules/ssh/client.rs
+++ b/src-tauri/src/modules/ssh/client.rs
@@ -19,18 +19,23 @@ use super::prompt::{PromptKind, PromptRegistry, PromptReply, PromptRequest};
 /// user's reply. This is the single emit+register+await primitive shared by the
 /// host-key check and every interactive auth prompt.
 ///
+/// The event is scoped to `window_label` (the window that initiated the
+/// connection) with `emit_to`, so the prompt appears only there instead of being
+/// broadcast to every open window.
+///
 /// The caller owns the `id` (so it can be made unique per prompt). A dropped
 /// sender — registry gone, session torn down — surfaces as an `Err`, so an
 /// abandoned prompt fails closed rather than silently succeeding.
 async fn request_prompt(
     app: &AppHandle,
+    window_label: &str,
     registry: &Arc<PromptRegistry>,
     id: String,
     kind: PromptKind,
     message: String,
 ) -> Result<PromptReply, String> {
     let rx = registry.register(&id);
-    app.emit("ssh-prompt", PromptRequest { id, kind, message })
+    app.emit_to(window_label, "ssh-prompt", PromptRequest { id, kind, message })
         .map_err(|e| e.to_string())?;
     rx.await.map_err(|_| "prompt cancelled".to_string())
 }
@@ -41,6 +46,9 @@ async fn request_prompt(
 pub struct VerifyingClient {
     /// Used to emit the `ssh-prompt` Tauri event to the frontend.
     pub app: AppHandle,
+    /// Label of the window that initiated this connection. The `ssh-prompt`
+    /// event is scoped to this window so it doesn't broadcast to every window.
+    pub window_label: String,
     /// Shared registry that pairs a prompt id with the oneshot that the
     /// `ssh_prompt_reply` command resolves.
     pub registry: Arc<PromptRegistry>,
@@ -107,6 +115,7 @@ impl russh::client::Handler for VerifyingClient {
                 // session torn down) aborts the connection, exactly as before.
                 let reply = request_prompt(
                     &self.app,
+                    &self.window_label,
                     &self.registry,
                     self.new_request_id(),
                     kind,
@@ -242,11 +251,16 @@ pub async fn authenticate(
     args: &AuthArgs,
     registry: &Arc<PromptRegistry>,
     app: &AppHandle,
+    window_label: &str,
     session_id: u32,
 ) -> Result<bool, String> {
     match args.auth_method.as_str() {
-        "password" => authenticate_password(handle, args, registry, app, session_id).await,
-        "keyFile" => authenticate_key_file(handle, args, registry, app, session_id).await,
+        "password" => {
+            authenticate_password(handle, args, registry, app, window_label, session_id).await
+        }
+        "keyFile" => {
+            authenticate_key_file(handle, args, registry, app, window_label, session_id).await
+        }
         "agent" => authenticate_agent(handle, args).await,
         other => Err(format!("unsupported auth method: {other}")),
     }
@@ -257,6 +271,7 @@ pub async fn authenticate(
 /// reply routes back to this exact request.
 async fn request_secret(
     app: &AppHandle,
+    window_label: &str,
     registry: &Arc<PromptRegistry>,
     session_id: u32,
     kind: PromptKind,
@@ -269,7 +284,15 @@ async fn request_secret(
         // rather than panicking if the set ever grows.
         PromptKind::HostKeyUnknown | PromptKind::HostKeyChanged => "hostkey",
     };
-    request_prompt(app, registry, format!("{session_id}-{tag}"), kind, message).await
+    request_prompt(
+        app,
+        window_label,
+        registry,
+        format!("{session_id}-{tag}"),
+        kind,
+        message,
+    )
+    .await
 }
 
 /// Password auth: try the stored secret first, then fall back to prompting.
@@ -281,6 +304,7 @@ async fn authenticate_password(
     args: &AuthArgs,
     registry: &Arc<PromptRegistry>,
     app: &AppHandle,
+    window_label: &str,
     session_id: u32,
 ) -> Result<bool, String> {
     // 1. Try a previously stored password without bothering the user.
@@ -303,6 +327,7 @@ async fn authenticate_password(
     // 2. Prompt the user for a password and retry.
     let reply = request_secret(
         app,
+        window_label,
         registry,
         session_id,
         PromptKind::Password,
@@ -399,6 +424,7 @@ async fn authenticate_key_file(
     args: &AuthArgs,
     registry: &Arc<PromptRegistry>,
     app: &AppHandle,
+    window_label: &str,
     session_id: u32,
 ) -> Result<bool, String> {
     let key_path = args
@@ -411,7 +437,7 @@ async fn authenticate_key_file(
     let key = match russh::keys::load_secret_key(key_path, None) {
         Ok(key) => key,
         Err(russh::keys::Error::KeyIsEncrypted) => {
-            load_encrypted_key(key_path, args, registry, app, session_id).await?
+            load_encrypted_key(key_path, args, registry, app, window_label, session_id).await?
         }
         Err(e) => return Err(format!("failed to load key file: {e}")),
     };
@@ -426,6 +452,7 @@ async fn load_encrypted_key(
     args: &AuthArgs,
     registry: &Arc<PromptRegistry>,
     app: &AppHandle,
+    window_label: &str,
     session_id: u32,
 ) -> Result<russh::keys::PrivateKey, String> {
     // 1. Stored passphrase, if any.
@@ -439,6 +466,7 @@ async fn load_encrypted_key(
     // 2. Prompt for the passphrase.
     let reply = request_secret(
         app,
+        window_label,
         registry,
         session_id,
         PromptKind::Passphrase,

--- a/src-tauri/src/modules/ssh/client.rs
+++ b/src-tauri/src/modules/ssh/client.rs
@@ -13,7 +13,27 @@ use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 
 use super::known_hosts::{classify, known_hosts_line, HostKeyStatus};
-use super::prompt::{PromptKind, PromptRegistry, PromptRequest};
+use super::prompt::{PromptKind, PromptRegistry, PromptReply, PromptRequest};
+
+/// Emit an `ssh-prompt` to the frontend, register the request id, and await the
+/// user's reply. This is the single emit+register+await primitive shared by the
+/// host-key check and every interactive auth prompt.
+///
+/// The caller owns the `id` (so it can be made unique per prompt). A dropped
+/// sender — registry gone, session torn down — surfaces as an `Err`, so an
+/// abandoned prompt fails closed rather than silently succeeding.
+async fn request_prompt(
+    app: &AppHandle,
+    registry: &Arc<PromptRegistry>,
+    id: String,
+    kind: PromptKind,
+    message: String,
+) -> Result<PromptReply, String> {
+    let rx = registry.register(&id);
+    app.emit("ssh-prompt", PromptRequest { id, kind, message })
+        .map_err(|e| e.to_string())?;
+    rx.await.map_err(|_| "prompt cancelled".to_string())
+}
 
 /// The russh `Handler` that verifies the server's host key before the session
 /// is allowed to proceed. Carries everything `check_server_key` needs to read
@@ -82,22 +102,18 @@ impl russh::client::Handler for VerifyingClient {
                     _ => PromptKind::HostKeyUnknown,
                 };
 
-                let id = self.new_request_id();
-                let rx = self.registry.register(&id);
-                self.app
-                    .emit(
-                        "ssh-prompt",
-                        PromptRequest {
-                            id,
-                            kind,
-                            message: fingerprint,
-                        },
-                    )
-                    .map_err(|_| russh::Error::Disconnect)?;
-
-                // Await the user's decision. A dropped sender (registry gone /
-                // session torn down) aborts the connection.
-                let reply = rx.await.map_err(|_| russh::Error::Disconnect)?;
+                // Emit the host-key prompt and await the user's decision. Any
+                // failure (emit error or dropped sender — registry gone /
+                // session torn down) aborts the connection, exactly as before.
+                let reply = request_prompt(
+                    &self.app,
+                    &self.registry,
+                    self.new_request_id(),
+                    kind,
+                    fingerprint,
+                )
+                .await
+                .map_err(|_| russh::Error::Disconnect)?;
 
                 if reply.approved {
                     // Unknown -> append; Changed -> replace this host's lines.
@@ -193,4 +209,326 @@ pub async fn connect(
     russh::client::connect(config, (args.host.as_str(), args.port), args.handler)
         .await
         .map_err(|e| e.to_string())
+}
+
+// ===========================================================================
+// Authentication
+//
+// `authenticate` runs after `connect` on the returned handle and dispatches on
+// the user's chosen method. Secrets (passwords / key passphrases) are read from
+// the OS keyring (backend-only) or obtained through an `ssh-prompt`, and are
+// never logged or returned to the webview. A prompt that is cancelled or fails
+// fails the auth attempt (`Err`) — it never silently reports success.
+// ===========================================================================
+
+/// Everything the auth dispatch needs that isn't the transport handle itself.
+pub struct AuthArgs {
+    /// SSH username.
+    pub user: String,
+    /// `"password"` | `"keyFile"` | `"agent"`.
+    pub auth_method: String,
+    /// Path to the private key file (only used by `"keyFile"`).
+    pub key_path: Option<String>,
+    /// Stable id used to key this connection's stored secret in the keyring.
+    pub connection_id: String,
+}
+
+/// Authenticate the (already host-key-verified) connection using the method the
+/// user selected. Returns `Ok(true)` if the server accepted the credentials,
+/// `Ok(false)` if it rejected them, and `Err` on an operational failure (key
+/// load error, cancelled prompt, transport error, unknown method).
+pub async fn authenticate(
+    handle: &mut russh::client::Handle<VerifyingClient>,
+    args: &AuthArgs,
+    registry: &Arc<PromptRegistry>,
+    app: &AppHandle,
+    session_id: u32,
+) -> Result<bool, String> {
+    match args.auth_method.as_str() {
+        "password" => authenticate_password(handle, args, registry, app, session_id).await,
+        "keyFile" => authenticate_key_file(handle, args, registry, app, session_id).await,
+        "agent" => authenticate_agent(handle, args).await,
+        other => Err(format!("unsupported auth method: {other}")),
+    }
+}
+
+/// Prompt the user for a secret (password or passphrase) and return their reply.
+/// Wraps `request_prompt` with an auth-specific, per-session prompt id so the
+/// reply routes back to this exact request.
+async fn request_secret(
+    app: &AppHandle,
+    registry: &Arc<PromptRegistry>,
+    session_id: u32,
+    kind: PromptKind,
+    message: String,
+) -> Result<PromptReply, String> {
+    let tag = match kind {
+        PromptKind::Password => "password",
+        PromptKind::Passphrase => "passphrase",
+        // Host-key kinds don't flow through here, but give them a stable id
+        // rather than panicking if the set ever grows.
+        PromptKind::HostKeyUnknown | PromptKind::HostKeyChanged => "hostkey",
+    };
+    request_prompt(app, registry, format!("{session_id}-{tag}"), kind, message).await
+}
+
+/// Password auth: try the stored secret first, then fall back to prompting.
+/// On a successful prompt with `remember` set, persist the password to the
+/// keyring. If the server only offers keyboard-interactive, satisfy it with the
+/// same password.
+async fn authenticate_password(
+    handle: &mut russh::client::Handle<VerifyingClient>,
+    args: &AuthArgs,
+    registry: &Arc<PromptRegistry>,
+    app: &AppHandle,
+    session_id: u32,
+) -> Result<bool, String> {
+    // 1. Try a previously stored password without bothering the user.
+    if let Some(stored) = crate::modules::secrets::ssh_get_secret(&args.connection_id)? {
+        let result = handle
+            .authenticate_password(args.user.clone(), stored.clone())
+            .await
+            .map_err(|e| e.to_string())?;
+        if result.success() {
+            return Ok(true);
+        }
+        if let Some(true) =
+            try_keyboard_interactive(handle, &args.user, &stored, &result).await?
+        {
+            return Ok(true);
+        }
+        // Stored password rejected — fall through to prompting.
+    }
+
+    // 2. Prompt the user for a password and retry.
+    let reply = request_secret(
+        app,
+        registry,
+        session_id,
+        PromptKind::Password,
+        "Enter password".to_string(),
+    )
+    .await?;
+    if !reply.approved {
+        return Ok(false);
+    }
+    let password = match reply.secret {
+        Some(secret) => secret,
+        // Approved with no secret can't authenticate; treat as a failed attempt.
+        None => return Ok(false),
+    };
+
+    let result = handle
+        .authenticate_password(args.user.clone(), password.clone())
+        .await
+        .map_err(|e| e.to_string())?;
+    let ok = if result.success() {
+        true
+    } else {
+        matches!(
+            try_keyboard_interactive(handle, &args.user, &password, &result).await?,
+            Some(true)
+        )
+    };
+
+    // Only persist a password the server actually accepted, and only if the
+    // user opted in.
+    if ok && reply.remember {
+        crate::modules::secrets::ssh_secret_set(
+            args.connection_id.clone(),
+            password,
+        )?;
+    }
+    Ok(ok)
+}
+
+/// If the failed password attempt left keyboard-interactive on the table, try
+/// it with the same password (the common single-prompt PAM case). Returns
+/// `Ok(None)` when the server didn't offer keyboard-interactive, `Ok(Some(ok))`
+/// otherwise.
+async fn try_keyboard_interactive(
+    handle: &mut russh::client::Handle<VerifyingClient>,
+    user: &str,
+    password: &str,
+    last: &russh::client::AuthResult,
+) -> Result<Option<bool>, String> {
+    use russh::client::KeyboardInteractiveAuthResponse;
+    use russh::MethodKind;
+
+    // Only proceed if the server's failure response still lists
+    // keyboard-interactive as an available method.
+    let offered = match last {
+        russh::client::AuthResult::Failure {
+            remaining_methods, ..
+        } => remaining_methods.contains(&MethodKind::KeyboardInteractive),
+        russh::client::AuthResult::Success => return Ok(Some(true)),
+    };
+    if !offered {
+        return Ok(None);
+    }
+
+    let mut response = handle
+        .authenticate_keyboard_interactive_start(user.to_string(), None)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // Answer every prompt round with the password until the server resolves the
+    // attempt one way or the other. Bounded so a server that keeps sending info
+    // requests can't spin this loop forever — give up (fail) after a few rounds.
+    for _ in 0..16 {
+        match response {
+            KeyboardInteractiveAuthResponse::Success => return Ok(Some(true)),
+            KeyboardInteractiveAuthResponse::Failure { .. } => return Ok(Some(false)),
+            KeyboardInteractiveAuthResponse::InfoRequest { prompts, .. } => {
+                let answers = vec![password.to_string(); prompts.len()];
+                response = handle
+                    .authenticate_keyboard_interactive_respond(answers)
+                    .await
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+    }
+    Ok(Some(false))
+}
+
+/// Key-file auth: load the private key, decrypting with the stored passphrase or
+/// a prompted one if it's encrypted, then authenticate with publickey. On a
+/// successful prompt with `remember` set, persist the passphrase.
+async fn authenticate_key_file(
+    handle: &mut russh::client::Handle<VerifyingClient>,
+    args: &AuthArgs,
+    registry: &Arc<PromptRegistry>,
+    app: &AppHandle,
+    session_id: u32,
+) -> Result<bool, String> {
+    let key_path = args
+        .key_path
+        .as_deref()
+        .ok_or_else(|| "key file auth requires a key path".to_string())?;
+
+    // Try unencrypted first. If the key is encrypted, russh signals it with
+    // `Error::KeyIsEncrypted`, which is our cue to obtain a passphrase.
+    let key = match russh::keys::load_secret_key(key_path, None) {
+        Ok(key) => key,
+        Err(russh::keys::Error::KeyIsEncrypted) => {
+            load_encrypted_key(key_path, args, registry, app, session_id).await?
+        }
+        Err(e) => return Err(format!("failed to load key file: {e}")),
+    };
+
+    authenticate_with_private_key(handle, &args.user, key).await
+}
+
+/// Decrypt an encrypted private key: try the stored passphrase first, otherwise
+/// prompt. On a successful prompt with `remember` set, persist the passphrase.
+async fn load_encrypted_key(
+    key_path: &str,
+    args: &AuthArgs,
+    registry: &Arc<PromptRegistry>,
+    app: &AppHandle,
+    session_id: u32,
+) -> Result<russh::keys::PrivateKey, String> {
+    // 1. Stored passphrase, if any.
+    if let Some(stored) = crate::modules::secrets::ssh_get_secret(&args.connection_id)? {
+        if let Ok(key) = russh::keys::load_secret_key(key_path, Some(&stored)) {
+            return Ok(key);
+        }
+        // Stored passphrase is stale — fall through to prompting.
+    }
+
+    // 2. Prompt for the passphrase.
+    let reply = request_secret(
+        app,
+        registry,
+        session_id,
+        PromptKind::Passphrase,
+        "Enter key passphrase".to_string(),
+    )
+    .await?;
+    if !reply.approved {
+        return Err("passphrase prompt cancelled".to_string());
+    }
+    let passphrase = reply
+        .secret
+        .ok_or_else(|| "no passphrase provided".to_string())?;
+
+    let key = russh::keys::load_secret_key(key_path, Some(&passphrase))
+        .map_err(|e| format!("failed to decrypt key: {e}"))?;
+
+    if reply.remember {
+        crate::modules::secrets::ssh_secret_set(
+            args.connection_id.clone(),
+            passphrase,
+        )?;
+    }
+    Ok(key)
+}
+
+/// Authenticate with a loaded private key, choosing the best RSA hash the server
+/// advertises (so RSA keys aren't forced onto legacy SHA-1).
+async fn authenticate_with_private_key(
+    handle: &mut russh::client::Handle<VerifyingClient>,
+    user: &str,
+    key: russh::keys::PrivateKey,
+) -> Result<bool, String> {
+    // For RSA keys, ask the server which hash it prefers; non-RSA keys ignore
+    // the hash. `best_supported_rsa_hash` returns Some(hash) when the server
+    // advertised its sig-algs, None otherwise — fall back to None (legacy) only
+    // when the server told us nothing.
+    let hash_alg = if key.algorithm().is_rsa() {
+        handle
+            .best_supported_rsa_hash()
+            .await
+            .map_err(|e| e.to_string())?
+            .flatten()
+    } else {
+        None
+    };
+
+    let key_with_hash =
+        russh::keys::PrivateKeyWithHashAlg::new(Arc::new(key), hash_alg);
+    let result = handle
+        .authenticate_publickey(user.to_string(), key_with_hash)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(result.success())
+}
+
+/// Agent auth: connect to the running ssh-agent, then try each identity it
+/// holds until one authenticates (the agent does the signing — no private key
+/// material ever reaches this process).
+async fn authenticate_agent(
+    handle: &mut russh::client::Handle<VerifyingClient>,
+    args: &AuthArgs,
+) -> Result<bool, String> {
+    use russh::keys::agent::client::AgentClient;
+    use russh::keys::agent::AgentIdentity;
+
+    let mut agent = AgentClient::connect_env()
+        .await
+        .map_err(|e| format!("could not connect to ssh-agent: {e}"))?;
+
+    let identities = agent
+        .request_identities()
+        .await
+        .map_err(|e| format!("could not list agent identities: {e}"))?;
+
+    for identity in identities {
+        // Only plain public keys are tried here; certificate identities need a
+        // different auth call and aren't part of this task's scope.
+        let public_key = match identity {
+            AgentIdentity::PublicKey { key, .. } => key,
+            AgentIdentity::Certificate { .. } => continue,
+        };
+
+        let result = handle
+            .authenticate_publickey_with(args.user.clone(), public_key, None, &mut agent)
+            .await
+            .map_err(|e| e.to_string())?;
+        if result.success() {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }

--- a/src-tauri/src/modules/ssh/client.rs
+++ b/src-tauri/src/modules/ssh/client.rs
@@ -220,6 +220,30 @@ pub async fn connect(
         .map_err(|e| e.to_string())
 }
 
+/// Expand a leading `~` or `~/` in `path` to `home`. A bare `~` becomes `home`;
+/// `~/x` becomes `home/x`. Other shapes (absolute, relative, `~other/...`) are
+/// returned unchanged. Pure so it can be unit-tested without touching the env.
+fn expand_tilde_with(path: &str, home: &str) -> String {
+    if path == "~" {
+        return home.to_string();
+    }
+    match path.strip_prefix("~/") {
+        Some(rest) => format!("{}/{}", home.trim_end_matches('/'), rest),
+        None => path.to_string(),
+    }
+}
+
+/// Expand a leading `~`/`~/` against `$HOME`. Shells expand the tilde before a
+/// path ever reaches a program, but a key path typed into the UI (or pasted from
+/// an `ssh -i ~/...` command) arrives literal, so the backend must do it here.
+/// Mirrors the `$HOME` lookup used elsewhere (see `modules::fs::dir::home_dir`).
+fn expand_tilde(path: &str) -> String {
+    match std::env::var("HOME") {
+        Ok(home) if !home.is_empty() => expand_tilde_with(path, &home),
+        _ => path.to_string(),
+    }
+}
+
 // ===========================================================================
 // Authentication
 //
@@ -427,10 +451,15 @@ async fn authenticate_key_file(
     window_label: &str,
     session_id: u32,
 ) -> Result<bool, String> {
-    let key_path = args
+    let key_path_raw = args
         .key_path
         .as_deref()
         .ok_or_else(|| "key file auth requires a key path".to_string())?;
+    // The path may be typed or pasted with a leading `~` (e.g. from an
+    // `ssh -i ~/.ssh/id_ed25519` command); russh reads the file as-is and would
+    // not find it, so expand the tilde against `$HOME` first.
+    let key_path = expand_tilde(key_path_raw);
+    let key_path = key_path.as_str();
 
     // Try unencrypted first. If the key is encrypted, russh signals it with
     // `Error::KeyIsEncrypted`, which is our cue to obtain a passphrase.
@@ -559,4 +588,48 @@ async fn authenticate_agent(
     }
 
     Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_leading_tilde_slash_to_home() {
+        assert_eq!(
+            expand_tilde_with("~/Documents/key.pem", "/Users/muki"),
+            "/Users/muki/Documents/key.pem"
+        );
+    }
+
+    #[test]
+    fn expands_bare_tilde_to_home() {
+        assert_eq!(expand_tilde_with("~", "/Users/muki"), "/Users/muki");
+    }
+
+    #[test]
+    fn tolerates_a_home_with_a_trailing_slash() {
+        assert_eq!(
+            expand_tilde_with("~/key.pem", "/Users/muki/"),
+            "/Users/muki/key.pem"
+        );
+    }
+
+    #[test]
+    fn leaves_absolute_and_relative_paths_untouched() {
+        assert_eq!(
+            expand_tilde_with("/abs/key.pem", "/Users/muki"),
+            "/abs/key.pem"
+        );
+        assert_eq!(expand_tilde_with("key.pem", "/Users/muki"), "key.pem");
+    }
+
+    #[test]
+    fn does_not_expand_other_users_home() {
+        // `~other/x` is a different user's home — out of scope; leave it as-is.
+        assert_eq!(
+            expand_tilde_with("~other/key.pem", "/Users/muki"),
+            "~other/key.pem"
+        );
+    }
 }

--- a/src-tauri/src/modules/ssh/known_hosts.rs
+++ b/src-tauri/src/modules/ssh/known_hosts.rs
@@ -10,7 +10,7 @@ pub enum HostKeyStatus {
 
 /// The host token an entry is keyed by: bare host on port 22, `[host]:port`
 /// otherwise (OpenSSH convention).
-fn host_token(host: &str, port: u16) -> String {
+pub(crate) fn host_token(host: &str, port: u16) -> String {
     if port == 22 {
         host.to_string()
     } else {
@@ -44,6 +44,30 @@ pub fn classify(lines: &[String], host: &str, port: u16, presented_key: &str) ->
     } else {
         HostKeyStatus::Unknown
     }
+}
+
+/// Remove every existing entry for `token` and append `new_line`.
+/// Comments and blank lines are preserved. This is the filter+append
+/// primitive for both the Unknown (new host) and Changed (stale key)
+/// cases in `persist_host_key`.
+pub(crate) fn rewrite_lines(lines: &[String], token: &str, new_line: &str) -> Vec<String> {
+    let mut kept: Vec<String> = lines
+        .iter()
+        .filter(|raw| {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return true;
+            }
+            let entry_host = trimmed
+                .split(char::is_whitespace)
+                .next()
+                .unwrap_or("");
+            entry_host != token
+        })
+        .map(|l| l.to_string())
+        .collect();
+    kept.push(new_line.to_string());
+    kept
 }
 
 /// The line to append when the user trusts a key.
@@ -81,5 +105,44 @@ mod tests {
         assert!(matches!(classify(&lines, "h", 2222, "ssh-ed25519 BBBB"), HostKeyStatus::Trusted));
         assert_eq!(known_hosts_line("h", 2222, "ssh-ed25519 BBBB"), "[h]:2222 ssh-ed25519 BBBB");
         assert_eq!(known_hosts_line("h", 22, "ssh-ed25519 BBBB"), "h ssh-ed25519 BBBB");
+    }
+
+    // --- rewrite_lines tests ---
+
+    #[test]
+    fn append_when_absent() {
+        let lines: Vec<String> = vec![];
+        let result = rewrite_lines(&lines, "h", "h ssh-ed25519 NEWKEY");
+        assert_eq!(result, vec!["h ssh-ed25519 NEWKEY".to_string()]);
+    }
+
+    #[test]
+    fn replace_single() {
+        let lines = vec!["h ssh-ed25519 OLDKEY".to_string()];
+        let result = rewrite_lines(&lines, "h", "h ssh-ed25519 NEWKEY");
+        assert_eq!(result, vec!["h ssh-ed25519 NEWKEY".to_string()]);
+    }
+
+    #[test]
+    fn replace_duplicates() {
+        let lines = vec![
+            "h ssh-ed25519 STALE1".to_string(),
+            "h ssh-ed25519 STALE2".to_string(),
+        ];
+        let result = rewrite_lines(&lines, "h", "h ssh-ed25519 NEWKEY");
+        assert_eq!(result, vec!["h ssh-ed25519 NEWKEY".to_string()]);
+    }
+
+    #[test]
+    fn do_not_touch_look_alike() {
+        let lines = vec![
+            "h ssh-ed25519 KEEP".to_string(),
+            "h2 ssh-ed25519 ALSO_KEEP".to_string(),
+        ];
+        let result = rewrite_lines(&lines, "h", "h ssh-ed25519 NEWKEY");
+        assert_eq!(result, vec![
+            "h2 ssh-ed25519 ALSO_KEEP".to_string(),
+            "h ssh-ed25519 NEWKEY".to_string(),
+        ]);
     }
 }

--- a/src-tauri/src/modules/ssh/known_hosts.rs
+++ b/src-tauri/src/modules/ssh/known_hosts.rs
@@ -1,0 +1,85 @@
+//! Pure parsing and classification of an app-managed known_hosts file.
+//! No IO here so the decision logic is unit-testable.
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum HostKeyStatus {
+    Trusted,
+    Unknown,
+    Changed,
+}
+
+/// The host token an entry is keyed by: bare host on port 22, `[host]:port`
+/// otherwise (OpenSSH convention).
+fn host_token(host: &str, port: u16) -> String {
+    if port == 22 {
+        host.to_string()
+    } else {
+        format!("[{host}]:{port}")
+    }
+}
+
+/// Compare a presented key (`"<type> <base64>"`, no comment) against the file.
+pub fn classify(lines: &[String], host: &str, port: u16, presented_key: &str) -> HostKeyStatus {
+    let token = host_token(host, port);
+    let presented = presented_key.trim();
+    let mut seen_host = false;
+    for raw in lines {
+        let l = raw.trim();
+        if l.is_empty() || l.starts_with('#') {
+            continue;
+        }
+        let mut parts = l.splitn(2, char::is_whitespace);
+        let entry_host = parts.next().unwrap_or("");
+        let entry_key = parts.next().unwrap_or("").trim();
+        if entry_host != token {
+            continue;
+        }
+        seen_host = true;
+        if entry_key == presented {
+            return HostKeyStatus::Trusted;
+        }
+    }
+    if seen_host {
+        HostKeyStatus::Changed
+    } else {
+        HostKeyStatus::Unknown
+    }
+}
+
+/// The line to append when the user trusts a key.
+pub fn known_hosts_line(host: &str, port: u16, key: &str) -> String {
+    format!("{} {}", host_token(host, port), key.trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(h: &str, k: &str) -> String { format!("{h} ssh-ed25519 {k}") }
+
+    #[test]
+    fn unknown_when_host_absent() {
+        let lines = vec![line("other", "AAAA")];
+        assert!(matches!(classify(&lines, "h", 22, "ssh-ed25519 BBBB"), HostKeyStatus::Unknown));
+    }
+
+    #[test]
+    fn trusted_when_key_matches() {
+        let lines = vec![line("h", "BBBB")];
+        assert!(matches!(classify(&lines, "h", 22, "ssh-ed25519 BBBB"), HostKeyStatus::Trusted));
+    }
+
+    #[test]
+    fn changed_when_key_differs() {
+        let lines = vec![line("h", "BBBB")];
+        assert!(matches!(classify(&lines, "h", 22, "ssh-ed25519 CCCC"), HostKeyStatus::Changed));
+    }
+
+    #[test]
+    fn non_default_port_uses_bracket_form() {
+        let lines = vec![line("[h]:2222", "BBBB")];
+        assert!(matches!(classify(&lines, "h", 2222, "ssh-ed25519 BBBB"), HostKeyStatus::Trusted));
+        assert_eq!(known_hosts_line("h", 2222, "ssh-ed25519 BBBB"), "[h]:2222 ssh-ed25519 BBBB");
+        assert_eq!(known_hosts_line("h", 22, "ssh-ed25519 BBBB"), "h ssh-ed25519 BBBB");
+    }
+}

--- a/src-tauri/src/modules/ssh/mod.rs
+++ b/src-tauri/src/modules/ssh/mod.rs
@@ -1,2 +1,64 @@
+mod client;
 mod known_hosts;
-pub mod prompt;
+mod prompt;
+mod session;
+
+pub use prompt::PromptReply;
+pub use session::SshState;
+
+use tauri::ipc::{Channel, Response};
+use tauri::{AppHandle, State};
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SshOpenRequest {
+    pub connection_id: String,
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub auth_method: String, // "password" | "keyFile" | "agent"
+    pub key_path: Option<String>,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[tauri::command]
+pub fn ssh_open(
+    app: AppHandle,
+    state: State<'_, SshState>,
+    req: SshOpenRequest,
+    on_data: Channel<Response>,
+    on_exit: Channel<i32>,
+) -> Result<u32, String> {
+    session::open(&app, &state, req, on_data, on_exit)
+}
+
+#[tauri::command]
+pub fn ssh_write(state: State<'_, SshState>, id: u32, data: String) -> Result<(), String> {
+    session::write_input(&state, id, data.into_bytes())
+}
+
+#[tauri::command]
+pub fn ssh_resize(
+    state: State<'_, SshState>,
+    id: u32,
+    cols: u16,
+    rows: u16,
+) -> Result<(), String> {
+    session::resize(&state, id, cols, rows)
+}
+
+#[tauri::command]
+pub fn ssh_close(state: State<'_, SshState>, id: u32) {
+    session::close(&state, id);
+}
+
+#[tauri::command]
+pub fn ssh_prompt_reply(
+    state: State<'_, SshState>,
+    id: String,
+    reply: PromptReply,
+) -> Result<(), String> {
+    state.resolve_prompt(&id, reply);
+    Ok(())
+}

--- a/src-tauri/src/modules/ssh/mod.rs
+++ b/src-tauri/src/modules/ssh/mod.rs
@@ -1,1 +1,2 @@
 mod known_hosts;
+pub mod prompt;

--- a/src-tauri/src/modules/ssh/mod.rs
+++ b/src-tauri/src/modules/ssh/mod.rs
@@ -1,0 +1,1 @@
+mod known_hosts;

--- a/src-tauri/src/modules/ssh/mod.rs
+++ b/src-tauri/src/modules/ssh/mod.rs
@@ -25,12 +25,17 @@ pub struct SshOpenRequest {
 #[tauri::command]
 pub fn ssh_open(
     app: AppHandle,
+    window: tauri::WebviewWindow,
     state: State<'_, SshState>,
     req: SshOpenRequest,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
-    session::open(&app, &state, req, on_data, on_exit)
+    // Capture the label of the window that initiated this connection so the
+    // interactive `ssh-prompt` event is delivered only there, not broadcast to
+    // every open window.
+    let window_label = window.label().to_string();
+    session::open(&app, window_label, &state, req, on_data, on_exit)
 }
 
 #[tauri::command]

--- a/src-tauri/src/modules/ssh/prompt.rs
+++ b/src-tauri/src/modules/ssh/prompt.rs
@@ -51,6 +51,16 @@ impl PromptRegistry {
             false
         }
     }
+
+    /// Remove every pending prompt whose id starts with `"{session_id}-"`.
+    /// The hyphen suffix prevents session 1 from accidentally matching session 12.
+    pub fn discard_session(&self, session_id: u32) {
+        let prefix = format!("{session_id}-");
+        self.pending
+            .lock()
+            .unwrap()
+            .retain(|id, _| !id.starts_with(&prefix));
+    }
 }
 
 #[cfg(test)]
@@ -70,5 +80,27 @@ mod tests {
     fn resolve_unknown_id_returns_false() {
         let reg = PromptRegistry::new();
         assert!(!reg.resolve("nope", PromptReply { approved: false, secret: None, remember: false }));
+    }
+
+    #[test]
+    fn discard_session_removes_all_entries_for_that_session() {
+        let reg = PromptRegistry::new();
+        reg.register("1-hostkey");
+        reg.register("1-password");
+        reg.discard_session(1);
+        assert!(!reg.resolve("1-hostkey", PromptReply { approved: false, secret: None, remember: false }));
+        assert!(!reg.resolve("1-password", PromptReply { approved: false, secret: None, remember: false }));
+    }
+
+    #[test]
+    fn discard_session_does_not_remove_other_sessions() {
+        let reg = PromptRegistry::new();
+        reg.register("1-hostkey");
+        let _rx12 = reg.register("12-hostkey");
+        reg.discard_session(1);
+        // session 1 gone
+        assert!(!reg.resolve("1-hostkey", PromptReply { approved: false, secret: None, remember: false }));
+        // session 12 still there (prefix "12-" does not start with "1-")
+        assert!(reg.resolve("12-hostkey", PromptReply { approved: true, secret: None, remember: false }));
     }
 }

--- a/src-tauri/src/modules/ssh/prompt.rs
+++ b/src-tauri/src/modules/ssh/prompt.rs
@@ -1,0 +1,74 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+use tokio::sync::oneshot;
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PromptKind {
+    HostKeyUnknown,
+    HostKeyChanged,
+    Password,
+    Passphrase,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptRequest {
+    pub id: String,
+    pub kind: PromptKind,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptReply {
+    pub approved: bool,
+    pub secret: Option<String>,
+    #[serde(default)]
+    pub remember: bool,
+}
+
+#[derive(Default)]
+pub struct PromptRegistry {
+    pending: Mutex<HashMap<String, oneshot::Sender<PromptReply>>>,
+}
+
+impl PromptRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&self, id: &str) -> oneshot::Receiver<PromptReply> {
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().unwrap().insert(id.to_string(), tx);
+        rx
+    }
+
+    pub fn resolve(&self, id: &str, reply: PromptReply) -> bool {
+        if let Some(tx) = self.pending.lock().unwrap().remove(id) {
+            tx.send(reply).is_ok()
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolve_completes_a_registered_request() {
+        let reg = PromptRegistry::new();
+        let rx = reg.register("req-1");
+        assert!(reg.resolve("req-1", PromptReply { approved: true, secret: None, remember: false }));
+        let reply = rx.await.unwrap();
+        assert!(reply.approved);
+    }
+
+    #[test]
+    fn resolve_unknown_id_returns_false() {
+        let reg = PromptRegistry::new();
+        assert!(!reg.resolve("nope", PromptReply { approved: false, secret: None, remember: false }));
+    }
+}

--- a/src-tauri/src/modules/ssh/prompt.rs
+++ b/src-tauri/src/modules/ssh/prompt.rs
@@ -52,6 +52,13 @@ impl PromptRegistry {
         }
     }
 
+    /// Drop a single pending prompt by id. Used by `request_prompt`'s cleanup
+    /// guard so a prompt whose future is dropped (cancelled, emit failed) does
+    /// not linger in the map until the coarser per-session sweep runs.
+    pub fn remove(&self, id: &str) {
+        self.pending.lock().unwrap().remove(id);
+    }
+
     /// Remove every pending prompt whose id starts with `"{session_id}-"`.
     /// The hyphen suffix prevents session 1 from accidentally matching session 12.
     pub fn discard_session(&self, session_id: u32) {

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -116,6 +116,7 @@ pub fn open(
             Err(_) => {
                 // Couldn't even build the runtime; report a non-zero exit so the
                 // frontend tears the pane down rather than waiting forever.
+                emit_line(&on_data, "ssh: could not start session runtime");
                 let _ = on_exit.send(-1);
                 return;
             }
@@ -293,6 +294,7 @@ async fn run_session(
         }
     }
 
+    registry.discard_session(session_id);
     0
 }
 
@@ -316,18 +318,9 @@ pub fn resize(state: &State<'_, SshState>, id: u32, cols: u16, rows: u16) -> Res
     send(state, id, SshControl::Resize { cols, rows })
 }
 
-/// Tear a session down: signal the worker to stop, then drop the registry entry.
-/// Sending may fail if the worker already exited (natural EOF) — that's fine, we
-/// remove the (now stale) entry either way so the id doesn't leak.
-pub fn close(state: &State<'_, SshState>, id: u32) {
-    let _ = send(state, id, SshControl::Close);
-    state.sessions.lock().unwrap().remove(&id);
-}
-
-/// Look up a session and forward a control message. Returns a readable error if
-/// the session is unknown (never opened, or already closed). The lock is only
-/// held to clone the sender — never across an `.await`.
-fn send(state: &State<'_, SshState>, id: u32, msg: SshControl) -> Result<(), String> {
+/// Inner implementation of `send` that operates on `&SshState` directly
+/// so it can be called from unit tests without constructing `State<'_, SshState>`.
+fn send_inner(state: &SshState, id: u32, msg: SshControl) -> Result<(), String> {
     let sessions = state.sessions.lock().unwrap();
     let handle = sessions
         .get(&id)
@@ -336,6 +329,27 @@ fn send(state: &State<'_, SshState>, id: u32, msg: SshControl) -> Result<(), Str
         .control
         .send(msg)
         .map_err(|_| "ssh session closed".to_string())
+}
+
+/// Look up a session and forward a control message. Returns a readable error if
+/// the session is unknown (never opened, or already closed). The lock is only
+/// held to clone the sender — never across an `.await`.
+fn send(state: &State<'_, SshState>, id: u32, msg: SshControl) -> Result<(), String> {
+    send_inner(state, id, msg)
+}
+
+/// Inner implementation of `close` that operates on `&SshState` directly
+/// for unit testing.
+fn close_inner(state: &SshState, id: u32) {
+    let _ = send_inner(state, id, SshControl::Close);
+    state.sessions.lock().unwrap().remove(&id);
+}
+
+/// Tear a session down: signal the worker to stop, then drop the registry entry.
+/// Sending may fail if the worker already exited (natural EOF) — that's fine, we
+/// remove the (now stale) entry either way so the id doesn't leak.
+pub fn close(state: &State<'_, SshState>, id: u32) {
+    close_inner(state, id)
 }
 
 #[cfg(test)]
@@ -353,5 +367,28 @@ mod tests {
                 remember: false,
             }
         ));
+    }
+
+    #[test]
+    fn send_inner_unknown_id_returns_err() {
+        let state = SshState::new();
+        let result = send_inner(&state, 99, SshControl::Input(vec![]));
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("not found"), "expected 'not found' in: {msg}");
+    }
+
+    #[test]
+    fn write_input_equivalent_unknown_id_returns_err() {
+        let state = SshState::new();
+        let result = send_inner(&state, 99, SshControl::Input(vec![]));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn close_inner_unknown_id_is_noop() {
+        let state = SshState::new();
+        // Should not panic
+        close_inner(&state, 99);
     }
 }

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -1,0 +1,65 @@
+//! SSH session manager — real SshState + stub command bodies.
+//! Tasks 6–8 replace the stubs with real async SSH logic.
+
+use std::sync::Arc;
+
+use tauri::{AppHandle, State};
+use tauri::ipc::{Channel, Response};
+
+use super::prompt::{PromptRegistry, PromptReply};
+use super::SshOpenRequest;
+
+/// Manages all active SSH sessions and the shared prompt registry.
+/// Registered as Tauri managed state so every command can access it.
+pub struct SshState {
+    pub(crate) registry: Arc<PromptRegistry>,
+}
+
+impl SshState {
+    pub fn new() -> Self {
+        Self {
+            registry: Arc::new(PromptRegistry::new()),
+        }
+    }
+
+    /// Forward a prompt reply to the waiting async task.
+    /// Returns `true` if a pending prompt was found and resolved.
+    pub fn resolve_prompt(&self, id: &str, reply: PromptReply) -> bool {
+        self.registry.resolve(id, reply)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stub implementations — Task 8 fills these in with real async logic.
+// ---------------------------------------------------------------------------
+
+pub fn open(
+    _app: &AppHandle,
+    _state: &State<'_, SshState>,
+    _req: SshOpenRequest,
+    _on_data: Channel<Response>,
+    _on_exit: Channel<i32>,
+) -> Result<u32, String> {
+    Err("ssh not implemented yet".into())
+}
+
+pub fn write_input(
+    _state: &State<'_, SshState>,
+    _id: u32,
+    _data: Vec<u8>,
+) -> Result<(), String> {
+    Err("ssh not implemented yet".into())
+}
+
+pub fn resize(
+    _state: &State<'_, SshState>,
+    _id: u32,
+    _cols: u16,
+    _rows: u16,
+) -> Result<(), String> {
+    Err("ssh not implemented yet".into())
+}
+
+pub fn close(_state: &State<'_, SshState>, _id: u32) {
+    // no-op stub
+}

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -1,25 +1,67 @@
-//! SSH session manager — real SshState + stub command bodies.
-//! Tasks 6–8 replace the stubs with real async SSH logic.
+//! SSH session manager: owns every live SSH session and the shared prompt
+//! registry.
+//!
+//! Each session runs on its own OS thread with a dedicated current-thread tokio
+//! runtime. The thread owns the russh connection end-to-end (connect → auth →
+//! pty + shell → stream), and the only cross-thread channel *in* is the
+//! per-session control `mpsc`. Output streams *out* to the frontend over the
+//! Tauri `on_data` Channel, and the final exit code over `on_exit`. This mirrors
+//! the PTY session model (one worker thread per session) so SSH and local
+//! terminals behave the same way from the frontend's point of view.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
 
-use tauri::{AppHandle, State};
 use tauri::ipc::{Channel, Response};
+use tauri::{AppHandle, Manager, State};
+use tokio::sync::mpsc;
 
+use super::client::{self, AuthArgs, ConnectArgs, VerifyingClient};
 use super::prompt::{PromptRegistry, PromptReply};
 use super::SshOpenRequest;
+
+/// A control message sent from a Tauri command thread to a session's worker
+/// thread. This is the only thing that crosses into the worker after `open`.
+pub enum SshControl {
+    /// Bytes the user typed, to be written to the remote shell.
+    Input(Vec<u8>),
+    /// The terminal was resized; tell the remote pty.
+    Resize { cols: u16, rows: u16 },
+    /// Tear the session down.
+    Close,
+}
+
+/// The frontend-facing handle to one running session: just the sender side of
+/// its control channel. The worker thread holds the receiver.
+struct SshHandle {
+    control: mpsc::UnboundedSender<SshControl>,
+}
 
 /// Manages all active SSH sessions and the shared prompt registry.
 /// Registered as Tauri managed state so every command can access it.
 pub struct SshState {
+    /// id → control sender for every live session.
+    sessions: Mutex<HashMap<u32, SshHandle>>,
+    /// Monotonic session id allocator.
+    next_id: AtomicU32,
+    /// Shared registry that pairs a prompt id with the oneshot the
+    /// `ssh_prompt_reply` command resolves. Cloned into each worker so its
+    /// `connect`/`authenticate` prompts route back here.
     pub(crate) registry: Arc<PromptRegistry>,
 }
 
 impl SshState {
     pub fn new() -> Self {
         Self {
+            sessions: Mutex::new(HashMap::new()),
+            next_id: AtomicU32::new(0),
             registry: Arc::new(PromptRegistry::new()),
         }
+    }
+
+    fn alloc_id(&self) -> u32 {
+        self.next_id.fetch_add(1, Ordering::Relaxed) + 1
     }
 
     /// Forward a prompt reply to the waiting async task.
@@ -30,36 +72,276 @@ impl SshState {
 }
 
 // ---------------------------------------------------------------------------
-// Stub implementations — Task 8 fills these in with real async logic.
+// Open: allocate, register, spawn the worker thread.
 // ---------------------------------------------------------------------------
 
+/// Open a new SSH session. Allocates an id, registers a control channel, and
+/// spawns a worker thread that drives the whole connection. Returns the id
+/// immediately; the connection happens asynchronously on the worker. Output
+/// arrives on `on_data`, and `on_exit` fires exactly once when the worker ends.
 pub fn open(
-    _app: &AppHandle,
-    _state: &State<'_, SshState>,
-    _req: SshOpenRequest,
-    _on_data: Channel<Response>,
-    _on_exit: Channel<i32>,
+    app: &AppHandle,
+    state: &State<'_, SshState>,
+    req: SshOpenRequest,
+    on_data: Channel<Response>,
+    on_exit: Channel<i32>,
 ) -> Result<u32, String> {
-    Err("ssh not implemented yet".into())
+    let id = state.alloc_id();
+    let (control_tx, control_rx) = mpsc::unbounded_channel::<SshControl>();
+
+    // Register the handle before spawning so a write/resize/close that races in
+    // right after `open` returns can find the session. Don't hold the lock
+    // across the spawn.
+    state
+        .sessions
+        .lock()
+        .unwrap()
+        .insert(id, SshHandle { control: control_tx });
+
+    let registry = state.registry.clone();
+    let app = app.clone();
+    let known_hosts_path = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("ssh_known_hosts");
+
+    std::thread::spawn(move || {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(_) => {
+                // Couldn't even build the runtime; report a non-zero exit so the
+                // frontend tears the pane down rather than waiting forever.
+                let _ = on_exit.send(-1);
+                return;
+            }
+        };
+
+        let code = rt.block_on(run_session(
+            app,
+            registry,
+            known_hosts_path,
+            req,
+            id,
+            &on_data,
+            control_rx,
+        ));
+
+        // `on_exit` fires exactly once, on every exit path of the worker
+        // (auth failure, channel close, control Close, or error).
+        let _ = on_exit.send(code);
+    });
+
+    Ok(id)
 }
 
-pub fn write_input(
-    _state: &State<'_, SshState>,
-    _id: u32,
-    _data: Vec<u8>,
-) -> Result<(), String> {
-    Err("ssh not implemented yet".into())
+// ---------------------------------------------------------------------------
+// run_session: the worker body. Connect, auth, pty + shell, then pump IO.
+// ---------------------------------------------------------------------------
+
+/// Drive a single SSH session to completion on the worker thread's runtime.
+/// Returns the exit code: `0` for a clean end (remote EOF/close, exit status 0,
+/// or an explicit Close), non-zero for an auth/connection/setup failure.
+///
+/// Readable failures are also written into `on_data` so the user sees *why* the
+/// pane closed (e.g. `ssh: authentication failed`) instead of a silent blank.
+async fn run_session(
+    app: AppHandle,
+    registry: Arc<PromptRegistry>,
+    known_hosts_path: std::path::PathBuf,
+    req: SshOpenRequest,
+    session_id: u32,
+    on_data: &Channel<Response>,
+    mut control_rx: mpsc::UnboundedReceiver<SshControl>,
+) -> i32 {
+    let handler = VerifyingClient {
+        app: app.clone(),
+        registry: registry.clone(),
+        known_hosts_path,
+        host: req.host.clone(),
+        port: req.port,
+        session_id,
+    };
+
+    // 1. Transport handshake + host-key verification.
+    let mut handle = match client::connect(ConnectArgs {
+        handler,
+        host: req.host.clone(),
+        port: req.port,
+    })
+    .await
+    {
+        Ok(handle) => handle,
+        Err(e) => {
+            emit_line(on_data, &format!("ssh: connection failed: {e}"));
+            return 1;
+        }
+    };
+
+    // 2. Authenticate. Ok(false) = server rejected; Err = operational failure.
+    let auth_args = AuthArgs {
+        user: req.user.clone(),
+        auth_method: req.auth_method.clone(),
+        key_path: req.key_path.clone(),
+        connection_id: req.connection_id.clone(),
+    };
+    match client::authenticate(&mut handle, &auth_args, &registry, &app, session_id).await {
+        Ok(true) => {}
+        Ok(false) => {
+            emit_line(on_data, "ssh: authentication failed");
+            return 1;
+        }
+        Err(e) => {
+            emit_line(on_data, &format!("ssh: authentication error: {e}"));
+            return 1;
+        }
+    }
+
+    // 3. Open a session channel and request an interactive shell on a pty.
+    let channel = match handle.channel_open_session().await {
+        Ok(channel) => channel,
+        Err(e) => {
+            emit_line(on_data, &format!("ssh: could not open channel: {e}"));
+            return 1;
+        }
+    };
+    if let Err(e) = channel
+        .request_pty(
+            false,
+            "xterm-256color",
+            req.cols as u32,
+            req.rows as u32,
+            0,
+            0,
+            &[],
+        )
+        .await
+    {
+        emit_line(on_data, &format!("ssh: could not request pty: {e}"));
+        return 1;
+    }
+    if let Err(e) = channel.request_shell(false).await {
+        emit_line(on_data, &format!("ssh: could not start shell: {e}"));
+        return 1;
+    }
+
+    // 4. Split so the read loop (`wait`, &mut) and the control writes
+    // (`data`/`window_change`, &) can run in the same select! without a borrow
+    // conflict — `wait` needs `&mut`, the writers need `&`.
+    let (mut read_half, write_half) = channel.split();
+
+    loop {
+        tokio::select! {
+            // Remote → frontend. `wait` polls russh's event loop, which is what
+            // keeps the connection alive on this current-thread runtime.
+            msg = read_half.wait() => {
+                match msg {
+                    Some(russh::ChannelMsg::Data { data }) => {
+                        if on_data.send(Response::new(data.to_vec())).is_err() {
+                            // Frontend channel gone (pane closed) — stop.
+                            break;
+                        }
+                    }
+                    Some(russh::ChannelMsg::ExtendedData { data, .. }) => {
+                        if on_data.send(Response::new(data.to_vec())).is_err() {
+                            break;
+                        }
+                    }
+                    // Remote closed the channel / shell exited.
+                    Some(russh::ChannelMsg::Eof)
+                    | Some(russh::ChannelMsg::Close)
+                    | Some(russh::ChannelMsg::ExitStatus { .. })
+                    | None => break,
+                    // PTY/shell request replies and other server messages don't
+                    // carry terminal output; ignore and keep pumping.
+                    Some(_) => {}
+                }
+            }
+
+            // Frontend → remote. The control channel is the only way in.
+            control = control_rx.recv() => {
+                match control {
+                    Some(SshControl::Input(bytes)) => {
+                        // A write error means the connection is dead; end.
+                        if write_half.data(&bytes[..]).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(SshControl::Resize { cols, rows }) => {
+                        // Best-effort: a failed resize shouldn't kill the session.
+                        let _ = write_half
+                            .window_change(cols as u32, rows as u32, 0, 0)
+                            .await;
+                    }
+                    // Close requested, or every sender dropped (session removed).
+                    Some(SshControl::Close) | None => break,
+                }
+            }
+        }
+    }
+
+    0
 }
 
-pub fn resize(
-    _state: &State<'_, SshState>,
-    _id: u32,
-    _cols: u16,
-    _rows: u16,
-) -> Result<(), String> {
-    Err("ssh not implemented yet".into())
+/// Write a human-readable status line to the terminal stream, CRLF-wrapped so it
+/// renders cleanly in xterm. Used only for connect/auth/setup failures — never
+/// for secrets. A failed send is ignored (the pane is already going away).
+fn emit_line(on_data: &Channel<Response>, message: &str) {
+    let line = format!("\r\n{message}\r\n");
+    let _ = on_data.send(Response::new(line.into_bytes()));
 }
 
-pub fn close(_state: &State<'_, SshState>, _id: u32) {
-    // no-op stub
+// ---------------------------------------------------------------------------
+// Control plane: write_input / resize / close route through the registry.
+// ---------------------------------------------------------------------------
+
+pub fn write_input(state: &State<'_, SshState>, id: u32, data: Vec<u8>) -> Result<(), String> {
+    send(state, id, SshControl::Input(data))
+}
+
+pub fn resize(state: &State<'_, SshState>, id: u32, cols: u16, rows: u16) -> Result<(), String> {
+    send(state, id, SshControl::Resize { cols, rows })
+}
+
+/// Tear a session down: signal the worker to stop, then drop the registry entry.
+/// Sending may fail if the worker already exited (natural EOF) — that's fine, we
+/// remove the (now stale) entry either way so the id doesn't leak.
+pub fn close(state: &State<'_, SshState>, id: u32) {
+    let _ = send(state, id, SshControl::Close);
+    state.sessions.lock().unwrap().remove(&id);
+}
+
+/// Look up a session and forward a control message. Returns a readable error if
+/// the session is unknown (never opened, or already closed). The lock is only
+/// held to clone the sender — never across an `.await`.
+fn send(state: &State<'_, SshState>, id: u32, msg: SshControl) -> Result<(), String> {
+    let sessions = state.sessions.lock().unwrap();
+    let handle = sessions
+        .get(&id)
+        .ok_or_else(|| format!("ssh session {id} not found"))?;
+    handle
+        .control
+        .send(msg)
+        .map_err(|_| "ssh session closed".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_prompt_unknown_is_false() {
+        let state = SshState::new();
+        assert!(!state.resolve_prompt(
+            "x",
+            PromptReply {
+                approved: false,
+                secret: None,
+                remember: false,
+            }
+        ));
+    }
 }

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -81,6 +81,7 @@ impl SshState {
 /// arrives on `on_data`, and `on_exit` fires exactly once when the worker ends.
 pub fn open(
     app: &AppHandle,
+    window_label: String,
     state: &State<'_, SshState>,
     req: SshOpenRequest,
     on_data: Channel<Response>,
@@ -122,6 +123,7 @@ pub fn open(
 
         let code = rt.block_on(run_session(
             app,
+            window_label,
             registry,
             known_hosts_path,
             req,
@@ -150,6 +152,7 @@ pub fn open(
 /// pane closed (e.g. `ssh: authentication failed`) instead of a silent blank.
 async fn run_session(
     app: AppHandle,
+    window_label: String,
     registry: Arc<PromptRegistry>,
     known_hosts_path: std::path::PathBuf,
     req: SshOpenRequest,
@@ -159,6 +162,7 @@ async fn run_session(
 ) -> i32 {
     let handler = VerifyingClient {
         app: app.clone(),
+        window_label: window_label.clone(),
         registry: registry.clone(),
         known_hosts_path,
         host: req.host.clone(),
@@ -188,7 +192,9 @@ async fn run_session(
         key_path: req.key_path.clone(),
         connection_id: req.connection_id.clone(),
     };
-    match client::authenticate(&mut handle, &auth_args, &registry, &app, session_id).await {
+    match client::authenticate(&mut handle, &auth_args, &registry, &app, &window_label, session_id)
+        .await
+    {
         Ok(true) => {}
         Ok(false) => {
             emit_line(on_data, "ssh: authentication failed");

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -108,6 +108,9 @@ pub fn open(
         .join("ssh_known_hosts");
 
     std::thread::spawn(move || {
+        // Keep a handle to drop the registry entry ourselves when the worker
+        // ends. `app` is moved into `run_session`, so clone for the cleanup.
+        let cleanup_app = app.clone();
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -117,6 +120,7 @@ pub fn open(
                 // Couldn't even build the runtime; report a non-zero exit so the
                 // frontend tears the pane down rather than waiting forever.
                 emit_line(&on_data, "ssh: could not start session runtime");
+                remove_session(&cleanup_app, id);
                 let _ = on_exit.send(-1);
                 return;
             }
@@ -132,6 +136,13 @@ pub fn open(
             &on_data,
             control_rx,
         ));
+
+        // Drop our own registry entry on exit. A connection that fails async
+        // (the frontend's openSsh resolved but the worker then errored) would
+        // otherwise leak the handle, since the frontend never calls ssh_close
+        // for a session it never saw succeed. close() from the frontend is a
+        // harmless no-op once the entry is gone.
+        remove_session(&cleanup_app, id);
 
         // `on_exit` fires exactly once, on every exit path of the worker
         // (auth failure, channel close, control Close, or error).
@@ -350,6 +361,14 @@ fn close_inner(state: &SshState, id: u32) {
 /// remove the (now stale) entry either way so the id doesn't leak.
 pub fn close(state: &State<'_, SshState>, id: u32) {
     close_inner(state, id)
+}
+
+/// Drop a session's registry entry, looked up from the app's managed `SshState`.
+/// Called by the worker thread on exit so a connection that fails before the
+/// frontend ever calls `ssh_close` does not leak its handle.
+fn remove_session(app: &AppHandle, id: u32) {
+    let state = app.state::<SshState>();
+    state.sessions.lock().unwrap().remove(&id);
 }
 
 #[cfg(test)]

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -170,6 +170,10 @@ async fn run_session(
         session_id,
     };
 
+    // Give the user immediate feedback — the connect can take a moment, and the
+    // pane would otherwise sit blank until output (or an error) arrives.
+    emit_line(on_data, &format!("Connecting to {}:{}...", req.host, req.port));
+
     // 1. Transport handshake + host-key verification.
     let mut handle = match client::connect(ConnectArgs {
         handler,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { useWatchSessions } from "@/modules/claude-progress/lib/useWatchSessions
 import { installStatusHook, installCodexStatusHook } from "@/modules/claude-progress/lib/statusHookBridge";
 import { useWatchNotes } from "@/modules/notes/lib/useWatchNotes";
 import { registerSecondaryWindowCleanup } from "@/lib/windowLifecycle";
+import { SshPromptDialog } from "@/modules/ssh/SshPromptDialog";
 
 const MIN_SIDEBAR = 180;
 const MAX_SIDEBAR = 640;
@@ -163,6 +164,7 @@ function App() {
       <StatusBar />
       {settingsOpen && <SettingsModal />}
       <UpdateModal />
+      <SshPromptDialog />
     </div>
   );
 }

--- a/src/components/LauncherPanel.tsx
+++ b/src/components/LauncherPanel.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   FilePlus,
   FileText,
   FolderOpen,
   Globe,
+  Server,
   SquareTerminal,
   Waypoints,
   type LucideIcon,
@@ -17,6 +19,7 @@ import { pickNotesFolder } from "@/modules/notes/lib/pickNotesFolder";
 import { pickFile, pickFolder } from "@/lib/dialog";
 import { IS_MAC } from "@/lib/platform";
 import type { PaneContent } from "@/modules/terminal/lib/terminalLayout";
+import { ConnectionForm } from "@/modules/ssh/ConnectionForm";
 
 const DEFAULT_PREVIEW_URL = "http://localhost:3000";
 
@@ -54,6 +57,7 @@ interface LauncherGroup {
 
 export function LauncherPanel({ target }: LauncherPanelProps) {
   const { t } = useTranslation();
+  const [sshFormOpen, setSshFormOpen] = useState(false);
   const newTerminalTab = useTabsStore((s) => s.newTerminalTab);
   const openEditorTab = useTabsStore((s) => s.openEditorTab);
   const openNoteTab = useTabsStore((s) => s.openNoteTab);
@@ -138,6 +142,12 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
             apply({ kind: "editor", path: file });
           },
         },
+        {
+          key: "connect-ssh",
+          label: t("workspace.connectSsh"),
+          icon: Server,
+          run: () => setSshFormOpen(true),
+        },
       ],
     },
     {
@@ -181,36 +191,41 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
   ];
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-6 px-4 bg-bg text-fg-subtle">
-      <p className="text-center text-sm">{t("workspace.launcherHint")}</p>
-      <div className="flex w-full max-w-72 flex-col gap-5">
-        {groups.map((group) => (
-          <div key={group.key}>
-            <h3 className="mb-1 text-xs font-medium uppercase tracking-wide text-fg-subtle">
-              {group.label}
-            </h3>
-            <ul className="divide-y divide-border">
-              {group.actions.map(({ key, label, icon: Icon, shortcut, run }) => (
-                <li key={key}>
-                  <button
-                    type="button"
-                    onClick={() => void run()}
-                    className="flex w-full items-center gap-2.5 rounded-md px-2 py-2.5 text-sm text-fg-muted transition-colors hover:bg-bg-elevated hover:text-fg"
-                  >
-                    <Icon size={16} className="shrink-0" />
-                    <span className="flex-1 text-left">{label}</span>
-                    {shortcut && (
-                      <kbd className="shrink-0 rounded border border-border-strong bg-bg-inset px-2 py-0.5 font-mono text-xs text-fg">
-                        {shortcut}
-                      </kbd>
-                    )}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
+    <>
+      <div className="flex h-full flex-col items-center justify-center gap-6 px-4 bg-bg text-fg-subtle">
+        <p className="text-center text-sm">{t("workspace.launcherHint")}</p>
+        <div className="flex w-full max-w-72 flex-col gap-5">
+          {groups.map((group) => (
+            <div key={group.key}>
+              <h3 className="mb-1 text-xs font-medium uppercase tracking-wide text-fg-subtle">
+                {group.label}
+              </h3>
+              <ul className="divide-y divide-border">
+                {group.actions.map(({ key, label, icon: Icon, shortcut, run }) => (
+                  <li key={key}>
+                    <button
+                      type="button"
+                      onClick={() => void run()}
+                      className="flex w-full items-center gap-2.5 rounded-md px-2 py-2.5 text-sm text-fg-muted transition-colors hover:bg-bg-elevated hover:text-fg"
+                    >
+                      <Icon size={16} className="shrink-0" />
+                      <span className="flex-1 text-left">{label}</span>
+                      {shortcut && (
+                        <kbd className="shrink-0 rounded border border-border-strong bg-bg-inset px-2 py-0.5 font-mono text-xs text-fg">
+                          {shortcut}
+                        </kbd>
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+      {sshFormOpen && (
+        <ConnectionForm onClose={() => setSshFormOpen(false)} />
+      )}
+    </>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,10 +1,11 @@
 import { useTranslation } from "react-i18next";
-import { Bot, FolderTree, GitBranch, LayoutGrid, NotebookPen, type LucideIcon } from "lucide-react";
+import { Bot, FolderTree, GitBranch, LayoutGrid, NotebookPen, Server, type LucideIcon } from "lucide-react";
 import { ExplorerView } from "@/modules/explorer/ExplorerView";
 import { SourceControlView } from "@/modules/source-control/SourceControlView";
 import { AIView } from "@/modules/ai/AIView";
 import { NotesSidebar } from "@/modules/notes/NotesSidebar";
 import { WorkspacePanel } from "@/modules/workspace/WorkspacePanel";
+import { ConnectionsPanel } from "@/modules/ssh/ConnectionsPanel";
 import { Tooltip } from "@/components/Tooltip";
 import { useUiStore, type SidebarView } from "@/stores/uiStore";
 
@@ -20,6 +21,7 @@ const SIDEBAR_TABS: SidebarTab[] = [
   { id: "sourceControl", icon: GitBranch, labelKey: "nav.git" },
   { id: "notes", icon: NotebookPen, labelKey: "nav.notes" },
   { id: "ai", icon: Bot, labelKey: "nav.ai" },
+  { id: "connections", icon: Server, labelKey: "nav.connections" },
 ];
 
 export function Sidebar() {
@@ -56,6 +58,7 @@ export function Sidebar() {
         {sidebarView === "sourceControl" && <SourceControlView />}
         {sidebarView === "notes" && <NotesSidebar />}
         {sidebarView === "ai" && <AIView />}
+        {sidebarView === "connections" && <ConnectionsPanel />}
       </div>
     </div>
   );

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -3,6 +3,10 @@
   "tagline": "AI-powered terminal workspace",
   "terminalConnecting": "Starting shell…",
   "openLinkHint": "{{mods}}-click to open",
+  "ssh": {
+    "disconnected": "Disconnected — click to reconnect",
+    "reconnect": "Reconnect"
+  },
   "nav": {
     "workspaces": "Workspaces",
     "terminal": "Terminal",
@@ -114,6 +118,7 @@
     "terminal": "Terminal",
     "note": "Note",
     "newTerminal": "New terminal",
+    "connectSsh": "Connect SSH",
     "launcherHint": "Choose what to open",
     "launcherGroup": {
       "workspace": "Workspace",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -105,7 +105,8 @@
     },
     "save": "Save",
     "connect": "Connect",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "browse": "Browse"
   },
   "workspace": {
     "openFolder": "Open Folder",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -35,6 +35,35 @@
     "terminalArea": "Terminal sessions will appear here",
     "search": "Search files, commands and settings"
   },
+  "sshPrompt": {
+    "hostKeyUnknown": {
+      "title": "Unknown Host Key",
+      "body": "The authenticity of this host cannot be established. Fingerprint:",
+      "trust": "Trust",
+      "cancel": "Cancel"
+    },
+    "hostKeyChanged": {
+      "title": "Host Key Changed",
+      "warning": "WARNING: The host key has changed. This could mean someone is intercepting your connection (man-in-the-middle attack). Only proceed if you are certain the host key was legitimately updated.",
+      "body": "New fingerprint:",
+      "replace": "Replace",
+      "cancel": "Cancel"
+    },
+    "password": {
+      "title": "Password Required",
+      "label": "Password",
+      "remember": "Remember password",
+      "connect": "Connect",
+      "cancel": "Cancel"
+    },
+    "passphrase": {
+      "title": "Passphrase Required",
+      "label": "Passphrase",
+      "remember": "Remember passphrase",
+      "ok": "OK",
+      "cancel": "Cancel"
+    }
+  },
   "workspace": {
     "openFolder": "Open Folder",
     "openFile": "Open File",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -64,6 +64,34 @@
       "cancel": "Cancel"
     }
   },
+  "connectionForm": {
+    "titleCreate": "New SSH Connection",
+    "titleEdit": "Edit SSH Connection",
+    "pasteLabel": "Paste ssh command",
+    "pastePlaceholder": "ssh user@host -p 2222 -i ~/.ssh/id_ed25519",
+    "pasteHint": "Paste an ssh command to auto-fill the fields below",
+    "ignoredPrefix": "Ignored:",
+    "fields": {
+      "name": "Name",
+      "host": "Host",
+      "port": "Port",
+      "user": "Username",
+      "authMethod": "Auth method",
+      "keyPath": "Private key path",
+      "secret": "Password",
+      "passphrase": "Passphrase",
+      "remember": "Remember password",
+      "rememberPassphrase": "Remember passphrase"
+    },
+    "authMethod": {
+      "password": "Password",
+      "keyFile": "Key file",
+      "agent": "SSH agent"
+    },
+    "save": "Save",
+    "connect": "Connect",
+    "cancel": "Cancel"
+  },
   "workspace": {
     "openFolder": "Open Folder",
     "openFile": "Open File",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -13,7 +13,8 @@
     "ai": "AI Assistant",
     "notes": "Notes",
     "gitGraph": "Git Graph",
-    "settings": "Settings"
+    "settings": "Settings",
+    "connections": "Connections"
   },
   "statusBar": {
     "ready": "Ready",
@@ -63,6 +64,16 @@
       "ok": "OK",
       "cancel": "Cancel"
     }
+  },
+  "connectionsPanel": {
+    "title": "Connections",
+    "newConnection": "New connection",
+    "edit": "Edit",
+    "delete": "Delete",
+    "confirmDelete": "Delete?",
+    "cancelDelete": "Cancel",
+    "emptyTitle": "No saved connections",
+    "emptyHint": "Save SSH connections here to connect with one click"
   },
   "connectionForm": {
     "titleCreate": "New SSH Connection",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -3,6 +3,10 @@
   "tagline": "AI 驅動的終端機工作區",
   "terminalConnecting": "啟動中…",
   "openLinkHint": "{{mods}} + 點擊開啟",
+  "ssh": {
+    "disconnected": "已斷線，點擊重新連線",
+    "reconnect": "重新連線"
+  },
   "nav": {
     "workspaces": "工作區",
     "terminal": "終端機",
@@ -114,6 +118,7 @@
     "terminal": "終端機",
     "note": "筆記",
     "newTerminal": "新增終端機",
+    "connectSsh": "SSH 連線",
     "launcherHint": "選擇要開啟的內容",
     "launcherGroup": {
       "workspace": "工作區",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -13,7 +13,8 @@
     "ai": "AI 助手",
     "notes": "筆記",
     "gitGraph": "Git 線圖",
-    "settings": "設定"
+    "settings": "設定",
+    "connections": "SSH 連線"
   },
   "statusBar": {
     "ready": "就緒",
@@ -63,6 +64,16 @@
       "ok": "確定",
       "cancel": "取消"
     }
+  },
+  "connectionsPanel": {
+    "title": "SSH 連線",
+    "newConnection": "新增連線",
+    "edit": "編輯",
+    "delete": "刪除",
+    "confirmDelete": "確認刪除？",
+    "cancelDelete": "取消",
+    "emptyTitle": "尚無已儲存的連線",
+    "emptyHint": "在這裡儲存 SSH 連線，即可一鍵連線"
   },
   "connectionForm": {
     "titleCreate": "新增 SSH 連線",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -64,6 +64,34 @@
       "cancel": "取消"
     }
   },
+  "connectionForm": {
+    "titleCreate": "新增 SSH 連線",
+    "titleEdit": "編輯 SSH 連線",
+    "pasteLabel": "貼上 ssh 指令",
+    "pastePlaceholder": "ssh user@host -p 2222 -i ~/.ssh/id_ed25519",
+    "pasteHint": "貼上 ssh 指令可自動填入以下欄位",
+    "ignoredPrefix": "已略過：",
+    "fields": {
+      "name": "名稱",
+      "host": "主機",
+      "port": "埠號",
+      "user": "使用者名稱",
+      "authMethod": "驗證方式",
+      "keyPath": "私鑰路徑",
+      "secret": "密碼",
+      "passphrase": "金鑰密碼",
+      "remember": "記住密碼",
+      "rememberPassphrase": "記住金鑰密碼"
+    },
+    "authMethod": {
+      "password": "密碼",
+      "keyFile": "金鑰檔案",
+      "agent": "SSH Agent"
+    },
+    "save": "儲存",
+    "connect": "連線",
+    "cancel": "取消"
+  },
   "workspace": {
     "openFolder": "開啟資料夾",
     "openFile": "開啟檔案",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -35,6 +35,35 @@
     "terminalArea": "終端機工作階段會顯示在這裡",
     "search": "搜尋檔案、指令與設定"
   },
+  "sshPrompt": {
+    "hostKeyUnknown": {
+      "title": "未知主機金鑰",
+      "body": "無法確認此主機的真實性。指紋：",
+      "trust": "信任",
+      "cancel": "取消"
+    },
+    "hostKeyChanged": {
+      "title": "主機金鑰已變更",
+      "warning": "警告：主機金鑰已變更。這可能表示有人正在攔截您的連線（中間人攻擊）。請只在確認主機金鑰是正當更新的情況下繼續。",
+      "body": "新指紋：",
+      "replace": "取代",
+      "cancel": "取消"
+    },
+    "password": {
+      "title": "需要密碼",
+      "label": "密碼",
+      "remember": "記住密碼",
+      "connect": "連線",
+      "cancel": "取消"
+    },
+    "passphrase": {
+      "title": "需要金鑰密碼",
+      "label": "金鑰密碼",
+      "remember": "記住金鑰密碼",
+      "ok": "確定",
+      "cancel": "取消"
+    }
+  },
   "workspace": {
     "openFolder": "開啟資料夾",
     "openFile": "開啟檔案",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -105,7 +105,8 @@
     },
     "save": "儲存",
     "connect": "連線",
-    "cancel": "取消"
+    "cancel": "取消",
+    "browse": "瀏覽"
   },
   "workspace": {
     "openFolder": "開啟資料夾",

--- a/src/modules/ssh/ConnectionForm.test.tsx
+++ b/src/modules/ssh/ConnectionForm.test.tsx
@@ -1,22 +1,31 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectionForm } from "./ConnectionForm";
 import "../../i18n";
 
+// vi.mock is hoisted to the top of the file, so mocks must be created with
+// vi.hoisted() to be accessible inside the factory callbacks.
+const { mockInvoke, mockOpenSshTab, mockAddConnection, mockUpdateConnection } = vi.hoisted(
+  () => ({
+    mockInvoke: vi.fn().mockResolvedValue(undefined),
+    mockOpenSshTab: vi.fn(),
+    mockAddConnection: vi.fn().mockReturnValue("test-id-123"),
+    mockUpdateConnection: vi.fn(),
+  }),
+);
+
 // Stub Tauri's invoke so the component can import without a Tauri runtime
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: vi.fn().mockResolvedValue(undefined),
+  invoke: mockInvoke,
 }));
 
 // Stub the tabs store so openSshTab doesn't blow up in jsdom
 vi.mock("@/stores/tabsStore", () => ({
   useTabsStore: (sel: (s: Record<string, unknown>) => unknown) =>
-    sel({ openSshTab: vi.fn() }),
+    sel({ openSshTab: mockOpenSshTab }),
 }));
 
 // Stub the connections store — track calls but don't need real persistence
-const mockAddConnection = vi.fn().mockReturnValue("test-id-123");
-const mockUpdateConnection = vi.fn();
 vi.mock("@/stores/connectionsStore", () => ({
   useConnectionsStore: (sel: (s: Record<string, unknown>) => unknown) =>
     sel({
@@ -25,10 +34,20 @@ vi.mock("@/stores/connectionsStore", () => ({
     }),
 }));
 
+/** Open the Auth method Combobox and click the given display label. */
+function selectAuthMethod(displayLabel: string) {
+  // The Combobox trigger button has aria-label="Auth method"
+  const triggers = screen.getAllByRole("button", { name: /auth method/i });
+  fireEvent.click(triggers[0]);
+  fireEvent.click(screen.getByText(displayLabel));
+}
+
 describe("ConnectionForm", () => {
   beforeEach(() => {
     mockAddConnection.mockClear();
     mockUpdateConnection.mockClear();
+    mockInvoke.mockClear();
+    mockOpenSshTab.mockClear();
   });
 
   it("renders the paste box and form fields", () => {
@@ -92,11 +111,21 @@ describe("ConnectionForm", () => {
     fireEvent.change(pasteBox, { target: { value: "not an ssh command at all!!!" } });
   });
 
-  it("hides the secret field when authMethod is agent (combobox select)", () => {
+  it("hides secret field and remember checkbox when authMethod is agent", () => {
     render(<ConnectionForm onClose={() => {}} />);
-    // Paste a command to populate form, then switch auth to agent via the paste shortcut
-    // We verify secret input visibility indirectly: in default password mode it is shown
-    expect(screen.getByLabelText(/Password/i)).toBeInTheDocument();
+
+    // Verify the secret field IS present before switching (sanity check)
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+
+    // Switch to "SSH agent" via the Combobox
+    selectAuthMethod("SSH agent");
+
+    // Secret input must be gone
+    expect(screen.queryByLabelText(/password/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/passphrase/i)).not.toBeInTheDocument();
+
+    // Remember checkbox must be gone too
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
   });
 
   it("pre-fills fields from existing connection in edit mode", () => {
@@ -114,5 +143,108 @@ describe("ConnectionForm", () => {
     expect(screen.getByDisplayValue("server.example.com")).toBeInTheDocument();
     expect(screen.getByDisplayValue("2222")).toBeInTheDocument();
     expect(screen.getByDisplayValue("admin")).toBeInTheDocument();
+  });
+
+  // ──────────────────────────────────────────────
+  // W2: Save / Connect handler behavior
+  // ──────────────────────────────────────────────
+
+  it("Save persists profile without secret and calls ssh_secret_set with the returned id", async () => {
+    render(<ConnectionForm onClose={() => {}} />);
+
+    // Fill required fields
+    fireEvent.change(screen.getByPlaceholderText("example.com"), {
+      target: { value: "myserver.io" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("root"), {
+      target: { value: "deploy" },
+    });
+
+    // Enter a secret — query by input type to avoid ambiguity with the
+    // "Remember password" label that also contains the word "password"
+    const secretInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+    fireEvent.change(secretInput, { target: { value: "s3cr3t" } });
+
+    // Check the remember checkbox
+    const rememberCheckbox = screen.getByRole("checkbox");
+    fireEvent.click(rememberCheckbox);
+
+    // Click Save
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mockAddConnection).toHaveBeenCalledTimes(1);
+    });
+
+    // The profile passed to addConnection must NOT contain a secret/password field
+    const profile = mockAddConnection.mock.calls[0][0] as Record<string, unknown>;
+    expect(profile).not.toHaveProperty("secret");
+    expect(profile).not.toHaveProperty("password");
+    expect(profile).not.toHaveProperty("passphrase");
+
+    // ssh_secret_set must be invoked with the id that addConnection returned
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("ssh_secret_set", {
+        connectionId: "test-id-123",
+        secret: "s3cr3t",
+      });
+    });
+  });
+
+  it("remember UNCHECKED → profile still saved but ssh_secret_set NOT called", async () => {
+    render(<ConnectionForm onClose={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText("example.com"), {
+      target: { value: "myserver.io" },
+    });
+
+    // Enter a secret but leave remember UNCHECKED (default)
+    // Query by type to avoid ambiguity with the "Remember password" label
+    const secretInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+    fireEvent.change(secretInput, { target: { value: "s3cr3t" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    // Profile must still be persisted
+    await waitFor(() => {
+      expect(mockAddConnection).toHaveBeenCalledTimes(1);
+    });
+
+    // But the secret must NOT be written to keyring
+    await waitFor(() => {
+      expect(mockInvoke).not.toHaveBeenCalledWith(
+        "ssh_secret_set",
+        expect.anything(),
+      );
+    });
+  });
+
+  it("Connect persists the profile then opens the SSH tab with the same id", async () => {
+    const onClose = vi.fn();
+    render(<ConnectionForm onClose={onClose} />);
+
+    fireEvent.change(screen.getByPlaceholderText("example.com"), {
+      target: { value: "myserver.io" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("root"), {
+      target: { value: "deploy" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /connect/i }));
+
+    // addConnection must be called first (persist before open)
+    await waitFor(() => {
+      expect(mockAddConnection).toHaveBeenCalledTimes(1);
+    });
+
+    // openSshTab must be called with the SAME id that addConnection returned
+    await waitFor(() => {
+      expect(mockOpenSshTab).toHaveBeenCalledWith("test-id-123", expect.any(String));
+    });
+
+    // Verify ordering: addConnection was called before openSshTab
+    const addOrder = mockAddConnection.mock.invocationCallOrder[0];
+    const openOrder = mockOpenSshTab.mock.invocationCallOrder[0];
+    expect(addOrder).toBeLessThan(openOrder);
   });
 });

--- a/src/modules/ssh/ConnectionForm.test.tsx
+++ b/src/modules/ssh/ConnectionForm.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectionForm } from "./ConnectionForm";
+import "../../i18n";
+
+// Stub Tauri's invoke so the component can import without a Tauri runtime
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Stub the tabs store so openSshTab doesn't blow up in jsdom
+vi.mock("@/stores/tabsStore", () => ({
+  useTabsStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({ openSshTab: vi.fn() }),
+}));
+
+// Stub the connections store — track calls but don't need real persistence
+const mockAddConnection = vi.fn().mockReturnValue("test-id-123");
+const mockUpdateConnection = vi.fn();
+vi.mock("@/stores/connectionsStore", () => ({
+  useConnectionsStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({
+      addConnection: mockAddConnection,
+      updateConnection: mockUpdateConnection,
+    }),
+}));
+
+describe("ConnectionForm", () => {
+  beforeEach(() => {
+    mockAddConnection.mockClear();
+    mockUpdateConnection.mockClear();
+  });
+
+  it("renders the paste box and form fields", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+    expect(screen.getByPlaceholderText(/ssh user@host/i)).toBeInTheDocument();
+    expect(screen.getByText(/Host/i)).toBeInTheDocument();
+    expect(screen.getByText(/Port/i)).toBeInTheDocument();
+    expect(screen.getByText(/Username/i)).toBeInTheDocument();
+  });
+
+  it("auto-fills host field when an ssh command is pasted", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+    const pasteBox = screen.getByPlaceholderText(/ssh user@host/i);
+    fireEvent.change(pasteBox, { target: { value: "ssh muki@example.com" } });
+    // Both name and host auto-fill to "example.com" — use getAllBy to handle both
+    const matches = screen.getAllByDisplayValue("example.com");
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("auto-fills user from user@host syntax", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+    const pasteBox = screen.getByPlaceholderText(/ssh user@host/i);
+    fireEvent.change(pasteBox, { target: { value: "ssh muki@example.com" } });
+    expect(screen.getByDisplayValue("muki")).toBeInTheDocument();
+  });
+
+  it("auto-fills port when -p flag is used", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+    const pasteBox = screen.getByPlaceholderText(/ssh user@host/i);
+    fireEvent.change(pasteBox, { target: { value: "ssh -p 2222 muki@example.com" } });
+    expect(screen.getByDisplayValue("2222")).toBeInTheDocument();
+  });
+
+  it("shows ignored message when deferred flags like -J are used", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+    const pasteBox = screen.getByPlaceholderText(/ssh user@host/i);
+    fireEvent.change(pasteBox, {
+      target: { value: "ssh -J bastion muki@example.com" },
+    });
+    expect(screen.getByText(/jump host/i)).toBeInTheDocument();
+  });
+
+  it("hides the key path field when authMethod is password", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+    expect(screen.queryByPlaceholderText("~/.ssh/id_ed25519")).not.toBeInTheDocument();
+  });
+
+  it("shows the key path field when pasting a -i command", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+    const pasteBox = screen.getByPlaceholderText(/ssh user@host/i);
+    fireEvent.change(pasteBox, {
+      target: { value: "ssh -i ~/.ssh/id_ed25519 muki@example.com" },
+    });
+    expect(screen.getByDisplayValue("~/.ssh/id_ed25519")).toBeInTheDocument();
+  });
+
+  it("does not crash on garbage input", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+    const pasteBox = screen.getByPlaceholderText(/ssh user@host/i);
+    // Should not throw
+    fireEvent.change(pasteBox, { target: { value: "not an ssh command at all!!!" } });
+  });
+
+  it("hides the secret field when authMethod is agent (combobox select)", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+    // Paste a command to populate form, then switch auth to agent via the paste shortcut
+    // We verify secret input visibility indirectly: in default password mode it is shown
+    expect(screen.getByLabelText(/Password/i)).toBeInTheDocument();
+  });
+
+  it("pre-fills fields from existing connection in edit mode", () => {
+    const existing = {
+      id: "abc-123",
+      name: "My Server",
+      host: "server.example.com",
+      port: 2222,
+      user: "admin",
+      authMethod: "password" as const,
+      rememberSecret: false,
+    };
+    render(<ConnectionForm connection={existing} onClose={() => {}} />);
+    expect(screen.getByDisplayValue("My Server")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("server.example.com")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("2222")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("admin")).toBeInTheDocument();
+  });
+});

--- a/src/modules/ssh/ConnectionForm.tsx
+++ b/src/modules/ssh/ConnectionForm.tsx
@@ -1,0 +1,393 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { invoke } from "@tauri-apps/api/core";
+import { Combobox } from "@/components/Combobox";
+import { parseSshCommand } from "@/modules/ssh/lib/parseSshCommand";
+import { useConnectionsStore, type SshConnection } from "@/stores/connectionsStore";
+import { useTabsStore } from "@/stores/tabsStore";
+import type { SshAuthMethod } from "@/modules/ssh/lib/parseSshCommand";
+
+interface ConnectionFormProps {
+  /** When provided, the form is in edit mode pre-filled from this connection. */
+  connection?: SshConnection;
+  onClose: () => void;
+}
+
+interface FormState {
+  name: string;
+  host: string;
+  port: string;
+  user: string;
+  authMethod: SshAuthMethod;
+  keyPath: string;
+  secret: string;
+  remember: boolean;
+}
+
+function blankForm(): FormState {
+  return {
+    name: "",
+    host: "",
+    port: "22",
+    user: "",
+    authMethod: "password",
+    keyPath: "",
+    secret: "",
+    remember: false,
+  };
+}
+
+function fromConnection(conn: SshConnection): FormState {
+  return {
+    name: conn.name,
+    host: conn.host,
+    port: String(conn.port),
+    user: conn.user,
+    authMethod: conn.authMethod,
+    keyPath: conn.keyPath ?? "",
+    secret: "",
+    remember: conn.rememberSecret,
+  };
+}
+
+/** Persist the connection to the store and return its id. */
+async function persistConnection(
+  form: FormState,
+  existingId: string | undefined,
+  addConnection: (input: Omit<SshConnection, "id">) => string,
+  updateConnection: (id: string, patch: Partial<Omit<SshConnection, "id">>) => void,
+): Promise<string> {
+  const profile: Omit<SshConnection, "id"> = {
+    name: form.name.trim() || form.host.trim(),
+    host: form.host.trim(),
+    port: parseInt(form.port, 10) || 22,
+    user: form.user.trim(),
+    authMethod: form.authMethod,
+    keyPath: form.authMethod === "keyFile" ? form.keyPath.trim() || undefined : undefined,
+    rememberSecret: form.remember,
+  };
+
+  if (existingId) {
+    updateConnection(existingId, profile);
+    return existingId;
+  }
+  return addConnection(profile);
+}
+
+/** Write the secret to keyring only when the user opted in. Never logs the secret. */
+async function maybeStoreSecret(
+  connectionId: string,
+  secret: string,
+  remember: boolean,
+  authMethod: SshAuthMethod,
+): Promise<void> {
+  if (!remember || !secret || authMethod === "agent") {
+    return;
+  }
+  await invoke("ssh_secret_set", { connectionId, secret });
+}
+
+/** Delete the keyring entry (best-effort; silently ignored on failure). */
+async function maybeDeleteSecret(connectionId: string): Promise<void> {
+  try {
+    await invoke("ssh_secret_delete", { connectionId });
+  } catch {
+    // not stored — ignore
+  }
+}
+
+const AUTH_METHOD_OPTIONS: SshAuthMethod[] = ["password", "keyFile", "agent"];
+
+export function ConnectionForm({ connection, onClose }: ConnectionFormProps) {
+  const { t } = useTranslation("common");
+
+  const addConnection = useConnectionsStore((s) => s.addConnection);
+  const updateConnection = useConnectionsStore((s) => s.updateConnection);
+  const openSshTab = useTabsStore((s) => s.openSshTab);
+
+  const [form, setForm] = useState<FormState>(
+    connection ? fromConnection(connection) : blankForm(),
+  );
+  const [pasteInput, setPasteInput] = useState("");
+  const [pasteIgnored, setPasteIgnored] = useState<string[]>([]);
+  const [pasteWarnings, setPasteWarnings] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const isEdit = !!connection;
+
+  function handlePasteChange(value: string) {
+    setPasteInput(value);
+    if (!value.trim()) {
+      setPasteIgnored([]);
+      setPasteWarnings([]);
+      return;
+    }
+    try {
+      const { draft, ignored, warnings } = parseSshCommand(value);
+      setPasteIgnored(ignored);
+      setPasteWarnings(warnings);
+      // Merge draft into form — only overwrite fields the draft provides
+      setForm((prev) => ({
+        ...prev,
+        ...(draft.name !== undefined ? { name: draft.name } : {}),
+        ...(draft.host !== undefined ? { host: draft.host } : {}),
+        ...(draft.port !== undefined ? { port: String(draft.port) } : {}),
+        ...(draft.user !== undefined ? { user: draft.user } : {}),
+        ...(draft.authMethod !== undefined ? { authMethod: draft.authMethod } : {}),
+        ...(draft.keyPath !== undefined ? { keyPath: draft.keyPath } : {}),
+      }));
+    } catch {
+      // Ignore parse errors — garbage input should not crash the form
+    }
+  }
+
+  function setField<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSave() {
+    if (saving) return;
+    setSaving(true);
+    try {
+      const id = await persistConnection(form, connection?.id, addConnection, updateConnection);
+      await maybeStoreSecret(id, form.secret, form.remember, form.authMethod);
+      // In edit mode, if remember is unchecked and previously was checked, clear keyring
+      if (isEdit && !form.remember) {
+        await maybeDeleteSecret(id);
+      }
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleConnect() {
+    if (saving) return;
+    setSaving(true);
+    try {
+      const id = await persistConnection(form, connection?.id, addConnection, updateConnection);
+      await maybeStoreSecret(id, form.secret, form.remember, form.authMethod);
+      // In edit mode, if remember is unchecked and previously was checked, clear keyring
+      if (isEdit && !form.remember) {
+        await maybeDeleteSecret(id);
+      }
+      const name = form.name.trim() || form.host.trim();
+      openSshTab(id, name);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const showSecret = form.authMethod !== "agent";
+  const secretLabel =
+    form.authMethod === "keyFile"
+      ? t("connectionForm.fields.passphrase")
+      : t("connectionForm.fields.secret");
+  const rememberLabel =
+    form.authMethod === "keyFile"
+      ? t("connectionForm.fields.rememberPassphrase")
+      : t("connectionForm.fields.remember");
+
+  const authMethodDisplayOptions = AUTH_METHOD_OPTIONS.map(
+    (m) => t(`connectionForm.authMethod.${m}`),
+  );
+  const authMethodDisplay = t(`connectionForm.authMethod.${form.authMethod}`);
+
+  function handleAuthMethodChange(display: string) {
+    const idx = authMethodDisplayOptions.indexOf(display);
+    if (idx !== -1) {
+      setField("authMethod", AUTH_METHOD_OPTIONS[idx]);
+    }
+  }
+
+  const hasPasteNotes = pasteIgnored.length > 0 || pasteWarnings.length > 0;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[95] bg-black/60" onClick={onClose} />
+      <div className="fixed left-1/2 top-1/2 z-[100] w-[520px] max-w-[94vw] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-bg-elevated shadow-2xl">
+
+        {/* Header */}
+        <div className="flex items-center border-b border-border px-4 py-3">
+          <span className="text-sm font-semibold text-fg">
+            {isEdit ? t("connectionForm.titleEdit") : t("connectionForm.titleCreate")}
+          </span>
+        </div>
+
+        {/* Body */}
+        <div className="max-h-[70vh] overflow-y-auto px-4 py-4 space-y-4">
+
+          {/* Paste box */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-fg-muted">
+              {t("connectionForm.pasteLabel")}
+            </label>
+            <input
+              type="text"
+              value={pasteInput}
+              onChange={(e) => handlePasteChange(e.target.value)}
+              placeholder={t("connectionForm.pastePlaceholder")}
+              className="w-full rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent font-mono"
+            />
+            <p className="mt-1 text-xs text-fg-subtle">{t("connectionForm.pasteHint")}</p>
+            {hasPasteNotes && (
+              <ul className="mt-2 space-y-0.5">
+                {pasteIgnored.map((msg) => (
+                  <li key={msg} className="text-xs text-fg-muted">
+                    <span className="font-medium">{t("connectionForm.ignoredPrefix")}</span>{" "}
+                    {msg}
+                  </li>
+                ))}
+                {pasteWarnings.map((msg) => (
+                  <li key={msg} className="text-xs text-yellow-500">
+                    {msg}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="border-t border-border" />
+
+          {/* Name */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-fg-muted">
+              {t("connectionForm.fields.name")}
+            </label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setField("name", e.target.value)}
+              placeholder={form.host || "my-server"}
+              className="w-full rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent"
+            />
+          </div>
+
+          {/* Host + Port */}
+          <div className="flex gap-3">
+            <div className="flex-1">
+              <label className="mb-1 block text-xs font-medium text-fg-muted">
+                {t("connectionForm.fields.host")}
+              </label>
+              <input
+                type="text"
+                value={form.host}
+                onChange={(e) => setField("host", e.target.value)}
+                placeholder="example.com"
+                className="w-full rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent"
+              />
+            </div>
+            <div className="w-24">
+              <label className="mb-1 block text-xs font-medium text-fg-muted">
+                {t("connectionForm.fields.port")}
+              </label>
+              <input
+                type="number"
+                value={form.port}
+                onChange={(e) => setField("port", e.target.value)}
+                min={1}
+                max={65535}
+                className="w-full rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent"
+              />
+            </div>
+          </div>
+
+          {/* User */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-fg-muted">
+              {t("connectionForm.fields.user")}
+            </label>
+            <input
+              type="text"
+              value={form.user}
+              onChange={(e) => setField("user", e.target.value)}
+              placeholder="root"
+              className="w-full rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent"
+            />
+          </div>
+
+          {/* Auth method */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-fg-muted">
+              {t("connectionForm.fields.authMethod")}
+            </label>
+            <Combobox
+              value={authMethodDisplay}
+              options={authMethodDisplayOptions}
+              onChange={handleAuthMethodChange}
+              ariaLabel={t("connectionForm.fields.authMethod")}
+            />
+          </div>
+
+          {/* Key path — only when authMethod = keyFile */}
+          {form.authMethod === "keyFile" && (
+            <div>
+              <label className="mb-1 block text-xs font-medium text-fg-muted">
+                {t("connectionForm.fields.keyPath")}
+              </label>
+              <input
+                type="text"
+                value={form.keyPath}
+                onChange={(e) => setField("keyPath", e.target.value)}
+                placeholder="~/.ssh/id_ed25519"
+                className="w-full rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent font-mono"
+              />
+            </div>
+          )}
+
+          {/* Secret input — hidden for agent */}
+          {showSecret && (
+            <div>
+              <label className="mb-1 block text-xs font-medium text-fg-muted">
+                {secretLabel}
+              </label>
+              <input
+                type="password"
+                value={form.secret}
+                onChange={(e) => setField("secret", e.target.value)}
+                className="w-full rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent"
+              />
+              <label className="mt-2 flex items-center gap-2 text-xs text-fg-muted select-none cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={form.remember}
+                  onChange={(e) => setField("remember", e.target.checked)}
+                  className="accent-accent"
+                />
+                {rememberLabel}
+              </label>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 border-t border-border px-4 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-3 py-1.5 text-xs text-fg-muted hover:text-fg"
+          >
+            {t("connectionForm.cancel")}
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={saving}
+            className="rounded-md border border-border px-4 py-1.5 text-xs font-medium text-fg hover:bg-bg-inset disabled:opacity-50"
+          >
+            {t("connectionForm.save")}
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleConnect()}
+            disabled={saving}
+            className="rounded-md bg-accent px-4 py-1.5 text-xs font-medium text-white disabled:opacity-50"
+          >
+            {t("connectionForm.connect")}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/modules/ssh/ConnectionForm.tsx
+++ b/src/modules/ssh/ConnectionForm.tsx
@@ -6,6 +6,7 @@ import { parseSshCommand } from "@/modules/ssh/lib/parseSshCommand";
 import { useConnectionsStore, type SshConnection } from "@/stores/connectionsStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import type { SshAuthMethod } from "@/modules/ssh/lib/parseSshCommand";
+import { pickFile } from "@/lib/dialog";
 
 interface ConnectionFormProps {
   /** When provided, the form is in edit mode pre-filled from this connection. */
@@ -326,13 +327,26 @@ export function ConnectionForm({ connection, onClose }: ConnectionFormProps) {
               <label className="mb-1 block text-xs font-medium text-fg-muted">
                 {t("connectionForm.fields.keyPath")}
               </label>
-              <input
-                type="text"
-                value={form.keyPath}
-                onChange={(e) => setField("keyPath", e.target.value)}
-                placeholder="~/.ssh/id_ed25519"
-                className="w-full rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent font-mono"
-              />
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={form.keyPath}
+                  onChange={(e) => setField("keyPath", e.target.value)}
+                  placeholder="~/.ssh/id_ed25519"
+                  className="min-w-0 flex-1 rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent font-mono"
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    void pickFile().then((file) => {
+                      if (file) setField("keyPath", file);
+                    });
+                  }}
+                  className="shrink-0 rounded border border-border px-3 py-1.5 text-xs text-fg-muted hover:bg-bg-inset hover:text-fg"
+                >
+                  {t("connectionForm.browse")}
+                </button>
+              </div>
             </div>
           )}
 

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -1,0 +1,199 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { invoke } from "@tauri-apps/api/core";
+import { Pencil, Plus, Server, Trash2 } from "lucide-react";
+import { useConnectionsStore, type SshConnection } from "@/stores/connectionsStore";
+import { useTabsStore } from "@/stores/tabsStore";
+import { ConnectionForm } from "@/modules/ssh/ConnectionForm";
+
+interface ConnectionRowProps {
+  connection: SshConnection;
+  onEdit: (conn: SshConnection) => void;
+  onDelete: (conn: SshConnection) => void;
+}
+
+function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
+  const { t } = useTranslation("common");
+  const openSshTab = useTabsStore((s) => s.openSshTab);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  function handleRowClick() {
+    openSshTab(connection.id, connection.name);
+  }
+
+  function handleDeleteClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    setConfirmingDelete(true);
+  }
+
+  function handleConfirmDelete(e: React.MouseEvent) {
+    e.stopPropagation();
+    onDelete(connection);
+    setConfirmingDelete(false);
+  }
+
+  function handleCancelDelete(e: React.MouseEvent) {
+    e.stopPropagation();
+    setConfirmingDelete(false);
+  }
+
+  function handleEditClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    onEdit(connection);
+  }
+
+  return (
+    <li className="group flex items-center">
+      <button
+        type="button"
+        onClick={handleRowClick}
+        className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left hover:bg-bg-elevated"
+      >
+        <Server size={14} className="shrink-0 text-fg-subtle" />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm text-fg-muted group-hover:text-fg">
+            {connection.name}
+          </div>
+          <div className="truncate text-xs text-fg-subtle">
+            {connection.user ? `${connection.user}@${connection.host}` : connection.host}
+            {connection.port !== 22 ? `:${connection.port}` : ""}
+          </div>
+        </div>
+      </button>
+
+      {confirmingDelete ? (
+        <div className="flex shrink-0 items-center gap-1 pr-2">
+          <button
+            type="button"
+            onClick={handleConfirmDelete}
+            className="rounded px-1.5 py-0.5 text-xs font-medium text-danger hover:bg-border-strong"
+          >
+            {t("connectionsPanel.confirmDelete")}
+          </button>
+          <button
+            type="button"
+            onClick={handleCancelDelete}
+            className="rounded px-1.5 py-0.5 text-xs text-fg-muted hover:bg-border-strong hover:text-fg"
+          >
+            {t("connectionsPanel.cancelDelete")}
+          </button>
+        </div>
+      ) : (
+        <div className="flex shrink-0 items-center opacity-0 group-hover:opacity-100 pr-2">
+          <button
+            type="button"
+            aria-label={t("connectionsPanel.edit")}
+            title={t("connectionsPanel.edit")}
+            onClick={handleEditClick}
+            className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
+          >
+            <Pencil size={13} />
+          </button>
+          <button
+            type="button"
+            aria-label={t("connectionsPanel.delete")}
+            title={t("connectionsPanel.delete")}
+            onClick={handleDeleteClick}
+            className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-danger"
+          >
+            <Trash2 size={13} />
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}
+
+export function ConnectionsPanel() {
+  const { t } = useTranslation("common");
+  const connections = useConnectionsStore((s) => s.connections);
+  const removeConnection = useConnectionsStore((s) => s.removeConnection);
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingConnection, setEditingConnection] = useState<SshConnection | undefined>(undefined);
+
+  function openNewForm() {
+    setEditingConnection(undefined);
+    setFormOpen(true);
+  }
+
+  function openEditForm(conn: SshConnection) {
+    setEditingConnection(conn);
+    setFormOpen(true);
+  }
+
+  function closeForm() {
+    setFormOpen(false);
+    setEditingConnection(undefined);
+  }
+
+  async function handleDelete(conn: SshConnection) {
+    removeConnection(conn.id);
+    try {
+      await invoke("ssh_secret_delete", { connectionId: conn.id });
+    } catch {
+      // Not stored in keyring — ignore
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col bg-bg-inset">
+      {/* Header */}
+      <div className="flex h-9 shrink-0 items-center justify-between border-b border-border px-3">
+        <span className="text-xs font-semibold uppercase tracking-wide text-fg-subtle">
+          {t("connectionsPanel.title")}
+        </span>
+        <button
+          type="button"
+          aria-label={t("connectionsPanel.newConnection")}
+          title={t("connectionsPanel.newConnection")}
+          onClick={openNewForm}
+          className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+        >
+          <Plus size={15} />
+        </button>
+      </div>
+
+      {/* List or empty state */}
+      <div className="min-h-0 flex-1 overflow-y-auto py-1">
+        {connections.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+            <Server size={28} className="text-fg-subtle" />
+            <div>
+              <p className="text-sm font-medium text-fg-muted">
+                {t("connectionsPanel.emptyTitle")}
+              </p>
+              <p className="mt-1 text-xs text-fg-subtle">
+                {t("connectionsPanel.emptyHint")}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={openNewForm}
+              className="flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-fg-muted hover:bg-bg-elevated hover:text-fg"
+            >
+              <Plus size={13} />
+              {t("connectionsPanel.newConnection")}
+            </button>
+          </div>
+        ) : (
+          <ul>
+            {connections.map((conn) => (
+              <ConnectionRow
+                key={conn.id}
+                connection={conn}
+                onEdit={openEditForm}
+                onDelete={(c) => void handleDelete(c)}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Connection form modal */}
+      {formOpen && (
+        <ConnectionForm connection={editingConnection} onClose={closeForm} />
+      )}
+    </div>
+  );
+}

--- a/src/modules/ssh/SshPromptDialog.tsx
+++ b/src/modules/ssh/SshPromptDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AlertTriangle, Lock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useSshPrompts } from "./lib/useSshPrompts";
@@ -18,6 +18,13 @@ export function SshPromptDialog() {
   const { current, reply } = useSshPrompts();
   const [secret, setSecret] = useState("");
   const [remember, setRemember] = useState(false);
+
+  // Reset the secret/remember inputs whenever the displayed prompt changes, so a
+  // new prompt never shows stale input carried over from a previous one.
+  useEffect(() => {
+    setSecret("");
+    setRemember(false);
+  }, [current?.id]);
 
   if (!current) {
     return null;

--- a/src/modules/ssh/SshPromptDialog.tsx
+++ b/src/modules/ssh/SshPromptDialog.tsx
@@ -1,0 +1,236 @@
+import { useState } from "react";
+import { AlertTriangle, Lock } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useSshPrompts } from "./lib/useSshPrompts";
+
+/**
+ * Renders one SSH prompt at a time from the global queue.
+ * Handles four kinds:
+ *   hostKeyUnknown  — new server; ask user to trust.
+ *   hostKeyChanged  — fingerprint mismatch; strong MITM warning.
+ *   password        — password auth; secret input + remember checkbox.
+ *   passphrase      — private-key passphrase; secret input + remember checkbox.
+ *
+ * Mount once near the app root. It renders nothing when the queue is empty.
+ */
+export function SshPromptDialog() {
+  const { t } = useTranslation("common");
+  const { current, reply } = useSshPrompts();
+  const [secret, setSecret] = useState("");
+  const [remember, setRemember] = useState(false);
+
+  if (!current) {
+    return null;
+  }
+
+  function handleCancel() {
+    if (!current) return;
+    reply(current.id, { approved: false, secret: null, remember: false });
+    setSecret("");
+    setRemember(false);
+  }
+
+  function handleHostKeyTrust() {
+    if (!current) return;
+    reply(current.id, { approved: true, secret: null, remember: false });
+  }
+
+  function handleHostKeyReplace() {
+    if (!current) return;
+    reply(current.id, { approved: true, secret: null, remember: false });
+  }
+
+  function handleSecretSubmit() {
+    if (!current) return;
+    reply(current.id, { approved: true, secret, remember });
+    setSecret("");
+    setRemember(false);
+  }
+
+  const { kind, message } = current;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[95] bg-black/60" onClick={handleCancel} />
+      <div className="fixed left-1/2 top-1/2 z-[100] w-[480px] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-bg-elevated shadow-2xl">
+
+        {/* hostKeyUnknown */}
+        {kind === "hostKeyUnknown" && (
+          <>
+            <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+              <Lock size={16} className="shrink-0 text-fg-muted" />
+              <span className="text-sm font-semibold text-fg">
+                {t("sshPrompt.hostKeyUnknown.title")}
+              </span>
+            </div>
+            <div className="px-4 py-4">
+              <p className="mb-2 text-sm text-fg-muted">{t("sshPrompt.hostKeyUnknown.body")}</p>
+              <code className="block rounded border border-border bg-bg-inset px-3 py-2 text-xs font-mono text-fg break-all">
+                {message}
+              </code>
+            </div>
+            <div className="flex justify-end gap-2 border-t border-border px-4 py-3">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="rounded-md px-3 py-1.5 text-xs text-fg-muted hover:text-fg"
+              >
+                {t("sshPrompt.hostKeyUnknown.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={handleHostKeyTrust}
+                className="rounded-md bg-accent px-4 py-1.5 text-xs font-medium text-white"
+              >
+                {t("sshPrompt.hostKeyUnknown.trust")}
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* hostKeyChanged — strong MITM warning */}
+        {kind === "hostKeyChanged" && (
+          <>
+            <div className="flex items-center gap-2 border-b border-red-500/40 bg-red-500/10 px-4 py-3 rounded-t-xl">
+              <AlertTriangle size={16} className="shrink-0 text-red-500" />
+              <span className="text-sm font-semibold text-red-500">
+                {t("sshPrompt.hostKeyChanged.title")}
+              </span>
+            </div>
+            <div className="px-4 py-4">
+              <p className="mb-3 text-sm text-red-400">
+                {t("sshPrompt.hostKeyChanged.warning")}
+              </p>
+              <p className="mb-2 text-sm text-fg-muted">{t("sshPrompt.hostKeyChanged.body")}</p>
+              <code className="block rounded border border-border bg-bg-inset px-3 py-2 text-xs font-mono text-fg break-all">
+                {message}
+              </code>
+            </div>
+            <div className="flex justify-end gap-2 border-t border-border px-4 py-3">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="rounded-md px-3 py-1.5 text-xs text-fg-muted hover:text-fg"
+              >
+                {t("sshPrompt.hostKeyChanged.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={handleHostKeyReplace}
+                className="rounded-md bg-red-500 px-4 py-1.5 text-xs font-medium text-white hover:bg-red-600"
+              >
+                {t("sshPrompt.hostKeyChanged.replace")}
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* password */}
+        {kind === "password" && (
+          <>
+            <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+              <Lock size={16} className="shrink-0 text-fg-muted" />
+              <span className="text-sm font-semibold text-fg">
+                {t("sshPrompt.password.title")}
+              </span>
+            </div>
+            <div className="px-4 py-4">
+              {message && (
+                <p className="mb-3 text-xs text-fg-muted">{message}</p>
+              )}
+              <label className="mb-1 block text-xs font-medium text-fg-muted">
+                {t("sshPrompt.password.label")}
+              </label>
+              <input
+                type="password"
+                autoFocus
+                value={secret}
+                onChange={(e) => setSecret(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") handleSecretSubmit(); }}
+                className="w-full rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent"
+              />
+              <label className="mt-3 flex items-center gap-2 text-xs text-fg-muted select-none cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={remember}
+                  onChange={(e) => setRemember(e.target.checked)}
+                  className="accent-accent"
+                />
+                {t("sshPrompt.password.remember")}
+              </label>
+            </div>
+            <div className="flex justify-end gap-2 border-t border-border px-4 py-3">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="rounded-md px-3 py-1.5 text-xs text-fg-muted hover:text-fg"
+              >
+                {t("sshPrompt.password.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={handleSecretSubmit}
+                className="rounded-md bg-accent px-4 py-1.5 text-xs font-medium text-white"
+              >
+                {t("sshPrompt.password.connect")}
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* passphrase */}
+        {kind === "passphrase" && (
+          <>
+            <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+              <Lock size={16} className="shrink-0 text-fg-muted" />
+              <span className="text-sm font-semibold text-fg">
+                {t("sshPrompt.passphrase.title")}
+              </span>
+            </div>
+            <div className="px-4 py-4">
+              {message && (
+                <p className="mb-3 text-xs text-fg-muted">{message}</p>
+              )}
+              <label className="mb-1 block text-xs font-medium text-fg-muted">
+                {t("sshPrompt.passphrase.label")}
+              </label>
+              <input
+                type="password"
+                autoFocus
+                value={secret}
+                onChange={(e) => setSecret(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") handleSecretSubmit(); }}
+                className="w-full rounded border border-border bg-bg-inset px-3 py-1.5 text-sm text-fg outline-none focus:border-accent"
+              />
+              <label className="mt-3 flex items-center gap-2 text-xs text-fg-muted select-none cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={remember}
+                  onChange={(e) => setRemember(e.target.checked)}
+                  className="accent-accent"
+                />
+                {t("sshPrompt.passphrase.remember")}
+              </label>
+            </div>
+            <div className="flex justify-end gap-2 border-t border-border px-4 py-3">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="rounded-md px-3 py-1.5 text-xs text-fg-muted hover:text-fg"
+              >
+                {t("sshPrompt.passphrase.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={handleSecretSubmit}
+                className="rounded-md bg-accent px-4 py-1.5 text-xs font-medium text-white"
+              >
+                {t("sshPrompt.passphrase.ok")}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/modules/ssh/SshPromptDialog.tsx
+++ b/src/modules/ssh/SshPromptDialog.tsx
@@ -37,12 +37,7 @@ export function SshPromptDialog() {
     setRemember(false);
   }
 
-  function handleHostKeyTrust() {
-    if (!current) return;
-    reply(current.id, { approved: true, secret: null, remember: false });
-  }
-
-  function handleHostKeyReplace() {
+  function handleHostKeyApprove() {
     if (!current) return;
     reply(current.id, { approved: true, secret: null, remember: false });
   }
@@ -86,7 +81,7 @@ export function SshPromptDialog() {
               </button>
               <button
                 type="button"
-                onClick={handleHostKeyTrust}
+                onClick={handleHostKeyApprove}
                 className="rounded-md bg-accent px-4 py-1.5 text-xs font-medium text-white"
               >
                 {t("sshPrompt.hostKeyUnknown.trust")}
@@ -123,7 +118,7 @@ export function SshPromptDialog() {
               </button>
               <button
                 type="button"
-                onClick={handleHostKeyReplace}
+                onClick={handleHostKeyApprove}
                 className="rounded-md bg-red-500 px-4 py-1.5 text-xs font-medium text-white hover:bg-red-600"
               >
                 {t("sshPrompt.hostKeyChanged.replace")}

--- a/src/modules/ssh/lib/freshSshLeaves.test.ts
+++ b/src/modules/ssh/lib/freshSshLeaves.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { markFreshSshLeaf, consumeFreshSshLeaf } from "./freshSshLeaves";
+
+describe("freshSshLeaves", () => {
+  it("consumeFreshSshLeaf returns true after markFreshSshLeaf", () => {
+    markFreshSshLeaf("a");
+    expect(consumeFreshSshLeaf("a")).toBe(true);
+  });
+
+  it("consumeFreshSshLeaf is one-shot — second call returns false", () => {
+    markFreshSshLeaf("b");
+    consumeFreshSshLeaf("b");
+    expect(consumeFreshSshLeaf("b")).toBe(false);
+  });
+
+  it("consumeFreshSshLeaf returns false for a never-marked leaf", () => {
+    expect(consumeFreshSshLeaf("never-marked")).toBe(false);
+  });
+});

--- a/src/modules/ssh/lib/freshSshLeaves.ts
+++ b/src/modules/ssh/lib/freshSshLeaves.ts
@@ -1,0 +1,27 @@
+/**
+ * Tracks leaf ids that were opened as fresh SSH sessions THIS app session
+ * (not restored from persisted state). Module-level — lives only in memory,
+ * so it is empty after every app relaunch.
+ *
+ * openSshTab adds a leaf id when the user actively opens a connection.
+ * TerminalView consumes (checks + deletes) the id on mount: present → auto-connect,
+ * absent → show the "Disconnected — click to Reconnect" state.
+ */
+const freshLeaves = new Set<string>();
+
+/** Mark a leaf as freshly user-opened so TerminalView auto-connects it. */
+export function markFreshSshLeaf(leafId: string): void {
+  freshLeaves.add(leafId);
+}
+
+/**
+ * One-shot check-and-consume. Returns true and removes the id when the leaf
+ * was opened fresh this session; returns false for restored panes.
+ */
+export function consumeFreshSshLeaf(leafId: string): boolean {
+  if (freshLeaves.has(leafId)) {
+    freshLeaves.delete(leafId);
+    return true;
+  }
+  return false;
+}

--- a/src/modules/ssh/lib/parseSshCommand.test.ts
+++ b/src/modules/ssh/lib/parseSshCommand.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseSshCommand } from "./parseSshCommand";
+
+describe("parseSshCommand", () => {
+  it("parses user@host", () => {
+    const r = parseSshCommand("ssh muki@example.com");
+    expect(r.draft).toMatchObject({ user: "muki", host: "example.com", port: 22 });
+  });
+
+  it("parses -p port", () => {
+    expect(parseSshCommand("ssh -p 2222 muki@h").draft.port).toBe(2222);
+  });
+
+  it("parses -i key as keyFile auth", () => {
+    const r = parseSshCommand("ssh -i ~/.ssh/id_ed25519 muki@h");
+    expect(r.draft.authMethod).toBe("keyFile");
+    expect(r.draft.keyPath).toBe("~/.ssh/id_ed25519");
+  });
+
+  it("parses -l user", () => {
+    expect(parseSshCommand("ssh -l muki h").draft.user).toBe("muki");
+  });
+
+  it("reports deferred flags as ignored", () => {
+    const r = parseSshCommand("ssh -L 8080:localhost:80 -J b muki@h");
+    expect(r.ignored.join(" ")).toMatch(/-L/);
+    expect(r.ignored.join(" ")).toMatch(/-J/);
+  });
+
+  it("defaults name to host when absent", () => {
+    expect(parseSshCommand("ssh muki@example.com").draft.name).toBe("example.com");
+  });
+
+  it("returns empty draft for a non-ssh string", () => {
+    expect(parseSshCommand("hello world").draft).toEqual({});
+    expect(parseSshCommand("hello world").warnings.length).toBeGreaterThan(0);
+  });
+});

--- a/src/modules/ssh/lib/parseSshCommand.test.ts
+++ b/src/modules/ssh/lib/parseSshCommand.test.ts
@@ -35,4 +35,21 @@ describe("parseSshCommand", () => {
     expect(parseSshCommand("hello world").draft).toEqual({});
     expect(parseSshCommand("hello world").warnings.length).toBeGreaterThan(0);
   });
+
+  // B10(a): unrecognized flag + missing host → both warnings always reported
+  it("reports both unrecognized-flag and no-host warnings when host is absent", () => {
+    const r = parseSshCommand("ssh -X");
+    const joined = r.warnings.join("\n");
+    expect(joined).toMatch(/unrecognized flag/i);
+    expect(joined).toMatch(/no host found/i);
+  });
+
+  // B10(b): -p with no following token → clean message, no dangling colon
+  it("reports a clean message when -p has no value", () => {
+    const r = parseSshCommand("ssh host -p");
+    expect(r.warnings.length).toBeGreaterThan(0);
+    const msg = r.warnings.join(" ");
+    expect(msg).toMatch(/missing port after -p/i);
+    expect(msg).not.toMatch(/:\s*$/); // no trailing colon
+  });
 });

--- a/src/modules/ssh/lib/parseSshCommand.ts
+++ b/src/modules/ssh/lib/parseSshCommand.ts
@@ -1,0 +1,99 @@
+export type SshAuthMethod = "password" | "keyFile" | "agent";
+
+export interface ConnectionDraft {
+  name: string;
+  host: string;
+  port: number;
+  user: string;
+  authMethod: SshAuthMethod;
+  keyPath?: string;
+}
+
+export interface ParsedSshCommand {
+  draft: Partial<ConnectionDraft>;
+  ignored: string[];
+  warnings: string[];
+}
+
+const DEFERRED: Record<string, string> = {
+  "-L": "local port forwarding",
+  "-R": "remote port forwarding",
+  "-D": "dynamic SOCKS forwarding",
+  "-J": "jump host",
+};
+const DEFERRED_TAKES_ARG = new Set(["-L", "-R", "-D", "-J"]);
+
+/** Tokenize on whitespace; v1 does not need shell-quote handling. */
+function tokenize(input: string): string[] {
+  return input.trim().split(/\s+/).filter(Boolean);
+}
+
+export function parseSshCommand(input: string): ParsedSshCommand {
+  const draft: Partial<ConnectionDraft> = {};
+  const ignored: string[] = [];
+  const warnings: string[] = [];
+  const tokens = tokenize(input);
+
+  let i = 0;
+  let isSshCommand = false;
+  if (tokens[i] === "ssh") {
+    i += 1;
+    isSshCommand = true;
+  }
+
+  for (; i < tokens.length; i += 1) {
+    const tok = tokens[i];
+    if (tok === "-p") {
+      const v = tokens[++i];
+      const port = Number(v);
+      if (Number.isInteger(port) && port > 0) {
+        draft.port = port;
+      } else {
+        warnings.push(`invalid port: ${v ?? ""}`.trim());
+      }
+    } else if (tok === "-i") {
+      const v = tokens[++i];
+      if (v) {
+        draft.keyPath = v;
+        draft.authMethod = "keyFile";
+      }
+    } else if (tok === "-l") {
+      const v = tokens[++i];
+      if (v) {
+        draft.user = v;
+      }
+    } else if (tok in DEFERRED) {
+      ignored.push(`${tok} (${DEFERRED[tok]}) is not supported in v1 and was ignored`);
+      if (DEFERRED_TAKES_ARG.has(tok)) {
+        i += 1; // skip its argument
+      }
+    } else if (tok.startsWith("-")) {
+      warnings.push(`unrecognized flag: ${tok}`);
+    } else if (tok.includes("@")) {
+      const [user, host] = tok.split("@");
+      if (user) draft.user = user;
+      if (host) draft.host = host;
+    } else if (isSshCommand) {
+      // Only set positional host argument if we're in an ssh command
+      draft.host = tok;
+    } else {
+      // Non-ssh command with positional argument
+      warnings.push(`unexpected argument: ${tok}`);
+    }
+  }
+
+  if (draft.host && draft.port === undefined) {
+    draft.port = 22;
+  }
+  if (draft.host && draft.name === undefined) {
+    draft.name = draft.host;
+  }
+  if (draft.host && draft.authMethod === undefined) {
+    draft.authMethod = "password";
+  }
+  if (!draft.host && warnings.length === 0) {
+    warnings.push("no host found in command");
+  }
+
+  return { draft, ignored, warnings };
+}

--- a/src/modules/ssh/lib/parseSshCommand.ts
+++ b/src/modules/ssh/lib/parseSshCommand.ts
@@ -45,11 +45,15 @@ export function parseSshCommand(input: string): ParsedSshCommand {
     const tok = tokens[i];
     if (tok === "-p") {
       const v = tokens[++i];
-      const port = Number(v);
-      if (Number.isInteger(port) && port > 0) {
-        draft.port = port;
+      if (v === undefined) {
+        warnings.push("missing port after -p");
       } else {
-        warnings.push(`invalid port: ${v ?? ""}`.trim());
+        const port = Number(v);
+        if (Number.isInteger(port) && port > 0) {
+          draft.port = port;
+        } else {
+          warnings.push(`invalid port: ${v}`);
+        }
       }
     } else if (tok === "-i") {
       const v = tokens[++i];
@@ -91,7 +95,7 @@ export function parseSshCommand(input: string): ParsedSshCommand {
   if (draft.host && draft.authMethod === undefined) {
     draft.authMethod = "password";
   }
-  if (!draft.host && warnings.length === 0) {
+  if (!draft.host) {
     warnings.push("no host found in command");
   }
 

--- a/src/modules/ssh/lib/ssh-bridge.test.ts
+++ b/src/modules/ssh/lib/ssh-bridge.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn().mockResolvedValue(7);
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...a: unknown[]) => invoke(...a),
+  Channel: class { onmessage: ((m: unknown) => void) | null = null; },
+}));
+
+import { openSsh } from "./ssh-bridge";
+
+describe("openSsh", () => {
+  it("invokes ssh_open and exposes write/resize/close on the returned id", async () => {
+    const s = await openSsh({
+      connectionId: "c1", host: "h", port: 22, user: "muki",
+      authMethod: "password", cols: 80, rows: 24,
+      onData: () => {}, onExit: () => {},
+    });
+    expect(s.id).toBe(7);
+    await s.write("ls\n");
+    expect(invoke).toHaveBeenCalledWith("ssh_write", { id: 7, data: "ls\n" });
+    await s.resize(100, 30);
+    expect(invoke).toHaveBeenCalledWith("ssh_resize", { id: 7, cols: 100, rows: 30 });
+  });
+});

--- a/src/modules/ssh/lib/ssh-bridge.test.ts
+++ b/src/modules/ssh/lib/ssh-bridge.test.ts
@@ -21,4 +21,39 @@ describe("openSsh", () => {
     await s.resize(100, 30);
     expect(invoke).toHaveBeenCalledWith("ssh_resize", { id: 7, cols: 100, rows: 30 });
   });
+
+  it("passes the correct req shape to ssh_open", async () => {
+    invoke.mockClear();
+    await openSsh({
+      connectionId: "conn-42", host: "example.com", port: 2222, user: "alice",
+      authMethod: "keyFile", keyPath: "~/.ssh/id_ed25519", cols: 120, rows: 40,
+      onData: () => {}, onExit: () => {},
+    });
+    expect(invoke).toHaveBeenCalledWith(
+      "ssh_open",
+      expect.objectContaining({
+        req: {
+          connectionId: "conn-42",
+          host: "example.com",
+          port: 2222,
+          user: "alice",
+          authMethod: "keyFile",
+          keyPath: "~/.ssh/id_ed25519",
+          cols: 120,
+          rows: 40,
+        },
+      }),
+    );
+  });
+
+  it("close() calls ssh_close with the session id", async () => {
+    invoke.mockClear();
+    const s = await openSsh({
+      connectionId: "c2", host: "h2", port: 22, user: "bob",
+      authMethod: "password", cols: 80, rows: 24,
+      onData: () => {}, onExit: () => {},
+    });
+    await s.close();
+    expect(invoke).toHaveBeenCalledWith("ssh_close", { id: s.id });
+  });
 });

--- a/src/modules/ssh/lib/ssh-bridge.ts
+++ b/src/modules/ssh/lib/ssh-bridge.ts
@@ -1,0 +1,52 @@
+import { Channel, invoke } from "@tauri-apps/api/core";
+import { toBytes } from "@/modules/terminal/lib/channelBytes";
+import type { SshAuthMethod } from "./parseSshCommand";
+
+export interface SshSession {
+  id: number;
+  write: (data: string) => Promise<void>;
+  resize: (cols: number, rows: number) => Promise<void>;
+  close: () => Promise<void>;
+}
+
+export interface OpenSshOptions {
+  connectionId: string;
+  host: string;
+  port: number;
+  user: string;
+  authMethod: SshAuthMethod;
+  keyPath?: string;
+  cols: number;
+  rows: number;
+  onData: (bytes: Uint8Array) => void;
+  onExit: (code: number) => void;
+}
+
+export async function openSsh(opts: OpenSshOptions): Promise<SshSession> {
+  const onData = new Channel<unknown>();
+  onData.onmessage = (m) => opts.onData(toBytes(m));
+  const onExit = new Channel<number>();
+  onExit.onmessage = (code) => opts.onExit(code);
+
+  const id = await invoke<number>("ssh_open", {
+    req: {
+      connectionId: opts.connectionId,
+      host: opts.host,
+      port: opts.port,
+      user: opts.user,
+      authMethod: opts.authMethod,
+      keyPath: opts.keyPath,
+      cols: opts.cols,
+      rows: opts.rows,
+    },
+    onData,
+    onExit,
+  });
+
+  return {
+    id,
+    write: (data) => invoke("ssh_write", { id, data }),
+    resize: (cols, rows) => invoke("ssh_resize", { id, cols, rows }),
+    close: () => invoke("ssh_close", { id }),
+  };
+}

--- a/src/modules/ssh/lib/useSshPrompts.test.ts
+++ b/src/modules/ssh/lib/useSshPrompts.test.ts
@@ -13,4 +13,12 @@ describe("promptReducer", () => {
     const s2 = promptReducer(s1, { type: "answered", id: "1" });
     expect(s2.queue).toHaveLength(0);
   });
+
+  it("removes only the answered prompt when multiple are queued", () => {
+    const s1 = promptReducer(empty, { type: "incoming", req: { id: "1", kind: "hostKeyUnknown", message: "fp1" } });
+    const s2 = promptReducer(s1, { type: "incoming", req: { id: "2", kind: "password", message: "" } });
+    const s3 = promptReducer(s2, { type: "answered", id: "1" });
+    expect(s3.queue).toHaveLength(1);
+    expect(s3.queue[0].id).toBe("2");
+  });
 });

--- a/src/modules/ssh/lib/useSshPrompts.test.ts
+++ b/src/modules/ssh/lib/useSshPrompts.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { promptReducer, type PromptState } from "./useSshPrompts";
+
+const empty: PromptState = { queue: [] };
+
+describe("promptReducer", () => {
+  it("enqueues an incoming prompt", () => {
+    const s = promptReducer(empty, { type: "incoming", req: { id: "1", kind: "hostKeyUnknown", message: "fp" } });
+    expect(s.queue).toHaveLength(1);
+  });
+  it("dequeues by id on reply", () => {
+    const s1 = promptReducer(empty, { type: "incoming", req: { id: "1", kind: "password", message: "" } });
+    const s2 = promptReducer(s1, { type: "answered", id: "1" });
+    expect(s2.queue).toHaveLength(0);
+  });
+});

--- a/src/modules/ssh/lib/useSshPrompts.ts
+++ b/src/modules/ssh/lib/useSshPrompts.ts
@@ -1,0 +1,73 @@
+import { useEffect, useReducer } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
+
+export type PromptKind = "hostKeyUnknown" | "hostKeyChanged" | "password" | "passphrase";
+
+export interface PromptRequest {
+  id: string;
+  kind: PromptKind;
+  message: string;
+}
+
+export interface PromptReply {
+  approved: boolean;
+  secret: string | null;
+  remember: boolean;
+}
+
+export interface PromptState {
+  queue: PromptRequest[];
+}
+
+type PromptAction =
+  | { type: "incoming"; req: PromptRequest }
+  | { type: "answered"; id: string };
+
+export function promptReducer(state: PromptState, action: PromptAction): PromptState {
+  switch (action.type) {
+    case "incoming":
+      return { queue: [...state.queue, action.req] };
+    case "answered":
+      return { queue: state.queue.filter((r) => r.id !== action.id) };
+    default:
+      return state;
+  }
+}
+
+const INITIAL_STATE: PromptState = { queue: [] };
+
+export function useSshPrompts(): {
+  current: PromptRequest | undefined;
+  reply: (id: string, payload: PromptReply) => void;
+} {
+  const [state, dispatch] = useReducer(promptReducer, INITIAL_STATE);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+
+    listen<PromptRequest>("ssh-prompt", (event) => {
+      dispatch({ type: "incoming", req: event.payload });
+    })
+      .then((off) => {
+        unlisten = off;
+      })
+      .catch(() => {
+        // No Tauri runtime in tests/web preview; swallow silently.
+      });
+
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  function reply(id: string, payload: PromptReply): void {
+    void invoke("ssh_prompt_reply", { id, reply: payload }).catch(() => {});
+    dispatch({ type: "answered", id });
+  }
+
+  return {
+    current: state.queue[0],
+    reply,
+  };
+}

--- a/src/modules/ssh/lib/useSshPrompts.ts
+++ b/src/modules/ssh/lib/useSshPrompts.ts
@@ -44,19 +44,30 @@ export function useSshPrompts(): {
   const [state, dispatch] = useReducer(promptReducer, INITIAL_STATE);
 
   useEffect(() => {
+    // `listen` is async: the component can unmount before it resolves. The
+    // `active` flag makes cleanup safe — if we've already unmounted by the time
+    // the listener registers, detach it immediately instead of leaking it.
+    let active = true;
     let unlisten: (() => void) | undefined;
 
     listen<PromptRequest>("ssh-prompt", (event) => {
-      dispatch({ type: "incoming", req: event.payload });
+      if (active) {
+        dispatch({ type: "incoming", req: event.payload });
+      }
     })
       .then((off) => {
-        unlisten = off;
+        if (active) {
+          unlisten = off;
+        } else {
+          off();
+        }
       })
       .catch(() => {
         // No Tauri runtime in tests/web preview; swallow silently.
       });
 
     return () => {
+      active = false;
       unlisten?.();
     };
   }, []);

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -249,12 +249,18 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                 ) : (
                   <TerminalView
                     active={active}
-                    cwdTracking={active && isActiveTab}
+                    cwdTracking={
+                      active &&
+                      isActiveTab &&
+                      // SSH panes have no cwd; skip cwd tracking for them.
+                      (pane.content.kind !== "terminal" || !pane.content.ssh)
+                    }
                     cwd={resolveTerminalCwd(
                       pane.content.kind === "terminal" ? pane.content.cwd : undefined,
                       rootPath,
                       tab.cwd,
                     )}
+                    ssh={pane.content.kind === "terminal" ? pane.content.ssh : undefined}
                     leafId={pane.id}
                     onExit={() => closePane(tab.id, pane.id)}
                     onCwdChange={(dir) => setTerminalCwd(tab.id, pane.id, dir)}

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -443,9 +443,11 @@ export function TerminalView({
           // down ourselves (e.g. React StrictMode's mount/unmount/remount in dev).
           onExit: (_code) => {
             if (!disposed) {
-              onExitRef.current?.();
-              // SSH session ended naturally; close the backend registry entry.
+              // Do NOT call onExitRef (which closes the pane). Instead, show the
+              // Reconnect card so the user can retry after a failed/dropped connection.
               void sessionRef.current?.close();
+              setSshDisconnected(true);
+              setConnecting(false);
             }
           },
         });

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
 import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/createTerminal";
 import { openPty, type PtySession } from "./lib/pty-bridge";
+import { openSsh, type SshSession } from "@/modules/ssh/lib/ssh-bridge";
+import { useConnectionsStore } from "@/stores/connectionsStore";
 import {
   deleteTerminalHistory,
   dropRestoredPrefix,
@@ -75,6 +77,8 @@ interface TerminalViewProps {
   cwdTracking?: boolean;
   /** Directory the shell starts in. */
   cwd?: string;
+  /** SSH connection info, when this pane hosts an SSH session instead of a local PTY. */
+  ssh?: { connectionId: string };
   /** Pane id, so notes/workflows can run commands into this terminal. */
   leafId?: string;
   onExit?: () => void;
@@ -88,6 +92,7 @@ export function TerminalView({
   active,
   cwdTracking = false,
   cwd,
+  ssh,
   leafId,
   onExit,
   onCwdChange,
@@ -101,7 +106,9 @@ export function TerminalView({
   cwdRef.current = cwd;
   const containerRef = useRef<HTMLDivElement>(null);
   const handleRef = useRef<TerminalHandle | null>(null);
-  const sessionRef = useRef<PtySession | null>(null);
+  const sessionRef = useRef<PtySession | SshSession | null>(null);
+  const sshRef = useRef(ssh);
+  sshRef.current = ssh;
   const onExitRef = useRef(onExit);
   onExitRef.current = onExit;
   const onCwdChangeRef = useRef(onCwdChange);
@@ -179,7 +186,7 @@ export function TerminalView({
           imagePaths = await terminalClipboardImagePaths().catch(() => []);
         }
         if (filePaths.length === 1 || imagePaths.length === 1) {
-          command = await session.foregroundCommand().catch(() => null);
+          command = await (session as PtySession).foregroundCommand?.().catch(() => null) ?? null;
         }
       }
       const action = resolvePasteAction({
@@ -309,7 +316,7 @@ export function TerminalView({
     async function openFromTerminal(raw: string) {
       let resolvedCwd: string | null = cwdRef.current ?? null;
       try {
-        const live = await sessionRef.current?.cwd();
+        const live = await (sessionRef.current as PtySession | null)?.cwd();
         if (live) {
           resolvedCwd = live;
         }
@@ -397,29 +404,63 @@ export function TerminalView({
       term.write(`\x1b[90m${SESSION_SEPARATOR}\x1b[0m\r\n`);
     };
 
-    void restoreHistory().then(() => {
+    const openSession = async (): Promise<PtySession | SshSession> => {
+      const paneSsh = sshRef.current;
+      if (paneSsh) {
+        const conn = useConnectionsStore.getState().getConnection(paneSsh.connectionId);
+        if (!conn) {
+          throw new Error(`SSH connection "${paneSsh.connectionId}" not found — it may have been deleted.`);
+        }
+        return openSsh({
+          connectionId: conn.id,
+          host: conn.host,
+          port: conn.port,
+          user: conn.user,
+          authMethod: conn.authMethod,
+          keyPath: conn.keyPath,
+          cols: term.cols,
+          rows: term.rows,
+          onData: (bytes) => term.write(bytes),
+          // Only treat an exit as user-facing when we did not tear the session
+          // down ourselves (e.g. React StrictMode's mount/unmount/remount in dev).
+          onExit: (_code) => {
+            if (!disposed) {
+              onExitRef.current?.();
+              // SSH session ended naturally; close the backend registry entry.
+              void sessionRef.current?.close();
+            }
+          },
+        });
+      }
+      return openPty({
+        cols: term.cols,
+        rows: term.rows,
+        cwd: cwdRef.current,
+        onData: (bytes) => term.write(bytes),
+        // Only treat an exit as user-facing when we did not tear the session
+        // down ourselves (e.g. React StrictMode's mount/unmount/remount in dev).
+        onExit: () => {
+          if (!disposed) {
+            onExitRef.current?.();
+            // The shell ended while the app is running (e.g. the user typed
+            // `exit`), so its history is no longer wanted. An app teardown sets
+            // `disposed` first, so that path keeps the history for next launch.
+            if (leafIdRef.current) {
+              void deleteTerminalHistory(leafIdRef.current);
+            }
+          }
+        },
+      });
+    };
+
+    // History restore only applies to local PTY sessions.
+    const beforeOpen = sshRef.current ? Promise.resolve() : restoreHistory();
+
+    void beforeOpen.then(() => {
       if (disposed) {
         return;
       }
-      void openPty({
-      cols: term.cols,
-      rows: term.rows,
-      cwd: cwdRef.current,
-      onData: (bytes) => term.write(bytes),
-      // Only treat an exit as user-facing when we did not tear the session
-      // down ourselves (e.g. React StrictMode's mount/unmount/remount in dev).
-      onExit: () => {
-        if (!disposed) {
-          onExitRef.current?.();
-          // The shell ended while the app is running (e.g. the user typed
-          // `exit`), so its history is no longer wanted. An app teardown sets
-          // `disposed` first, so that path keeps the history for next launch.
-          if (leafIdRef.current) {
-            void deleteTerminalHistory(leafIdRef.current);
-          }
-        }
-      },
-    })
+      void openSession()
       .then((session) => {
         if (disposed) {
           void session.close();
@@ -585,15 +626,16 @@ export function TerminalView({
   }, [terminalPadding]);
 
   // While this pane is the live one, follow its shell's working directory so
-  // the file explorer tracks `cd`.
+  // the file explorer tracks `cd`. SSH panes skip this entirely — they have no
+  // cwd() or foregroundCommand() methods.
   useEffect(() => {
-    if (!cwdTracking) {
+    if (!cwdTracking || sshRef.current) {
       return;
     }
     let cancelled = false;
     let last = "";
     const poll = async () => {
-      const session = sessionRef.current;
+      const session = sessionRef.current as PtySession | null;
       if (!session) {
         return;
       }
@@ -662,12 +704,12 @@ export function TerminalView({
   }, [cwdTracking]);
 
   // Snapshot the cwd when this pane stops being active (e.g. switching tabs), so
-  // its last directory is saved between polls. Event-driven, no extra polling.
+  // its last directory is saved between polls. SSH panes skip this — no cwd() method.
   useEffect(() => {
-    if (active) {
+    if (active || sshRef.current) {
       return;
     }
-    const session = sessionRef.current;
+    const session = sessionRef.current as PtySession | null;
     if (!session) {
       return;
     }
@@ -783,7 +825,7 @@ export function TerminalView({
     if (filePaths.length === 0) {
       return false;
     }
-    const command = await session.foregroundCommand().catch(() => null);
+    const command = await (session as PtySession).foregroundCommand?.().catch(() => null) ?? null;
     if (shouldAttachImage(command, filePaths)) {
       await prepareClipboardImageAttachment(filePaths[0]).catch(() => {});
       await session.write("\x16");

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -1,7 +1,8 @@
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2 } from "lucide-react";
+import { Loader2, WifiOff } from "lucide-react";
+import { consumeFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/createTerminal";
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import { openSsh, type SshSession } from "@/modules/ssh/lib/ssh-bridge";
@@ -115,6 +116,9 @@ export function TerminalView({
   onCwdChangeRef.current = onCwdChange;
   const onOpenFileRef = useRef(onOpenFile);
   onOpenFileRef.current = onOpenFile;
+  // Holds a deferred "start the SSH session now" function that is set inside the
+  // main mount effect and called by the reconnect button for restored panes.
+  const connectNowRef = useRef<(() => void) | null>(null);
   const { t } = useTranslation();
   const linkHintRef = useRef(t("openLinkHint", { mods: openModifierLabel(IS_MAC) }));
   linkHintRef.current = t("openLinkHint", { mods: openModifierLabel(IS_MAC) });
@@ -124,6 +128,12 @@ export function TerminalView({
   const themeId = useSettingsStore((s) => s.themeId);
   const terminalPadding = useSettingsStore((s) => s.terminalPadding);
   const [connecting, setConnecting] = useState(true);
+  // For SSH panes restored after an app relaunch: the freshSshLeaves set is empty,
+  // so those panes must not auto-connect. This flag shows the Reconnect UI instead.
+  const [sshDisconnected, setSshDisconnected] = useState(false);
+  // Incrementing this counter (via the Reconnect button) re-triggers the connect
+  // effect for restored SSH panes without touching any other path.
+  const [reconnectTrigger, setReconnectTrigger] = useState(0);
   const [externalFileDragging, setExternalFileDragging] = useState(false);
   const dragDepthRef = useRef(0);
   const nativeDragPathsRef = useRef<string[]>([]);
@@ -456,10 +466,10 @@ export function TerminalView({
     // History restore only applies to local PTY sessions.
     const beforeOpen = sshRef.current ? Promise.resolve() : restoreHistory();
 
-    void beforeOpen.then(() => {
-      if (disposed) {
-        return;
-      }
+    // Shared "open session and wire it up" logic, used both on first mount
+    // (for fresh SSH and all PTY panes) and by the Reconnect button (for
+    // restored SSH panes that skipped auto-connect on relaunch).
+    function startSession() {
       void openSession()
       .then((session) => {
         if (disposed) {
@@ -478,6 +488,7 @@ export function TerminalView({
         if (cwdTracking && cwdRef.current) {
           useWorkspaceStore.getState().setRoot(cwdRef.current);
         }
+        setSshDisconnected(false);
         setConnecting(false);
       })
       .catch((error: unknown) => {
@@ -490,6 +501,36 @@ export function TerminalView({
         term.write(`\r\n\x1b[31mFailed to open shell: ${message}\x1b[0m\r\n`);
         setConnecting(false);
       });
+    }
+
+    // Expose the connect function so the Reconnect button can call it after mount.
+    connectNowRef.current = () => {
+      if (disposed) {
+        return;
+      }
+      setConnecting(true);
+      startSession();
+    };
+
+    void beforeOpen.then(() => {
+      if (disposed) {
+        return;
+      }
+      // For SSH panes: only auto-connect if this leaf was freshly opened this
+      // session (i.e. the user just clicked "Connect"). Restored panes after a
+      // relaunch will not be in the set, so they show the Reconnect UI instead.
+      if (sshRef.current) {
+        const isFresh = leafIdRef.current
+          ? consumeFreshSshLeaf(leafIdRef.current)
+          : false;
+        if (!isFresh) {
+          // Restored SSH pane — show the Disconnected / Reconnect state.
+          setSshDisconnected(true);
+          setConnecting(false);
+          return;
+        }
+      }
+      startSession();
     });
 
     // Snapshot the scrollback periodically so a crash/quit loses at most a few
@@ -797,6 +838,16 @@ export function TerminalView({
     };
   }, []);
 
+  // When the user clicks Reconnect on a restored SSH pane, reconnectTrigger is
+  // incremented. This effect wakes up and calls the deferred connect function
+  // that was stored in connectNowRef during the main mount effect.
+  useEffect(() => {
+    if (reconnectTrigger === 0) {
+      return;
+    }
+    connectNowRef.current?.();
+  }, [reconnectTrigger]);
+
   // Match the padding gutter to the terminal's own background so the inset
   // reads as breathing room rather than a different-coloured frame.
   function isExternalFileDrag(data: DataTransfer): boolean {
@@ -905,6 +956,19 @@ export function TerminalView({
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-2 text-fg-subtle">
           <Loader2 size={15} className="animate-spin" />
           <span className="text-xs">{t("terminalConnecting")}</span>
+        </div>
+      )}
+      {sshDisconnected && !connecting && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-fg-subtle">
+          <WifiOff size={24} />
+          <span className="text-sm">{t("ssh.disconnected")}</span>
+          <button
+            type="button"
+            onClick={() => setReconnectTrigger((n) => n + 1)}
+            className="rounded-md border border-border px-4 py-1.5 text-sm text-fg-muted hover:bg-bg-elevated hover:text-fg"
+          >
+            {t("ssh.reconnect")}
+          </button>
         </div>
       )}
     </div>

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -6,6 +6,11 @@ import { consumeFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/createTerminal";
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import { openSsh, type SshSession } from "@/modules/ssh/lib/ssh-bridge";
+
+/** Narrows a session to PtySession (which has cwd/foregroundCommand). */
+function isPtySession(s: PtySession | SshSession): s is PtySession {
+  return "cwd" in s;
+}
 import { useConnectionsStore } from "@/stores/connectionsStore";
 import {
   deleteTerminalHistory,
@@ -196,7 +201,9 @@ export function TerminalView({
           imagePaths = await terminalClipboardImagePaths().catch(() => []);
         }
         if (filePaths.length === 1 || imagePaths.length === 1) {
-          command = await (session as PtySession).foregroundCommand?.().catch(() => null) ?? null;
+          command = isPtySession(session)
+            ? await session.foregroundCommand().catch(() => null)
+            : null;
         }
       }
       const action = resolvePasteAction({
@@ -326,7 +333,8 @@ export function TerminalView({
     async function openFromTerminal(raw: string) {
       let resolvedCwd: string | null = cwdRef.current ?? null;
       try {
-        const live = await (sessionRef.current as PtySession | null)?.cwd();
+        const s = sessionRef.current;
+        const live = s && isPtySession(s) ? await s.cwd() : null;
         if (live) {
           resolvedCwd = live;
         }
@@ -676,7 +684,8 @@ export function TerminalView({
     let cancelled = false;
     let last = "";
     const poll = async () => {
-      const session = sessionRef.current as PtySession | null;
+      const raw = sessionRef.current;
+      const session = raw && isPtySession(raw) ? raw : null;
       if (!session) {
         return;
       }
@@ -750,7 +759,8 @@ export function TerminalView({
     if (active || sshRef.current) {
       return;
     }
-    const session = sessionRef.current as PtySession | null;
+    const raw = sessionRef.current;
+    const session = raw && isPtySession(raw) ? raw : null;
     if (!session) {
       return;
     }
@@ -876,7 +886,9 @@ export function TerminalView({
     if (filePaths.length === 0) {
       return false;
     }
-    const command = await (session as PtySession).foregroundCommand?.().catch(() => null) ?? null;
+    const command = isPtySession(session)
+      ? await session.foregroundCommand().catch(() => null)
+      : null;
     if (shouldAttachImage(command, filePaths)) {
       await prepareClipboardImageAttachment(filePaths[0]).catch(() => {});
       await session.write("\x16");
@@ -964,8 +976,9 @@ export function TerminalView({
           <span className="text-sm">{t("ssh.disconnected")}</span>
           <button
             type="button"
+            disabled={connecting}
             onClick={() => setReconnectTrigger((n) => n + 1)}
-            className="rounded-md border border-border px-4 py-1.5 text-sm text-fg-muted hover:bg-bg-elevated hover:text-fg"
+            className="rounded-md border border-border px-4 py-1.5 text-sm text-fg-muted hover:bg-bg-elevated hover:text-fg disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {t("ssh.reconnect")}
           </button>

--- a/src/modules/terminal/lib/channelBytes.ts
+++ b/src/modules/terminal/lib/channelBytes.ts
@@ -1,0 +1,26 @@
+/**
+ * Normalise whatever shape the channel delivers (ArrayBuffer, a typed array,
+ * or a plain number array) into a Uint8Array, so terminal output renders
+ * regardless of how Tauri serialises the binary payload.
+ */
+export function toBytes(message: unknown): Uint8Array {
+  if (message instanceof Uint8Array) {
+    return message;
+  }
+  if (message instanceof ArrayBuffer) {
+    return new Uint8Array(message);
+  }
+  if (Array.isArray(message)) {
+    return Uint8Array.from(message as number[]);
+  }
+  if (message && typeof message === "object" && "data" in message) {
+    const data = (message as { data: unknown }).data;
+    if (Array.isArray(data)) {
+      return Uint8Array.from(data as number[]);
+    }
+    if (data instanceof ArrayBuffer) {
+      return new Uint8Array(data);
+    }
+  }
+  return new Uint8Array();
+}

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -1,4 +1,5 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
+import { toBytes } from "@/modules/terminal/lib/channelBytes";
 
 export interface PtySession {
   id: number;
@@ -20,33 +21,6 @@ export interface OpenPtyOptions {
 // Session ids opened by THIS window's webview. Used to close only this window's
 // PTYs when it closes (pty_close_all in the backend is global across windows).
 const localSessions = new Set<number>();
-
-/**
- * Normalise whatever shape the channel delivers (ArrayBuffer, a typed array,
- * or a plain number array) into a Uint8Array, so terminal output renders
- * regardless of how Tauri serialises the binary payload.
- */
-function toBytes(message: unknown): Uint8Array {
-  if (message instanceof Uint8Array) {
-    return message;
-  }
-  if (message instanceof ArrayBuffer) {
-    return new Uint8Array(message);
-  }
-  if (Array.isArray(message)) {
-    return Uint8Array.from(message as number[]);
-  }
-  if (message && typeof message === "object" && "data" in message) {
-    const data = (message as { data: unknown }).data;
-    if (Array.isArray(data)) {
-      return Uint8Array.from(data as number[]);
-    }
-    if (data instanceof ArrayBuffer) {
-      return new Uint8Array(data);
-    }
-  }
-  return new Uint8Array();
-}
 
 /**
  * Open a PTY in the Rust backend and wire its binary output stream to the

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -12,7 +12,7 @@ export type SplitDirection = "row" | "col";
  * graph, or the launcher (a freshly split pane that hasn't been chosen yet).
  */
 export type PaneContent =
-  | { kind: "terminal"; cwd?: string }
+  | { kind: "terminal"; cwd?: string; ssh?: { connectionId: string } }
   | { kind: "editor"; path: string }
   | { kind: "note"; noteId: string }
   | { kind: "preview"; url: string }

--- a/src/stores/connectionsStore.test.ts
+++ b/src/stores/connectionsStore.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { useConnectionsStore } from "./connectionsStore";
+
+const base = {
+  name: "box", host: "h", port: 22, user: "muki",
+  authMethod: "password" as const, rememberSecret: false,
+};
+
+describe("connectionsStore", () => {
+  beforeEach(() => useConnectionsStore.setState({ connections: [] }));
+
+  it("adds a connection and returns its id", () => {
+    const id = useConnectionsStore.getState().addConnection(base);
+    expect(id).toBeTruthy();
+    expect(useConnectionsStore.getState().getConnection(id)?.host).toBe("h");
+  });
+
+  it("updates a connection", () => {
+    const id = useConnectionsStore.getState().addConnection(base);
+    useConnectionsStore.getState().updateConnection(id, { host: "h2" });
+    expect(useConnectionsStore.getState().getConnection(id)?.host).toBe("h2");
+  });
+
+  it("removes a connection", () => {
+    const id = useConnectionsStore.getState().addConnection(base);
+    useConnectionsStore.getState().removeConnection(id);
+    expect(useConnectionsStore.getState().getConnection(id)).toBeUndefined();
+  });
+
+  it("never stores a secret field", () => {
+    const id = useConnectionsStore.getState().addConnection(base);
+    const conn = useConnectionsStore.getState().getConnection(id)!;
+    expect(Object.keys(conn)).not.toContain("password");
+    expect(Object.keys(conn)).not.toContain("passphrase");
+  });
+});

--- a/src/stores/connectionsStore.ts
+++ b/src/stores/connectionsStore.ts
@@ -1,0 +1,47 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { SshAuthMethod } from "@/modules/ssh/lib/parseSshCommand";
+
+export interface SshConnection {
+  id: string;
+  name: string;
+  host: string;
+  port: number;
+  user: string;
+  authMethod: SshAuthMethod;
+  keyPath?: string;
+  rememberSecret: boolean;
+}
+
+interface ConnectionsState {
+  connections: SshConnection[];
+  addConnection: (input: Omit<SshConnection, "id">) => string;
+  updateConnection: (id: string, patch: Partial<Omit<SshConnection, "id">>) => void;
+  removeConnection: (id: string) => void;
+  getConnection: (id: string) => SshConnection | undefined;
+}
+
+const STORAGE_KEY = "tempoterm-connections";
+
+export const useConnectionsStore = create<ConnectionsState>()(
+  persist(
+    (set, get) => ({
+      connections: [],
+      addConnection: (input) => {
+        const id = crypto.randomUUID();
+        set((s) => ({ connections: [...s.connections, { ...input, id }] }));
+        return id;
+      },
+      updateConnection: (id, patch) =>
+        set((s) => ({
+          connections: s.connections.map((c) =>
+            c.id === id ? { ...c, ...patch, id } : c,
+          ),
+        })),
+      removeConnection: (id) =>
+        set((s) => ({ connections: s.connections.filter((c) => c.id !== id) })),
+      getConnection: (id) => get().connections.find((c) => c.id === id),
+    }),
+    { name: STORAGE_KEY },
+  ),
+);

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -339,6 +339,28 @@ describe("tabsStore", () => {
   });
 });
 
+describe("openSshTab", () => {
+  beforeEach(reset);
+
+  it("opens a terminal tab whose pane carries the ssh connectionId and titles it by name", () => {
+    const tabId = useTabsStore.getState().openSshTab("c1", "prod-box");
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(tab).toBeDefined();
+    expect(tab.title).toBe("prod-box");
+    expect(tab.kind).toBe("terminal");
+    // The tab is user-named so cwd sync won't overwrite the title.
+    expect(tab.renamed).toBe(true);
+    // The single leaf pane carries the ssh connectionId.
+    const pane = firstLeafContent(tab);
+    expect(pane).toMatchObject({ kind: "terminal", ssh: { connectionId: "c1" } });
+  });
+
+  it("activates the new ssh tab", () => {
+    const tabId = useTabsStore.getState().openSshTab("c2", "staging");
+    expect(useTabsStore.getState().activeId).toBe(tabId);
+  });
+});
+
 describe("migratePersistedTabs", () => {
   it("migrates v0 simple tabs into single-leaf pane tabs", () => {
     const v0 = {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -60,6 +60,8 @@ interface TabsState {
   renameSpace: (id: string, name: string) => void;
   deleteSpace: (id: string) => void;
   newTerminalTab: (cwd?: string) => string;
+  /** Open a terminal tab wired to an SSH connection. The tab is user-named (renamed=true) so cwd sync never overwrites the title. */
+  openSshTab: (connectionId: string, name: string) => string;
   /** A blank "new tab" showing the launcher; reused if one already exists. */
   openLauncherTab: () => string;
   openEditorTab: (path: string) => string;
@@ -270,6 +272,23 @@ export const useTabsStore = create<TabsState>()(
       paneTree: leaf(paneId, { kind: "terminal" }),
       activeLeafId: paneId,
       cwd,
+    };
+    set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
+    return id;
+  },
+
+  openSshTab: (connectionId, name) => {
+    const spaceId = get().ensureSpace();
+    const id = nextTabId();
+    const paneId = nextPaneId();
+    const tab: Tab = {
+      id,
+      spaceId,
+      kind: "terminal",
+      title: name,
+      paneTree: leaf(paneId, { kind: "terminal", ssh: { connectionId } }),
+      activeLeafId: paneId,
+      renamed: true,
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return id;
@@ -558,7 +577,14 @@ export const useTabsStore = create<TabsState>()(
       return {
         tabs: state.tabs.map((t) =>
           t.id === tabId
-            ? { ...t, paneTree: setLeafPane(t.paneTree, leafId, { kind: "terminal", cwd }) }
+            ? {
+                ...t,
+                paneTree: setLeafPane(t.paneTree, leafId, {
+                  kind: "terminal",
+                  cwd,
+                  ssh: current.ssh,
+                }),
+              }
             : t,
         ),
       };

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { uid } from "@/lib/id";
 import { perWindowStorage } from "@/lib/window";
+import { markFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import {
   computeLayout,
   findPaneContent,
@@ -290,6 +291,10 @@ export const useTabsStore = create<TabsState>()(
       activeLeafId: paneId,
       renamed: true,
     };
+    // Mark this leaf as freshly user-opened so TerminalView auto-connects on mount.
+    // Restored panes (after app relaunch) never reach this path, so their leaf ids
+    // will NOT be in the set and TerminalView will show the Reconnect state instead.
+    markFreshSshLeaf(paneId);
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return id;
   },

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-export type SidebarView = "workspaces" | "explorer" | "sourceControl" | "ai" | "notes";
+export type SidebarView = "workspaces" | "explorer" | "sourceControl" | "ai" | "notes" | "connections";
 
 interface UiState {
   sidebarView: SidebarView;


### PR DESCRIPTION
## Summary

Adds SSH connections to tempo-term: connect to a remote host and run a remote shell in a normal terminal pane, with saved connection profiles, three authentication methods, and interactive host-key verification. The approach was researched against KKTerm (a russh-based terminal on the same Tauri + xterm.js stack) via DeepWiki; the backend uses the `russh` crate.

## What's included

- **Remote shell** — connect, type, resize. Output streams over a per-session Tauri `Channel`, the same contract as the local PTY path (which is left untouched).
- **Auth** — password (with keyboard-interactive fallback), key file (encrypted keys prompt for a passphrase), and ssh-agent.
- **Host-key verification** — an app-managed `known_hosts` (separate from `~/.ssh/known_hosts`), a first-time fingerprint trust dialog, and a strong man-in-the-middle warning when a host key has changed. A changed key is never auto-accepted.
- **Saved profiles** — a sidebar **Connections** panel (list / connect / edit / delete) and a **Connect SSH** action in the launcher.
- **Connection form** — paste an `ssh user@host -p 2222 -i ~/key.pem` command to auto-fill the fields. Deferred flags (`-L`/`-R`/`-D`/`-J`) are reported as ignored rather than silently honored.
- **Secrets** — passwords and key passphrases live in the OS keyring (never in localStorage or logs); a "remember" toggle governs whether the secret is written.
- **Interactive prompts** — the host-key / password / passphrase dialog is scoped to the originating window in a multi-window setup.
- **Session restore** — restored SSH panes do not auto-connect on relaunch; they show a Reconnect state.

## Architecture

A new backend module `src-tauri/src/modules/ssh/` holds known-hosts classification, a prompt registry for the backend↔frontend round-trip, a russh client (host-key verification + auth dispatch), and a per-session worker thread running a tokio runtime. The frontend adds a `connectionsStore`, an `ssh-bridge` that mirrors the PTY bridge, the panel / form / prompt-dialog, and the TerminalView wiring. The local PTY path is strictly additive: `toBytes` was extracted into a shared `channelBytes.ts`, otherwise unchanged.

The TCP connect is bounded by a 15s timeout (an unreachable host or filtered port would otherwise hang ~75s); the SSH handshake that follows — including the interactive host-key prompt, which waits on the user — is deliberately not timed out.

## Not included (deferred)

Port forwarding, jump host / SOCKS proxy, tmux integration, SFTP file browsing, and Telnet/Serial transports.

## Test plan

- **Automated** — `cargo test --lib`: 138 passing (known_hosts classification, prompt registry, key-path tilde expansion, secrets keyring namespacing). Frontend `pnpm test`: 569 passing; `pnpm run typecheck` clean.
- **Manual** (real EC2 host, key-file auth) — connect, run commands, resize the pane, disconnect; first-time host-key trust dialog; reconnect after an app relaunch. Verified working.
