### PR TITLE
fix(sftp): close sftp sessions that finish opening after teardown

### DIFF
--- a/src/modules/ssh/lib/sftpSessionStore.test.ts
+++ b/src/modules/ssh/lib/sftpSessionStore.test.ts
@@ -72,7 +72,7 @@ describe("sftpSessionStore", () => {
     // Tear everything down while the connect is still in flight.
     sftpSessionStore.getState().closeAll();
     resolveStart(7);
-    await open;
+    await expect(open).rejects.toThrow();
     expect(sftpClose).toHaveBeenCalledWith(7);
     expect(sftpSessionStore.getState().sessions.c1).toBeUndefined();
   });
@@ -87,7 +87,7 @@ describe("sftpSessionStore", () => {
     const open = sftpSessionStore.getState().ensure("c1");
     sftpSessionStore.getState().closeFor("c1");
     resolveStart(7);
-    await open;
+    await expect(open).rejects.toThrow();
     expect(sftpClose).toHaveBeenCalledWith(7);
     expect(sftpSessionStore.getState().sessions.c1).toBeUndefined();
   });
@@ -112,7 +112,8 @@ describe("sftpSessionStore", () => {
     // The discarded open resolves first, then the one we actually want.
     resolveStale(1);
     resolveFresh(2);
-    await Promise.all([stale, fresh]);
+    await expect(stale).rejects.toThrow();
+    await expect(fresh).resolves.toBe(2);
     expect(sftpClose).toHaveBeenCalledWith(1);
     expect(sftpClose).not.toHaveBeenCalledWith(2);
     expect(sftpSessionStore.getState().sessions.c1).toBe(2);

--- a/src/modules/ssh/lib/sftpSessionStore.test.ts
+++ b/src/modules/ssh/lib/sftpSessionStore.test.ts
@@ -60,4 +60,61 @@ describe("sftpSessionStore", () => {
     expect(sftpClose).toHaveBeenCalledWith(7);
     expect(sftpSessionStore.getState().sessions.c1).toBeUndefined();
   });
+
+  it("closes a session that finishes opening after closeAll", async () => {
+    let resolveStart!: (id: number) => void;
+    sftpStart.mockReturnValue(
+      new Promise<number>((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const open = sftpSessionStore.getState().ensure("c1");
+    // Tear everything down while the connect is still in flight.
+    sftpSessionStore.getState().closeAll();
+    resolveStart(7);
+    await open;
+    expect(sftpClose).toHaveBeenCalledWith(7);
+    expect(sftpSessionStore.getState().sessions.c1).toBeUndefined();
+  });
+
+  it("closes a session that finishes opening after closeFor", async () => {
+    let resolveStart!: (id: number) => void;
+    sftpStart.mockReturnValue(
+      new Promise<number>((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const open = sftpSessionStore.getState().ensure("c1");
+    sftpSessionStore.getState().closeFor("c1");
+    resolveStart(7);
+    await open;
+    expect(sftpClose).toHaveBeenCalledWith(7);
+    expect(sftpSessionStore.getState().sessions.c1).toBeUndefined();
+  });
+
+  it("keeps only the latest open when a connection is reopened mid-flight", async () => {
+    let resolveStale!: (id: number) => void;
+    let resolveFresh!: (id: number) => void;
+    sftpStart
+      .mockReturnValueOnce(
+        new Promise<number>((resolve) => {
+          resolveStale = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise<number>((resolve) => {
+          resolveFresh = resolve;
+        }),
+      );
+    const stale = sftpSessionStore.getState().ensure("c1");
+    sftpSessionStore.getState().closeFor("c1");
+    const fresh = sftpSessionStore.getState().ensure("c1");
+    // The discarded open resolves first, then the one we actually want.
+    resolveStale(1);
+    resolveFresh(2);
+    await Promise.all([stale, fresh]);
+    expect(sftpClose).toHaveBeenCalledWith(1);
+    expect(sftpClose).not.toHaveBeenCalledWith(2);
+    expect(sftpSessionStore.getState().sessions.c1).toBe(2);
+  });
 });

--- a/src/modules/ssh/lib/sftpSessionStore.ts
+++ b/src/modules/ssh/lib/sftpSessionStore.ts
@@ -54,6 +54,9 @@ export const sftpSessionStore = create<SftpSessionState>()((set, get) => ({
         });
         if (dropped) {
           void sftpClose(id).catch(() => {});
+          // Reject rather than hand back a session id we just closed, so callers
+          // never operate on a dead session.
+          throw new Error(`sftp session for ${connectionId} was closed before it opened`);
         }
         return id;
       })

--- a/src/modules/ssh/lib/sftpSessionStore.ts
+++ b/src/modules/ssh/lib/sftpSessionStore.ts
@@ -38,15 +38,31 @@ export const sftpSessionStore = create<SftpSessionState>()((set, get) => ({
       keyPath: conn.keyPath,
     })
       .then((id) => {
+        let dropped = false;
         set((s) => {
+          // Only keep this session if our open is still the tracked one.
+          // closeAll/closeFor clears the entry, and a re-open replaces it with a
+          // newer promise; in both cases this result is stale and must be closed
+          // rather than added, or it leaks a background connection.
+          if (s.pending[connectionId] !== open) {
+            dropped = true;
+            return {};
+          }
           const pending = { ...s.pending };
           delete pending[connectionId];
           return { sessions: { ...s.sessions, [connectionId]: id }, pending };
         });
+        if (dropped) {
+          void sftpClose(id).catch(() => {});
+        }
         return id;
       })
       .catch((err: unknown) => {
         set((s) => {
+          // Don't clear a newer pending open that superseded this failed one.
+          if (s.pending[connectionId] !== open) {
+            return {};
+          }
           const pending = { ...s.pending };
           delete pending[connectionId];
           return { pending };
@@ -65,7 +81,9 @@ export const sftpSessionStore = create<SftpSessionState>()((set, get) => ({
     set((s) => {
       const sessions = { ...s.sessions };
       delete sessions[connectionId];
-      return { sessions };
+      const pending = { ...s.pending };
+      delete pending[connectionId];
+      return { sessions, pending };
     });
   },
 


### PR DESCRIPTION
## Summary

Fixes a connection leak in `sftpSessionStore` flagged in the #48 review (high). When an `sftpStart` was still in flight and `closeAll` / `closeFor` ran, the resolving `.then` unconditionally wrote the session back into `sessions`, leaving a live SFTP connection open in the Rust backend that nothing tracked.

### Fix
- On resolve, keep the session only when its promise is still the tracked `pending` entry; otherwise close the just-opened session immediately.
- `closeFor` now also clears `pending` (previously it only cleared `sessions`), so an in-flight open during a close is dropped.
- The check uses promise identity (`pending[id] !== this open`), so a connection that is closed and re-opened while the first connect is still running resolves correctly: the stale open is closed and the latest one wins, rather than the stale one clobbering it.

## Test plan

- [x] `pnpm test` — 650 passing (3 new cases: resolve-after-closeAll, resolve-after-closeFor, reopen-mid-flight)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean

## Notes

Follow-up to #48 (already merged). The medium "filter `.` / `..` from SFTP listings" comment from the same review is not included here — can be a separate small change if wanted.