### PR TITLE
feat(sftp): browse and edit remote files over SFTP when an SSH pane is active

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1039,6 +1039,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2098,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2225,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -4502,6 +4534,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "russh-sftp"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed8949eca4163c18a8f59ff96d32cf61e9c13b9735e21ef32b3907f4aafa1a9"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "gloo-timers",
+ "log",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "russh-util"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4823,6 +4875,16 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5804,6 +5866,7 @@ dependencies = [
  "portable-pty",
  "reqwest 0.12.28",
  "russh",
+ "russh-sftp",
  "serde",
  "serde_json",
  "tauri",
@@ -5968,6 +6031,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ notify = "6"
 toml_edit = "0.22"
 chrono = "0.4"
 russh = "0.61.2"
+russh-sftp = "2"
 
 # keyring 3.x ships no credential store by default; each platform must opt into
 # its native backend or every keychain operation fails silently.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,7 +38,9 @@ use modules::ssh::{
     ssh_close, ssh_forward_start, ssh_forward_stop, ssh_open, ssh_prompt_reply, ssh_resize,
     ssh_write, SshState,
 };
-use modules::sftp::{sftp_close, sftp_home, sftp_read_dir, sftp_start, SftpState};
+use modules::sftp::{
+    sftp_close, sftp_home, sftp_read_dir, sftp_read_file, sftp_start, sftp_write_file, SftpState,
+};
 use modules::terminal_history::{
     terminal_history_clear, terminal_history_delete, terminal_history_load,
     terminal_history_prune, terminal_history_save,
@@ -189,6 +191,8 @@ pub fn run() {
             sftp_start,
             sftp_home,
             sftp_read_dir,
+            sftp_read_file,
+            sftp_write_file,
             sftp_close,
             ssh_secret_set,
             ssh_secret_delete

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ use modules::ssh::{
     ssh_close, ssh_forward_start, ssh_forward_stop, ssh_open, ssh_prompt_reply, ssh_resize,
     ssh_write, SshState,
 };
+use modules::sftp::{sftp_close, sftp_home, sftp_read_dir, sftp_start, SftpState};
 use modules::terminal_history::{
     terminal_history_clear, terminal_history_delete, terminal_history_load,
     terminal_history_prune, terminal_history_save,
@@ -80,6 +81,7 @@ pub fn run() {
         )
         .manage(PtyState::new())
         .manage(SshState::new())
+        .manage(SftpState::new())
         .manage(ClaudeProgressState::new())
         .manage(CodexProgressState::new())
         .manage(NotesWatchState::new())
@@ -184,6 +186,10 @@ pub fn run() {
             ssh_prompt_reply,
             ssh_forward_start,
             ssh_forward_stop,
+            sftp_start,
+            sftp_home,
+            sftp_read_dir,
+            sftp_close,
             ssh_secret_set,
             ssh_secret_delete
         ])

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,5 +1,6 @@
 pub mod ai;
 pub mod ssh;
+pub mod sftp;
 pub mod claude_progress;
 pub mod claude_status_hook;
 pub mod codex_progress;

--- a/src-tauri/src/modules/sftp/mod.rs
+++ b/src-tauri/src/modules/sftp/mod.rs
@@ -1,0 +1,38 @@
+mod session;
+
+pub use session::SftpState;
+use session::{SftpEntry, SftpStartRequest};
+
+use tauri::{AppHandle, State};
+
+use crate::modules::ssh::SshState;
+
+#[tauri::command]
+pub fn sftp_start(
+    app: AppHandle,
+    window: tauri::WebviewWindow,
+    ssh_state: State<'_, SshState>,
+    state: State<'_, SftpState>,
+    req: SftpStartRequest,
+) -> Result<u32, String> {
+    session::start(&app, window.label().to_string(), &ssh_state, &state, req)
+}
+
+#[tauri::command]
+pub async fn sftp_home(state: State<'_, SftpState>, id: u32) -> Result<String, String> {
+    session::home(&state, id).await
+}
+
+#[tauri::command]
+pub async fn sftp_read_dir(
+    state: State<'_, SftpState>,
+    id: u32,
+    path: String,
+) -> Result<Vec<SftpEntry>, String> {
+    session::read_dir_cmd(&state, id, path).await
+}
+
+#[tauri::command]
+pub fn sftp_close(state: State<'_, SftpState>, id: u32) {
+    session::close(&state, id)
+}

--- a/src-tauri/src/modules/sftp/mod.rs
+++ b/src-tauri/src/modules/sftp/mod.rs
@@ -33,6 +33,25 @@ pub async fn sftp_read_dir(
 }
 
 #[tauri::command]
+pub async fn sftp_read_file(
+    state: State<'_, SftpState>,
+    id: u32,
+    path: String,
+) -> Result<String, String> {
+    session::read_file_cmd(&state, id, path).await
+}
+
+#[tauri::command]
+pub async fn sftp_write_file(
+    state: State<'_, SftpState>,
+    id: u32,
+    path: String,
+    contents: String,
+) -> Result<(), String> {
+    session::write_file_cmd(&state, id, path, contents).await
+}
+
+#[tauri::command]
 pub fn sftp_close(state: State<'_, SftpState>, id: u32) {
     session::close(&state, id)
 }

--- a/src-tauri/src/modules/sftp/session.rs
+++ b/src-tauri/src/modules/sftp/session.rs
@@ -1,0 +1,257 @@
+//! SFTP session manager. Each session owns its own dedicated SSH connection
+//! (separate from the interactive shell), driven on one worker thread with a
+//! current-thread tokio runtime, exactly like the `ssh` and `pty` modules.
+//! Control messages carry a `oneshot` so each command awaits its own reply.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tauri::{AppHandle, Manager, State};
+use tokio::sync::{mpsc, oneshot};
+
+use russh_sftp::client::SftpSession;
+
+use crate::modules::ssh::{
+    connect_authenticated, AuthedConnectArgs, PromptRegistryHandle, SshState,
+};
+
+/// One remote directory entry, shaped to match the frontend `DirEntry`.
+#[derive(serde::Serialize)]
+pub struct SftpEntry {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+    pub size: u64,
+}
+
+/// A control message from a Tauri command thread to a session's worker.
+pub enum SftpControl {
+    ReadDir {
+        path: String,
+        reply: oneshot::Sender<Result<Vec<SftpEntry>, String>>,
+    },
+    Home {
+        reply: oneshot::Sender<Result<String, String>>,
+    },
+    Close,
+}
+
+struct SftpHandle {
+    control: mpsc::UnboundedSender<SftpControl>,
+}
+
+/// Inbound connection parameters, mirroring `SshOpenRequest` minus the
+/// terminal-only fields. The frontend supplies these from `connectionsStore`.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SftpStartRequest {
+    pub connection_id: String,
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub auth_method: String,
+    pub key_path: Option<String>,
+}
+
+/// Holds every live SFTP session. Ids start high so a session's interactive
+/// prompt id (`{id}-password`) never collides with a shell session's, since
+/// both share the ssh PromptRegistry.
+pub struct SftpState {
+    sessions: Mutex<HashMap<u32, SftpHandle>>,
+    next_id: AtomicU32,
+}
+
+impl SftpState {
+    pub fn new() -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            next_id: AtomicU32::new(1_000_000),
+        }
+    }
+
+    fn alloc_id(&self) -> u32 {
+        self.next_id.fetch_add(1, Ordering::Relaxed) + 1
+    }
+}
+
+pub fn start(
+    app: &AppHandle,
+    window_label: String,
+    ssh_state: &State<'_, SshState>,
+    state: &State<'_, SftpState>,
+    req: SftpStartRequest,
+) -> Result<u32, String> {
+    let id = state.alloc_id();
+    let (tx, rx) = mpsc::unbounded_channel::<SftpControl>();
+    state
+        .sessions
+        .lock()
+        .unwrap()
+        .insert(id, SftpHandle { control: tx });
+
+    let registry = ssh_state.registry.clone();
+    let app = app.clone();
+    let known_hosts_path = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("ssh_known_hosts");
+
+    std::thread::spawn(move || {
+        let cleanup_app = app.clone();
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(_) => {
+                remove_session(&cleanup_app, id);
+                return;
+            }
+        };
+        rt.block_on(run(app, window_label, registry, known_hosts_path, req, id, rx));
+        remove_session(&cleanup_app, id);
+    });
+
+    Ok(id)
+}
+
+async fn run(
+    app: AppHandle,
+    window_label: String,
+    registry: Arc<PromptRegistryHandle>,
+    known_hosts_path: std::path::PathBuf,
+    req: SftpStartRequest,
+    session_id: u32,
+    rx: mpsc::UnboundedReceiver<SftpControl>,
+) {
+    let handle = match connect_authenticated(AuthedConnectArgs {
+        app,
+        window_label,
+        registry,
+        known_hosts_path,
+        host: req.host,
+        port: req.port,
+        user: req.user,
+        auth_method: req.auth_method,
+        key_path: req.key_path,
+        connection_id: req.connection_id,
+        session_id,
+    })
+    .await
+    {
+        Ok(handle) => handle,
+        Err(e) => return fail(rx, e).await,
+    };
+
+    let channel = match handle.channel_open_session().await {
+        Ok(c) => c,
+        Err(e) => return fail(rx, format!("failed to open SFTP channel: {e}")).await,
+    };
+    if let Err(e) = channel.request_subsystem(true, "sftp").await {
+        return fail(rx, format!("failed to start SFTP subsystem: {e}")).await;
+    }
+    let sftp = match SftpSession::new(channel.into_stream()).await {
+        Ok(s) => s,
+        Err(e) => return fail(rx, format!("failed to initialize SFTP: {e}")).await,
+    };
+
+    let mut rx = rx;
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            SftpControl::ReadDir { path, reply } => {
+                let _ = reply.send(read_dir(&sftp, &path).await);
+            }
+            SftpControl::Home { reply } => {
+                let _ = reply.send(
+                    sftp.canonicalize(".".to_string())
+                        .await
+                        .map_err(|e| e.to_string()),
+                );
+            }
+            SftpControl::Close => break,
+        }
+    }
+}
+
+/// After a connect/auth failure, answer every queued and future request with the
+/// same readable error until the channel closes, so callers see why.
+async fn fail(mut rx: mpsc::UnboundedReceiver<SftpControl>, reason: String) {
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            SftpControl::ReadDir { reply, .. } => {
+                let _ = reply.send(Err(reason.clone()));
+            }
+            SftpControl::Home { reply } => {
+                let _ = reply.send(Err(reason.clone()));
+            }
+            SftpControl::Close => break,
+        }
+    }
+}
+
+async fn read_dir(sftp: &SftpSession, path: &str) -> Result<Vec<SftpEntry>, String> {
+    let canonical = sftp
+        .canonicalize(path.to_string())
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for entry in sftp
+        .read_dir(canonical.clone())
+        .await
+        .map_err(|e| e.to_string())?
+    {
+        let md = entry.metadata();
+        let name = entry.file_name();
+        let full = if canonical.ends_with('/') {
+            format!("{canonical}{name}")
+        } else {
+            format!("{canonical}/{name}")
+        };
+        out.push(SftpEntry {
+            name,
+            path: full,
+            is_dir: md.file_type().is_dir(),
+            size: md.size.unwrap_or(0),
+        });
+    }
+    Ok(out)
+}
+
+fn send(state: &State<'_, SftpState>, id: u32, msg: SftpControl) -> Result<(), String> {
+    let sessions = state.sessions.lock().unwrap();
+    let handle = sessions
+        .get(&id)
+        .ok_or_else(|| format!("sftp session {id} not found"))?;
+    handle
+        .control
+        .send(msg)
+        .map_err(|_| "sftp session closed".to_string())
+}
+
+pub async fn home(state: &State<'_, SftpState>, id: u32) -> Result<String, String> {
+    let (tx, rx) = oneshot::channel();
+    send(state, id, SftpControl::Home { reply: tx })?;
+    rx.await.map_err(|_| "sftp session closed".to_string())?
+}
+
+pub async fn read_dir_cmd(
+    state: &State<'_, SftpState>,
+    id: u32,
+    path: String,
+) -> Result<Vec<SftpEntry>, String> {
+    let (tx, rx) = oneshot::channel();
+    send(state, id, SftpControl::ReadDir { path, reply: tx })?;
+    rx.await.map_err(|_| "sftp session closed".to_string())?
+}
+
+pub fn close(state: &State<'_, SftpState>, id: u32) {
+    let _ = send(state, id, SftpControl::Close);
+    state.sessions.lock().unwrap().remove(&id);
+}
+
+fn remove_session(app: &AppHandle, id: u32) {
+    let state = app.state::<SftpState>();
+    state.sessions.lock().unwrap().remove(&id);
+}

--- a/src-tauri/src/modules/sftp/session.rs
+++ b/src-tauri/src/modules/sftp/session.rs
@@ -34,6 +34,15 @@ pub enum SftpControl {
     Home {
         reply: oneshot::Sender<Result<String, String>>,
     },
+    ReadFile {
+        path: String,
+        reply: oneshot::Sender<Result<String, String>>,
+    },
+    WriteFile {
+        path: String,
+        contents: String,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
     Close,
 }
 
@@ -170,6 +179,16 @@ async fn run(
                         .map_err(|e| e.to_string()),
                 );
             }
+            SftpControl::ReadFile { path, reply } => {
+                let _ = reply.send(read_file(&sftp, &path).await);
+            }
+            SftpControl::WriteFile {
+                path,
+                contents,
+                reply,
+            } => {
+                let _ = reply.send(write_file(&sftp, &path, &contents).await);
+            }
             SftpControl::Close => break,
         }
     }
@@ -184,6 +203,12 @@ async fn fail(mut rx: mpsc::UnboundedReceiver<SftpControl>, reason: String) {
                 let _ = reply.send(Err(reason.clone()));
             }
             SftpControl::Home { reply } => {
+                let _ = reply.send(Err(reason.clone()));
+            }
+            SftpControl::ReadFile { reply, .. } => {
+                let _ = reply.send(Err(reason.clone()));
+            }
+            SftpControl::WriteFile { reply, .. } => {
                 let _ = reply.send(Err(reason.clone()));
             }
             SftpControl::Close => break,
@@ -219,6 +244,31 @@ async fn read_dir(sftp: &SftpSession, path: &str) -> Result<Vec<SftpEntry>, Stri
     Ok(out)
 }
 
+async fn read_file(sftp: &SftpSession, path: &str) -> Result<String, String> {
+    use tokio::io::AsyncReadExt;
+    let mut file = sftp.open(path.to_string()).await.map_err(|e| e.to_string())?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).await.map_err(|e| e.to_string())?;
+    String::from_utf8(buf).map_err(|_| "file is not valid UTF-8".to_string())
+}
+
+async fn write_file(sftp: &SftpSession, path: &str, contents: &str) -> Result<(), String> {
+    use russh_sftp::protocol::OpenFlags;
+    use tokio::io::AsyncWriteExt;
+    let mut file = sftp
+        .open_with_flags(
+            path.to_string(),
+            OpenFlags::CREATE | OpenFlags::WRITE | OpenFlags::TRUNCATE,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    file.write_all(contents.as_bytes())
+        .await
+        .map_err(|e| e.to_string())?;
+    file.shutdown().await.map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 fn send(state: &State<'_, SftpState>, id: u32, msg: SftpControl) -> Result<(), String> {
     let sessions = state.sessions.lock().unwrap();
     let handle = sessions
@@ -243,6 +293,35 @@ pub async fn read_dir_cmd(
 ) -> Result<Vec<SftpEntry>, String> {
     let (tx, rx) = oneshot::channel();
     send(state, id, SftpControl::ReadDir { path, reply: tx })?;
+    rx.await.map_err(|_| "sftp session closed".to_string())?
+}
+
+pub async fn read_file_cmd(
+    state: &State<'_, SftpState>,
+    id: u32,
+    path: String,
+) -> Result<String, String> {
+    let (tx, rx) = oneshot::channel();
+    send(state, id, SftpControl::ReadFile { path, reply: tx })?;
+    rx.await.map_err(|_| "sftp session closed".to_string())?
+}
+
+pub async fn write_file_cmd(
+    state: &State<'_, SftpState>,
+    id: u32,
+    path: String,
+    contents: String,
+) -> Result<(), String> {
+    let (tx, rx) = oneshot::channel();
+    send(
+        state,
+        id,
+        SftpControl::WriteFile {
+            path,
+            contents,
+            reply: tx,
+        },
+    )?;
     rx.await.map_err(|_| "sftp session closed".to_string())?
 }
 

--- a/src-tauri/src/modules/ssh/client.rs
+++ b/src-tauri/src/modules/ssh/client.rs
@@ -630,6 +630,70 @@ async fn authenticate_agent(
     Ok(false)
 }
 
+/// Public alias for the shared prompt registry handle, so sibling modules can
+/// name the type of `SshState.registry` without touching `prompt`'s internals.
+pub type PromptRegistryHandle = PromptRegistry;
+
+/// Everything needed to open a fresh, fully-authenticated SSH connection that
+/// reuses the same host-key verification and keyring secret lookup the shell
+/// uses. Used by the sftp module so SFTP rides its own connection without
+/// duplicating auth.
+pub struct AuthedConnectArgs {
+    pub app: AppHandle,
+    pub window_label: String,
+    pub registry: Arc<PromptRegistry>,
+    pub known_hosts_path: PathBuf,
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub auth_method: String,
+    pub key_path: Option<String>,
+    pub connection_id: String,
+    pub session_id: u32,
+}
+
+/// Connect, verify the host key, and authenticate in one call. Returns the live
+/// handle on success; `Err` on connect failure, rejected credentials, or a
+/// cancelled prompt.
+pub async fn connect_authenticated(
+    args: AuthedConnectArgs,
+) -> Result<russh::client::Handle<VerifyingClient>, String> {
+    let handler = VerifyingClient {
+        app: args.app.clone(),
+        window_label: args.window_label.clone(),
+        registry: args.registry.clone(),
+        known_hosts_path: args.known_hosts_path,
+        host: args.host.clone(),
+        port: args.port,
+        session_id: args.session_id,
+    };
+    let mut handle = connect(ConnectArgs {
+        handler,
+        host: args.host.clone(),
+        port: args.port,
+    })
+    .await?;
+    let auth = AuthArgs {
+        user: args.user,
+        auth_method: args.auth_method,
+        key_path: args.key_path,
+        connection_id: args.connection_id,
+    };
+    match authenticate(
+        &mut handle,
+        &auth,
+        &args.registry,
+        &args.app,
+        &args.window_label,
+        args.session_id,
+    )
+    .await?
+    {
+        true => Ok(handle),
+        false => Err("authentication failed".to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/modules/ssh/mod.rs
+++ b/src-tauri/src/modules/ssh/mod.rs
@@ -1,4 +1,4 @@
-mod client;
+pub(crate) mod client;
 mod forward;
 mod known_hosts;
 mod prompt;
@@ -6,6 +6,7 @@ mod session;
 
 pub use prompt::PromptReply;
 pub use session::SshState;
+pub(crate) use client::{connect_authenticated, AuthedConnectArgs, PromptRegistryHandle};
 
 use tauri::ipc::{Channel, Response};
 use tauri::{AppHandle, State};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { useWatchNotes } from "@/modules/notes/lib/useWatchNotes";
 import { registerSecondaryWindowCleanup } from "@/lib/windowLifecycle";
 import { SshPromptDialog } from "@/modules/ssh/SshPromptDialog";
 import { useForwardStatusListener } from "@/modules/ssh/lib/useForwardStatus";
+import { sftpSessionStore } from "@/modules/ssh/lib/sftpSessionStore";
 
 const MIN_SIDEBAR = 180;
 const MAX_SIDEBAR = 640;
@@ -65,6 +66,12 @@ function App() {
       })
       .catch(() => {});
     return () => unlisten?.();
+  }, []);
+
+  // Close any open SFTP connections when this window goes away so no remote
+  // connection leaks.
+  useEffect(() => {
+    return () => sftpSessionStore.getState().closeAll();
   }, []);
 
   // Keep the Claude session-status hook installed when tracking is enabled, so

--- a/src/components/TabsArea.test.tsx
+++ b/src/components/TabsArea.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useTabsStore } from "@/stores/tabsStore";
+import { leaf } from "@/modules/terminal/lib/terminalLayout";
+
+// Track when a tab's content mounts/unmounts so we can assert that switching
+// workspaces never tears a running terminal down.
+const { mountSpy, unmountSpy } = vi.hoisted(() => ({
+  mountSpy: vi.fn(),
+  unmountSpy: vi.fn(),
+}));
+
+vi.mock("@/modules/terminal/PaneTabContent", async () => {
+  const { useEffect } = await import("react");
+  return {
+    PaneTabContent: ({ tab }: { tab: { id: string } }) => {
+      useEffect(() => {
+        mountSpy(tab.id);
+        return () => unmountSpy(tab.id);
+      }, [tab.id]);
+      return <div data-testid={`pane-${tab.id}`} />;
+    },
+  };
+});
+
+vi.mock("@/components/LauncherPanel", () => ({
+  LauncherPanel: () => <div data-testid="launcher" />,
+}));
+
+import { TabsArea } from "./TabsArea";
+
+beforeEach(() => {
+  mountSpy.mockClear();
+  unmountSpy.mockClear();
+  useTabsStore.setState({
+    spaces: [{ id: "s1", name: "One" }],
+    activeSpaceId: "s1",
+    tabs: [
+      {
+        id: "t1",
+        spaceId: "s1",
+        title: "Terminal 1",
+        kind: "terminal",
+        paneTree: leaf("p1", { kind: "terminal" }),
+        activeLeafId: "p1",
+      },
+    ],
+    activeId: "t1",
+  });
+});
+
+describe("TabsArea", () => {
+  it("keeps an existing tab mounted when a new workspace clears the active tab", () => {
+    render(<TabsArea />);
+    expect(mountSpy).toHaveBeenCalledWith("t1");
+    expect(unmountSpy).not.toHaveBeenCalled();
+
+    // Opening a new, empty workspace leaves no active tab. The terminal running
+    // in the previous workspace must keep its session alive, not be torn down.
+    act(() => {
+      useTabsStore.getState().newSpace("Two");
+    });
+
+    expect(unmountSpy).not.toHaveBeenCalled();
+    expect(screen.getByTestId("pane-t1")).toBeInTheDocument();
+  });
+
+  it("returns to the same running session after a round trip through a new workspace", () => {
+    render(<TabsArea />);
+
+    act(() => {
+      useTabsStore.getState().newSpace("Two");
+    });
+    act(() => {
+      useTabsStore.getState().setActiveSpace("s1");
+    });
+
+    // Mounted exactly once and never torn down: the terminal the user comes back
+    // to is the original live session, not a fresh shell restored from history.
+    expect(mountSpy).toHaveBeenCalledTimes(1);
+    expect(unmountSpy).not.toHaveBeenCalled();
+    expect(screen.getByTestId("pane-t1")).toBeInTheDocument();
+  });
+});

--- a/src/components/TabsArea.tsx
+++ b/src/components/TabsArea.tsx
@@ -10,7 +10,11 @@ import { useTabsStore } from "@/stores/tabsStore";
  * session restored with many tabs does not spawn every shell and read every
  * file at once. Once a tab has been activated it stays mounted (kept hidden
  * when inactive) so its terminals keep running for the rest of the session.
- * With no tabs at all, the launcher takes over the whole area.
+ *
+ * When there is no active tab (a fresh launch, or after opening a new, empty
+ * workspace) the launcher is shown as an overlay on top of the still-mounted
+ * tabs — it must NOT replace the tab subtree, or every space's terminals would
+ * unmount and their shells (e.g. a running Claude session) would be killed.
  */
 export function TabsArea() {
   const tabs = useTabsStore((s) => s.tabs);
@@ -24,10 +28,6 @@ export function TabsArea() {
   );
   if (activeId && !mountedIds.has(activeId)) {
     setMountedIds((prev) => new Set(prev).add(activeId));
-  }
-
-  if (!activeId) {
-    return <LauncherPanel />;
   }
 
   return (
@@ -50,6 +50,14 @@ export function TabsArea() {
           </div>
         );
       })}
+
+      {/* No active tab: overlay the launcher without unmounting the tabs behind
+          it, so their terminal sessions keep running. */}
+      {!activeId && (
+        <div className="absolute inset-0">
+          <LauncherPanel />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/modules/explorer/ExplorerView.test.tsx
+++ b/src/modules/explorer/ExplorerView.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/i18n";
+
+vi.mock("./lib/fsBridge", () => ({ fsReadDir: vi.fn().mockResolvedValue([]) }));
+
+import { ExplorerView } from "./ExplorerView";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+beforeEach(() => {
+  useWorkspaceStore.setState({ rootPath: null, openFiles: [], activeFile: null });
+});
+
+describe("ExplorerView remote root", () => {
+  it("hides the open-folder and find buttons and shows the remote path", () => {
+    useWorkspaceStore.setState({ rootPath: "ssh://c1/home/me" });
+    render(<ExplorerView />);
+    expect(screen.queryByLabelText("Open folder")).toBeNull();
+    expect(screen.queryByLabelText("Find files")).toBeNull();
+    expect(screen.getByText("/home/me")).toBeInTheDocument();
+  });
+
+  it("keeps the buttons for a local root", () => {
+    useWorkspaceStore.setState({ rootPath: "/home/me" });
+    render(<ExplorerView />);
+    expect(screen.getByLabelText("Open folder")).toBeInTheDocument();
+    expect(screen.getByLabelText("Find files")).toBeInTheDocument();
+  });
+});

--- a/src/modules/explorer/ExplorerView.tsx
+++ b/src/modules/explorer/ExplorerView.tsx
@@ -7,6 +7,7 @@ import { fsReadDir, type DirEntry } from "./lib/fsBridge";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useUiStore } from "@/stores/uiStore";
 import { pickFolder } from "@/lib/dialog";
+import { isRemoteUri, parseRemoteUri } from "@/modules/ssh/lib/remotePath";
 
 export function ExplorerView() {
   const { t } = useTranslation("explorer");
@@ -16,6 +17,11 @@ export function ExplorerView() {
   const setFinderOpen = useUiStore((s) => s.setFileFinderOpen);
   const [entries, setEntries] = useState<DirEntry[]>([]);
   const [loading, setLoading] = useState(false);
+
+  // A remote (SFTP) root hides local-only controls and shows the remote path
+  // rather than the raw ssh:// uri.
+  const remote = rootPath ? isRemoteUri(rootPath) : false;
+  const displayRoot = rootPath ? (parseRemoteUri(rootPath)?.path ?? rootPath) : null;
 
   async function openFolder() {
     const folder = await pickFolder();
@@ -49,34 +55,36 @@ export function ExplorerView() {
         <span className="truncate text-xs font-semibold uppercase tracking-wide text-fg-subtle">
           {t("title")}
         </span>
-        <div className="flex items-center gap-0.5">
-          <button
-            type="button"
-            aria-label={t("openFolder")}
-            title={t("openFolder")}
-            onClick={() => void openFolder()}
-            className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
-          >
-            <FolderOpen size={15} />
-          </button>
-          <button
-            type="button"
-            aria-label={t("findFiles")}
-            title={t("findFiles")}
-            onClick={() => setFinderOpen(true)}
-            className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
-          >
-            <Search size={15} />
-          </button>
-        </div>
+        {!remote && (
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              aria-label={t("openFolder")}
+              title={t("openFolder")}
+              onClick={() => void openFolder()}
+              className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+            >
+              <FolderOpen size={15} />
+            </button>
+            <button
+              type="button"
+              aria-label={t("findFiles")}
+              title={t("findFiles")}
+              onClick={() => setFinderOpen(true)}
+              className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+            >
+              <Search size={15} />
+            </button>
+          </div>
+        )}
       </div>
 
       {rootPath && (
         <div
           className="truncate border-b border-border px-3 py-1 text-[11px] text-fg-subtle"
-          title={rootPath}
+          title={displayRoot ?? rootPath}
         >
-          {rootPath}
+          {displayRoot}
         </div>
       )}
 
@@ -90,7 +98,7 @@ export function ExplorerView() {
         )}
       </div>
 
-      {finderOpen && rootPath && (
+      {finderOpen && rootPath && !remote && (
         <FileFinder root={rootPath} onClose={() => setFinderOpen(false)} />
       )}
     </div>

--- a/src/modules/explorer/lib/fsBridge.test.ts
+++ b/src/modules/explorer/lib/fsBridge.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+const ensure = vi.fn();
+vi.mock("@/modules/ssh/lib/sftpSessionStore", () => ({
+  sftpSessionStore: { getState: () => ({ ensure }) },
+}));
+
+const sftpReadDir = vi.fn();
+const sftpReadFile = vi.fn();
+const sftpWriteFile = vi.fn();
+vi.mock("@/modules/ssh/lib/sftp-bridge", () => ({
+  sftpReadDir: (...a: unknown[]) => sftpReadDir(...a),
+  sftpReadFile: (...a: unknown[]) => sftpReadFile(...a),
+  sftpWriteFile: (...a: unknown[]) => sftpWriteFile(...a),
+}));
+
+import { fsReadDir, fsReadFile, fsWriteFile } from "./fsBridge";
+
+beforeEach(() => {
+  invoke.mockReset();
+  ensure.mockReset();
+  sftpReadDir.mockReset();
+  sftpReadFile.mockReset();
+  sftpWriteFile.mockReset();
+});
+
+describe("fsBridge routing", () => {
+  it("reads a local directory through fs_read_dir", async () => {
+    invoke.mockResolvedValue([]);
+    await fsReadDir("/home/me");
+    expect(invoke).toHaveBeenCalledWith("fs_read_dir", { path: "/home/me" });
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("reads a remote directory over sftp and wraps entry paths as uris", async () => {
+    ensure.mockResolvedValue(7);
+    sftpReadDir.mockResolvedValue([{ name: "sub", path: "/home/me/sub", is_dir: true, size: 0 }]);
+    const entries = await fsReadDir("ssh://c1/home/me");
+    expect(ensure).toHaveBeenCalledWith("c1");
+    expect(sftpReadDir).toHaveBeenCalledWith(7, "/home/me");
+    expect(entries[0].path).toBe("ssh://c1/home/me/sub");
+  });
+
+  it("reads and writes a remote file over sftp", async () => {
+    ensure.mockResolvedValue(7);
+    sftpReadFile.mockResolvedValue("body");
+    sftpWriteFile.mockResolvedValue(undefined);
+    expect(await fsReadFile("ssh://c1/a.txt")).toBe("body");
+    expect(sftpReadFile).toHaveBeenCalledWith(7, "/a.txt");
+    await fsWriteFile("ssh://c1/a.txt", "new");
+    expect(sftpWriteFile).toHaveBeenCalledWith(7, "/a.txt", "new");
+  });
+
+  it("writes a local file through fs_write_file", async () => {
+    invoke.mockResolvedValue(undefined);
+    await fsWriteFile("/a.txt", "x");
+    expect(invoke).toHaveBeenCalledWith("fs_write_file", { path: "/a.txt", contents: "x" });
+  });
+});

--- a/src/modules/explorer/lib/fsBridge.ts
+++ b/src/modules/explorer/lib/fsBridge.ts
@@ -1,4 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
+import { buildRemoteUri, parseRemoteUri } from "@/modules/ssh/lib/remotePath";
+import { sftpReadDir, sftpReadFile, sftpWriteFile } from "@/modules/ssh/lib/sftp-bridge";
+import { sftpSessionStore } from "@/modules/ssh/lib/sftpSessionStore";
 
 export interface DirEntry {
   name: string;
@@ -17,15 +20,31 @@ export function fsHomeDir(): Promise<string> {
   return invoke<string>("fs_home_dir");
 }
 
-export function fsReadDir(path: string): Promise<DirEntry[]> {
+export async function fsReadDir(path: string): Promise<DirEntry[]> {
+  const remote = parseRemoteUri(path);
+  if (remote) {
+    const id = await sftpSessionStore.getState().ensure(remote.connectionId);
+    const entries = await sftpReadDir(id, remote.path);
+    return entries.map((e) => ({ ...e, path: buildRemoteUri(remote.connectionId, e.path) }));
+  }
   return invoke<DirEntry[]>("fs_read_dir", { path });
 }
 
-export function fsReadFile(path: string): Promise<string> {
+export async function fsReadFile(path: string): Promise<string> {
+  const remote = parseRemoteUri(path);
+  if (remote) {
+    const id = await sftpSessionStore.getState().ensure(remote.connectionId);
+    return sftpReadFile(id, remote.path);
+  }
   return invoke<string>("fs_read_file", { path });
 }
 
-export function fsWriteFile(path: string, contents: string): Promise<void> {
+export async function fsWriteFile(path: string, contents: string): Promise<void> {
+  const remote = parseRemoteUri(path);
+  if (remote) {
+    const id = await sftpSessionStore.getState().ensure(remote.connectionId);
+    return sftpWriteFile(id, remote.path, contents);
+  }
   return invoke("fs_write_file", { path, contents });
 }
 

--- a/src/modules/ssh/lib/remotePath.test.ts
+++ b/src/modules/ssh/lib/remotePath.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildRemoteUri, isRemoteUri, parseRemoteUri } from "./remotePath";
+
+describe("remotePath", () => {
+  it("builds a uri with a leading slash on the path", () => {
+    expect(buildRemoteUri("c1", "/home/me")).toBe("ssh://c1/home/me");
+    expect(buildRemoteUri("c1", "home/me")).toBe("ssh://c1/home/me");
+  });
+
+  it("detects remote uris and rejects local paths", () => {
+    expect(isRemoteUri("ssh://c1/home/me")).toBe(true);
+    expect(isRemoteUri("/home/me")).toBe(false);
+    expect(isRemoteUri("C:\\Users\\me")).toBe(false);
+  });
+
+  it("parses a uri back into its parts and round-trips", () => {
+    expect(parseRemoteUri("ssh://c1/home/me/file.txt")).toEqual({
+      connectionId: "c1",
+      path: "/home/me/file.txt",
+    });
+    const uri = buildRemoteUri("conn_42", "/var/log");
+    expect(parseRemoteUri(uri)).toEqual({ connectionId: "conn_42", path: "/var/log" });
+  });
+
+  it("returns null for a local path and root for a bare connection", () => {
+    expect(parseRemoteUri("/home/me")).toBeNull();
+    expect(parseRemoteUri("ssh://c1")).toEqual({ connectionId: "c1", path: "/" });
+  });
+});

--- a/src/modules/ssh/lib/remotePath.ts
+++ b/src/modules/ssh/lib/remotePath.ts
@@ -1,0 +1,27 @@
+const SCHEME = "ssh://";
+
+/** Build `ssh://<connectionId>/<path>`; ensures the path has a leading slash. */
+export function buildRemoteUri(connectionId: string, path: string): string {
+  const clean = path.startsWith("/") ? path : `/${path}`;
+  return `${SCHEME}${connectionId}${clean}`;
+}
+
+/** True when a path string is a remote SFTP uri rather than a local path. */
+export function isRemoteUri(value: string): boolean {
+  return value.startsWith(SCHEME);
+}
+
+/** Split a remote uri into its connection id and remote path, or null if local. */
+export function parseRemoteUri(
+  uri: string,
+): { connectionId: string; path: string } | null {
+  if (!uri.startsWith(SCHEME)) {
+    return null;
+  }
+  const rest = uri.slice(SCHEME.length);
+  const slash = rest.indexOf("/");
+  if (slash === -1) {
+    return { connectionId: rest, path: "/" };
+  }
+  return { connectionId: rest.slice(0, slash), path: rest.slice(slash) };
+}

--- a/src/modules/ssh/lib/sftp-bridge.test.ts
+++ b/src/modules/ssh/lib/sftp-bridge.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
+
+import { sftpReadDir, sftpStart, sftpWriteFile } from "./sftp-bridge";
+
+beforeEach(() => invoke.mockReset());
+
+describe("sftp-bridge", () => {
+  it("starts a session with the connection fields", async () => {
+    invoke.mockResolvedValue(7);
+    const id = await sftpStart({
+      connectionId: "c1",
+      host: "h",
+      port: 22,
+      user: "me",
+      authMethod: "agent",
+    });
+    expect(id).toBe(7);
+    expect(invoke).toHaveBeenCalledWith("sftp_start", {
+      req: { connectionId: "c1", host: "h", port: 22, user: "me", authMethod: "agent" },
+    });
+  });
+
+  it("lists a remote directory by session id and path", async () => {
+    invoke.mockResolvedValue([{ name: "a", path: "/a", is_dir: true, size: 0 }]);
+    const entries = await sftpReadDir(7, "/home");
+    expect(entries).toHaveLength(1);
+    expect(invoke).toHaveBeenCalledWith("sftp_read_dir", { id: 7, path: "/home" });
+  });
+
+  it("writes a remote file", async () => {
+    invoke.mockResolvedValue(undefined);
+    await sftpWriteFile(7, "/a.txt", "hi");
+    expect(invoke).toHaveBeenCalledWith("sftp_write_file", {
+      id: 7,
+      path: "/a.txt",
+      contents: "hi",
+    });
+  });
+});

--- a/src/modules/ssh/lib/sftp-bridge.ts
+++ b/src/modules/ssh/lib/sftp-bridge.ts
@@ -1,0 +1,35 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { DirEntry } from "@/modules/explorer/lib/fsBridge";
+
+export interface SftpStartInput {
+  connectionId: string;
+  host: string;
+  port: number;
+  user: string;
+  authMethod: string;
+  keyPath?: string;
+}
+
+export function sftpStart(req: SftpStartInput): Promise<number> {
+  return invoke<number>("sftp_start", { req });
+}
+
+export function sftpHome(id: number): Promise<string> {
+  return invoke<string>("sftp_home", { id });
+}
+
+export function sftpReadDir(id: number, path: string): Promise<DirEntry[]> {
+  return invoke<DirEntry[]>("sftp_read_dir", { id, path });
+}
+
+export function sftpReadFile(id: number, path: string): Promise<string> {
+  return invoke<string>("sftp_read_file", { id, path });
+}
+
+export function sftpWriteFile(id: number, path: string, contents: string): Promise<void> {
+  return invoke("sftp_write_file", { id, path, contents });
+}
+
+export function sftpClose(id: number): Promise<void> {
+  return invoke("sftp_close", { id });
+}

--- a/src/modules/ssh/lib/sftpSessionStore.test.ts
+++ b/src/modules/ssh/lib/sftpSessionStore.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sftpStart = vi.fn();
+const sftpClose = vi.fn();
+vi.mock("./sftp-bridge", () => ({
+  sftpStart: (...a: unknown[]) => sftpStart(...a),
+  sftpClose: (...a: unknown[]) => sftpClose(...a),
+}));
+
+vi.mock("@/stores/connectionsStore", () => ({
+  useConnectionsStore: {
+    getState: () => ({
+      getConnection: (id: string) =>
+        id === "c1"
+          ? { id: "c1", name: "n", host: "h", port: 22, user: "me", authMethod: "agent" }
+          : undefined,
+    }),
+  },
+}));
+
+import { sftpSessionStore } from "./sftpSessionStore";
+
+beforeEach(() => {
+  sftpStart.mockReset();
+  sftpClose.mockReset();
+  sftpClose.mockResolvedValue(undefined);
+  sftpSessionStore.setState({ sessions: {}, pending: {} });
+});
+
+describe("sftpSessionStore", () => {
+  it("opens a session once and reuses it", async () => {
+    sftpStart.mockResolvedValue(7);
+    const a = await sftpSessionStore.getState().ensure("c1");
+    const b = await sftpSessionStore.getState().ensure("c1");
+    expect(a).toBe(7);
+    expect(b).toBe(7);
+    expect(sftpStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes concurrent opens", async () => {
+    sftpStart.mockResolvedValue(7);
+    const [a, b] = await Promise.all([
+      sftpSessionStore.getState().ensure("c1"),
+      sftpSessionStore.getState().ensure("c1"),
+    ]);
+    expect(a).toBe(7);
+    expect(b).toBe(7);
+    expect(sftpStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an unknown connection", async () => {
+    await expect(sftpSessionStore.getState().ensure("nope")).rejects.toThrow();
+    expect(sftpStart).not.toHaveBeenCalled();
+  });
+
+  it("closes a cached session", async () => {
+    sftpStart.mockResolvedValue(7);
+    await sftpSessionStore.getState().ensure("c1");
+    sftpSessionStore.getState().closeFor("c1");
+    expect(sftpClose).toHaveBeenCalledWith(7);
+    expect(sftpSessionStore.getState().sessions.c1).toBeUndefined();
+  });
+});

--- a/src/modules/ssh/lib/sftpSessionStore.ts
+++ b/src/modules/ssh/lib/sftpSessionStore.ts
@@ -1,0 +1,78 @@
+import { create } from "zustand";
+import { sftpClose, sftpStart } from "./sftp-bridge";
+import { useConnectionsStore } from "@/stores/connectionsStore";
+
+interface SftpSessionState {
+  /** connectionId -> live sftp session id */
+  sessions: Record<string, number>;
+  /** connectionId -> in-flight open, so concurrent callers share one connect */
+  pending: Record<string, Promise<number>>;
+  ensure: (connectionId: string) => Promise<number>;
+  closeFor: (connectionId: string) => void;
+  closeAll: () => void;
+}
+
+export const sftpSessionStore = create<SftpSessionState>()((set, get) => ({
+  sessions: {},
+  pending: {},
+
+  ensure: (connectionId) => {
+    const existing = get().sessions[connectionId];
+    if (existing !== undefined) {
+      return Promise.resolve(existing);
+    }
+    const inflight = get().pending[connectionId];
+    if (inflight) {
+      return inflight;
+    }
+    const conn = useConnectionsStore.getState().getConnection(connectionId);
+    if (!conn) {
+      return Promise.reject(new Error(`unknown connection ${connectionId}`));
+    }
+    const open = sftpStart({
+      connectionId: conn.id,
+      host: conn.host,
+      port: conn.port,
+      user: conn.user,
+      authMethod: conn.authMethod,
+      keyPath: conn.keyPath,
+    })
+      .then((id) => {
+        set((s) => {
+          const pending = { ...s.pending };
+          delete pending[connectionId];
+          return { sessions: { ...s.sessions, [connectionId]: id }, pending };
+        });
+        return id;
+      })
+      .catch((err: unknown) => {
+        set((s) => {
+          const pending = { ...s.pending };
+          delete pending[connectionId];
+          return { pending };
+        });
+        throw err;
+      });
+    set((s) => ({ pending: { ...s.pending, [connectionId]: open } }));
+    return open;
+  },
+
+  closeFor: (connectionId) => {
+    const id = get().sessions[connectionId];
+    if (id !== undefined) {
+      void sftpClose(id).catch(() => {});
+    }
+    set((s) => {
+      const sessions = { ...s.sessions };
+      delete sessions[connectionId];
+      return { sessions };
+    });
+  },
+
+  closeAll: () => {
+    for (const id of Object.values(get().sessions)) {
+      void sftpClose(id).catch(() => {});
+    }
+    set({ sessions: {}, pending: {} });
+  },
+}));

--- a/src/modules/ssh/lib/useRemoteExplorerRoot.test.tsx
+++ b/src/modules/ssh/lib/useRemoteExplorerRoot.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ensure = vi.fn();
+vi.mock("./sftpSessionStore", () => ({
+  sftpSessionStore: { getState: () => ({ ensure }) },
+}));
+const sftpHome = vi.fn();
+vi.mock("./sftp-bridge", () => ({ sftpHome: (...a: unknown[]) => sftpHome(...a) }));
+
+const setRoot = vi.fn();
+vi.mock("@/stores/workspaceStore", () => ({
+  useWorkspaceStore: { getState: () => ({ setRoot }) },
+}));
+
+import { useRemoteExplorerRoot } from "./useRemoteExplorerRoot";
+
+function Probe({ id }: { id: string | null }) {
+  useRemoteExplorerRoot(id);
+  return null;
+}
+
+beforeEach(() => {
+  ensure.mockReset();
+  sftpHome.mockReset();
+  setRoot.mockReset();
+});
+
+describe("useRemoteExplorerRoot", () => {
+  it("sets the explorer root to the remote home for an active ssh connection", async () => {
+    ensure.mockResolvedValue(7);
+    sftpHome.mockResolvedValue("/home/me");
+    render(<Probe id="c1" />);
+    await vi.waitFor(() => expect(setRoot).toHaveBeenCalledWith("ssh://c1/home/me"));
+    expect(ensure).toHaveBeenCalledWith("c1");
+  });
+
+  it("does nothing when there is no active ssh connection", async () => {
+    render(<Probe id={null} />);
+    await Promise.resolve();
+    expect(ensure).not.toHaveBeenCalled();
+    expect(setRoot).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/ssh/lib/useRemoteExplorerRoot.ts
+++ b/src/modules/ssh/lib/useRemoteExplorerRoot.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { sftpSessionStore } from "./sftpSessionStore";
+import { sftpHome } from "./sftp-bridge";
+import { buildRemoteUri } from "./remotePath";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+/**
+ * When the active pane is an SSH terminal, point the file explorer at that
+ * host's remote home over SFTP. A null id (local pane active) is a no-op, so the
+ * existing local cwd tracking keeps driving the root.
+ */
+export function useRemoteExplorerRoot(activeSshConnectionId: string | null): void {
+  useEffect(() => {
+    if (!activeSshConnectionId) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const id = await sftpSessionStore.getState().ensure(activeSshConnectionId);
+        const home = await sftpHome(id);
+        if (!cancelled) {
+          useWorkspaceStore.getState().setRoot(buildRemoteUri(activeSshConnectionId, home));
+        }
+      } catch {
+        // Connect/auth failed; the explorer shows its empty/error state.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSshConnectionId]);
+}

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -40,6 +40,7 @@ import { insertLinkIntoNote } from "@/modules/notes/lib/noteBus";
 import { deleteTerminalHistory } from "./lib/terminalHistory";
 import { useTabsStore, type Tab } from "@/stores/tabsStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useRemoteExplorerRoot } from "@/modules/ssh/lib/useRemoteExplorerRoot";
 
 const MIN_FRACTION = 0.1;
 const MAX_FRACTION = 0.9;
@@ -79,6 +80,16 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   const panes = computeLayout(tab.paneTree);
   const splitters = computeSplitters(tab.paneTree);
   const multiple = panes.length > 1;
+
+  // When this tab's active pane is an SSH terminal, point the file explorer at
+  // that host's remote files. A local (or non-active) pane yields null, so the
+  // existing local cwd tracking keeps driving the root.
+  const activeLeaf = panes.find((p) => p.id === tab.activeLeafId);
+  const activeSshConnectionId =
+    isActiveTab && activeLeaf?.content.kind === "terminal" && activeLeaf.content.ssh
+      ? activeLeaf.content.ssh.connectionId
+      : null;
+  useRemoteExplorerRoot(activeSshConnectionId);
   // The splitter currently being dragged, used to drive the drag overlay's
   // resize cursor (see the overlay below).
   const draggingSplitter = draggingSplitterId


### PR DESCRIPTION
## Summary

Adds a remote file explorer: when an SSH terminal pane is active, the file explorer browses and edits the remote host's filesystem over SFTP, KKTerm-style, using its own dedicated SFTP connection (separate from the terminal's SSH session). Remote paths are addressed with an `ssh://` URI scheme that routes through the existing fs bridge.

### Backend (Rust / Tauri)
- SFTP backend with connect, home, and `read_dir` (`src-tauri/src/modules/sftp/`).
- Remote `read_file` / `write_file` commands.
- `refactor(ssh)`: expose `connect_authenticated` so SFTP can reuse the SSH auth path.

### Frontend
- `ssh://` remote path helpers (`remotePath.ts`).
- `sftp-bridge` invoke wrappers.
- SFTP session store with lazy open and connection reuse (`sftpSessionStore.ts`).
- `fsBridge` routes `ssh://` paths to SFTP, local paths stay local.
- Explorer follows the active SSH pane to show that host's remote files.
- Local-only explorer controls are hidden when the root is remote.

### Also included
- `fix: keep tabs mounted when there is no active tab` — TabsArea no longer unmounts every tab when `activeId` is null (the random-disconnect bug when opening a new workspace).

## Test plan

- [x] `pnpm test` — full suite passing
- [x] `pnpm build` — typecheck + production build clean
- [ ] Manual: open an SSH pane, confirm the explorer switches to the remote host's files
- [ ] Manual: open / edit / save a remote file over SFTP
- [ ] Manual: confirm local explorer still works when no SSH pane is active
- [ ] Manual: open a new workspace, confirm tabs no longer disconnect (keep-tabs fix)

## Notes

This branch was developed on top of `master` locally but never pushed; it is independent of #47 (AI context features) and touches a disjoint set of files, so the two can merge in either order.