### PR TITLE
feat(updater): proactively notify about updates while the app is running

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Resizer } from "@/components/Resizer";
 import { StatusBar } from "@/components/StatusBar";
 import { SettingsModal } from "@/components/SettingsModal";
 import { UpdateModal } from "@/components/UpdateModal";
+import { UpdateToast } from "@/components/UpdateToast";
 import { TabsArea } from "@/components/TabsArea";
 import { useUiStore } from "@/stores/uiStore";
 import { useUpdaterStore } from "@/stores/updaterStore";
@@ -92,6 +93,16 @@ function App() {
     return () => clearTimeout(timer);
   }, []);
 
+  // While the app stays open, re-check on a fixed cadence so a release published
+  // mid-session is surfaced without a restart. A hit toasts once per version.
+  useEffect(() => {
+    const SIX_HOURS = 6 * 60 * 60 * 1000;
+    const timer = setInterval(() => {
+      void useUpdaterStore.getState().runPeriodicCheck();
+    }, SIX_HOURS);
+    return () => clearInterval(timer);
+  }, []);
+
   // Stream Claude Code progress: the backend watcher emits appended transcript
   // lines, which we feed through the normalizer into the progress store.
   useEffect(() => {
@@ -173,6 +184,7 @@ function App() {
       <StatusBar />
       {settingsOpen && <SettingsModal />}
       <UpdateModal />
+      <UpdateToast />
       <SshPromptDialog />
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,11 +83,11 @@ function App() {
     }
   }, []);
 
-  // Quietly check for a new release a few seconds after launch; the prompt only
+  // Quietly check for a new release a few seconds after launch; the modal only
   // appears if one actually exists, so a normal start stays uninterrupted.
   useEffect(() => {
     const timer = setTimeout(() => {
-      void useUpdaterStore.getState().checkForUpdate({ silent: true });
+      void useUpdaterStore.getState().runLaunchCheck();
     }, 5000);
     return () => clearTimeout(timer);
   }, []);

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { StatusBar } from "./StatusBar";
+import "../i18n";
+import { useUpdaterStore } from "@/stores/updaterStore";
+
+const AVAILABLE = {
+  version: "0.0.9",
+  notes: "",
+  releaseUrl: "",
+  update: null as never,
+};
+
+describe("StatusBar update indicator", () => {
+  beforeEach(() => {
+    useUpdaterStore.setState({ available: null, modalOpen: false });
+  });
+  afterEach(() => {
+    useUpdaterStore.setState({ available: null, modalOpen: false });
+  });
+
+  it("hides the indicator when no update is available", () => {
+    render(<StatusBar />);
+    expect(screen.queryByLabelText("Update available")).not.toBeInTheDocument();
+  });
+
+  it("shows the indicator when an update is available and the modal is closed", () => {
+    useUpdaterStore.setState({ available: AVAILABLE, modalOpen: false });
+    render(<StatusBar />);
+    expect(screen.getByLabelText("Update available")).toBeInTheDocument();
+  });
+
+  it("hides the indicator while the modal is open", () => {
+    useUpdaterStore.setState({ available: AVAILABLE, modalOpen: true });
+    render(<StatusBar />);
+    expect(screen.queryByLabelText("Update available")).not.toBeInTheDocument();
+  });
+
+  it("opens the modal when the indicator is clicked", () => {
+    useUpdaterStore.setState({ available: AVAILABLE, modalOpen: false });
+    render(<StatusBar />);
+
+    fireEvent.click(screen.getByLabelText("Update available"));
+
+    expect(useUpdaterStore.getState().modalOpen).toBe(true);
+  });
+});

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,10 +1,15 @@
 import { useTranslation } from "react-i18next";
-import { Circle, Settings } from "lucide-react";
+import { ArrowUpCircle, Circle, Settings } from "lucide-react";
 import { useUiStore } from "@/stores/uiStore";
+import { useUpdaterStore } from "@/stores/updaterStore";
 
 export function StatusBar() {
   const { t } = useTranslation();
   const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
+  const hasUpdate = useUpdaterStore((s) => s.available !== null);
+  const modalOpen = useUpdaterStore((s) => s.modalOpen);
+  const openModal = useUpdaterStore((s) => s.openModal);
+  const showIndicator = hasUpdate && !modalOpen;
 
   return (
     <footer className="flex h-7 shrink-0 items-center gap-1 border-t border-border bg-bg-inset px-2 text-xs text-fg-muted">
@@ -14,12 +19,24 @@ export function StatusBar() {
       </span>
       <span className="ml-3">{t("statusBar.encoding")}</span>
 
+      {showIndicator && (
+        <button
+          type="button"
+          title={t("statusBar.updateAvailable")}
+          aria-label={t("statusBar.updateAvailable")}
+          onClick={openModal}
+          className="ml-auto flex h-5 items-center gap-1 rounded px-1.5 text-accent transition-colors hover:bg-bg-elevated"
+        >
+          <ArrowUpCircle size={13} strokeWidth={2} />
+        </button>
+      )}
+
       <button
         type="button"
         title={t("nav.settings")}
         aria-label={t("nav.settings")}
         onClick={() => setSettingsOpen(true)}
-        className="ml-auto flex h-5 w-6 items-center justify-center rounded text-fg-subtle transition-colors hover:text-fg"
+        className={`${showIndicator ? "" : "ml-auto"} flex h-5 w-6 items-center justify-center rounded text-fg-subtle transition-colors hover:text-fg`}
       >
         <Settings size={14} strokeWidth={1.75} />
       </button>

--- a/src/components/UpdateModal.test.tsx
+++ b/src/components/UpdateModal.test.tsx
@@ -15,11 +15,12 @@ describe("UpdateModal release notes", () => {
         update: null as never,
       },
       installing: false,
+      errorMessage: "",
     });
   });
 
   afterEach(() => {
-    useUpdaterStore.setState({ modalOpen: false, available: null });
+    useUpdaterStore.setState({ modalOpen: false, available: null, errorMessage: "" });
   });
 
   it("renders markdown notes as real heading and list elements", () => {
@@ -30,5 +31,13 @@ describe("UpdateModal release notes", () => {
     expect(screen.getByText("Second item").tagName).toBe("LI");
     // The raw markdown markers must not leak through as plain text.
     expect(screen.queryByText(/## What's new/)).not.toBeInTheDocument();
+  });
+
+  it("shows the install error message when one is set", () => {
+    useUpdaterStore.setState({ errorMessage: "disk full" });
+
+    render(<UpdateModal />);
+
+    expect(screen.getByText("disk full")).toBeInTheDocument();
   });
 });

--- a/src/components/UpdateModal.test.tsx
+++ b/src/components/UpdateModal.test.tsx
@@ -7,16 +7,19 @@ import { useUpdaterStore } from "@/stores/updaterStore";
 describe("UpdateModal release notes", () => {
   beforeEach(() => {
     useUpdaterStore.setState({
-      status: "available",
-      version: "0.0.6",
-      notes: "## What's new\n\n- First item\n- Second item",
-      releaseUrl: "",
+      modalOpen: true,
+      available: {
+        version: "0.0.6",
+        notes: "## What's new\n\n- First item\n- Second item",
+        releaseUrl: "",
+        update: null as never,
+      },
       installing: false,
     });
   });
 
   afterEach(() => {
-    useUpdaterStore.setState({ status: "idle", notes: "", version: "" });
+    useUpdaterStore.setState({ modalOpen: false, available: null });
   });
 
   it("renders markdown notes as real heading and list elements", () => {

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -13,16 +13,18 @@ const NOTES_PREVIEW_CHARS = 600;
  */
 export function UpdateModal() {
   const { t } = useTranslation("settings");
-  const status = useUpdaterStore((s) => s.status);
-  const version = useUpdaterStore((s) => s.version);
-  const notes = useUpdaterStore((s) => s.notes);
+  const available = useUpdaterStore((s) => s.available);
+  const modalOpen = useUpdaterStore((s) => s.modalOpen);
   const installing = useUpdaterStore((s) => s.installing);
   const installUpdate = useUpdaterStore((s) => s.installUpdate);
-  const dismiss = useUpdaterStore((s) => s.dismiss);
+  const dismiss = useUpdaterStore((s) => s.dismissModal);
 
-  if (status !== "available") {
+  if (!modalOpen || !available) {
     return null;
   }
+
+  const version = available.version;
+  const notes = available.notes;
 
   const divided = separateLanguageSections(notes);
   const truncated = divided.length > NOTES_PREVIEW_CHARS;

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -16,6 +16,7 @@ export function UpdateModal() {
   const available = useUpdaterStore((s) => s.available);
   const modalOpen = useUpdaterStore((s) => s.modalOpen);
   const installing = useUpdaterStore((s) => s.installing);
+  const errorMessage = useUpdaterStore((s) => s.errorMessage);
   const installUpdate = useUpdaterStore((s) => s.installUpdate);
   const dismiss = useUpdaterStore((s) => s.dismissModal);
 
@@ -64,6 +65,9 @@ export function UpdateModal() {
         </div>
 
         <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+          {errorMessage && (
+            <span className="mr-auto text-xs text-danger">{errorMessage}</span>
+          )}
           <button
             type="button"
             onClick={dismiss}

--- a/src/components/UpdateToast.test.tsx
+++ b/src/components/UpdateToast.test.tsx
@@ -1,0 +1,41 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UpdateToast } from "./UpdateToast";
+import "../i18n";
+import { useUpdaterStore } from "@/stores/updaterStore";
+
+describe("UpdateToast", () => {
+  beforeEach(() => {
+    useUpdaterStore.setState({ toast: { version: "0.0.9" }, modalOpen: false });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    useUpdaterStore.setState({ toast: null, modalOpen: false });
+  });
+
+  it("shows nothing when there is no toast", () => {
+    useUpdaterStore.setState({ toast: null });
+    const { container } = render(<UpdateToast />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the new version and opens the modal when clicked", () => {
+    render(<UpdateToast />);
+
+    expect(screen.getByText(/0\.0\.9/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(useUpdaterStore.getState().modalOpen).toBe(true);
+  });
+
+  it("auto-clears the toast after the fade timeout", () => {
+    vi.useFakeTimers();
+    render(<UpdateToast />);
+
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+
+    expect(useUpdaterStore.getState().toast).toBeNull();
+  });
+});

--- a/src/components/UpdateToast.tsx
+++ b/src/components/UpdateToast.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Sparkles } from "lucide-react";
+import { useUpdaterStore } from "@/stores/updaterStore";
+
+const FADE_MS = 6000;
+
+/**
+ * Transient bottom-right notice shown when a periodic check finds a newer build.
+ * Auto-fades after a few seconds; clicking opens the full UpdateModal. Never
+ * blocks input, so it doesn't interrupt work in the terminal.
+ */
+export function UpdateToast() {
+  const { t } = useTranslation("settings");
+  const toast = useUpdaterStore((s) => s.toast);
+  const clearToast = useUpdaterStore((s) => s.clearToast);
+  const openModal = useUpdaterStore((s) => s.openModal);
+
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+    const timer = setTimeout(clearToast, FADE_MS);
+    return () => clearTimeout(timer);
+  }, [toast, clearToast]);
+
+  if (!toast) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={openModal}
+      className="fixed bottom-10 right-4 z-[90] flex items-center gap-2 rounded-lg border border-border bg-bg-elevated px-3.5 py-2.5 text-xs text-fg shadow-2xl transition-colors hover:border-accent"
+    >
+      <Sparkles size={14} className="shrink-0 text-accent" />
+      <span>{t("update.toast", { version: toast.version })}</span>
+    </button>
+  );
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -24,7 +24,8 @@
     "ready": "Ready",
     "shell": "Shell",
     "encoding": "UTF-8",
-    "language": "Language"
+    "language": "Language",
+    "updateAvailable": "Update available"
   },
   "actions": {
     "newTab": "New Tab",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -46,6 +46,7 @@
   },
   "update": {
     "available": "Update available: v{{version}}",
+    "toast": "New version v{{version}} available",
     "notes": "What's new",
     "install": "Update now",
     "later": "Later",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -24,7 +24,8 @@
     "ready": "就緒",
     "shell": "Shell",
     "encoding": "UTF-8",
-    "language": "語言"
+    "language": "語言",
+    "updateAvailable": "有可用更新"
   },
   "actions": {
     "newTab": "新增分頁",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -46,6 +46,7 @@
   },
   "update": {
     "available": "有新版本 v{{version}}",
+    "toast": "發現新版本 v{{version}}",
     "notes": "更新內容",
     "install": "立即更新",
     "later": "稍後",

--- a/src/modules/settings/AboutSettingsSection.tsx
+++ b/src/modules/settings/AboutSettingsSection.tsx
@@ -23,9 +23,8 @@ export function AboutSettingsSection() {
   const [build, setBuild] = useState<AppBuildInfo | null>(null);
 
   const updaterStatus = useUpdaterStore((s) => s.status);
-  const updaterVersion = useUpdaterStore((s) => s.version);
   const updaterError = useUpdaterStore((s) => s.errorMessage);
-  const checkForUpdate = useUpdaterStore((s) => s.checkForUpdate);
+  const checkManually = useUpdaterStore((s) => s.checkManually);
 
   useEffect(() => {
     let active = true;
@@ -55,8 +54,6 @@ export function AboutSettingsSection() {
         return t("update.checking");
       case "upToDate":
         return t("update.upToDate");
-      case "available":
-        return t("update.available", { version: updaterVersion });
       case "error":
         return updaterError || t("update.checkFailed");
       default:
@@ -102,7 +99,7 @@ export function AboutSettingsSection() {
       <div className="mt-6 flex flex-wrap items-center gap-3">
         <button
           type="button"
-          onClick={() => void checkForUpdate()}
+          onClick={() => void checkManually()}
           disabled={updaterStatus === "checking"}
           className="inline-flex items-center gap-1.5 rounded-md bg-accent px-3.5 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
         >

--- a/src/stores/updaterStore.test.ts
+++ b/src/stores/updaterStore.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Stub the Tauri updater/process plugins so the store can run outside a real
-// app window. vi.hoisted keeps the mock fns reachable from the hoisted factory.
 const { check, relaunch } = vi.hoisted(() => ({
   check: vi.fn(),
   relaunch: vi.fn(),
@@ -14,14 +12,16 @@ import { useUpdaterStore } from "./updaterStore";
 function resetStore() {
   useUpdaterStore.setState({
     status: "idle",
-    version: "",
-    notes: "",
-    releaseUrl: "",
-    update: null,
+    available: null,
+    modalOpen: false,
+    toast: null,
+    notifiedVersions: [],
     installing: false,
     errorMessage: "",
   });
 }
+
+const FOUND = { version: "0.0.2", body: "Bug fixes" };
 
 describe("updaterStore", () => {
   beforeEach(() => {
@@ -30,55 +30,150 @@ describe("updaterStore", () => {
     resetStore();
   });
 
-  it("flags an update as available with its version, notes and release link", async () => {
-    check.mockResolvedValue({ version: "0.0.2", body: "Bug fixes" });
+  it("runLaunchCheck opens the modal and records the version on a hit", async () => {
+    check.mockResolvedValue(FOUND);
 
-    await useUpdaterStore.getState().checkForUpdate();
+    await useUpdaterStore.getState().runLaunchCheck();
 
     const s = useUpdaterStore.getState();
-    expect(s.status).toBe("available");
-    expect(s.version).toBe("0.0.2");
-    expect(s.notes).toBe("Bug fixes");
-    expect(s.releaseUrl).toContain("v0.0.2");
+    expect(s.available?.version).toBe("0.0.2");
+    expect(s.available?.notes).toBe("Bug fixes");
+    expect(s.available?.releaseUrl).toContain("v0.0.2");
+    expect(s.modalOpen).toBe(true);
+    expect(s.notifiedVersions).toContain("0.0.2");
   });
 
-  it("reports up to date when nothing newer exists", async () => {
+  it("runLaunchCheck leaves the modal closed when nothing is newer", async () => {
     check.mockResolvedValue(null);
 
-    await useUpdaterStore.getState().checkForUpdate();
+    await useUpdaterStore.getState().runLaunchCheck();
+
+    expect(useUpdaterStore.getState().modalOpen).toBe(false);
+    expect(useUpdaterStore.getState().available).toBeNull();
+  });
+
+  it("runPeriodicCheck toasts the first time a version is found", async () => {
+    check.mockResolvedValue(FOUND);
+
+    await useUpdaterStore.getState().runPeriodicCheck();
+
+    const s = useUpdaterStore.getState();
+    expect(s.toast).toEqual({ version: "0.0.2" });
+    expect(s.modalOpen).toBe(false);
+    expect(s.available?.version).toBe("0.0.2");
+  });
+
+  it("runPeriodicCheck does not toast the same version twice", async () => {
+    check.mockResolvedValue(FOUND);
+    await useUpdaterStore.getState().runPeriodicCheck();
+    useUpdaterStore.getState().clearToast();
+
+    await useUpdaterStore.getState().runPeriodicCheck();
+
+    expect(useUpdaterStore.getState().toast).toBeNull();
+  });
+
+  it("runPeriodicCheck toasts again for a newer version", async () => {
+    check.mockResolvedValue(FOUND);
+    await useUpdaterStore.getState().runPeriodicCheck();
+    useUpdaterStore.getState().clearToast();
+    check.mockResolvedValue({ version: "0.0.3", body: "More" });
+
+    await useUpdaterStore.getState().runPeriodicCheck();
+
+    expect(useUpdaterStore.getState().toast).toEqual({ version: "0.0.3" });
+  });
+
+  it("a launch modal suppresses a later periodic toast of the same version", async () => {
+    check.mockResolvedValue(FOUND);
+    await useUpdaterStore.getState().runLaunchCheck();
+    useUpdaterStore.getState().dismissModal();
+
+    await useUpdaterStore.getState().runPeriodicCheck();
+
+    expect(useUpdaterStore.getState().toast).toBeNull();
+  });
+
+  it("checkManually reports up to date when nothing newer exists", async () => {
+    check.mockResolvedValue(null);
+
+    await useUpdaterStore.getState().checkManually();
 
     expect(useUpdaterStore.getState().status).toBe("upToDate");
+    expect(useUpdaterStore.getState().modalOpen).toBe(false);
   });
 
-  it("stays idle when a silent background check finds nothing", async () => {
-    check.mockResolvedValue(null);
+  it("checkManually opens the modal on a hit", async () => {
+    check.mockResolvedValue(FOUND);
 
-    await useUpdaterStore.getState().checkForUpdate({ silent: true });
+    await useUpdaterStore.getState().checkManually();
 
-    expect(useUpdaterStore.getState().status).toBe("idle");
+    expect(useUpdaterStore.getState().modalOpen).toBe(true);
+    expect(useUpdaterStore.getState().available?.version).toBe("0.0.2");
   });
 
-  it("surfaces the error message when the check fails", async () => {
+  it("checkManually surfaces the error message when the check fails", async () => {
     check.mockRejectedValue(new Error("network down"));
 
-    await useUpdaterStore.getState().checkForUpdate();
+    await useUpdaterStore.getState().checkManually();
 
     const s = useUpdaterStore.getState();
     expect(s.status).toBe("error");
     expect(s.errorMessage).toBe("network down");
   });
 
-  it("downloads, installs and relaunches into the new build", async () => {
+  it("silent checks stay quiet when the check fails", async () => {
+    check.mockRejectedValue(new Error("network down"));
+
+    await useUpdaterStore.getState().runPeriodicCheck();
+
+    const s = useUpdaterStore.getState();
+    expect(s.status).toBe("idle");
+    expect(s.toast).toBeNull();
+  });
+
+  it("dismissModal keeps the available update so the indicator stays", async () => {
+    check.mockResolvedValue(FOUND);
+    await useUpdaterStore.getState().runLaunchCheck();
+
+    useUpdaterStore.getState().dismissModal();
+
+    const s = useUpdaterStore.getState();
+    expect(s.modalOpen).toBe(false);
+    expect(s.available?.version).toBe("0.0.2");
+  });
+
+  it("clearToast clears the toast", () => {
+    useUpdaterStore.setState({ toast: { version: "0.0.2" } });
+
+    useUpdaterStore.getState().clearToast();
+
+    expect(useUpdaterStore.getState().toast).toBeNull();
+  });
+
+  it("installUpdate downloads, installs and relaunches into the new build", async () => {
     const downloadAndInstall = vi.fn().mockResolvedValue(undefined);
     relaunch.mockResolvedValue(undefined);
     useUpdaterStore.setState({
-      status: "available",
-      update: { downloadAndInstall } as never,
+      available: {
+        version: "0.0.2",
+        notes: "",
+        releaseUrl: "",
+        update: { downloadAndInstall } as never,
+      },
     });
 
     await useUpdaterStore.getState().installUpdate();
 
     expect(downloadAndInstall).toHaveBeenCalledOnce();
     expect(relaunch).toHaveBeenCalledOnce();
+  });
+
+  it("installUpdate is a no-op when no update is available", async () => {
+    useUpdaterStore.setState({ available: null });
+
+    await useUpdaterStore.getState().installUpdate();
+
+    expect(relaunch).not.toHaveBeenCalled();
   });
 });

--- a/src/stores/updaterStore.test.ts
+++ b/src/stores/updaterStore.test.ts
@@ -132,6 +132,16 @@ describe("updaterStore", () => {
     expect(s.toast).toBeNull();
   });
 
+  it("runPeriodicCheck does nothing while an install is in progress", async () => {
+    check.mockResolvedValue(FOUND);
+    useUpdaterStore.setState({ installing: true });
+
+    await useUpdaterStore.getState().runPeriodicCheck();
+
+    expect(check).not.toHaveBeenCalled();
+    expect(useUpdaterStore.getState().toast).toBeNull();
+  });
+
   it("dismissModal keeps the available update so the indicator stays", async () => {
     check.mockResolvedValue(FOUND);
     await useUpdaterStore.getState().runLaunchCheck();

--- a/src/stores/updaterStore.ts
+++ b/src/stores/updaterStore.ts
@@ -5,78 +5,140 @@ import { relaunch } from "@tauri-apps/plugin-process";
 // Where a given version's release notes live, so the modal can deep-link out.
 const RELEASE_TAG_BASE = "https://github.com/mukiwu/tempo-term/releases/tag/v";
 
-export type UpdaterStatus = "idle" | "checking" | "upToDate" | "available" | "error";
+export type UpdaterStatus = "idle" | "checking" | "upToDate" | "error";
 
-interface UpdaterState {
-  status: UpdaterStatus;
+export interface AvailableUpdate {
   version: string;
   notes: string;
   releaseUrl: string;
-  update: Update | null;
+  update: Update;
+}
+
+interface UpdaterState {
+  /** Feedback for the manual check only; never "available" (that is `available`). */
+  status: UpdaterStatus;
+  /** Single source of truth that a newer build exists; drives the status-bar dot. */
+  available: AvailableUpdate | null;
+  /** Whether the UpdateModal is shown. */
+  modalOpen: boolean;
+  /** Transient corner toast to render, or null. */
+  toast: { version: string } | null;
+  /** Versions already surfaced this session (modal or toast); resets on relaunch. */
+  notifiedVersions: string[];
   installing: boolean;
   errorMessage: string;
-  /**
-   * Ask the update server whether a newer build exists. A `silent` check (run
-   * in the background on launch) only ever flips to "available"; it never shows
-   * the "up to date" or error states, so the user isn't nagged on every start.
-   */
-  checkForUpdate: (opts?: { silent?: boolean }) => Promise<void>;
-  /** Download + install the pending update, then relaunch into it. */
+  /** Launch-time silent check: opens the modal directly on a hit. */
+  runLaunchCheck: () => Promise<void>;
+  /** Interval silent check: toasts once per session per version, never nags. */
+  runPeriodicCheck: () => Promise<void>;
+  /** Manual check from settings: surfaces checking/upToDate/error, opens modal on a hit. */
+  checkManually: () => Promise<void>;
+  openModal: () => void;
+  dismissModal: () => void;
+  clearToast: () => void;
   installUpdate: () => Promise<void>;
-  /** Close the update prompt without installing. */
-  dismiss: () => void;
 }
 
 function messageOf(err: unknown): string {
   return err instanceof Error ? err.message : "unexpected error";
 }
 
+/**
+ * Ask the update server for a newer build. A silent check never touches `status`
+ * (no "up to date"/"error" nagging); a visible check drives it. Always sets
+ * `available` on a hit and returns it so callers decide how to present it.
+ */
+async function runCheck(
+  apply: (partial: Partial<UpdaterState>) => void,
+  silent: boolean,
+): Promise<AvailableUpdate | null> {
+  if (!silent) {
+    apply({ status: "checking", errorMessage: "" });
+  }
+  try {
+    const update = await check();
+    if (update) {
+      const found: AvailableUpdate = {
+        version: update.version,
+        notes: update.body ?? "",
+        releaseUrl: `${RELEASE_TAG_BASE}${update.version}`,
+        update,
+      };
+      apply({ available: found });
+      return found;
+    }
+    if (!silent) {
+      apply({ status: "upToDate" });
+    }
+    return null;
+  } catch (err: unknown) {
+    if (!silent) {
+      apply({ status: "error", errorMessage: messageOf(err) });
+    }
+    return null;
+  }
+}
+
 export const useUpdaterStore = create<UpdaterState>((set, get) => ({
   status: "idle",
-  version: "",
-  notes: "",
-  releaseUrl: "",
-  update: null,
+  available: null,
+  modalOpen: false,
+  toast: null,
+  notifiedVersions: [],
   installing: false,
   errorMessage: "",
 
-  checkForUpdate: async (opts) => {
-    if (!opts?.silent) {
-      set({ status: "checking", errorMessage: "" });
-    }
-    try {
-      const update = await check();
-      if (update) {
-        set({
-          status: "available",
-          version: update.version,
-          notes: update.body ?? "",
-          releaseUrl: `${RELEASE_TAG_BASE}${update.version}`,
-          update,
-        });
-      } else if (!opts?.silent) {
-        set({ status: "upToDate" });
-      }
-    } catch (err: unknown) {
-      if (!opts?.silent) {
-        set({ status: "error", errorMessage: messageOf(err) });
-      }
+  runLaunchCheck: async () => {
+    const found = await runCheck((p) => set(p), true);
+    if (found) {
+      get().openModal();
     }
   },
 
+  runPeriodicCheck: async () => {
+    const found = await runCheck((p) => set(p), true);
+    if (found && !get().notifiedVersions.includes(found.version)) {
+      set((s) => ({
+        toast: { version: found.version },
+        notifiedVersions: [...s.notifiedVersions, found.version],
+      }));
+    }
+  },
+
+  checkManually: async () => {
+    const found = await runCheck((p) => set(p), false);
+    if (found) {
+      get().openModal();
+    }
+  },
+
+  openModal: () => {
+    const a = get().available;
+    set((s) => ({
+      modalOpen: true,
+      toast: null,
+      notifiedVersions:
+        a && !s.notifiedVersions.includes(a.version)
+          ? [...s.notifiedVersions, a.version]
+          : s.notifiedVersions,
+    }));
+  },
+
+  dismissModal: () => set({ modalOpen: false }),
+
+  clearToast: () => set({ toast: null }),
+
   installUpdate: async () => {
-    const { update } = get();
-    if (!update) {
+    const a = get().available;
+    if (!a) {
       return;
     }
     set({ installing: true, errorMessage: "" });
     try {
-      await update.downloadAndInstall();
+      await a.update.downloadAndInstall();
       await relaunch();
     } catch (err: unknown) {
       set({ installing: false, status: "error", errorMessage: messageOf(err) });
     }
   },
-
-  dismiss: () => set({ status: "idle" }),
 }));

--- a/src/stores/updaterStore.ts
+++ b/src/stores/updaterStore.ts
@@ -96,6 +96,11 @@ export const useUpdaterStore = create<UpdaterState>((set, get) => ({
   },
 
   runPeriodicCheck: async () => {
+    // An install is mid-flight (download + relaunch); a background check then is
+    // redundant and could toast over the install.
+    if (get().installing) {
+      return;
+    }
     const found = await runCheck((p) => set(p), true);
     if (found && !get().notifiedVersions.includes(found.version)) {
       set((s) => ({


### PR DESCRIPTION
## Summary

The app already checks for updates 5s after launch and pops the modal. The gap: that check runs once per start, so a release published while a long-lived terminal stays open is never surfaced until restart. This adds a periodic re-check with a non-intrusive notification that doesn't interrupt work.

- **Re-check every 6 hours** while the app runs, in addition to the launch check.
- **Non-intrusive notification:** a periodic hit shows a transient bottom-right toast (`New version vX.Y.Z available`) that fades after ~6s, plus a persistent status-bar indicator. Clicking either opens the existing `UpdateModal`.
- **No nagging:** a version notifies at most once per app session (toast or modal); the indicator stays lit until the user updates or quits. A new version notifies again; restarting notifies once more.
- **Launch behavior unchanged:** the 5s launch check still opens the modal directly. Manual check in About settings is unchanged. Notify only, nothing auto-installs. No new setting (always on).

## Implementation

Core change: `updaterStore` now separates "an update exists" (`available`) from "show the modal" (`modalOpen`), and adds a transient `toast` plus a session-scoped `notifiedVersions` list. Previously `status === 'available'` was both the data and the UI intent, which is why any silent check auto-opened the modal.

- `refactor(updater)`: split state + actions (`runLaunchCheck` / `runPeriodicCheck` / `checkManually` / `openModal` / `dismissModal` / `clearToast`), migrate `UpdateModal`, `AboutSettingsSection`, and the `App` launch effect.
- `feat(updater)`: `UpdateToast` corner toast + i18n.
- `feat(updater)`: status-bar indicator.
- `feat(updater)`: 6h interval wiring + render the toast.

## Test plan

- [x] `pnpm test` — 666 passing (new: store notify policy, `UpdateToast`, status-bar indicator)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [ ] Manual: launch with a newer release present, confirm the modal still pops ~5s in; dismiss it, confirm the status-bar indicator stays and reopens the modal on click.
- [ ] Manual: temporarily lower the 6h interval in a dev build, confirm the toast appears bottom-right, fades after ~6s, the indicator persists, the same version does not re-toast, and clicking the toast opens the modal.

## Notes

Polling, not webhooks: a desktop client behind NAT cannot receive a GitHub `release` webhook directly, and a relay server is disproportionate for a serverless app. This matches the existing updater architecture (it already fetches `latest.json`).