### PR TITLE
feat(ai): context-aware assistant and editor inline completion

### DIFF
--- a/src/i18n/locales/en/ai.json
+++ b/src/i18n/locales/en/ai.json
@@ -18,5 +18,11 @@
   "you": "You",
   "assistant": "Assistant",
   "contextHint": "The assistant sees your current folder and open file as context",
-  "removeAttachment": "Remove attachment"
+  "removeAttachment": "Remove attachment",
+  "grabTerminal": "Add active terminal output as context",
+  "grabTerminalActive": "Terminal output attached — click to refresh",
+  "insertCommand": "Insert into terminal",
+  "terminalContextChip": "Terminal output",
+  "terminalContextTitle": "The active terminal's recent output is attached as context",
+  "removeTerminalContext": "Remove terminal output"
 }

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -94,6 +94,10 @@
     "model": "Model",
     "customPlaceholder": "Type a custom model name"
   },
+  "aiInline": {
+    "label": "Inline code completion",
+    "description": "Show AI ghost-text suggestions while typing in the editor. Tab accepts, Escape dismisses. Uses your default model and counts against its usage."
+  },
   "aiKeys": {
     "title": "API keys",
     "description": "Keys are stored in your OS keychain and read only by the backend, never returned to the app window",

--- a/src/i18n/locales/zh-Hant/ai.json
+++ b/src/i18n/locales/zh-Hant/ai.json
@@ -18,5 +18,11 @@
   "you": "你",
   "assistant": "助手",
   "contextHint": "助手會把你目前的資料夾與開啟的檔案當作情境",
-  "removeAttachment": "移除附件"
+  "removeAttachment": "移除附件",
+  "grabTerminal": "把目前終端機的輸出加入情境",
+  "grabTerminalActive": "終端機輸出已加入，點擊可重新抓取",
+  "insertCommand": "插入終端機",
+  "terminalContextChip": "終端機輸出",
+  "terminalContextTitle": "目前終端機最近的輸出已加入情境",
+  "removeTerminalContext": "移除終端機輸出"
 }

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -94,6 +94,10 @@
     "model": "模型",
     "customPlaceholder": "輸入自訂模型名稱"
   },
+  "aiInline": {
+    "label": "行內程式碼補完",
+    "description": "在編輯器打字時顯示 AI 灰字建議，Tab 接受、Esc 取消。使用你的預設模型，會計入該模型的用量。"
+  },
   "aiKeys": {
     "title": "API 金鑰",
     "description": "金鑰存在你的系統 keychain，只由後端讀取，不會回傳到 app 視窗",

--- a/src/modules/ai/AIView.tsx
+++ b/src/modules/ai/AIView.tsx
@@ -1,19 +1,28 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Bot, KeyRound, Paperclip, SendHorizontal, Trash2, X } from "lucide-react";
+import { Bot, KeyRound, Paperclip, SendHorizontal, SquareTerminal, Trash2, X } from "lucide-react";
 import { useChatStore } from "./store/chatStore";
 import { providerById, PROVIDERS } from "./lib/providers";
 import { secretsHasKey, secretsSetKey } from "./lib/aiBridge";
 import { buildAttachmentsBlock, type AttachedFile } from "./lib/attachments";
+import { buildActiveFileBlock, buildTerminalBlock } from "./lib/context";
+import { extractCommand, sanitizeForInsertion } from "./lib/command";
 import { ChatMarkdown } from "./ChatMarkdown";
 import { Combobox } from "@/components/Combobox";
 import { fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import { basename } from "@/modules/explorer/lib/paths";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useEditorStore } from "@/modules/editor/store/editorStore";
+import {
+  insertIntoActiveTerminal,
+  readActiveTerminalBuffer,
+} from "@/modules/terminal/lib/terminalBus";
 
 function buildSystemPrompt(
   rootPath: string | null,
   activeFile: string | null,
+  activeFileBlock: string,
+  terminalBlock: string,
   attachments: string,
 ): string {
   const parts = [
@@ -24,6 +33,12 @@ function buildSystemPrompt(
   }
   if (activeFile) {
     parts.push(`The user is currently looking at: ${activeFile}`);
+  }
+  if (activeFileBlock) {
+    parts.push(activeFileBlock);
+  }
+  if (terminalBlock) {
+    parts.push(terminalBlock);
   }
   if (attachments) {
     parts.push(attachments);
@@ -99,6 +114,8 @@ export function AIView() {
   const clear = useChatStore((s) => s.clear);
   const attachedPaths = useChatStore((s) => s.attachedPaths);
   const removeAttached = useChatStore((s) => s.removeAttached);
+  const terminalContext = useChatStore((s) => s.terminalContext);
+  const setTerminalContext = useChatStore((s) => s.setTerminalContext);
 
   const rootPath = useWorkspaceStore((s) => s.rootPath);
   const activeFile = useWorkspaceStore((s) => s.activeFile);
@@ -125,14 +142,25 @@ export function AIView() {
     listRef.current?.scrollTo({ top: listRef.current.scrollHeight });
   }, [messages, sending]);
 
+  function grabTerminal() {
+    const raw = readActiveTerminalBuffer();
+    setTerminalContext(raw ? buildTerminalBlock(raw) || null : null);
+  }
+
   function submit() {
     if (!input.trim() || sending) {
       return;
     }
     const text = input;
     setInput("");
+    const activeFileBlock = activeFile
+      ? buildActiveFileBlock(activeFile, useEditorStore.getState().contentOf(activeFile))
+      : "";
     void buildAttachmentsContext(attachedPaths).then((attachments) =>
-      send(text, buildSystemPrompt(rootPath, activeFile, attachments)),
+      send(
+        text,
+        buildSystemPrompt(rootPath, activeFile, activeFileBlock, terminalContext ?? "", attachments),
+      ),
     );
   }
 
@@ -186,26 +214,45 @@ export function AIView() {
             <p className="mt-2 max-w-xs text-[11px]">{t("contextHint")}</p>
           </div>
         ) : (
-          messages.map((message, index) => (
-            <div
-              key={index}
-              className={message.role === "user" ? "flex justify-end" : "flex justify-start"}
-            >
+          messages.map((message, index) => {
+            const command =
+              message.role === "assistant" ? extractCommand(message.content) : null;
+            return (
               <div
-                className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
+                key={index}
+                className={
                   message.role === "user"
-                    ? "whitespace-pre-wrap bg-accent text-white"
-                    : "bg-bg-elevated text-fg"
-                }`}
+                    ? "flex justify-end"
+                    : "flex flex-col items-start gap-1"
+                }
               >
-                {message.role === "assistant" ? (
-                  <ChatMarkdown content={message.content} />
-                ) : (
-                  message.content
+                <div
+                  className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
+                    message.role === "user"
+                      ? "whitespace-pre-wrap bg-accent text-white"
+                      : "bg-bg-elevated text-fg"
+                  }`}
+                >
+                  {message.role === "assistant" ? (
+                    <ChatMarkdown content={message.content} />
+                  ) : (
+                    message.content
+                  )}
+                </div>
+                {command && (
+                  <button
+                    type="button"
+                    title={t("insertCommand")}
+                    onClick={() => insertIntoActiveTerminal(sanitizeForInsertion(command))}
+                    className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-fg-muted transition-colors hover:bg-bg-elevated hover:text-fg"
+                  >
+                    <SquareTerminal size={12} className="shrink-0 text-accent" />
+                    {t("insertCommand")}
+                  </button>
                 )}
               </div>
-            </div>
-          ))
+            );
+          })
         )}
         {sending && (
           <div className="flex justify-start">
@@ -223,8 +270,26 @@ export function AIView() {
 
       {/* Input */}
       <div className="shrink-0 border-t border-border bg-bg-inset p-3">
-        {attachedPaths.length > 0 && (
+        {(attachedPaths.length > 0 || terminalContext) && (
           <div className="mb-2 flex flex-wrap gap-1.5">
+            {terminalContext && (
+              <span
+                title={t("terminalContextTitle")}
+                className="inline-flex max-w-[200px] items-center gap-1 rounded-md border border-accent/40 bg-accent/10 px-2 py-1 text-xs text-fg-muted"
+              >
+                <SquareTerminal size={11} className="shrink-0 text-accent" />
+                <span className="truncate">{t("terminalContextChip")}</span>
+                <button
+                  type="button"
+                  aria-label={t("removeTerminalContext")}
+                  title={t("removeTerminalContext")}
+                  onClick={() => setTerminalContext(null)}
+                  className="shrink-0 rounded text-fg-subtle hover:text-fg"
+                >
+                  <X size={12} />
+                </button>
+              </span>
+            )}
             {attachedPaths.map((path) => (
               <span
                 key={path}
@@ -247,6 +312,20 @@ export function AIView() {
           </div>
         )}
         <div className="flex items-end gap-2">
+          <button
+            type="button"
+            aria-pressed={Boolean(terminalContext)}
+            aria-label={terminalContext ? t("grabTerminalActive") : t("grabTerminal")}
+            title={terminalContext ? t("grabTerminalActive") : t("grabTerminal")}
+            onClick={grabTerminal}
+            className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-md border transition-colors ${
+              terminalContext
+                ? "border-accent bg-accent/10 text-accent hover:bg-accent/15"
+                : "border-border text-fg-muted hover:bg-bg-elevated hover:text-fg"
+            }`}
+          >
+            <SquareTerminal size={16} />
+          </button>
           <textarea
             value={input}
             rows={2}

--- a/src/modules/ai/lib/command.test.ts
+++ b/src/modules/ai/lib/command.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { extractCommand, sanitizeForInsertion } from "./command";
+
+describe("extractCommand", () => {
+  it("pulls the command from a bash fenced block", () => {
+    expect(extractCommand("Run this:\n```bash\nnpm test\n```")).toBe("npm test");
+  });
+
+  it("treats a fenced block with no language as a shell command", () => {
+    expect(extractCommand("```\nls -la\n```")).toBe("ls -la");
+  });
+
+  it("ignores non-shell fenced blocks", () => {
+    expect(extractCommand('```json\n{"a":1}\n```')).toBeNull();
+  });
+
+  it("returns null when there is no fenced block", () => {
+    expect(extractCommand("just prose, no code here")).toBeNull();
+  });
+
+  it("returns the first shell block when there are several", () => {
+    const md = "First:\n```sh\necho one\n```\nThen:\n```bash\necho two\n```";
+    expect(extractCommand(md)).toBe("echo one");
+  });
+});
+
+describe("sanitizeForInsertion", () => {
+  it("strips trailing newlines so the command does not auto-run", () => {
+    expect(sanitizeForInsertion("npm test\n")).toBe("npm test");
+    expect(sanitizeForInsertion("ls  \n\n")).toBe("ls");
+  });
+
+  it("strips a leading shell prompt marker", () => {
+    expect(sanitizeForInsertion("$ npm test")).toBe("npm test");
+    expect(sanitizeForInsertion("% pwd")).toBe("pwd");
+  });
+});

--- a/src/modules/ai/lib/command.ts
+++ b/src/modules/ai/lib/command.ts
@@ -1,0 +1,45 @@
+/** Languages we treat as a runnable shell command in a fenced code block. An
+ * empty language tag (a bare ```) counts too, since the model often omits it. */
+const SHELL_LANGS = new Set([
+  "",
+  "bash",
+  "sh",
+  "shell",
+  "zsh",
+  "console",
+  "shell-session",
+  "shellsession",
+  "terminal",
+]);
+
+const FENCE = /```([\w-]*)\n([\s\S]*?)```/g;
+
+/**
+ * Pull the first shell command out of an assistant reply. Scans fenced code
+ * blocks in order and returns the first one whose language looks like a shell,
+ * trimmed. Returns null when no such block exists, so the caller can decide
+ * whether to offer an "insert into terminal" action.
+ */
+export function extractCommand(markdown: string): string | null {
+  FENCE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = FENCE.exec(markdown)) !== null) {
+    const lang = match[1].toLowerCase();
+    if (SHELL_LANGS.has(lang)) {
+      const body = match[2].trim();
+      if (body.length > 0) {
+        return body;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Prepare a command for insertion into the terminal prompt: trim surrounding
+ * whitespace (so no trailing newline auto-runs it) and drop a leading prompt
+ * marker like "$ " or "% " the model may have copied in.
+ */
+export function sanitizeForInsertion(command: string): string {
+  return command.trim().replace(/^[$%]\s+/u, "");
+}

--- a/src/modules/ai/lib/completion.test.ts
+++ b/src/modules/ai/lib/completion.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildCompletionMessages, cleanCompletion } from "./completion";
+
+describe("cleanCompletion", () => {
+  it("passes plain text through unchanged", () => {
+    expect(cleanCompletion("1 + 2")).toBe("1 + 2");
+  });
+
+  it("unwraps a fenced code block with a language tag", () => {
+    expect(cleanCompletion("```ts\nconst x = 1\n```")).toBe("const x = 1");
+  });
+
+  it("unwraps a bare fenced code block", () => {
+    expect(cleanCompletion("```\nfoo bar\n```")).toBe("foo bar");
+  });
+
+  it("strips the echoed prefix line the model repeats back", () => {
+    expect(cleanCompletion("const x = 1 + 2", "const x = ")).toBe("1 + 2");
+  });
+
+  it("only strips the echo of the current line, not earlier lines", () => {
+    expect(cleanCompletion("  return n", "function f() {\n  ")).toBe("return n");
+  });
+});
+
+describe("buildCompletionMessages", () => {
+  it("returns a system instruction followed by the code context", () => {
+    const messages = buildCompletionMessages("const x = ", "\nconsole.log(x)", "typescript");
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe("system");
+    expect(messages[1].role).toBe("user");
+    expect(messages[1].content).toContain("const x = ");
+    expect(messages[1].content).toContain("console.log(x)");
+    expect(messages[1].content.toLowerCase()).toContain("typescript");
+  });
+});

--- a/src/modules/ai/lib/completion.ts
+++ b/src/modules/ai/lib/completion.ts
@@ -1,0 +1,50 @@
+import type { ChatMessage } from "./chat";
+
+/**
+ * Clean a raw model completion into the exact text to insert at the cursor.
+ * Models tend to wrap completions in code fences and sometimes echo back the
+ * line they are continuing, so strip both. `prefix` is the document text before
+ * the cursor; its last line is what the model might repeat.
+ */
+export function cleanCompletion(raw: string, prefix: string = ""): string {
+  let text = raw;
+  const trimmed = raw.trim();
+  const fence = trimmed.match(/^```[\w-]*\n([\s\S]*?)\n?```$/);
+  if (fence) {
+    text = fence[1];
+  } else {
+    const inline = trimmed.match(/^`([^`]*)`$/);
+    if (inline) {
+      text = inline[1];
+    }
+  }
+  const lastLine = prefix.slice(prefix.lastIndexOf("\n") + 1);
+  if (lastLine.length > 0 && text.startsWith(lastLine)) {
+    text = text.slice(lastLine.length);
+  }
+  return text;
+}
+
+const COMPLETION_SYSTEM =
+  "You are a code completion engine. Continue the code at the <CURSOR> marker. " +
+  "Output ONLY the raw text to insert at the cursor: no explanation, no surrounding " +
+  "code fences, no repetition of the code before the cursor.";
+
+/**
+ * Build the provider messages for a fill-in-the-middle completion request. The
+ * user turn shows the code with a <CURSOR> marker between prefix and suffix so
+ * the model knows exactly where the insertion goes.
+ */
+export function buildCompletionMessages(
+  prefix: string,
+  suffix: string,
+  language: string,
+): ChatMessage[] {
+  return [
+    { role: "system", content: COMPLETION_SYSTEM },
+    {
+      role: "user",
+      content: `Language: ${language}\n${prefix}<CURSOR>${suffix}`,
+    },
+  ];
+}

--- a/src/modules/ai/lib/context.test.ts
+++ b/src/modules/ai/lib/context.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { buildActiveFileBlock, buildTerminalBlock } from "./context";
+
+describe("buildActiveFileBlock", () => {
+  it("returns empty string when there is no active file path", () => {
+    expect(buildActiveFileBlock(null, "some content")).toBe("");
+    expect(buildActiveFileBlock("", "some content")).toBe("");
+  });
+
+  it("returns empty string when the file content is blank", () => {
+    expect(buildActiveFileBlock("/a/b.ts", "")).toBe("");
+    expect(buildActiveFileBlock("/a/b.ts", "   \n  ")).toBe("");
+  });
+
+  it("includes the file path and its content", () => {
+    const block = buildActiveFileBlock("/a/b.ts", "const x = 1");
+    expect(block).toContain("/a/b.ts");
+    expect(block).toContain("const x = 1");
+  });
+
+  it("truncates very long content with a marker", () => {
+    const block = buildActiveFileBlock("/a/big.ts", "x".repeat(20000));
+    expect(block).toContain("[truncated]");
+    expect(block.length).toBeLessThan(20000);
+  });
+});
+
+describe("buildTerminalBlock", () => {
+  it("returns empty string for blank terminal output", () => {
+    expect(buildTerminalBlock("")).toBe("");
+    expect(buildTerminalBlock("  \n \n ")).toBe("");
+  });
+
+  it("includes the terminal output and a label so the model knows the source", () => {
+    const block = buildTerminalBlock("$ npm test\nError: boom");
+    expect(block.toLowerCase()).toContain("terminal");
+    expect(block).toContain("$ npm test");
+    expect(block).toContain("Error: boom");
+  });
+
+  it("keeps only the last lines when the output is very long", () => {
+    const lines = Array.from({ length: 500 }, (_, i) => `line ${i}`).join("\n");
+    const block = buildTerminalBlock(lines, 100);
+    expect(block).toContain("line 499");
+    expect(block).not.toContain("line 0\n");
+  });
+});

--- a/src/modules/ai/lib/context.ts
+++ b/src/modules/ai/lib/context.ts
@@ -1,0 +1,43 @@
+import { truncateContents } from "./attachments";
+
+/** Budget for the active-file context block — larger than a casual attachment
+ * because it is the primary thing the user is looking at. */
+export const ACTIVE_FILE_MAX_BYTES = 8000;
+
+/**
+ * Render the file the user is currently viewing as a context block for the
+ * system prompt. Returns an empty string when there is no file or it is blank,
+ * so the caller can omit it entirely. The content is truncated so a huge file
+ * never blows up the prompt.
+ */
+export function buildActiveFileBlock(
+  path: string | null,
+  content: string,
+): string {
+  if (!path || content.trim().length === 0) {
+    return "";
+  }
+  const body = truncateContents(content, ACTIVE_FILE_MAX_BYTES);
+  return `The file the user is currently viewing (${path}):\n${body}`;
+}
+
+/** Default number of trailing terminal lines to keep as context. */
+export const TERMINAL_CONTEXT_MAX_LINES = 200;
+
+/**
+ * Render the active terminal's scrollback as a context block for the system
+ * prompt. Keeps only the last `maxLines` lines so a long session does not blow
+ * up the prompt, and returns an empty string when there is nothing to show.
+ */
+export function buildTerminalBlock(
+  raw: string,
+  maxLines: number = TERMINAL_CONTEXT_MAX_LINES,
+): string {
+  const trimmed = raw.replace(/\s+$/u, "");
+  if (trimmed.trim().length === 0) {
+    return "";
+  }
+  const lines = trimmed.split("\n");
+  const tail = lines.length > maxLines ? lines.slice(lines.length - maxLines) : lines;
+  return `Recent output from the user's active terminal:\n${tail.join("\n")}`;
+}

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -23,6 +23,8 @@ interface ChatState {
   error: string | null;
   /** Absolute file paths the user attached as extra context for the assistant. */
   attachedPaths: string[];
+  /** A one-shot snapshot of the active terminal's output, grabbed by the user. */
+  terminalContext: string | null;
   setProvider: (id: string) => void;
   setModel: (model: string) => void;
   send: (text: string, systemPrompt: string) => Promise<void>;
@@ -30,6 +32,7 @@ interface ChatState {
   attachPath: (path: string) => void;
   removeAttached: (path: string) => void;
   clearAttached: () => void;
+  setTerminalContext: (block: string | null) => void;
 }
 
 export const CHAT_STORAGE_KEY = "tempoterm-chat";
@@ -43,6 +46,7 @@ export const useChatStore = create<ChatState>()(
       sending: false,
       error: null,
       attachedPaths: [],
+      terminalContext: null,
 
       setProvider: (id) => {
         const provider = providerById(id);
@@ -98,6 +102,8 @@ export const useChatStore = create<ChatState>()(
         })),
 
       clearAttached: () => set({ attachedPaths: [] }),
+
+      setTerminalContext: (terminalContext) => set({ terminalContext }),
     }),
     {
       name: CHAT_STORAGE_KEY,

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -5,7 +5,12 @@ import CodeMirror from "@uiw/react-codemirror";
 import { EditorView as CMView } from "@codemirror/view";
 import { editorSyntaxTheme } from "@/themes/editorTheme";
 import { languageExtension } from "./lib/language";
+import { inlineCompletion, type CompletionRequest } from "./lib/inlineCompletion";
 import { useEditorStore } from "./store/editorStore";
+import { aiChat } from "@/modules/ai/lib/aiBridge";
+import { providerById } from "@/modules/ai/lib/providers";
+import { useChatStore } from "@/modules/ai/store/chatStore";
+import { buildCompletionMessages, cleanCompletion } from "@/modules/ai/lib/completion";
 import { shouldReloadFromDisk } from "./lib/reload";
 import { fsReadFile, fsWriteFile } from "@/modules/explorer/lib/fsBridge";
 import { basename } from "@/modules/explorer/lib/paths";
@@ -26,6 +31,30 @@ function isMarkdownPath(path: string): boolean {
   return /\.(md|markdown|mdx)$/i.test(path);
 }
 
+/** Short language label from a file path, used to hint the completion model. */
+function languageLabel(path: string): string {
+  const ext = path.slice(path.lastIndexOf(".") + 1).toLowerCase();
+  return ext.length > 0 && ext !== path ? ext : "text";
+}
+
+/** Ask the active chat provider to complete the code around the cursor. */
+async function requestCompletion(
+  prefix: string,
+  suffix: string,
+  language: string,
+): Promise<string> {
+  const { providerId, model } = useChatStore.getState();
+  const provider = providerById(providerId);
+  const reply = await aiChat({
+    provider: provider.id,
+    kind: provider.kind,
+    baseUrl: provider.baseUrl,
+    model,
+    messages: buildCompletionMessages(prefix, suffix, language),
+  });
+  return cleanCompletion(reply, prefix);
+}
+
 /** One open file. Each editor tab renders a single file with its own buffer. */
 export function EditorTabContent({ path }: { path: string }) {
   const { t } = useTranslation("editor");
@@ -39,6 +68,7 @@ export function EditorTabContent({ path }: { path: string }) {
   const themeId = useSettingsStore((s) => s.themeId);
   const wordWrap = useSettingsStore((s) => s.wordWrap);
   const toggleWordWrap = useSettingsStore((s) => s.toggleWordWrap);
+  const aiInlineCompletionEnabled = useSettingsStore((s) => s.aiInlineCompletion);
 
   const isMarkdown = isMarkdownPath(path);
   const [mode, setMode] = useState<EditorMode>("edit");
@@ -55,17 +85,23 @@ export function EditorTabContent({ path }: { path: string }) {
       .catch(() => setBaseline(path, ""));
   }, [path, setBaseline]);
 
-  const extensions = useMemo(
-    () => [
+  const extensions = useMemo(() => {
+    const base = [
       CMView.theme({
         "&": { height: "100%", fontSize: `${fontSize}px` },
         ".cm-content, .cm-gutters, .cm-scroller": { fontFamily },
       }),
       ...(wordWrap ? [CMView.lineWrapping] : []),
       ...languageExtension(path),
-    ],
-    [path, fontFamily, fontSize, wordWrap],
-  );
+    ];
+    if (aiInlineCompletionEnabled) {
+      const language = languageLabel(path);
+      const request: CompletionRequest = (prefix, suffix) =>
+        requestCompletion(prefix, suffix, language);
+      base.push(inlineCompletion(request));
+    }
+    return base;
+  }, [path, fontFamily, fontSize, wordWrap, aiInlineCompletionEnabled]);
 
   async function save() {
     const current = useEditorStore.getState().contentOf(path);

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -4,7 +4,7 @@ import { Columns2, Eye, SquarePen, WrapText, type LucideIcon } from "lucide-reac
 import CodeMirror from "@uiw/react-codemirror";
 import { EditorView as CMView } from "@codemirror/view";
 import { editorSyntaxTheme } from "@/themes/editorTheme";
-import { languageExtension } from "./lib/language";
+import { languageExtension, languageLabel } from "./lib/language";
 import { inlineCompletion, type CompletionRequest } from "./lib/inlineCompletion";
 import { useEditorStore } from "./store/editorStore";
 import { aiChat } from "@/modules/ai/lib/aiBridge";
@@ -29,12 +29,6 @@ const MODES: { key: EditorMode; icon: LucideIcon }[] = [
 
 function isMarkdownPath(path: string): boolean {
   return /\.(md|markdown|mdx)$/i.test(path);
-}
-
-/** Short language label from a file path, used to hint the completion model. */
-function languageLabel(path: string): string {
-  const ext = path.slice(path.lastIndexOf(".") + 1).toLowerCase();
-  return ext.length > 0 && ext !== path ? ext : "text";
 }
 
 /** Ask the active chat provider to complete the code around the cursor. */

--- a/src/modules/editor/lib/inlineCompletion.ts
+++ b/src/modules/editor/lib/inlineCompletion.ts
@@ -63,6 +63,9 @@ class GhostWidget extends WidgetType {
     span.className = "cm-ghost-text";
     span.style.opacity = "0.4";
     span.style.whiteSpace = "pre-wrap";
+    // Let clicks fall through to the editor so tapping the ghost text never
+    // parks the cursor inside a suggestion that isn't real document content.
+    span.style.pointerEvents = "none";
     span.textContent = this.text;
     return span;
   }

--- a/src/modules/editor/lib/inlineCompletion.ts
+++ b/src/modules/editor/lib/inlineCompletion.ts
@@ -1,0 +1,165 @@
+import { StateEffect, StateField, type Extension } from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+  keymap,
+} from "@codemirror/view";
+
+/** Ask the backend for a completion given the text around the cursor. Returns
+ * the raw text to insert (already cleaned), or an empty string for "nothing". */
+export type CompletionRequest = (prefix: string, suffix: string) => Promise<string>;
+
+interface Suggestion {
+  text: string;
+  pos: number;
+}
+
+const setSuggestion = StateEffect.define<Suggestion | null>();
+
+/** Holds the ghost suggestion and renders it as a dim widget after the cursor.
+ * Any edit or cursor move (that isn't the one setting the suggestion) clears it
+ * so a stale ghost never lingers. */
+const suggestionField = StateField.define<Suggestion | null>({
+  create: () => null,
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setSuggestion)) {
+        return effect.value;
+      }
+    }
+    if (tr.docChanged || tr.selection) {
+      return null;
+    }
+    return value;
+  },
+  provide: (field) =>
+    EditorView.decorations.from(field, (value): DecorationSet => {
+      if (!value || value.text.length === 0) {
+        return Decoration.none;
+      }
+      const widget = Decoration.widget({
+        widget: new GhostWidget(value.text),
+        side: 1,
+      });
+      return Decoration.set([widget.range(value.pos)]);
+    }),
+});
+
+class GhostWidget extends WidgetType {
+  constructor(readonly text: string) {
+    super();
+  }
+
+  eq(other: GhostWidget): boolean {
+    return other.text === this.text;
+  }
+
+  toDOM(): HTMLElement {
+    const span = document.createElement("span");
+    span.className = "cm-ghost-text";
+    span.style.opacity = "0.4";
+    span.style.whiteSpace = "pre-wrap";
+    span.textContent = this.text;
+    return span;
+  }
+
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+/** Insert the current ghost suggestion at its position and clear it. */
+function acceptSuggestion(view: EditorView): boolean {
+  const suggestion = view.state.field(suggestionField, false);
+  if (!suggestion || suggestion.text.length === 0) {
+    return false;
+  }
+  view.dispatch({
+    changes: { from: suggestion.pos, insert: suggestion.text },
+    selection: { anchor: suggestion.pos + suggestion.text.length },
+    effects: setSuggestion.of(null),
+  });
+  return true;
+}
+
+function dismissSuggestion(view: EditorView): boolean {
+  if (!view.state.field(suggestionField, false)) {
+    return false;
+  }
+  view.dispatch({ effects: setSuggestion.of(null) });
+  return true;
+}
+
+const DEBOUNCE_MS = 400;
+
+/**
+ * CodeMirror extension that requests an AI completion shortly after the user
+ * stops typing and shows it as ghost text. Tab accepts, Escape dismisses. The
+ * request is debounced and stale results (cursor moved meanwhile) are dropped.
+ */
+export function inlineCompletion(request: CompletionRequest): Extension {
+  const plugin = ViewPlugin.fromClass(
+    class {
+      timer: ReturnType<typeof setTimeout> | null = null;
+
+      constructor(readonly view: EditorView) {}
+
+      update(update: ViewUpdate): void {
+        if (update.docChanged) {
+          this.schedule();
+        }
+      }
+
+      schedule(): void {
+        if (this.timer) {
+          clearTimeout(this.timer);
+        }
+        this.timer = setTimeout(() => void this.fire(), DEBOUNCE_MS);
+      }
+
+      async fire(): Promise<void> {
+        const state = this.view.state;
+        const selection = state.selection.main;
+        if (!selection.empty) {
+          return;
+        }
+        const pos = selection.head;
+        const prefix = state.sliceDoc(0, pos);
+        if (prefix.trim().length === 0) {
+          return;
+        }
+        const suffix = state.sliceDoc(pos);
+        let text: string;
+        try {
+          text = await request(prefix, suffix);
+        } catch {
+          return;
+        }
+        // Drop the result if the user moved on or typed while we waited.
+        if (text.length === 0 || this.view.state.selection.main.head !== pos) {
+          return;
+        }
+        this.view.dispatch({ effects: setSuggestion.of({ text, pos }) });
+      }
+
+      destroy(): void {
+        if (this.timer) {
+          clearTimeout(this.timer);
+        }
+      }
+    },
+  );
+
+  return [
+    suggestionField,
+    plugin,
+    keymap.of([
+      { key: "Tab", run: acceptSuggestion },
+      { key: "Escape", run: dismissSuggestion },
+    ]),
+  ];
+}

--- a/src/modules/editor/lib/language.test.ts
+++ b/src/modules/editor/lib/language.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { languageIdForPath } from "./language";
+import { languageIdForPath, languageLabel } from "./language";
 
 describe("languageIdForPath", () => {
   it("maps JavaScript and TypeScript family extensions", () => {
@@ -30,5 +30,25 @@ describe("languageIdForPath", () => {
     expect(languageIdForPath("Makefile")).toBe("plaintext");
     expect(languageIdForPath("notes.xyz")).toBe("plaintext");
     expect(languageIdForPath("/path/to/file")).toBe("plaintext");
+  });
+});
+
+describe("languageLabel", () => {
+  it("returns text for an extensionless path that contains uppercase letters", () => {
+    expect(languageLabel("/home/user/README")).toBe("text");
+  });
+
+  it("returns the lowercased extension for a normal path", () => {
+    expect(languageLabel("src/main.go")).toBe("go");
+    expect(languageLabel("src/Component.TSX")).toBe("tsx");
+  });
+
+  it("uses the last extension for multi-dot names", () => {
+    expect(languageLabel("archive.tar.gz")).toBe("gz");
+  });
+
+  it("returns text for dotfiles and trailing-dot names", () => {
+    expect(languageLabel(".bashrc")).toBe("text");
+    expect(languageLabel("weird.")).toBe("text");
   });
 });

--- a/src/modules/editor/lib/language.ts
+++ b/src/modules/editor/lib/language.ts
@@ -45,6 +45,22 @@ export function languageIdForPath(path: string): LanguageId {
   return EXTENSION_MAP[ext] ?? "plaintext";
 }
 
+/**
+ * Short, freeform language hint from a file path's extension, used to prime the
+ * inline-completion model. Unlike {@link languageIdForPath} this keeps the raw
+ * extension (e.g. "go", "java"), so it is not limited to the grammars we bundle.
+ * Falls back to "text" when there is no extension (including dotfiles).
+ */
+export function languageLabel(path: string): string {
+  const name = path.split(/[\\/]/).pop() ?? "";
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) {
+    return "text";
+  }
+  const ext = name.slice(dot + 1).toLowerCase();
+  return ext.length > 0 ? ext : "text";
+}
+
 /** Resolve the CodeMirror language extension for a path (empty for plaintext). */
 export function languageExtension(path: string): Extension[] {
   switch (languageIdForPath(path)) {

--- a/src/modules/settings/AiSettingsSection.tsx
+++ b/src/modules/settings/AiSettingsSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Check, KeyRound } from "lucide-react";
 import { PROVIDERS, providerById } from "@/modules/ai/lib/providers";
 import { useChatStore } from "@/modules/ai/store/chatStore";
+import { useSettingsStore } from "@/stores/settingsStore";
 import { Combobox } from "@/components/Combobox";
 import {
   secretsDeleteKey,
@@ -43,6 +44,27 @@ function DefaultModelRow() {
           className="w-56"
         />
       </div>
+    </div>
+  );
+}
+
+function InlineCompletionRow() {
+  const { t } = useTranslation("settings");
+  const enabled = useSettingsStore((s) => s.aiInlineCompletion);
+  const setEnabled = useSettingsStore((s) => s.setAiInlineCompletion);
+
+  return (
+    <div className="mb-6">
+      <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => setEnabled(e.target.checked)}
+          className="accent-accent"
+        />
+        {t("aiInline.label")}
+      </label>
+      <p className="mt-1 text-xs text-fg-muted">{t("aiInline.description")}</p>
     </div>
   );
 }
@@ -143,6 +165,8 @@ export function AiSettingsSection() {
       </h2>
 
       <DefaultModelRow />
+
+      <InlineCompletionRow />
 
       <label className="mb-1 block text-sm font-medium text-fg">{t("aiKeys.title")}</label>
       <p className="mb-2 text-xs text-fg-muted">{t("aiKeys.description")}</p>

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -27,8 +27,10 @@ import {
 import {
   registerTerminal,
   registerTerminalPathDrop,
+  registerTerminalReader,
   unregisterTerminal,
   unregisterTerminalPathDrop,
+  unregisterTerminalReader,
 } from "./lib/terminalBus";
 import { imageFilesFromDrop, pathsFromDrop } from "./lib/terminalDrop";
 import {
@@ -513,6 +515,9 @@ export function TerminalView({
         if (leafIdRef.current) {
           registerTerminal(leafIdRef.current, (text) => void session.write(text));
           registerTerminalPathDrop(leafIdRef.current, (paths) => handlePathDrop(paths));
+          // Let the AI panel pull this pane's scrollback as context. Reads the
+          // tail so a long session does not serialize thousands of rows.
+          registerTerminalReader(leafIdRef.current, () => serializeBufferText(term, 300));
         }
         // A freshly opened tracking pane drives the explorer to its start dir
         // right away instead of waiting for the next cwd poll. (Lets "open in
@@ -620,6 +625,7 @@ export function TerminalView({
       if (leafIdRef.current) {
         unregisterTerminal(leafIdRef.current);
         unregisterTerminalPathDrop(leafIdRef.current);
+        unregisterTerminalReader(leafIdRef.current);
         useSessionStatusStore.getState().clear(leafIdRef.current);
       }
       // Unregister live SSH session on pane close so the connections panel

--- a/src/modules/terminal/lib/terminalBus.test.ts
+++ b/src/modules/terminal/lib/terminalBus.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  readTerminalBuffer,
+  registerTerminalReader,
+  unregisterTerminalReader,
+} from "./terminalBus";
+
+describe("terminal buffer readers", () => {
+  it("returns null when no reader is registered for a leaf", () => {
+    expect(readTerminalBuffer("missing")).toBeNull();
+  });
+
+  it("returns the registered reader's current output", () => {
+    registerTerminalReader("leaf-1", () => "hello from shell");
+    expect(readTerminalBuffer("leaf-1")).toBe("hello from shell");
+    unregisterTerminalReader("leaf-1");
+  });
+
+  it("stops returning output after the reader is unregistered", () => {
+    registerTerminalReader("leaf-2", () => "bye");
+    unregisterTerminalReader("leaf-2");
+    expect(readTerminalBuffer("leaf-2")).toBeNull();
+  });
+});

--- a/src/modules/terminal/lib/terminalBus.ts
+++ b/src/modules/terminal/lib/terminalBus.ts
@@ -3,9 +3,11 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { formatPathsForTerminal } from "./terminalClipboard";
 
 type Writer = (text: string) => void;
+type Reader = () => string;
 type PathDropHandler = (paths: string[]) => boolean | Promise<boolean>;
 
 const writers = new Map<string, Writer>();
+const readers = new Map<string, Reader>();
 const pathDropHandlers = new Map<string, PathDropHandler>();
 const pending = new Map<string, string[]>();
 
@@ -21,6 +23,21 @@ export function registerTerminal(leafId: string, write: Writer): void {
 
 export function unregisterTerminal(leafId: string): void {
   writers.delete(leafId);
+}
+
+/** A terminal pane registers how to read its current scrollback as plain text. */
+export function registerTerminalReader(leafId: string, read: Reader): void {
+  readers.set(leafId, read);
+}
+
+export function unregisterTerminalReader(leafId: string): void {
+  readers.delete(leafId);
+}
+
+/** Read a specific pane's scrollback, or null if it has no reader registered. */
+export function readTerminalBuffer(leafId: string): string | null {
+  const read = readers.get(leafId);
+  return read ? read() : null;
 }
 
 export function registerTerminalPathDrop(leafId: string, drop: PathDropHandler): void {
@@ -68,11 +85,13 @@ export function dropPathsIntoTerminal(leafId: string, paths: string[]): boolean 
 }
 
 /**
- * Run a command in a terminal: reuse the active terminal tab if there is one,
- * otherwise the first terminal in the active space, otherwise open a new one.
- * The command is queued if the target pane's shell is still starting.
+ * Resolve the terminal pane to target: the active terminal tab if there is one,
+ * otherwise the first terminal in the active space, otherwise the first terminal
+ * anywhere. Returns the owning tab id and its active leaf id, or null when no
+ * terminal exists. Pure lookup — callers decide whether to focus the tab, since
+ * reading for context should not yank the user to another tab.
  */
-export function runCommandInTerminal(command: string): void {
+function resolveActiveTerminal(): { tabId: string; leafId: string } | null {
   const store = useTabsStore.getState();
   const active = store.tabs.find((t) => t.id === store.activeId);
   const tab =
@@ -80,14 +99,26 @@ export function runCommandInTerminal(command: string): void {
       ? active
       : (store.tabs.find((t) => t.kind === "terminal" && t.spaceId === store.activeSpaceId) ??
         store.tabs.find((t) => t.kind === "terminal"));
+  if (!tab || tab.kind !== "terminal") {
+    return null;
+  }
+  return { tabId: tab.id, leafId: tab.activeLeafId };
+}
 
+/**
+ * Run a command in a terminal: reuse the active terminal tab if there is one,
+ * otherwise the first terminal in the active space, otherwise open a new one.
+ * The command is queued if the target pane's shell is still starting.
+ */
+export function runCommandInTerminal(command: string): void {
+  const resolved = resolveActiveTerminal();
   let leafId: string;
-  if (tab && tab.kind === "terminal") {
-    leafId = tab.activeLeafId;
-    store.setActive(tab.id);
+  if (resolved) {
+    leafId = resolved.leafId;
+    useTabsStore.getState().setActive(resolved.tabId);
   } else {
     const root = useWorkspaceStore.getState().rootPath ?? undefined;
-    store.newTerminalTab(root);
+    useTabsStore.getState().newTerminalTab(root);
     const created = useTabsStore.getState().tabs.find(
       (t) => t.id === useTabsStore.getState().activeId,
     );
@@ -98,4 +129,27 @@ export function runCommandInTerminal(command: string): void {
   }
 
   writeToTerminal(leafId, command.endsWith("\n") ? command : `${command}\n`);
+}
+
+/** Read the active terminal's scrollback as plain text, or null if there is
+ * none. Does not change the active tab — it only reads for context. */
+export function readActiveTerminalBuffer(): string | null {
+  const resolved = resolveActiveTerminal();
+  return resolved ? readTerminalBuffer(resolved.leafId) : null;
+}
+
+/**
+ * Insert text into the active terminal's prompt WITHOUT running it (no trailing
+ * newline), so the user can review and press Enter themselves. Focuses the
+ * terminal so the inserted text is visible. Returns false when there is no
+ * terminal to insert into.
+ */
+export function insertIntoActiveTerminal(text: string): boolean {
+  const resolved = resolveActiveTerminal();
+  if (!resolved) {
+    return false;
+  }
+  useTabsStore.getState().setActive(resolved.tabId);
+  writeToTerminal(resolved.leafId, text);
+  return true;
 }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -41,6 +41,8 @@ interface SettingsState {
   prSource: WorkspacePrSource;
   /** Install the Claude Code hook that reports live session status to cards. */
   claudeStatusTracking: boolean;
+  /** Show AI ghost-text completions while typing in the code editor. */
+  aiInlineCompletion: boolean;
   setLanguage: (language: SupportedLanguage) => void;
   setThemeId: (themeId: string) => void;
   setTerminalPadding: (padding: number) => void;
@@ -50,6 +52,7 @@ interface SettingsState {
   setWorkspaceCardBlock: (key: keyof WorkspaceCardBlocks, value: boolean) => void;
   setPrSource: (source: WorkspacePrSource) => void;
   setClaudeStatusTracking: (value: boolean) => void;
+  setAiInlineCompletion: (value: boolean) => void;
 }
 
 export const SETTINGS_STORAGE_KEY = "tempoterm-settings";
@@ -73,6 +76,7 @@ export const useSettingsStore = create<SettingsState>()(
       workspaceCard: DEFAULT_WORKSPACE_CARD,
       prSource: "auto",
       claudeStatusTracking: true,
+      aiInlineCompletion: false,
       setLanguage: (language) => set({ language }),
       setThemeId: (themeId) => set({ themeId }),
       setTerminalPadding: (padding) => set({ terminalPadding: clampPadding(padding) }),
@@ -83,6 +87,7 @@ export const useSettingsStore = create<SettingsState>()(
         set((state) => ({ workspaceCard: { ...state.workspaceCard, [key]: value } })),
       setPrSource: (prSource) => set({ prSource }),
       setClaudeStatusTracking: (value) => set({ claudeStatusTracking: value }),
+      setAiInlineCompletion: (value) => set({ aiInlineCompletion: value }),
     }),
     {
       name: SETTINGS_STORAGE_KEY,


### PR DESCRIPTION
## Summary

Four features that make the AI assistant aware of what the user is doing and able to act on it, plus an editor inline-completion mode.

- **See the open file's content (F1):** the active editor file's content (truncated) is added to the system prompt, not just its path. New pure helper `buildActiveFileBlock` pulls the content from `editorStore` at send time.
- **Grab terminal output as context (F2):** a terminal button in the AI input row captures the active pane's scrollback as removable context (shown as a chip), reusing `serializeBufferText` through a `terminalBus` reader map. Reading never switches the pane the user is currently viewing. The button shows an accent active state while context is attached, with a state-aware tooltip.
- **Insert a suggested command (F3):** when an assistant reply contains a shell command, an "insert into terminal" button writes it to the active terminal prompt **without** a trailing newline, so it never auto-runs. Pure helpers `extractCommand` / `sanitizeForInsertion` handle extraction and trimming.
- **Editor inline completion / ghost text (F4):** after a typing pause, CodeMirror shows a greyed-out suggestion; Tab accepts, Esc dismisses. Off by default, toggled in the AI settings section (which notes it consumes the default model's quota). Pure logic lives in `completion.ts`; the ghost-text extension wires into the existing provider plumbing via `inlineCompletion.ts`.

## Implementation notes

- New pure modules with unit tests: `ai/lib/context.ts`, `ai/lib/command.ts`, `ai/lib/completion.ts`, `terminal/lib/terminalBus` reader, `editor/lib/inlineCompletion.ts`.
- Wiring touches `AIView`, `chatStore`, `TerminalView`, `terminalBus`, `EditorTabContent`, `settingsStore`, `AiSettingsSection`, plus en / zh-Hant i18n strings.
- Split into two commits: AI panel context features (F1/F2/F3) and editor inline completion (F4).

## Test plan

- [x] `pnpm test` — 643 passing
- [x] `pnpm build` — typecheck + production build clean
- [ ] Manual: open a file, ask the assistant about it, confirm it sees the content (F1)
- [ ] Manual: grab terminal output, confirm the chip appears and the active state shows, and the viewed pane does not switch (F2)
- [ ] Manual: get a command suggestion, click insert, confirm it lands at the prompt without running (F3)
- [ ] Manual: enable inline completion in settings, type and pause, confirm ghost text + Tab/Esc (F4)