### PR TITLE
feat: add SSH local port forwarding

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,7 +34,10 @@ use modules::pty::{
     pty_close, pty_close_all, pty_cwd, pty_foreground_command, pty_open, pty_resize,
     pty_shell_name, pty_write, PtyState,
 };
-use modules::ssh::{ssh_close, ssh_open, ssh_prompt_reply, ssh_resize, ssh_write, SshState};
+use modules::ssh::{
+    ssh_close, ssh_forward_start, ssh_forward_stop, ssh_open, ssh_prompt_reply, ssh_resize,
+    ssh_write, SshState,
+};
 use modules::terminal_history::{
     terminal_history_clear, terminal_history_delete, terminal_history_load,
     terminal_history_prune, terminal_history_save,
@@ -179,6 +182,8 @@ pub fn run() {
             ssh_resize,
             ssh_close,
             ssh_prompt_reply,
+            ssh_forward_start,
+            ssh_forward_stop,
             ssh_secret_set,
             ssh_secret_delete
         ])

--- a/src-tauri/src/modules/ssh/forward.rs
+++ b/src-tauri/src/modules/ssh/forward.rs
@@ -50,7 +50,6 @@ pub fn validate(spec: &ForwardSpec) -> Result<(), String> {
 ///
 /// **Send note**: `Channel<Msg>` and `ChannelStream<Msg>` are `Send` (all inner
 /// types are `Send`), so `tokio::spawn` accepts the per-connection future.
-#[allow(dead_code)] // wired up in Task 6
 pub async fn run_forward(
     handle: Arc<russh::client::Handle<VerifyingClient>>,
     spec: ForwardSpec,

--- a/src-tauri/src/modules/ssh/forward.rs
+++ b/src-tauri/src/modules/ssh/forward.rs
@@ -2,6 +2,13 @@
 //! accepted connection over the session's russh connection to a remote host.
 //! `validate` is pure so the rule checks are unit-tested without binding sockets.
 
+use std::sync::Arc;
+
+use tokio::net::TcpListener;
+use tokio::sync::watch;
+
+use super::client::VerifyingClient;
+
 #[derive(Debug, Clone)]
 pub struct ForwardSpec {
     pub id: String,
@@ -27,6 +34,70 @@ pub fn validate(spec: &ForwardSpec) -> Result<(), String> {
         return Err("destination port must be 1-65535".into());
     }
     Ok(())
+}
+
+/// Bind `spec.bind_host:spec.local_port` locally and bridge every accepted TCP
+/// connection over the SSH session's russh handle via a `direct-tcpip` channel.
+///
+/// Returns `Err(reason)` immediately if the local bind fails (the caller emits
+/// a `failed` event). Returns `Ok(())` when `cancel` fires with `true` (clean
+/// shutdown). A dial failure on a per-connection task closes only that connection
+/// and never the listener — the accept loop continues.
+///
+/// **Unpin note**: `ChannelStream<Msg>` is not `Unpin` because `ChannelTx`
+/// holds a `Pin<Box<dyn Future>>`. We pin both halves with `tokio::pin!` inside
+/// the per-connection task so `tokio::io::copy_bidirectional` is satisfied.
+///
+/// **Send note**: `Channel<Msg>` and `ChannelStream<Msg>` are `Send` (all inner
+/// types are `Send`), so `tokio::spawn` accepts the per-connection future.
+#[allow(dead_code)] // wired up in Task 6
+pub async fn run_forward(
+    handle: Arc<russh::client::Handle<VerifyingClient>>,
+    spec: ForwardSpec,
+    mut cancel: watch::Receiver<bool>,
+) -> Result<(), String> {
+    let listener = TcpListener::bind((spec.bind_host.as_str(), spec.local_port))
+        .await
+        .map_err(|e| format!("bind {}:{} failed: {e}", spec.bind_host, spec.local_port))?;
+
+    loop {
+        tokio::select! {
+            _ = cancel.changed() => {
+                if *cancel.borrow() {
+                    return Ok(());
+                }
+            }
+            accepted = listener.accept() => {
+                let (mut local, _peer) = match accepted {
+                    Ok(pair) => pair,
+                    Err(_) => continue, // transient accept error; keep listening
+                };
+                let handle = Arc::clone(&handle);
+                let dest_host = spec.dest_host.clone();
+                let dest_port = spec.dest_port as u32;
+                // Spawn one task per connection. A channel-open failure closes
+                // only this connection; the listener continues accepting.
+                tokio::spawn(async move {
+                    match handle
+                        .channel_open_direct_tcpip(dest_host, dest_port, "127.0.0.1", 0)
+                        .await
+                    {
+                        Ok(channel) => {
+                            let remote = channel.into_stream();
+                            // ChannelStream<Msg> is AsyncRead + AsyncWrite but not
+                            // Unpin. Pin it on the stack so copy_bidirectional
+                            // can poll it without boxing.
+                            tokio::pin!(remote);
+                            let _ = tokio::io::copy_bidirectional(&mut local, &mut remote).await;
+                        }
+                        Err(_) => {
+                            // Remote refused or unreachable: drop the local conn.
+                        }
+                    }
+                });
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/modules/ssh/forward.rs
+++ b/src-tauri/src/modules/ssh/forward.rs
@@ -1,0 +1,56 @@
+//! SSH local (-L) port forwarding: bind a local TCP port and bridge each
+//! accepted connection over the session's russh connection to a remote host.
+//! `validate` is pure so the rule checks are unit-tested without binding sockets.
+
+#[derive(Debug, Clone)]
+pub struct ForwardSpec {
+    pub id: String,
+    pub bind_host: String,
+    pub local_port: u16,
+    pub dest_host: String,
+    pub dest_port: u16,
+}
+
+/// Reject specs that can't bind or dial: empty hosts, zero ports. (u16 already
+/// caps at 65535; 0 is the only invalid port value.)
+pub fn validate(spec: &ForwardSpec) -> Result<(), String> {
+    if spec.bind_host.trim().is_empty() {
+        return Err("bind host is empty".into());
+    }
+    if spec.dest_host.trim().is_empty() {
+        return Err("destination host is empty".into());
+    }
+    if spec.local_port == 0 {
+        return Err("local port must be 1-65535".into());
+    }
+    if spec.dest_port == 0 {
+        return Err("destination port must be 1-65535".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(bind: &str, lp: u16, dh: &str, dp: u16) -> ForwardSpec {
+        ForwardSpec { id: "f1".into(), bind_host: bind.into(), local_port: lp, dest_host: dh.into(), dest_port: dp }
+    }
+
+    #[test]
+    fn accepts_a_valid_local_forward() {
+        assert!(validate(&spec("127.0.0.1", 5432, "localhost", 5432)).is_ok());
+    }
+
+    #[test]
+    fn rejects_zero_ports() {
+        assert!(validate(&spec("127.0.0.1", 0, "localhost", 5432)).is_err());
+        assert!(validate(&spec("127.0.0.1", 5432, "localhost", 0)).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_hosts() {
+        assert!(validate(&spec("", 5432, "localhost", 5432)).is_err());
+        assert!(validate(&spec("127.0.0.1", 5432, "  ", 5432)).is_err());
+    }
+}

--- a/src-tauri/src/modules/ssh/mod.rs
+++ b/src-tauri/src/modules/ssh/mod.rs
@@ -10,6 +10,31 @@ pub use session::SshState;
 use tauri::ipc::{Channel, Response};
 use tauri::{AppHandle, State};
 
+/// Frontend-facing port-forward spec, deserialized from camelCase JSON.
+/// Mirrors `forward::ForwardSpec` but lives here so Tauri commands can
+/// accept it directly without exposing `ForwardSpec`'s internal type.
+#[derive(serde::Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ForwardSpecInput {
+    pub id: String,
+    pub bind_host: String,
+    pub local_port: u16,
+    pub dest_host: String,
+    pub dest_port: u16,
+}
+
+impl From<&ForwardSpecInput> for forward::ForwardSpec {
+    fn from(input: &ForwardSpecInput) -> Self {
+        forward::ForwardSpec {
+            id: input.id.clone(),
+            bind_host: input.bind_host.clone(),
+            local_port: input.local_port,
+            dest_host: input.dest_host.clone(),
+            dest_port: input.dest_port,
+        }
+    }
+}
+
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SshOpenRequest {
@@ -21,6 +46,10 @@ pub struct SshOpenRequest {
     pub key_path: Option<String>,
     pub cols: u16,
     pub rows: u16,
+    /// Port forwards to set up after the session authenticates.
+    /// Defaults to an empty list when the field is absent.
+    #[serde(default)]
+    pub forwards: Vec<ForwardSpecInput>,
 }
 
 #[tauri::command]
@@ -67,4 +96,22 @@ pub fn ssh_prompt_reply(
 ) -> Result<(), String> {
     state.resolve_prompt(&id, reply);
     Ok(())
+}
+
+#[tauri::command]
+pub fn ssh_forward_start(
+    state: State<'_, SshState>,
+    id: u32,
+    forward: ForwardSpecInput,
+) -> Result<(), String> {
+    session::forward_start(&state, id, forward)
+}
+
+#[tauri::command]
+pub fn ssh_forward_stop(
+    state: State<'_, SshState>,
+    id: u32,
+    forward_id: String,
+) -> Result<(), String> {
+    session::forward_stop(&state, id, forward_id)
 }

--- a/src-tauri/src/modules/ssh/mod.rs
+++ b/src-tauri/src/modules/ssh/mod.rs
@@ -1,4 +1,5 @@
 mod client;
+mod forward;
 mod known_hosts;
 mod prompt;
 mod session;

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -371,6 +371,30 @@ fn remove_session(app: &AppHandle, id: u32) {
     state.sessions.lock().unwrap().remove(&id);
 }
 
+// ---------------------------------------------------------------------------
+// Forward control — stubs (Task 6 fills in the real bodies).
+// ---------------------------------------------------------------------------
+
+/// Start a port forward on an existing session. Stub: Task 6 will send the
+/// spec to the worker thread and wire up the `direct-tcpip` accept loop.
+pub fn forward_start(
+    _state: &State<'_, SshState>,
+    _id: u32,
+    _input: super::ForwardSpecInput,
+) -> Result<(), String> {
+    Ok(())
+}
+
+/// Stop a running port forward by its id. Stub: Task 6 will cancel the
+/// `run_forward` task via the per-forward `watch::Sender`.
+pub fn forward_stop(
+    _state: &State<'_, SshState>,
+    _id: u32,
+    _forward_id: String,
+) -> Result<(), String> {
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -286,6 +286,9 @@ async fn run_session(
             ),
         );
         let fid = spec.id.clone();
+        if let Some(old) = forwards.remove(&fid) {
+            let _ = old.send(true); // cancel the previous forward holding this id before replacing it
+        }
         let tx = start_one(spec, handle.clone(), &app, &window_label, session_id);
         forwards.insert(fid, tx);
     }
@@ -335,6 +338,9 @@ async fn run_session(
                     }
                     Some(SshControl::StartForward(spec)) => {
                         let fid = spec.id.clone();
+                        if let Some(old) = forwards.remove(&fid) {
+                            let _ = old.send(true); // cancel the previous forward holding this id before replacing it
+                        }
                         let tx = start_one(spec, handle.clone(), &app, &window_label, session_id);
                         forwards.insert(fid, tx);
                     }

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -14,10 +14,11 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tauri::ipc::{Channel, Response};
-use tauri::{AppHandle, Manager, State};
-use tokio::sync::mpsc;
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::sync::{mpsc, watch};
 
 use super::client::{self, AuthArgs, ConnectArgs, VerifyingClient};
+use super::forward::{self, ForwardSpec};
 use super::prompt::{PromptRegistry, PromptReply};
 use super::SshOpenRequest;
 
@@ -28,6 +29,10 @@ pub enum SshControl {
     Input(Vec<u8>),
     /// The terminal was resized; tell the remote pty.
     Resize { cols: u16, rows: u16 },
+    /// Start a local port forward on this live session.
+    StartForward(ForwardSpec),
+    /// Stop a running port forward by its id.
+    StopForward(String),
     /// Tear the session down.
     Close,
 }
@@ -222,6 +227,16 @@ async fn run_session(
         }
     }
 
+    // Auth is done with `handle` consumed mutably; from here the handle is only
+    // used through `&self` methods (channel opens), so share it via `Arc`. Both
+    // the shell channel and every port-forward listener clone this same `Arc`.
+    let handle = Arc::new(handle);
+
+    // Live port forwards: id → cancel sender. Sending `true` makes the matching
+    // `run_forward` task return `Ok(())` and stop its accept loop. We always
+    // drain + cancel on loop exit so no listener outlives the session.
+    let mut forwards: HashMap<String, watch::Sender<bool>> = HashMap::new();
+
     // 3. Open a session channel and request an interactive shell on a pty.
     let channel = match handle.channel_open_session().await {
         Ok(channel) => channel,
@@ -254,6 +269,26 @@ async fn run_session(
     // (`data`/`window_change`, &) can run in the same select! without a borrow
     // conflict — `wait` needs `&mut`, the writers need `&`.
     let (mut read_half, write_half) = channel.split();
+
+    // 5. Auto-start the forwards the request asked for. Invalid specs are
+    // reported on the terminal stream and skipped, never aborting the session.
+    for input in &req.forwards {
+        let spec = ForwardSpec::from(input);
+        if let Err(e) = forward::validate(&spec) {
+            emit_line(on_data, &format!("port-forward {}: {e}", spec.local_port));
+            continue;
+        }
+        emit_line(
+            on_data,
+            &format!(
+                "forwarding {}:{} -> {}:{}",
+                spec.bind_host, spec.local_port, spec.dest_host, spec.dest_port
+            ),
+        );
+        let fid = spec.id.clone();
+        let tx = start_one(spec, handle.clone(), &app, &window_label, session_id);
+        forwards.insert(fid, tx);
+    }
 
     loop {
         tokio::select! {
@@ -298,11 +333,37 @@ async fn run_session(
                             .window_change(cols as u32, rows as u32, 0, 0)
                             .await;
                     }
+                    Some(SshControl::StartForward(spec)) => {
+                        let fid = spec.id.clone();
+                        let tx = start_one(spec, handle.clone(), &app, &window_label, session_id);
+                        forwards.insert(fid, tx);
+                    }
+                    Some(SshControl::StopForward(fid)) => {
+                        if let Some(tx) = forwards.remove(&fid) {
+                            // Cancel the listener task, then drop its sender.
+                            let _ = tx.send(true);
+                            emit_forward_status(
+                                &app,
+                                &window_label,
+                                session_id,
+                                &fid,
+                                "stopped",
+                                None,
+                            );
+                        }
+                    }
                     // Close requested, or every sender dropped (session removed).
                     Some(SshControl::Close) | None => break,
                 }
             }
         }
+    }
+
+    // Cancel every remaining forward before its sender drops. Sending `true`
+    // first is required: if the watch sender is dropped without sending, the
+    // task's `cancel.changed()` returns Err and its accept loop never exits.
+    for (_, tx) in forwards.drain() {
+        let _ = tx.send(true);
     }
 
     registry.discard_session(session_id);
@@ -315,6 +376,70 @@ async fn run_session(
 fn emit_line(on_data: &Channel<Response>, message: &str) {
     let line = format!("\r\n{message}\r\n");
     let _ = on_data.send(Response::new(line.into_bytes()));
+}
+
+/// Emit a `ssh-forward-status` event to the window that owns the session, so a
+/// forward's lifecycle (`starting` → `active` → `stopped`/`failed`) only reaches
+/// the pane that requested it instead of being broadcast to every window.
+fn emit_forward_status(
+    app: &AppHandle,
+    window_label: &str,
+    session_id: u32,
+    forward_id: &str,
+    state: &str,
+    error: Option<&str>,
+) {
+    #[derive(serde::Serialize, Clone)]
+    #[serde(rename_all = "camelCase")]
+    struct Payload<'a> {
+        session_id: u32,
+        forward_id: &'a str,
+        state: &'a str,
+        error: Option<&'a str>,
+    }
+    let _ = app.emit_to(
+        window_label,
+        "ssh-forward-status",
+        Payload {
+            session_id,
+            forward_id,
+            state,
+            error,
+        },
+    );
+}
+
+/// Spin up one port forward: emit `starting` then `active`, spawn the bridge
+/// task, and return the cancel sender so the caller can stop it later. The task
+/// emits `stopped` on a clean cancel or `failed` (with the reason) on a bind
+/// error; a later `failed` overrides the optimistic `active` in the frontend.
+fn start_one(
+    spec: ForwardSpec,
+    handle: Arc<russh::client::Handle<VerifyingClient>>,
+    app: &AppHandle,
+    window_label: &str,
+    session_id: u32,
+) -> watch::Sender<bool> {
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+    let fid = spec.id.clone();
+
+    emit_forward_status(app, window_label, session_id, &fid, "starting", None);
+    emit_forward_status(app, window_label, session_id, &fid, "active", None);
+
+    let app = app.clone();
+    let window_label = window_label.to_string();
+    tokio::spawn(async move {
+        match forward::run_forward(handle, spec, cancel_rx).await {
+            Ok(()) => {
+                emit_forward_status(&app, &window_label, session_id, &fid, "stopped", None)
+            }
+            Err(e) => {
+                emit_forward_status(&app, &window_label, session_id, &fid, "failed", Some(&e))
+            }
+        }
+    });
+
+    cancel_tx
 }
 
 // ---------------------------------------------------------------------------
@@ -372,27 +497,30 @@ fn remove_session(app: &AppHandle, id: u32) {
 }
 
 // ---------------------------------------------------------------------------
-// Forward control — stubs (Task 6 fills in the real bodies).
+// Forward control — validate up front, then hand the spec to the worker.
 // ---------------------------------------------------------------------------
 
-/// Start a port forward on an existing session. Stub: Task 6 will send the
-/// spec to the worker thread and wire up the `direct-tcpip` accept loop.
+/// Start a port forward on an existing session. Validates the spec up front so a
+/// bad rule fails the command synchronously, then sends it to the worker thread
+/// which binds the local port and runs the `direct-tcpip` accept loop.
 pub fn forward_start(
-    _state: &State<'_, SshState>,
-    _id: u32,
-    _input: super::ForwardSpecInput,
+    state: &State<'_, SshState>,
+    id: u32,
+    input: super::ForwardSpecInput,
 ) -> Result<(), String> {
-    Ok(())
+    let spec = ForwardSpec::from(&input);
+    forward::validate(&spec)?;
+    send_inner(state, id, SshControl::StartForward(spec))
 }
 
-/// Stop a running port forward by its id. Stub: Task 6 will cancel the
-/// `run_forward` task via the per-forward `watch::Sender`.
+/// Stop a running port forward by its id. The worker cancels the matching
+/// `run_forward` task via its per-forward `watch::Sender`.
 pub fn forward_stop(
-    _state: &State<'_, SshState>,
-    _id: u32,
-    _forward_id: String,
+    state: &State<'_, SshState>,
+    id: u32,
+    forward_id: String,
 ) -> Result<(), String> {
-    Ok(())
+    send_inner(state, id, SshControl::StopForward(forward_id))
 }
 
 #[cfg(test)]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { installStatusHook, installCodexStatusHook } from "@/modules/claude-prog
 import { useWatchNotes } from "@/modules/notes/lib/useWatchNotes";
 import { registerSecondaryWindowCleanup } from "@/lib/windowLifecycle";
 import { SshPromptDialog } from "@/modules/ssh/SshPromptDialog";
+import { useForwardStatusListener } from "@/modules/ssh/lib/useForwardStatus";
 
 const MIN_SIDEBAR = 180;
 const MAX_SIDEBAR = 640;
@@ -37,6 +38,7 @@ function App() {
 
   useWatchSessions();
   useWatchNotes();
+  useForwardStatusListener();
 
   useEffect(() => {
     applyTheme(getTheme(themeId), document.documentElement);

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -77,7 +77,15 @@
     "confirmDelete": "Delete?",
     "cancelDelete": "Cancel",
     "emptyTitle": "No saved connections",
-    "emptyHint": "Save SSH connections here to connect with one click"
+    "emptyHint": "Save SSH connections here to connect with one click",
+    "forwards": {
+      "session": "Session {{id}}",
+      "statusActive": "Active",
+      "statusFailed": "Failed",
+      "statusStopped": "Stopped",
+      "toggleOff": "Stop forward",
+      "toggleOn": "Start forward"
+    }
   },
   "connectionForm": {
     "titleCreate": "New SSH Connection",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -106,7 +106,17 @@
     "save": "Save",
     "connect": "Connect",
     "cancel": "Cancel",
-    "browse": "Browse"
+    "browse": "Browse",
+    "portForwards": {
+      "sectionLabel": "Port forwarding",
+      "addButton": "Add forward",
+      "removeButton": "Remove",
+      "bindHost": "Bind host",
+      "localPort": "Local port",
+      "destHost": "Destination host",
+      "destPort": "Destination port",
+      "enabled": "Enabled"
+    }
   },
   "workspace": {
     "openFolder": "Open Folder",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -106,7 +106,17 @@
     "save": "儲存",
     "connect": "連線",
     "cancel": "取消",
-    "browse": "瀏覽"
+    "browse": "瀏覽",
+    "portForwards": {
+      "sectionLabel": "連接埠轉發",
+      "addButton": "新增轉發規則",
+      "removeButton": "移除",
+      "bindHost": "綁定主機",
+      "localPort": "本地埠號",
+      "destHost": "目標主機",
+      "destPort": "目標埠號",
+      "enabled": "啟用"
+    }
   },
   "workspace": {
     "openFolder": "開啟資料夾",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -77,7 +77,15 @@
     "confirmDelete": "確認刪除？",
     "cancelDelete": "取消",
     "emptyTitle": "尚無已儲存的連線",
-    "emptyHint": "在這裡儲存 SSH 連線，即可一鍵連線"
+    "emptyHint": "在這裡儲存 SSH 連線，即可一鍵連線",
+    "forwards": {
+      "session": "工作階段 {{id}}",
+      "statusActive": "作用中",
+      "statusFailed": "失敗",
+      "statusStopped": "已停止",
+      "toggleOff": "停止轉發",
+      "toggleOn": "啟動轉發"
+    }
   },
   "connectionForm": {
     "titleCreate": "新增 SSH 連線",

--- a/src/modules/ssh/ConnectionForm.test.tsx
+++ b/src/modules/ssh/ConnectionForm.test.tsx
@@ -54,7 +54,8 @@ describe("ConnectionForm", () => {
     render(<ConnectionForm onClose={() => {}} />);
     expect(screen.getByPlaceholderText(/ssh user@host/i)).toBeInTheDocument();
     expect(screen.getByText(/Host/i)).toBeInTheDocument();
-    expect(screen.getByText(/Port/i)).toBeInTheDocument();
+    // "Port" label matches "Port forwarding" too — use exact text match
+    expect(screen.getByText("Port")).toBeInTheDocument();
     expect(screen.getByText(/Username/i)).toBeInTheDocument();
   });
 
@@ -246,5 +247,95 @@ describe("ConnectionForm", () => {
     const addOrder = mockAddConnection.mock.invocationCallOrder[0];
     const openOrder = mockOpenSshTab.mock.invocationCallOrder[0];
     expect(addOrder).toBeLessThan(openOrder);
+  });
+
+  // ──────────────────────────────────────────────
+  // Port forwarding section
+  // ──────────────────────────────────────────────
+
+  it("renders the Port forwarding section header", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+    expect(screen.getByText(/port forwarding/i)).toBeInTheDocument();
+  });
+
+  it("clicking Add forward appends a row with 127.0.0.1 as the bind host default", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /add forward/i }));
+
+    // The new row should have a bind host input pre-filled with 127.0.0.1
+    const bindHostInputs = screen.getAllByDisplayValue("127.0.0.1");
+    expect(bindHostInputs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("clicking Remove on a port-forward row removes it", () => {
+    render(<ConnectionForm onClose={() => {}} />);
+
+    // Add a row
+    fireEvent.click(screen.getByRole("button", { name: /add forward/i }));
+    expect(screen.getAllByDisplayValue("127.0.0.1").length).toBe(1);
+
+    // Remove it
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
+    expect(screen.queryAllByDisplayValue("127.0.0.1").length).toBe(0);
+  });
+
+  it("persists portForwards when Save is clicked", async () => {
+    render(<ConnectionForm onClose={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText("example.com"), {
+      target: { value: "myserver.io" },
+    });
+
+    // Add a forward rule
+    fireEvent.click(screen.getByRole("button", { name: /add forward/i }));
+
+    // Fill in localPort
+    const localPortInputs = screen.getAllByRole("spinbutton");
+    // localPort input (spinbutton) — find the one labeled Local port
+    const localPortInput = localPortInputs.find((el) => {
+      const label = el.closest("div")?.querySelector("label");
+      return label && /local port/i.test(label.textContent ?? "");
+    });
+    if (localPortInput) {
+      fireEvent.change(localPortInput, { target: { value: "3000" } });
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mockAddConnection).toHaveBeenCalledTimes(1);
+    });
+
+    const profile = mockAddConnection.mock.calls[0][0] as Record<string, unknown>;
+    expect(Array.isArray(profile.portForwards)).toBe(true);
+    expect((profile.portForwards as unknown[]).length).toBe(1);
+  });
+
+  it("pre-fills portForwards from existing connection in edit mode", () => {
+    const existing = {
+      id: "abc-123",
+      name: "My Server",
+      host: "server.example.com",
+      port: 22,
+      user: "admin",
+      authMethod: "password" as const,
+      rememberSecret: false,
+      portForwards: [
+        {
+          id: "pf-1",
+          mode: "local" as const,
+          bindHost: "127.0.0.1",
+          localPort: 8080,
+          destHost: "internal.server",
+          destPort: 80,
+          enabled: true,
+        },
+      ],
+    };
+    render(<ConnectionForm connection={existing} onClose={() => {}} />);
+
+    // The row should be pre-filled with the saved destHost
+    expect(screen.getByDisplayValue("internal.server")).toBeInTheDocument();
   });
 });

--- a/src/modules/ssh/ConnectionForm.tsx
+++ b/src/modules/ssh/ConnectionForm.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { Combobox } from "@/components/Combobox";
 import { parseSshCommand } from "@/modules/ssh/lib/parseSshCommand";
-import { useConnectionsStore, type SshConnection } from "@/stores/connectionsStore";
+import { useConnectionsStore, type SshConnection, type PortForward } from "@/stores/connectionsStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import type { SshAuthMethod } from "@/modules/ssh/lib/parseSshCommand";
 import { pickFile } from "@/lib/dialog";
@@ -23,6 +23,7 @@ interface FormState {
   keyPath: string;
   secret: string;
   remember: boolean;
+  portForwards: PortForward[];
 }
 
 function blankForm(): FormState {
@@ -35,6 +36,7 @@ function blankForm(): FormState {
     keyPath: "",
     secret: "",
     remember: false,
+    portForwards: [],
   };
 }
 
@@ -48,6 +50,7 @@ function fromConnection(conn: SshConnection): FormState {
     keyPath: conn.keyPath ?? "",
     secret: "",
     remember: conn.rememberSecret,
+    portForwards: conn.portForwards ?? [],
   };
 }
 
@@ -66,6 +69,7 @@ async function persistConnection(
     authMethod: form.authMethod,
     keyPath: form.authMethod === "keyFile" ? form.keyPath.trim() || undefined : undefined,
     rememberSecret: form.remember,
+    portForwards: form.portForwards,
   };
 
   if (existingId) {
@@ -200,6 +204,35 @@ export function ConnectionForm({ connection, onClose }: ConnectionFormProps) {
     if (idx !== -1) {
       setField("authMethod", AUTH_METHOD_OPTIONS[idx]);
     }
+  }
+
+  function addForward() {
+    const newForward: PortForward = {
+      id: crypto.randomUUID(),
+      mode: "local",
+      bindHost: "127.0.0.1",
+      localPort: 0,
+      destHost: "",
+      destPort: 0,
+      enabled: true,
+    };
+    setForm((prev) => ({ ...prev, portForwards: [...prev.portForwards, newForward] }));
+  }
+
+  function removeForward(id: string) {
+    setForm((prev) => ({
+      ...prev,
+      portForwards: prev.portForwards.filter((pf) => pf.id !== id),
+    }));
+  }
+
+  function updateForward<K extends keyof PortForward>(id: string, key: K, value: PortForward[K]) {
+    setForm((prev) => ({
+      ...prev,
+      portForwards: prev.portForwards.map((pf) =>
+        pf.id === id ? { ...pf, [key]: value } : pf,
+      ),
+    }));
   }
 
   const hasPasteNotes = pasteIgnored.length > 0 || pasteWarnings.length > 0;
@@ -373,6 +406,115 @@ export function ConnectionForm({ connection, onClose }: ConnectionFormProps) {
               </label>
             </div>
           )}
+
+          <div className="border-t border-border" />
+
+          {/* Port forwarding */}
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-xs font-medium text-fg-muted">
+                {t("connectionForm.portForwards.sectionLabel")}
+              </span>
+              <button
+                type="button"
+                onClick={addForward}
+                className="rounded border border-border px-2 py-1 text-xs text-fg-muted hover:bg-bg-inset hover:text-fg"
+              >
+                {t("connectionForm.portForwards.addButton")}
+              </button>
+            </div>
+
+            {form.portForwards.length > 0 && (
+              <div className="space-y-2">
+                {form.portForwards.map((pf) => (
+                  <div
+                    key={pf.id}
+                    className="rounded border border-border bg-bg-inset p-2 space-y-2"
+                  >
+                    {/* Row 1: bindHost + localPort */}
+                    <div className="flex gap-2">
+                      <div className="flex-1">
+                        <label className="mb-1 block text-xs text-fg-subtle">
+                          {t("connectionForm.portForwards.bindHost")}
+                        </label>
+                        <input
+                          type="text"
+                          value={pf.bindHost}
+                          onChange={(e) => updateForward(pf.id, "bindHost", e.target.value)}
+                          className="w-full rounded border border-border bg-bg px-2 py-1 text-xs text-fg outline-none focus:border-accent font-mono"
+                        />
+                      </div>
+                      <div className="w-24">
+                        <label className="mb-1 block text-xs text-fg-subtle">
+                          {t("connectionForm.portForwards.localPort")}
+                        </label>
+                        <input
+                          type="number"
+                          value={pf.localPort}
+                          min={0}
+                          max={65535}
+                          onChange={(e) =>
+                            updateForward(pf.id, "localPort", parseInt(e.target.value, 10) || 0)
+                          }
+                          className="w-full rounded border border-border bg-bg px-2 py-1 text-xs text-fg outline-none focus:border-accent"
+                        />
+                      </div>
+                    </div>
+
+                    {/* Row 2: destHost + destPort */}
+                    <div className="flex gap-2">
+                      <div className="flex-1">
+                        <label className="mb-1 block text-xs text-fg-subtle">
+                          {t("connectionForm.portForwards.destHost")}
+                        </label>
+                        <input
+                          type="text"
+                          value={pf.destHost}
+                          onChange={(e) => updateForward(pf.id, "destHost", e.target.value)}
+                          className="w-full rounded border border-border bg-bg px-2 py-1 text-xs text-fg outline-none focus:border-accent font-mono"
+                        />
+                      </div>
+                      <div className="w-24">
+                        <label className="mb-1 block text-xs text-fg-subtle">
+                          {t("connectionForm.portForwards.destPort")}
+                        </label>
+                        <input
+                          type="number"
+                          value={pf.destPort}
+                          min={0}
+                          max={65535}
+                          onChange={(e) =>
+                            updateForward(pf.id, "destPort", parseInt(e.target.value, 10) || 0)
+                          }
+                          className="w-full rounded border border-border bg-bg px-2 py-1 text-xs text-fg outline-none focus:border-accent"
+                        />
+                      </div>
+                    </div>
+
+                    {/* Row 3: enabled + remove */}
+                    <div className="flex items-center justify-between">
+                      <label className="flex items-center gap-2 text-xs text-fg-muted select-none cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={pf.enabled}
+                          onChange={(e) => updateForward(pf.id, "enabled", e.target.checked)}
+                          className="accent-accent"
+                        />
+                        {t("connectionForm.portForwards.enabled")}
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => removeForward(pf.id)}
+                        className="rounded px-2 py-0.5 text-xs text-fg-muted hover:bg-bg hover:text-fg"
+                      >
+                        {t("connectionForm.portForwards.removeButton")}
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Footer */}

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -2,9 +2,121 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { Pencil, Plus, Server, Trash2 } from "lucide-react";
-import { useConnectionsStore, type SshConnection } from "@/stores/connectionsStore";
+import { useConnectionsStore, type SshConnection, type PortForward } from "@/stores/connectionsStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { ConnectionForm } from "@/modules/ssh/ConnectionForm";
+import { useLiveSessionsStore } from "@/modules/ssh/lib/liveSessionsStore";
+import { useForwardStatusStore } from "@/modules/ssh/lib/forwardStatusStore";
+import { startForward, stopForward } from "@/modules/ssh/lib/ssh-bridge";
+
+// ─── Status dot ───────────────────────────────────────────────────────────────
+
+type DotColor = "green" | "red" | "grey";
+
+interface StatusDotProps {
+  color: DotColor;
+  title?: string;
+}
+
+function StatusDot({ color, title }: StatusDotProps) {
+  const colorClass =
+    color === "green"
+      ? "bg-green-500"
+      : color === "red"
+        ? "bg-red-500"
+        : "bg-fg-subtle";
+  return (
+    <span
+      title={title}
+      className={`inline-block h-2 w-2 shrink-0 rounded-full ${colorClass}`}
+    />
+  );
+}
+
+// ─── Single forward row ────────────────────────────────────────────────────────
+
+interface ForwardRowProps {
+  sessionId: number;
+  forward: PortForward;
+}
+
+function ForwardRow({ sessionId, forward }: ForwardRowProps) {
+  const { t } = useTranslation("common");
+  const status = useForwardStatusStore((s) => s.getStatus(sessionId, forward.id));
+
+  const isActive = status?.state === "active";
+  const isFailed = status?.state === "failed";
+  const dotColor: DotColor = isActive ? "green" : isFailed ? "red" : "grey";
+  const dotTitle = isFailed
+    ? `${t("connectionsPanel.forwards.statusFailed")}: ${status?.error ?? ""}`
+    : isActive
+      ? t("connectionsPanel.forwards.statusActive")
+      : t("connectionsPanel.forwards.statusStopped");
+
+  async function handleToggle() {
+    if (isActive) {
+      await stopForward(sessionId, forward.id);
+    } else {
+      await startForward(sessionId, {
+        id: forward.id,
+        bindHost: forward.bindHost,
+        localPort: forward.localPort,
+        destHost: forward.destHost,
+        destPort: forward.destPort,
+      });
+    }
+  }
+
+  return (
+    <li className="flex items-center gap-2 py-0.5 pl-8 pr-2 text-xs text-fg-subtle">
+      <StatusDot color={dotColor} title={dotTitle} />
+      <span className="min-w-0 flex-1 truncate font-mono">
+        {forward.localPort} → {forward.destHost}:{forward.destPort}
+      </span>
+      <button
+        type="button"
+        title={isActive ? t("connectionsPanel.forwards.toggleOff") : t("connectionsPanel.forwards.toggleOn")}
+        aria-label={isActive ? t("connectionsPanel.forwards.toggleOff") : t("connectionsPanel.forwards.toggleOn")}
+        onClick={() => void handleToggle()}
+        className="shrink-0 rounded px-1 py-0.5 hover:bg-border-strong hover:text-fg"
+      >
+        {isActive ? "■" : "▶"}
+      </button>
+    </li>
+  );
+}
+
+// ─── Forwards grouped under one session ───────────────────────────────────────
+
+interface SessionForwardsProps {
+  sessionId: number;
+  forwards: PortForward[];
+  /** Show a "Session N" label when there are multiple live sessions. */
+  showSessionLabel: boolean;
+}
+
+function SessionForwards({ sessionId, forwards, showSessionLabel }: SessionForwardsProps) {
+  const { t } = useTranslation("common");
+
+  if (forwards.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul>
+      {showSessionLabel && (
+        <li className="py-0.5 pl-6 pr-2 text-xs text-fg-subtle opacity-60">
+          {t("connectionsPanel.forwards.session", { id: sessionId })}
+        </li>
+      )}
+      {forwards.map((fwd) => (
+        <ForwardRow key={fwd.id} sessionId={sessionId} forward={fwd} />
+      ))}
+    </ul>
+  );
+}
+
+// ─── Connection row ────────────────────────────────────────────────────────────
 
 interface ConnectionRowProps {
   connection: SshConnection;
@@ -16,6 +128,13 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   const { t } = useTranslation("common");
   const openSshTab = useTabsStore((s) => s.openSshTab);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  // Subscribe to live sessions for this connection
+  const sessionIds = useLiveSessionsStore((s) => s.sessionsFor(connection.id));
+  const hasLiveSessions = sessionIds.length > 0;
+  const hasForwards = (connection.portForwards?.length ?? 0) > 0;
+  const showForwards = hasLiveSessions && hasForwards;
+  const showSessionLabels = sessionIds.length > 1;
 
   function handleRowClick() {
     openSshTab(connection.id, connection.name);
@@ -43,66 +162,83 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   }
 
   return (
-    <li className="group flex items-center">
-      <button
-        type="button"
-        onClick={handleRowClick}
-        className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left hover:bg-bg-elevated"
-      >
-        <Server size={14} className="shrink-0 text-fg-subtle" />
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm text-fg-muted group-hover:text-fg">
-            {connection.name}
+    <li>
+      <div className="group flex items-center">
+        <button
+          type="button"
+          onClick={handleRowClick}
+          className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left hover:bg-bg-elevated"
+        >
+          <Server size={14} className="shrink-0 text-fg-subtle" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm text-fg-muted group-hover:text-fg">
+              {connection.name}
+            </div>
+            <div className="truncate text-xs text-fg-subtle">
+              {connection.user ? `${connection.user}@${connection.host}` : connection.host}
+              {connection.port !== 22 ? `:${connection.port}` : ""}
+            </div>
           </div>
-          <div className="truncate text-xs text-fg-subtle">
-            {connection.user ? `${connection.user}@${connection.host}` : connection.host}
-            {connection.port !== 22 ? `:${connection.port}` : ""}
-          </div>
-        </div>
-      </button>
+        </button>
 
-      {confirmingDelete ? (
-        <div className="flex shrink-0 items-center gap-1 pr-2">
-          <button
-            type="button"
-            onClick={handleConfirmDelete}
-            className="rounded px-1.5 py-0.5 text-xs font-medium text-danger hover:bg-border-strong"
-          >
-            {t("connectionsPanel.confirmDelete")}
-          </button>
-          <button
-            type="button"
-            onClick={handleCancelDelete}
-            className="rounded px-1.5 py-0.5 text-xs text-fg-muted hover:bg-border-strong hover:text-fg"
-          >
-            {t("connectionsPanel.cancelDelete")}
-          </button>
-        </div>
-      ) : (
-        <div className="flex shrink-0 items-center opacity-0 group-hover:opacity-100 pr-2">
-          <button
-            type="button"
-            aria-label={t("connectionsPanel.edit")}
-            title={t("connectionsPanel.edit")}
-            onClick={handleEditClick}
-            className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
-          >
-            <Pencil size={13} />
-          </button>
-          <button
-            type="button"
-            aria-label={t("connectionsPanel.delete")}
-            title={t("connectionsPanel.delete")}
-            onClick={handleDeleteClick}
-            className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-danger"
-          >
-            <Trash2 size={13} />
-          </button>
+        {confirmingDelete ? (
+          <div className="flex shrink-0 items-center gap-1 pr-2">
+            <button
+              type="button"
+              onClick={handleConfirmDelete}
+              className="rounded px-1.5 py-0.5 text-xs font-medium text-danger hover:bg-border-strong"
+            >
+              {t("connectionsPanel.confirmDelete")}
+            </button>
+            <button
+              type="button"
+              onClick={handleCancelDelete}
+              className="rounded px-1.5 py-0.5 text-xs text-fg-muted hover:bg-border-strong hover:text-fg"
+            >
+              {t("connectionsPanel.cancelDelete")}
+            </button>
+          </div>
+        ) : (
+          <div className="flex shrink-0 items-center opacity-0 group-hover:opacity-100 pr-2">
+            <button
+              type="button"
+              aria-label={t("connectionsPanel.edit")}
+              title={t("connectionsPanel.edit")}
+              onClick={handleEditClick}
+              className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
+            >
+              <Pencil size={13} />
+            </button>
+            <button
+              type="button"
+              aria-label={t("connectionsPanel.delete")}
+              title={t("connectionsPanel.delete")}
+              onClick={handleDeleteClick}
+              className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-danger"
+            >
+              <Trash2 size={13} />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {showForwards && (
+        <div>
+          {sessionIds.map((sessionId) => (
+            <SessionForwards
+              key={sessionId}
+              sessionId={sessionId}
+              forwards={connection.portForwards ?? []}
+              showSessionLabel={showSessionLabels}
+            />
+          ))}
         </div>
       )}
     </li>
   );
 }
+
+// ─── Panel ────────────────────────────────────────────────────────────────────
 
 export function ConnectionsPanel() {
   const { t } = useTranslation("common");

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -116,6 +116,10 @@ function SessionForwards({ sessionId, forwards, showSessionLabel }: SessionForwa
   );
 }
 
+// Stable empty array — returned by the selector when a connection has no live
+// sessions, so zustand's Object.is check doesn't see a new [] on every render.
+const EMPTY_SESSIONS: number[] = [];
+
 // ─── Connection row ────────────────────────────────────────────────────────────
 
 interface ConnectionRowProps {
@@ -129,8 +133,10 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   const openSshTab = useTabsStore((s) => s.openSshTab);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
-  // Subscribe to live sessions for this connection
-  const sessionIds = useLiveSessionsStore((s) => s.sessionsFor(connection.id));
+  // Subscribe to live sessions for this connection. Use a direct field lookup
+  // with a stable EMPTY_SESSIONS fallback so the selector returns the same
+  // reference when unchanged, avoiding spurious re-renders on every store update.
+  const sessionIds = useLiveSessionsStore((s) => s.sessions[connection.id] ?? EMPTY_SESSIONS);
   const hasLiveSessions = sessionIds.length > 0;
   const hasForwards = (connection.portForwards?.length ?? 0) > 0;
   const showForwards = hasLiveSessions && hasForwards;

--- a/src/modules/ssh/lib/forwardStatusStore.test.ts
+++ b/src/modules/ssh/lib/forwardStatusStore.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { useForwardStatusStore } from "./forwardStatusStore";
+
+describe("forwardStatusStore", () => {
+  beforeEach(() => useForwardStatusStore.setState({ statuses: {} }));
+
+  it("applies and reads a status", () => {
+    useForwardStatusStore.getState().applyStatus({ sessionId: 1, forwardId: "f1", state: "active" });
+    expect(useForwardStatusStore.getState().getStatus(1, "f1")?.state).toBe("active");
+  });
+
+  it("overwrites the same forward and keeps an error", () => {
+    const s = useForwardStatusStore.getState();
+    s.applyStatus({ sessionId: 1, forwardId: "f1", state: "starting" });
+    s.applyStatus({ sessionId: 1, forwardId: "f1", state: "failed", error: "address in use" });
+    expect(s.getStatus(1, "f1")).toMatchObject({ state: "failed", error: "address in use" });
+  });
+
+  it("clears all statuses for a session", () => {
+    const s = useForwardStatusStore.getState();
+    s.applyStatus({ sessionId: 1, forwardId: "f1", state: "active" });
+    s.applyStatus({ sessionId: 2, forwardId: "f2", state: "active" });
+    s.clearSession(1);
+    expect(s.getStatus(1, "f1")).toBeUndefined();
+    expect(s.getStatus(2, "f2")?.state).toBe("active");
+  });
+});

--- a/src/modules/ssh/lib/forwardStatusStore.ts
+++ b/src/modules/ssh/lib/forwardStatusStore.ts
@@ -1,0 +1,35 @@
+import { create } from "zustand";
+
+export type ForwardState = "starting" | "active" | "failed" | "stopped";
+
+export interface ForwardStatus {
+  sessionId: number;
+  forwardId: string;
+  state: ForwardState;
+  error?: string;
+}
+
+interface ForwardStatusState {
+  statuses: Record<number, Record<string, ForwardStatus>>;
+  applyStatus: (s: ForwardStatus) => void;
+  clearSession: (sessionId: number) => void;
+  getStatus: (sessionId: number, forwardId: string) => ForwardStatus | undefined;
+}
+
+export const useForwardStatusStore = create<ForwardStatusState>()((set, get) => ({
+  statuses: {},
+  applyStatus: (s) =>
+    set((prev) => ({
+      statuses: {
+        ...prev.statuses,
+        [s.sessionId]: { ...prev.statuses[s.sessionId], [s.forwardId]: s },
+      },
+    })),
+  clearSession: (sessionId) =>
+    set((prev) => {
+      const next = { ...prev.statuses };
+      delete next[sessionId];
+      return { statuses: next };
+    }),
+  getStatus: (sessionId, forwardId) => get().statuses[sessionId]?.[forwardId],
+}));

--- a/src/modules/ssh/lib/liveSessionsStore.test.ts
+++ b/src/modules/ssh/lib/liveSessionsStore.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { liveSessionsStore } from "./liveSessionsStore";
+
+describe("liveSessionsStore", () => {
+  beforeEach(() => {
+    liveSessionsStore.setState({ sessions: {} });
+  });
+
+  it("starts empty", () => {
+    expect(liveSessionsStore.getState().sessionsFor("conn-1")).toEqual([]);
+  });
+
+  it("register adds a sessionId under the given connectionId", () => {
+    liveSessionsStore.getState().register("conn-1", 42);
+    expect(liveSessionsStore.getState().sessionsFor("conn-1")).toEqual([42]);
+  });
+
+  it("register allows multiple sessions for the same connection", () => {
+    liveSessionsStore.getState().register("conn-1", 10);
+    liveSessionsStore.getState().register("conn-1", 20);
+    expect(liveSessionsStore.getState().sessionsFor("conn-1")).toEqual([10, 20]);
+  });
+
+  it("register does not mix sessions across connections", () => {
+    liveSessionsStore.getState().register("conn-1", 10);
+    liveSessionsStore.getState().register("conn-2", 20);
+    expect(liveSessionsStore.getState().sessionsFor("conn-1")).toEqual([10]);
+    expect(liveSessionsStore.getState().sessionsFor("conn-2")).toEqual([20]);
+  });
+
+  it("unregister removes a sessionId from its connection", () => {
+    liveSessionsStore.getState().register("conn-1", 10);
+    liveSessionsStore.getState().register("conn-1", 20);
+    liveSessionsStore.getState().unregister(10);
+    expect(liveSessionsStore.getState().sessionsFor("conn-1")).toEqual([20]);
+  });
+
+  it("unregister removes the connectionId entry when no sessions remain", () => {
+    liveSessionsStore.getState().register("conn-1", 10);
+    liveSessionsStore.getState().unregister(10);
+    // Key should be absent, not an empty array (keeps state clean)
+    expect("conn-1" in liveSessionsStore.getState().sessions).toBe(false);
+  });
+
+  it("unregister is a no-op for an unknown sessionId", () => {
+    liveSessionsStore.getState().register("conn-1", 10);
+    liveSessionsStore.getState().unregister(999);
+    expect(liveSessionsStore.getState().sessionsFor("conn-1")).toEqual([10]);
+  });
+
+  it("sessionsFor returns [] for an unknown connectionId", () => {
+    expect(liveSessionsStore.getState().sessionsFor("unknown")).toEqual([]);
+  });
+});

--- a/src/modules/ssh/lib/liveSessionsStore.ts
+++ b/src/modules/ssh/lib/liveSessionsStore.ts
@@ -1,0 +1,42 @@
+import { create } from "zustand";
+
+interface LiveSessionsState {
+  /** Maps connectionId -> list of live sessionIds */
+  sessions: Record<string, number[]>;
+  /** Register a new live session for a connection. */
+  register: (connectionId: string, sessionId: number) => void;
+  /** Remove a session when it exits. Cleans up the key if no sessions remain. */
+  unregister: (sessionId: number) => void;
+  /** Return the list of live sessionIds for a connection (empty array if none). */
+  sessionsFor: (connectionId: string) => number[];
+}
+
+export const liveSessionsStore = create<LiveSessionsState>()((set, get) => ({
+  sessions: {},
+
+  register: (connectionId, sessionId) =>
+    set((prev) => ({
+      sessions: {
+        ...prev.sessions,
+        [connectionId]: [...(prev.sessions[connectionId] ?? []), sessionId],
+      },
+    })),
+
+  unregister: (sessionId) =>
+    set((prev) => {
+      const next: Record<string, number[]> = {};
+      for (const [connId, ids] of Object.entries(prev.sessions)) {
+        const filtered = ids.filter((id) => id !== sessionId);
+        if (filtered.length > 0) {
+          next[connId] = filtered;
+        }
+        // Drop the key entirely if the list becomes empty
+      }
+      return { sessions: next };
+    }),
+
+  sessionsFor: (connectionId) => get().sessions[connectionId] ?? [],
+}));
+
+/** Hook alias — use inside React components. */
+export const useLiveSessionsStore = liveSessionsStore;

--- a/src/modules/ssh/lib/ssh-bridge.test.ts
+++ b/src/modules/ssh/lib/ssh-bridge.test.ts
@@ -6,7 +6,7 @@ vi.mock("@tauri-apps/api/core", () => ({
   Channel: class { onmessage: ((m: unknown) => void) | null = null; },
 }));
 
-import { openSsh } from "./ssh-bridge";
+import { openSsh, startForward, stopForward } from "./ssh-bridge";
 
 describe("openSsh", () => {
   it("invokes ssh_open and exposes write/resize/close on the returned id", async () => {
@@ -41,7 +41,29 @@ describe("openSsh", () => {
           keyPath: "~/.ssh/id_ed25519",
           cols: 120,
           rows: 40,
+          forwards: [],
         },
+      }),
+    );
+  });
+
+  it("includes forwards in the req when provided", async () => {
+    invoke.mockClear();
+    const forwards = [
+      { id: "f1", bindHost: "127.0.0.1", localPort: 5432, destHost: "localhost", destPort: 5432 },
+    ];
+    await openSsh({
+      connectionId: "conn-42", host: "example.com", port: 2222, user: "alice",
+      authMethod: "keyFile", keyPath: "~/.ssh/id_ed25519", cols: 120, rows: 40,
+      forwards,
+      onData: () => {}, onExit: () => {},
+    });
+    expect(invoke).toHaveBeenCalledWith(
+      "ssh_open",
+      expect.objectContaining({
+        req: expect.objectContaining({
+          forwards,
+        }),
       }),
     );
   });
@@ -55,5 +77,24 @@ describe("openSsh", () => {
     });
     await s.close();
     expect(invoke).toHaveBeenCalledWith("ssh_close", { id: s.id });
+  });
+});
+
+describe("startForward", () => {
+  it("invokes ssh_forward_start with the session id and forward", async () => {
+    invoke.mockClear();
+    await startForward(7, { id: "f1", bindHost: "127.0.0.1", localPort: 5432, destHost: "localhost", destPort: 5432 });
+    expect(invoke).toHaveBeenCalledWith("ssh_forward_start", {
+      id: 7,
+      forward: { id: "f1", bindHost: "127.0.0.1", localPort: 5432, destHost: "localhost", destPort: 5432 },
+    });
+  });
+});
+
+describe("stopForward", () => {
+  it("invokes ssh_forward_stop", async () => {
+    invoke.mockClear();
+    await stopForward(7, "f1");
+    expect(invoke).toHaveBeenCalledWith("ssh_forward_stop", { id: 7, forwardId: "f1" });
   });
 });

--- a/src/modules/ssh/lib/ssh-bridge.ts
+++ b/src/modules/ssh/lib/ssh-bridge.ts
@@ -9,6 +9,14 @@ export interface SshSession {
   close: () => Promise<void>;
 }
 
+export interface ForwardInput {
+  id: string;
+  bindHost: string;
+  localPort: number;
+  destHost: string;
+  destPort: number;
+}
+
 export interface OpenSshOptions {
   connectionId: string;
   host: string;
@@ -18,6 +26,7 @@ export interface OpenSshOptions {
   keyPath?: string;
   cols: number;
   rows: number;
+  forwards?: ForwardInput[];
   onData: (bytes: Uint8Array) => void;
   onExit: (code: number) => void;
 }
@@ -38,6 +47,7 @@ export async function openSsh(opts: OpenSshOptions): Promise<SshSession> {
       keyPath: opts.keyPath,
       cols: opts.cols,
       rows: opts.rows,
+      forwards: opts.forwards ?? [],
     },
     onData,
     onExit,
@@ -49,4 +59,12 @@ export async function openSsh(opts: OpenSshOptions): Promise<SshSession> {
     resize: (cols, rows) => invoke("ssh_resize", { id, cols, rows }),
     close: () => invoke("ssh_close", { id }),
   };
+}
+
+export function startForward(sessionId: number, forward: ForwardInput): Promise<void> {
+  return invoke("ssh_forward_start", { id: sessionId, forward });
+}
+
+export function stopForward(sessionId: number, forwardId: string): Promise<void> {
+  return invoke("ssh_forward_stop", { id: sessionId, forwardId });
 }

--- a/src/modules/ssh/lib/useForwardStatus.ts
+++ b/src/modules/ssh/lib/useForwardStatus.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { useForwardStatusStore, type ForwardStatus } from "./forwardStatusStore";
+
+/**
+ * Mounts once in App and feeds every `ssh-forward-status` event emitted by
+ * the backend into the forwardStatusStore. Uses the active-flag pattern so
+ * that if the component unmounts before `listen()` resolves we detach the
+ * listener immediately instead of leaking it.
+ */
+export function useForwardStatusListener(): void {
+  useEffect(() => {
+    let active = true;
+    let unlisten: (() => void) | undefined;
+
+    listen<ForwardStatus>("ssh-forward-status", (e) => {
+      if (active) useForwardStatusStore.getState().applyStatus(e.payload);
+    })
+      .then((off) => {
+        if (active) {
+          unlisten = off;
+        } else {
+          off();
+        }
+      })
+      .catch(() => {
+        // No Tauri runtime in tests / web preview — swallow silently.
+      });
+
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, []);
+}

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -6,6 +6,7 @@ import { consumeFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/createTerminal";
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import { openSsh, type SshSession } from "@/modules/ssh/lib/ssh-bridge";
+import { useForwardStatusStore } from "@/modules/ssh/lib/forwardStatusStore";
 
 /** Narrows a session to PtySession (which has cwd/foregroundCommand). */
 function isPtySession(s: PtySession | SshSession): s is PtySession {
@@ -455,7 +456,11 @@ export function TerminalView({
             if (!disposed) {
               // Do NOT call onExitRef (which closes the pane). Instead, show the
               // Reconnect card so the user can retry after a failed/dropped connection.
+              const sshSession = sessionRef.current as SshSession | null;
               void sessionRef.current?.close();
+              if (sshSession) {
+                useForwardStatusStore.getState().clearSession(sshSession.id);
+              }
               setSshDisconnected(true);
               setConnecting(false);
             }

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -626,6 +626,7 @@ export function TerminalView({
       // no longer shows forwarding rows for this session.
       const closingSession = sessionRef.current;
       if (closingSession && !isPtySession(closingSession)) {
+        useForwardStatusStore.getState().clearSession(closingSession.id);
         liveSessionsStore.getState().unregister(closingSession.id);
       }
       void sessionRef.current?.close();

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -7,6 +7,7 @@ import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import { openSsh, type SshSession } from "@/modules/ssh/lib/ssh-bridge";
 import { useForwardStatusStore } from "@/modules/ssh/lib/forwardStatusStore";
+import { liveSessionsStore } from "@/modules/ssh/lib/liveSessionsStore";
 
 /** Narrows a session to PtySession (which has cwd/foregroundCommand). */
 function isPtySession(s: PtySession | SshSession): s is PtySession {
@@ -460,6 +461,7 @@ export function TerminalView({
               void sessionRef.current?.close();
               if (sshSession) {
                 useForwardStatusStore.getState().clearSession(sshSession.id);
+                liveSessionsStore.getState().unregister(sshSession.id);
               }
               setSshDisconnected(true);
               setConnecting(false);
@@ -502,6 +504,11 @@ export function TerminalView({
           return;
         }
         sessionRef.current = session;
+        // Register live SSH session so ConnectionsPanel can show forwarding status.
+        const paneSshConn = sshRef.current;
+        if (paneSshConn && !isPtySession(session)) {
+          liveSessionsStore.getState().register(paneSshConn.connectionId, session.id);
+        }
         term.onData((data) => void session.write(data));
         if (leafIdRef.current) {
           registerTerminal(leafIdRef.current, (text) => void session.write(text));
@@ -614,6 +621,12 @@ export function TerminalView({
         unregisterTerminal(leafIdRef.current);
         unregisterTerminalPathDrop(leafIdRef.current);
         useSessionStatusStore.getState().clear(leafIdRef.current);
+      }
+      // Unregister live SSH session on pane close so the connections panel
+      // no longer shows forwarding rows for this session.
+      const closingSession = sessionRef.current;
+      if (closingSession && !isPtySession(closingSession)) {
+        liveSessionsStore.getState().unregister(closingSession.id);
       }
       void sessionRef.current?.close();
       term.dispose();

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -429,6 +429,15 @@ export function TerminalView({
         if (!conn) {
           throw new Error(`SSH connection "${paneSsh.connectionId}" not found — it may have been deleted.`);
         }
+        const forwards = conn.portForwards
+          ?.filter((pf) => pf.enabled)
+          .map((pf) => ({
+            id: pf.id,
+            bindHost: pf.bindHost,
+            localPort: pf.localPort,
+            destHost: pf.destHost,
+            destPort: pf.destPort,
+          }));
         return openSsh({
           connectionId: conn.id,
           host: conn.host,
@@ -438,6 +447,7 @@ export function TerminalView({
           keyPath: conn.keyPath,
           cols: term.cols,
           rows: term.rows,
+          forwards,
           onData: (bytes) => term.write(bytes),
           // Only treat an exit as user-facing when we did not tear the session
           // down ourselves (e.g. React StrictMode's mount/unmount/remount in dev).

--- a/src/stores/connectionsStore.test.ts
+++ b/src/stores/connectionsStore.test.ts
@@ -33,4 +33,16 @@ describe("connectionsStore", () => {
     expect(Object.keys(conn)).not.toContain("password");
     expect(Object.keys(conn)).not.toContain("passphrase");
   });
+
+  it("round-trips portForwards and still has no secret field", () => {
+    const id = useConnectionsStore.getState().addConnection({
+      ...base,
+      portForwards: [
+        { id: "f1", mode: "local", bindHost: "127.0.0.1", localPort: 5432, destHost: "localhost", destPort: 5432, enabled: true },
+      ],
+    });
+    const conn = useConnectionsStore.getState().getConnection(id)!;
+    expect(conn.portForwards?.[0]).toMatchObject({ localPort: 5432, destPort: 5432, enabled: true });
+    expect(Object.keys(conn)).not.toContain("password");
+  });
 });

--- a/src/stores/connectionsStore.ts
+++ b/src/stores/connectionsStore.ts
@@ -2,6 +2,16 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { SshAuthMethod } from "@/modules/ssh/lib/parseSshCommand";
 
+export interface PortForward {
+  id: string;
+  mode: "local";
+  bindHost: string;
+  localPort: number;
+  destHost: string;
+  destPort: number;
+  enabled: boolean;
+}
+
 export interface SshConnection {
   id: string;
   name: string;
@@ -11,6 +21,7 @@ export interface SshConnection {
   authMethod: SshAuthMethod;
   keyPath?: string;
   rememberSecret: boolean;
+  portForwards?: PortForward[];
 }
 
 interface ConnectionsState {

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -359,6 +359,28 @@ describe("openSshTab", () => {
     const tabId = useTabsStore.getState().openSshTab("c2", "staging");
     expect(useTabsStore.getState().activeId).toBe(tabId);
   });
+
+  it("focuses the existing tab instead of opening a duplicate for the same connection", () => {
+    const first = useTabsStore.getState().openSshTab("c1", "prod-box");
+    // Move focus away so we can prove the second call re-focuses the first tab.
+    useTabsStore.getState().newTerminalTab();
+    const second = useTabsStore.getState().openSshTab("c1", "prod-box");
+    expect(second).toBe(first);
+    expect(useTabsStore.getState().activeId).toBe(first);
+    const sshTabs = useTabsStore
+      .getState()
+      .tabs.filter((t) => {
+        const pane = firstLeafContent(t);
+        return pane.kind === "terminal" && pane.ssh?.connectionId === "c1";
+      });
+    expect(sshTabs).toHaveLength(1);
+  });
+
+  it("opens a separate tab for a different connection", () => {
+    const first = useTabsStore.getState().openSshTab("c1", "prod-box");
+    const second = useTabsStore.getState().openSshTab("c2", "staging");
+    expect(second).not.toBe(first);
+  });
 });
 
 describe("migratePersistedTabs", () => {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -280,6 +280,21 @@ export const useTabsStore = create<TabsState>()(
 
   openSshTab: (connectionId, name) => {
     const spaceId = get().ensureSpace();
+    // Re-opening a connection that's already showing in this space focuses that
+    // tab instead of spawning a duplicate session (two sessions would race for
+    // the same forwarded local port). Matches openLauncherTab's reuse.
+    const existing = get().tabs.find(
+      (t) =>
+        t.spaceId === spaceId &&
+        computeLayout(t.paneTree).some(
+          (p) =>
+            p.content.kind === "terminal" && p.content.ssh?.connectionId === connectionId,
+        ),
+    );
+    if (existing) {
+      set({ activeId: existing.id });
+      return existing.id;
+    }
     const id = nextTabId();
     const paneId = nextPaneId();
     const tab: Tab = {


### PR DESCRIPTION
## Summary

Adds SSH local (`-L`) port forwarding on top of the SSH feature (#44). Forwarding rules saved on a connection auto-start when it connects, sharing the terminal session's `russh` connection. A Connections-panel surface shows each forward's status and toggles it on/off without reconnecting.

## What's included

- **Local (`-L`) forwarding** — a local TCP port tunnelled over the existing SSH connection to a host:port reachable from the remote.
- **Rules on the profile** — edited in the connection form, auto-started on connect; a `forwarding 127.0.0.1:5432 -> localhost:5432` line prints in the terminal.
- **Status panel** — the Connections sidebar shows each connection's live forwards with an active / failed / stopped indicator and an on/off toggle that starts/stops the forward without reconnecting.
- **No duplicate sessions** — re-opening a connection that's already showing in the current space focuses its tab instead of spawning a second session (two sessions would race for the same forwarded local port).

## Architecture

Forwarding shares the terminal session's `russh` connection. After auth the worker wraps its `Handle` in an `Arc` (`channel_open_session`/`channel_open_direct_tcpip` are `&self`). Each forward runs as a task on the worker's runtime: `forward.rs` binds a `TcpListener` and bridges each accepted connection to a `channel_open_direct_tcpip` channel via `copy_bidirectional`. Control (start/stop) flows over the existing per-session `mpsc`; status flows back as window-scoped `ssh-forward-status` events. Forwards are tied to the session: closing the pane stops them, and every forward task is cancelled before its watch-sender drops, so no listener can leak its bound port. The shell read/write path is unchanged.

Frontend: `PortForward` on the profile, `forwardStatusStore` (live status), `liveSessionsStore` (connection→session), a `useForwardStatus` listener, and `ssh-bridge` start/stop plus forwards-on-connect.

## Not included (deferred — tracked in #45)

Remote (`-R`) and dynamic / SOCKS (`-D`) forwarding (the `mode` field is reserved for them), and pane-independent tunnels.

## Test plan

- **Automated** — `cargo test --lib`: 152 passing (incl. `ssh::forward::validate`). `pnpm test`: 599 passing; `pnpm run typecheck` clean.
- **Manual** (real EC2 host) — a saved local forward auto-starts on connect, prints the forwarding line, and carries traffic (`nc -v localhost:<localPort>` reaches the remote sshd banner); toggling it off stops the listener and on restarts it without reconnecting; a port already in use shows a failed forward without affecting the others or the shell; closing the pane releases the port; re-clicking a live connection focuses its existing tab. Verified.
