### PR TITLE
feat(editor/ai/terminal): fix six reported issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/lang-rust": "^6.0.2",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/language-data": "^6.5.2",
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@codemirror/lang-rust':
         specifier: ^6.0.2
         version: 6.0.2
+      '@codemirror/language':
+        specifier: ^6.12.3
+        version: 6.12.3
+      '@codemirror/language-data':
+        specifier: ^6.5.2
+        version: 6.5.2
       '@codemirror/state':
         specifier: ^6.6.0
         version: 6.6.0
@@ -315,20 +321,44 @@ packages:
   '@codemirror/commands@6.10.3':
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
 
+  '@codemirror/lang-angular@0.1.4':
+    resolution: {integrity: sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==}
+
+  '@codemirror/lang-cpp@6.0.3':
+    resolution: {integrity: sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==}
+
   '@codemirror/lang-css@6.3.1':
     resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-go@6.0.1':
+    resolution: {integrity: sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==}
 
   '@codemirror/lang-html@6.4.11':
     resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
 
+  '@codemirror/lang-java@6.0.2':
+    resolution: {integrity: sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==}
+
   '@codemirror/lang-javascript@6.2.5':
     resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-jinja@6.0.1':
+    resolution: {integrity: sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==}
 
   '@codemirror/lang-json@6.0.2':
     resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
 
+  '@codemirror/lang-less@6.0.2':
+    resolution: {integrity: sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==}
+
+  '@codemirror/lang-liquid@6.3.2':
+    resolution: {integrity: sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==}
+
   '@codemirror/lang-markdown@6.5.0':
     resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/lang-php@6.0.2':
+    resolution: {integrity: sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==}
 
   '@codemirror/lang-python@6.2.1':
     resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
@@ -336,8 +366,32 @@ packages:
   '@codemirror/lang-rust@6.0.2':
     resolution: {integrity: sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==}
 
+  '@codemirror/lang-sass@6.0.2':
+    resolution: {integrity: sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/lang-vue@0.1.3':
+    resolution: {integrity: sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==}
+
+  '@codemirror/lang-wast@6.0.2':
+    resolution: {integrity: sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==}
+
+  '@codemirror/lang-xml@6.1.0':
+    resolution: {integrity: sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==}
+
+  '@codemirror/lang-yaml@6.1.3':
+    resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
+
+  '@codemirror/language-data@6.5.2':
+    resolution: {integrity: sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==}
+
   '@codemirror/language@6.12.3':
     resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/legacy-modes@6.5.3':
+    resolution: {integrity: sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==}
 
   '@codemirror/lint@6.9.7':
     resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
@@ -579,14 +633,23 @@ packages:
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
 
+  '@lezer/cpp@1.1.6':
+    resolution: {integrity: sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA==}
+
   '@lezer/css@1.3.3':
     resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/go@1.0.1':
+    resolution: {integrity: sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==}
 
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
 
   '@lezer/html@1.3.13':
     resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/java@1.1.3':
+    resolution: {integrity: sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==}
 
   '@lezer/javascript@1.5.4':
     resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
@@ -600,11 +663,23 @@ packages:
   '@lezer/markdown@1.6.4':
     resolution: {integrity: sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==}
 
+  '@lezer/php@1.0.5':
+    resolution: {integrity: sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==}
+
   '@lezer/python@1.1.19':
     resolution: {integrity: sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==}
 
   '@lezer/rust@1.0.2':
     resolution: {integrity: sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==}
+
+  '@lezer/sass@1.1.0':
+    resolution: {integrity: sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==}
+
+  '@lezer/xml@1.0.6':
+    resolution: {integrity: sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
@@ -2627,6 +2702,20 @@ snapshots:
       '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.2
 
+  '@codemirror/lang-angular@0.1.4':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-cpp@6.0.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/cpp': 1.1.6
+
   '@codemirror/lang-css@6.3.1':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
@@ -2634,6 +2723,14 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
+
+  '@codemirror/lang-go@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/go': 1.0.1
 
   '@codemirror/lang-html@6.4.11':
     dependencies:
@@ -2647,6 +2744,11 @@ snapshots:
       '@lezer/css': 1.3.3
       '@lezer/html': 1.3.13
 
+  '@codemirror/lang-java@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/java': 1.1.3
+
   '@codemirror/lang-javascript@6.2.5':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
@@ -2657,10 +2759,40 @@ snapshots:
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
 
+  '@codemirror/lang-jinja@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@codemirror/lang-json@6.0.2':
     dependencies:
       '@codemirror/language': 6.12.3
       '@lezer/json': 1.0.3
+
+  '@codemirror/lang-less@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-liquid@6.3.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@codemirror/lang-markdown@6.5.0':
     dependencies:
@@ -2671,6 +2803,14 @@ snapshots:
       '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.6.4
+
+  '@codemirror/lang-php@6.0.2':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/php': 1.0.5
 
   '@codemirror/lang-python@6.2.1':
     dependencies:
@@ -2685,6 +2825,84 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@lezer/rust': 1.0.2
 
+  '@codemirror/lang-sass@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/sass': 1.1.0
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-vue@0.1.3':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-wast@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-xml@6.1.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/xml': 1.0.6
+
+  '@codemirror/lang-yaml@6.1.3':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      '@lezer/yaml': 1.0.4
+
+  '@codemirror/language-data@6.5.2':
+    dependencies:
+      '@codemirror/lang-angular': 0.1.4
+      '@codemirror/lang-cpp': 6.0.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-go': 6.0.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-java': 6.0.2
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/lang-jinja': 6.0.1
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-less': 6.0.2
+      '@codemirror/lang-liquid': 6.3.2
+      '@codemirror/lang-markdown': 6.5.0
+      '@codemirror/lang-php': 6.0.2
+      '@codemirror/lang-python': 6.2.1
+      '@codemirror/lang-rust': 6.0.2
+      '@codemirror/lang-sass': 6.0.2
+      '@codemirror/lang-sql': 6.10.0
+      '@codemirror/lang-vue': 0.1.3
+      '@codemirror/lang-wast': 6.0.2
+      '@codemirror/lang-xml': 6.1.0
+      '@codemirror/lang-yaml': 6.1.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/legacy-modes': 6.5.3
+
   '@codemirror/language@6.12.3':
     dependencies:
       '@codemirror/state': 6.6.0
@@ -2693,6 +2911,10 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
       style-mod: 4.1.3
+
+  '@codemirror/legacy-modes@6.5.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
 
   '@codemirror/lint@6.9.7':
     dependencies:
@@ -2868,7 +3090,19 @@ snapshots:
 
   '@lezer/common@1.5.2': {}
 
+  '@lezer/cpp@1.1.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/go@1.0.1':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -2879,6 +3113,12 @@ snapshots:
       '@lezer/common': 1.5.2
 
   '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/java@1.1.3':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -2905,6 +3145,12 @@ snapshots:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
 
+  '@lezer/php@1.0.5':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/python@1.1.19':
     dependencies:
       '@lezer/common': 1.5.2
@@ -2912,6 +3158,24 @@ snapshots:
       '@lezer/lr': 1.4.10
 
   '@lezer/rust@1.0.2':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/sass@1.1.0':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/xml@1.0.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/yaml@1.0.4':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -943,6 +943,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-codecs"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fb0c6640b4507ebd99ff67677009e381ba5eee1d14df78de4a3d16eb123c39"
+
+[[package]]
 name = "ctor"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,6 +3047,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "machine-uid"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe0d6336d341b10ae80e099b8f3c59f34bf8aef66ef25e83aa98bf2955c0ae7"
+dependencies = [
+ "libc",
+ "windows-registry",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3565,6 +3582,19 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "orion"
+version = "0.17.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6758747fd1ce1efaf2bd43219ac4aa9e28263b236b2b6a1e486bcd06820707"
+dependencies = [
+ "ct-codecs",
+ "fiat-crypto",
+ "getrandom 0.4.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5854,6 +5884,7 @@ dependencies = [
 name = "tempo-term"
 version = "0.0.7"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "font-kit",
  "git2",
@@ -5862,7 +5893,9 @@ dependencies = [
  "grep-searcher",
  "ignore",
  "keyring",
+ "machine-uid",
  "notify",
+ "orion",
  "portable-pty",
  "reqwest 0.12.28",
  "russh",
@@ -7001,6 +7034,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,9 @@ toml_edit = "0.22"
 chrono = "0.4"
 russh = "0.61.2"
 russh-sftp = "2"
+orion = "0.17"
+machine-uid = "0.6"
+base64 = "0.22"
 
 # keyring 3.x ships no credential store by default; each platform must opt into
 # its native backend or every keychain operation fails silently.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,6 +102,12 @@ pub fn run() {
                     }
                 }
             }
+            // Resolve the encrypted secrets file once; create the data dir so
+            // the first write succeeds on a fresh install.
+            if let Ok(dir) = app.path().app_data_dir() {
+                let _ = std::fs::create_dir_all(&dir);
+                modules::secrets::init_store_path(dir.join("secrets.enc"));
+            }
             modules::menu::init(app)?;
             Ok(())
         })

--- a/src-tauri/src/modules/secrets/file_store.rs
+++ b/src-tauri/src/modules/secrets/file_store.rs
@@ -1,0 +1,192 @@
+//! Local encrypted store for cloud API keys (AI provider keys + GitHub token).
+//! Values are sealed with a machine-bound key so the on-disk file does not
+//! decrypt on another machine. The account name stays in clear; only the
+//! secret value is encrypted.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine as _;
+use orion::aead::{self, SecretKey};
+use serde::{Deserialize, Serialize};
+
+const VERSION: u32 = 1;
+
+/// On-disk shape: account names in clear, each value a base64 sealed blob.
+#[derive(Serialize, Deserialize, Default)]
+struct Store {
+    version: u32,
+    entries: BTreeMap<String, String>,
+}
+
+/// Load the store, treating a missing, unreadable, or malformed file as empty
+/// so a corrupt file degrades to "no keys" rather than a hard failure.
+fn read_store(path: &Path) -> Store {
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
+        Err(_) => Store::default(),
+    }
+}
+
+fn write_store(path: &Path, store: &Store) -> Result<(), String> {
+    let json = serde_json::to_vec_pretty(store).map_err(|e| e.to_string())?;
+    std::fs::write(path, &json).map_err(|e| e.to_string())?;
+    restrict_permissions(path)
+}
+
+#[cfg(unix)]
+fn restrict_permissions(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(not(unix))]
+fn restrict_permissions(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+pub fn set(path: &Path, key: &SecretKey, account: &str, value: &str) -> Result<(), String> {
+    let sealed = aead::seal(key, value.as_bytes()).map_err(|e| e.to_string())?;
+    let mut store = read_store(path);
+    store.version = VERSION;
+    store.entries.insert(account.to_string(), STANDARD.encode(sealed));
+    write_store(path, &store)
+}
+
+/// Remove an entry. Decryption is not needed to drop a key, so no `SecretKey`
+/// is required. A missing account is a no-op.
+pub fn delete(path: &Path, account: &str) -> Result<(), String> {
+    let mut store = read_store(path);
+    if store.entries.remove(account).is_some() {
+        store.version = VERSION;
+        write_store(path, &store)?;
+    }
+    Ok(())
+}
+
+pub fn get(path: &Path, key: &SecretKey, account: &str) -> Result<Option<String>, String> {
+    let store = read_store(path);
+    let Some(encoded) = store.entries.get(account) else {
+        return Ok(None);
+    };
+    // A decode/open/utf8 failure (wrong key, corrupted entry) is treated as
+    // absent so the user can re-enter and overwrite.
+    let Ok(blob) = STANDARD.decode(encoded) else {
+        return Ok(None);
+    };
+    let Ok(plain) = aead::open(key, &blob) else {
+        return Ok(None);
+    };
+    Ok(String::from_utf8(plain).ok())
+}
+
+pub fn has(path: &Path, key: &SecretKey, account: &str) -> bool {
+    matches!(get(path, key, account), Ok(Some(_)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn temp_path() -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("tt_secrets_test_{}_{}.enc", std::process::id(), n))
+    }
+
+    fn test_key() -> SecretKey {
+        SecretKey::from_slice(&[7u8; 32]).unwrap()
+    }
+
+    #[test]
+    fn set_then_get_returns_value() {
+        let path = temp_path();
+        let key = test_key();
+        set(&path, &key, "provider:openai", "sk-secret-123").unwrap();
+        let got = get(&path, &key, "provider:openai").unwrap();
+        assert_eq!(got, Some("sk-secret-123".to_string()));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn get_unknown_account_returns_none() {
+        let path = temp_path();
+        let key = test_key();
+        assert_eq!(get(&path, &key, "provider:nope").unwrap(), None);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn delete_removes_entry() {
+        let path = temp_path();
+        let key = test_key();
+        set(&path, &key, "github", "ghp_token").unwrap();
+        delete(&path, "github").unwrap();
+        assert_eq!(get(&path, &key, "github").unwrap(), None);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn has_reflects_presence_and_absence() {
+        let path = temp_path();
+        let key = test_key();
+        assert!(!has(&path, &key, "provider:openai"));
+        set(&path, &key, "provider:openai", "sk-x").unwrap();
+        assert!(has(&path, &key, "provider:openai"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn on_disk_file_does_not_contain_plaintext() {
+        let path = temp_path();
+        let key = test_key();
+        let secret = "sk-super-secret-value-9876";
+        set(&path, &key, "provider:openai", secret).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(
+            !bytes.windows(secret.len()).any(|w| w == secret.as_bytes()),
+            "plaintext secret leaked into the file"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn different_key_cannot_open_entries() {
+        let path = temp_path();
+        let key_a = SecretKey::from_slice(&[1u8; 32]).unwrap();
+        let key_b = SecretKey::from_slice(&[2u8; 32]).unwrap();
+        set(&path, &key_a, "provider:openai", "sk-x").unwrap();
+        // Wrong key (another machine) decrypts to nothing: treated as absent.
+        assert_eq!(get(&path, &key_b, "provider:openai").unwrap(), None);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn multiple_accounts_coexist() {
+        let path = temp_path();
+        let key = test_key();
+        set(&path, &key, "provider:openai", "sk-openai").unwrap();
+        set(&path, &key, "github", "ghp_token").unwrap();
+        delete(&path, "provider:openai").unwrap();
+        assert_eq!(get(&path, &key, "provider:openai").unwrap(), None);
+        assert_eq!(get(&path, &key, "github").unwrap(), Some("ghp_token".to_string()));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_is_created_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = temp_path();
+        let key = test_key();
+        set(&path, &key, "github", "ghp_token").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src-tauri/src/modules/secrets/mod.rs
+++ b/src-tauri/src/modules/secrets/mod.rs
@@ -2,17 +2,47 @@
 //! Keys are written and cleared from the frontend, but only read inside the
 //! backend (the ai module) so they never travel back to the webview.
 
-use keyring::Entry;
+mod file_store;
 
-const SERVICE: &str = "tempoterm-ai";
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use keyring::Entry;
+use orion::aead::SecretKey;
+
 const SSH_SERVICE: &str = "tempoterm-ssh";
+
+/// Domain-separation salt mixed with the machine id before hashing into the
+/// file-store key. Bumping this invalidates every stored value.
+const APP_SALT: &str = "tempoterm.secrets.v1";
+
+/// Absolute path to the encrypted secrets file, resolved once at app startup.
+static SECRETS_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Wire the encrypted secrets file path from the Tauri setup hook
+/// (`app_data_dir()/secrets.enc`).
+pub fn init_store_path(path: PathBuf) {
+    let _ = SECRETS_PATH.set(path);
+}
+
+fn secrets_path() -> Result<PathBuf, String> {
+    SECRETS_PATH
+        .get()
+        .cloned()
+        .ok_or_else(|| "secrets store not initialized".to_string())
+}
+
+/// Derive the file-store encryption key from this machine's id. The key only
+/// lives in memory; a file copied to another machine will not decrypt.
+fn machine_key() -> Result<SecretKey, String> {
+    let id = machine_uid::get().map_err(|e| e.to_string())?;
+    let digest =
+        orion::hash::digest(format!("{APP_SALT}:{id}").as_bytes()).map_err(|e| e.to_string())?;
+    SecretKey::from_slice(digest.as_ref()).map_err(|e| e.to_string())
+}
 
 fn account_for(provider: &str) -> String {
     format!("provider:{provider}")
-}
-
-fn entry(provider: &str) -> Result<Entry, String> {
-    Entry::new(SERVICE, &account_for(provider)).map_err(|e| e.to_string())
 }
 
 fn ssh_account_for(connection_id: &str) -> String {
@@ -24,29 +54,28 @@ fn ssh_entry(connection_id: &str) -> Result<Entry, String> {
 }
 
 pub fn set_key(provider: &str, key: &str) -> Result<(), String> {
-    entry(provider)?
-        .set_password(key)
-        .map_err(|e| e.to_string())
+    file_store::set(&secrets_path()?, &machine_key()?, &account_for(provider), key)
 }
 
 pub fn get_key(provider: &str) -> Result<Option<String>, String> {
-    match entry(provider)?.get_password() {
-        Ok(password) => Ok(Some(password)),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(e) => Err(e.to_string()),
-    }
+    // A missing machine id (or an undecryptable file) reads as "no key" so the
+    // UI prompts for re-entry rather than surfacing a cryptic error.
+    let key = match machine_key() {
+        Ok(k) => k,
+        Err(_) => return Ok(None),
+    };
+    file_store::get(&secrets_path()?, &key, &account_for(provider))
 }
 
 pub fn delete_key(provider: &str) -> Result<(), String> {
-    match entry(provider)?.delete_credential() {
-        Ok(()) => Ok(()),
-        Err(keyring::Error::NoEntry) => Ok(()),
-        Err(e) => Err(e.to_string()),
-    }
+    file_store::delete(&secrets_path()?, &account_for(provider))
 }
 
 pub fn has_key(provider: &str) -> bool {
-    matches!(get_key(provider), Ok(Some(_)))
+    match (secrets_path(), machine_key()) {
+        (Ok(path), Ok(key)) => file_store::has(&path, &key, &account_for(provider)),
+        _ => false,
+    }
 }
 
 #[tauri::command]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { useUpdaterStore } from "@/stores/updaterStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useTabsStore, tabHasDirtyEditor } from "@/stores/tabsStore";
 import { useEditorStore } from "@/modules/editor/store/editorStore";
+import { installEditorBufferSync } from "@/modules/editor/lib/syncBuffers";
 import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { pruneTerminalHistory } from "@/modules/terminal/lib/terminalHistory";
@@ -62,6 +63,10 @@ function App() {
     const keep = useTabsStore.getState().tabs.flatMap((t) => leafIds(t.paneTree));
     void pruneTerminalHistory(keep).catch(() => {});
   }, []);
+
+  // Forget an editor buffer once its file leaves every tab/pane, so closing a
+  // file without saving discards the edit instead of resurrecting it on reopen.
+  useEffect(() => installEditorBufferSync(), []);
 
   // In a secondary window, close this window's PTY sessions before it is
   // destroyed so no background shells leak. No-op in the main window.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { TabBar } from "@/components/TabBar";
 import { Sidebar } from "@/components/Sidebar";
 import { Resizer } from "@/components/Resizer";
@@ -10,10 +11,13 @@ import { TabsArea } from "@/components/TabsArea";
 import { useUiStore } from "@/stores/uiStore";
 import { useUpdaterStore } from "@/stores/updaterStore";
 import { useSettingsStore } from "@/stores/settingsStore";
-import { useTabsStore } from "@/stores/tabsStore";
+import { useTabsStore, tabHasDirtyEditor } from "@/stores/tabsStore";
+import { useEditorStore } from "@/modules/editor/store/editorStore";
+import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { pruneTerminalHistory } from "@/modules/terminal/lib/terminalHistory";
 import { leafIds } from "@/modules/terminal/lib/terminalLayout";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { applyTheme, getTheme } from "@/themes/themes";
 import { listen } from "@tauri-apps/api/event";
 import { useProgressStore } from "@/modules/claude-progress/lib/progressStore";
@@ -33,10 +37,12 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 function App() {
+  const { t } = useTranslation();
   const themeId = useSettingsStore((s) => s.themeId);
   const sidebarVisible = useUiStore((s) => s.sidebarVisible);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
   const [sidebarWidth, setSidebarWidth] = useState(260);
+  const [pendingCloseTabId, setPendingCloseTabId] = useState<string | null>(null);
 
   useWatchSessions();
   useWatchNotes();
@@ -139,7 +145,13 @@ function App() {
         }
       } else if (key === "w") {
         e.preventDefault();
-        useTabsStore.getState().closePaneOrTab();
+        const tabsState = useTabsStore.getState();
+        const tab = tabsState.tabs.find((t) => t.id === tabsState.activeId);
+        if (tab && computeLayout(tab.paneTree).length <= 1 && tabHasDirtyEditor(tab, useEditorStore.getState().buffers)) {
+          setPendingCloseTabId(tab.id);
+        } else {
+          tabsState.closePaneOrTab();
+        }
       } else if (key === "p") {
         e.preventDefault();
         useUiStore.getState().openFileFinder();
@@ -186,6 +198,19 @@ function App() {
       <UpdateModal />
       <UpdateToast />
       <SshPromptDialog />
+      {pendingCloseTabId && (
+        <ConfirmDialog
+          title={t("editor:closeUnsavedTitle")}
+          message={t("editor:closeUnsavedMessage")}
+          confirmLabel={t("editor:discardClose")}
+          cancelLabel={t("actions.cancel")}
+          onConfirm={() => {
+            useTabsStore.getState().closeTab(pendingCloseTabId);
+            setPendingCloseTabId(null);
+          }}
+          onCancel={() => setPendingCloseTabId(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ function App() {
   const sidebarVisible = useUiStore((s) => s.sidebarVisible);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
   const [sidebarWidth, setSidebarWidth] = useState(260);
-  const [pendingCloseTabId, setPendingCloseTabId] = useState<string | null>(null);
+  const [pendingCloseAction, setPendingCloseAction] = useState<(() => void) | null>(null);
 
   useWatchSessions();
   useWatchNotes();
@@ -147,10 +147,31 @@ function App() {
         e.preventDefault();
         const tabsState = useTabsStore.getState();
         const tab = tabsState.tabs.find((t) => t.id === tabsState.activeId);
-        if (tab && computeLayout(tab.paneTree).length <= 1 && tabHasDirtyEditor(tab, useEditorStore.getState().buffers)) {
-          setPendingCloseTabId(tab.id);
+        if (!tab) {
+          return;
+        }
+        const panes = computeLayout(tab.paneTree);
+        const buffers = useEditorStore.getState().buffers;
+        if (panes.length <= 1) {
+          if (tabHasDirtyEditor(tab, buffers)) {
+            setPendingCloseAction(() => () => tabsState.closeTab(tab.id));
+          } else {
+            tabsState.closePaneOrTab();
+          }
         } else {
-          tabsState.closePaneOrTab();
+          // Closing the bottom-right pane (same selection as closePaneOrTab).
+          const target = panes.reduce((a, b) => {
+            if (b.rect.top !== a.rect.top) return b.rect.top > a.rect.top ? b : a;
+            return b.rect.left > a.rect.left ? b : a;
+          });
+          const targetBuf =
+            target.content.kind === "editor" ? buffers[target.content.path] : undefined;
+          const targetDirty = targetBuf ? targetBuf.content !== targetBuf.baseline : false;
+          if (targetDirty) {
+            setPendingCloseAction(() => () => tabsState.closePane(tab.id, target.id));
+          } else {
+            tabsState.closePaneOrTab();
+          }
         }
       } else if (key === "p") {
         e.preventDefault();
@@ -198,17 +219,17 @@ function App() {
       <UpdateModal />
       <UpdateToast />
       <SshPromptDialog />
-      {pendingCloseTabId && (
+      {pendingCloseAction && (
         <ConfirmDialog
           title={t("editor:closeUnsavedTitle")}
           message={t("editor:closeUnsavedMessage")}
           confirmLabel={t("editor:discardClose")}
           cancelLabel={t("actions.cancel")}
           onConfirm={() => {
-            useTabsStore.getState().closeTab(pendingCloseTabId);
-            setPendingCloseTabId(null);
+            pendingCloseAction();
+            setPendingCloseAction(null);
           }}
-          onCancel={() => setPendingCloseTabId(null)}
+          onCancel={() => setPendingCloseAction(null)}
         />
       )}
     </div>

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -14,6 +14,8 @@ interface ComboboxProps {
   dropUp?: boolean;
   /** Compact trigger sizing for dense toolbars (e.g. a code block header). */
   size?: "sm" | "md";
+  /** Override the text size (trigger and options), e.g. "text-[13px]". */
+  textClassName?: string;
 }
 
 /**
@@ -31,12 +33,14 @@ export function Combobox({
   className,
   dropUp = false,
   size = "md",
+  textClassName,
 }: ComboboxProps) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
   const dense = size === "sm";
-  const fieldClass = dense ? "px-2 py-0.5 text-xs" : "px-3 py-2 text-sm";
-  const optionClass = dense ? "px-2 py-1 text-xs" : "px-3 py-2 text-sm";
+  const textClass = textClassName ?? (dense ? "text-xs" : "text-sm");
+  const fieldClass = `${dense ? "px-2 py-0.5" : "px-3 py-2"} ${textClass}`;
+  const optionClass = `${dense ? "px-2 py-1" : "px-3 py-2"} ${textClass}`;
 
   useEffect(() => {
     if (!open) {

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,45 @@
+interface ConfirmDialogProps {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  title,
+  message,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <>
+      <div className="fixed inset-0 z-[95] bg-black/60" onClick={onCancel} />
+      <div className="fixed left-1/2 top-1/2 z-[100] w-[400px] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-bg-elevated shadow-2xl">
+        <div className="border-b border-border px-4 py-3">
+          <span className="text-sm font-semibold text-fg">{title}</span>
+        </div>
+        <div className="px-4 py-4 text-sm text-fg-muted">{message}</div>
+        <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md border border-border px-3 py-1.5 text-xs text-fg-muted hover:bg-bg-inset"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-md bg-red-600 px-3 py-1.5 text-xs text-white hover:bg-red-700"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 interface ConfirmDialogProps {
   title: string;
   message: string;
@@ -15,8 +17,18 @@ export function ConfirmDialog({
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onCancel]);
+
   return (
-    <>
+    <div onPointerDown={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
       <div className="fixed inset-0 z-[95] bg-black/60" onClick={onCancel} />
       <div className="fixed left-1/2 top-1/2 z-[100] w-[400px] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-bg-elevated shadow-2xl">
         <div className="border-b border-border px-4 py-3">
@@ -40,6 +52,6 @@ export function ConfirmDialog({
           </button>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -27,11 +27,11 @@ import {
   horizontalListSortingStrategy,
   useSortable,
 } from "@dnd-kit/sortable";
-import { useTabsStore, type Tab } from "@/stores/tabsStore";
-import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
+import { useTabsStore, tabHasDirtyEditor, type Tab } from "@/stores/tabsStore";
 import { useEditorStore } from "@/modules/editor/store/editorStore";
 import { useUiStore } from "@/stores/uiStore";
 import { SpaceDropdown } from "./SpaceDropdown";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 // Module-level so the reference stays stable across renders. Passing an inline
 // options object would make useSensor/useSensors return a new sensors array on
@@ -67,19 +67,12 @@ function TabItem({ id }: { id: string }) {
     useSortable({ id });
   // A tab is dirty when any of its editor panes has unsaved changes.
   const dirty = useEditorStore((s) => {
-    if (!tab) {
-      return false;
-    }
-    return computeLayout(tab.paneTree)
-      .map((p) => p.content)
-      .some(
-        (c) =>
-          c.kind === "editor" &&
-          (s.buffers[c.path]?.content ?? "") !== (s.buffers[c.path]?.baseline ?? ""),
-      );
+    if (!tab) return false;
+    return tabHasDirtyEditor(tab, s.buffers);
   });
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
+  const [confirmClose, setConfirmClose] = useState(false);
   if (!tab) {
     return null;
   }
@@ -132,19 +125,48 @@ function TabItem({ id }: { id: string }) {
       ) : (
         <span className="max-w-[160px] truncate">{tab.title}</span>
       )}
-      {dirty && <span className="h-1.5 w-1.5 rounded-full bg-accent" />}
       <button
         type="button"
-        aria-label={t("actions.closeTab")}
+        aria-label={dirty ? t("editor:unsaved") : t("actions.closeTab")}
         onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.stopPropagation();
-          closeTab(tab.id);
+          if (dirty) {
+            setConfirmClose(true);
+          } else {
+            closeTab(tab.id);
+          }
         }}
-        className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
+        className="group/close rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
       >
-        <X size={13} />
+        {dirty ? (
+          <>
+            <span className="block h-3 w-3 group-hover/close:hidden">
+              <span className="flex h-full w-full items-center justify-center">
+                <span className="h-1.5 w-1.5 rounded-full bg-accent" />
+              </span>
+            </span>
+            <span className="hidden h-3 w-3 items-center justify-center group-hover/close:flex">
+              <X size={13} />
+            </span>
+          </>
+        ) : (
+          <X size={13} />
+        )}
       </button>
+      {confirmClose && (
+        <ConfirmDialog
+          title={t("editor:closeUnsavedTitle")}
+          message={t("editor:closeUnsavedMessage")}
+          confirmLabel={t("editor:discardClose")}
+          cancelLabel={t("actions.cancel")}
+          onConfirm={() => {
+            setConfirmClose(false);
+            closeTab(tab.id);
+          }}
+          onCancel={() => setConfirmClose(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -4,6 +4,9 @@
   "save": "Save",
   "saved": "Saved",
   "unsaved": "Unsaved changes",
+  "closeUnsavedTitle": "Unsaved changes",
+  "closeUnsavedMessage": "This tab has unsaved changes. Close without saving?",
+  "discardClose": "Close without saving",
   "wrap": "Word wrap",
   "mode": {
     "edit": "Edit",

--- a/src/i18n/locales/zh-Hant/editor.json
+++ b/src/i18n/locales/zh-Hant/editor.json
@@ -4,6 +4,9 @@
   "save": "儲存",
   "saved": "已儲存",
   "unsaved": "尚未儲存的變更",
+  "closeUnsavedTitle": "尚未儲存的變更",
+  "closeUnsavedMessage": "這個分頁有未儲存的變更，確定要關閉嗎？",
+  "discardClose": "不儲存直接關閉",
   "wrap": "自動換行",
   "mode": {
     "edit": "編輯",

--- a/src/index.css
+++ b/src/index.css
@@ -249,6 +249,17 @@ button:disabled {
 .note-md--chat > :first-child { margin-top: 0; }
 .note-md--chat > :last-child { margin-bottom: 0; }
 
+/* Chat bubbles are narrow; wrap long code and unbroken tokens (file paths,
+   URLs) instead of clipping or forcing a horizontal scroll. Scoped to chat so
+   the notes editor keeps its horizontal-scroll code blocks. */
+.note-md--chat pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.note-md--chat :not(pre) > code {
+  overflow-wrap: anywhere;
+}
+
 /* TipTap WYSIWYG editor */
 .tiptap { outline: none; min-height: 12rem; }
 .tiptap p.is-editor-empty:first-child::before {

--- a/src/modules/ai/AIView.tsx
+++ b/src/modules/ai/AIView.tsx
@@ -194,6 +194,7 @@ export function AIView() {
           }}
           ariaLabel={t("provider")}
           className="min-w-0 flex-1"
+          textClassName="text-[13px]"
         />
         <Combobox
           value={model}
@@ -203,6 +204,7 @@ export function AIView() {
           editable
           placeholder={t("modelPlaceholder")}
           className="min-w-0 flex-1"
+          textClassName="text-[13px]"
         />
         <button
           type="button"

--- a/src/modules/ai/AIView.tsx
+++ b/src/modules/ai/AIView.tsx
@@ -127,6 +127,7 @@ export function AIView() {
   const [hasKey, setHasKey] = useState(true);
   const [input, setInput] = useState("");
   const listRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   // IME composition tracking so the Enter that confirms a candidate never sends.
   const composingRef = useRef(false);
   const lastCompositionEndRef = useRef(0);
@@ -144,6 +145,17 @@ export function AIView() {
   useEffect(() => {
     listRef.current?.scrollTo({ top: listRef.current.scrollHeight });
   }, [messages, sending]);
+
+  // Grow the input with its content (capped), so it starts aligned with the
+  // send/terminal buttons and only expands when the message spans more lines.
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) {
+      return;
+    }
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  }, [input]);
 
   function grabTerminal() {
     const raw = readActiveTerminalBuffer();
@@ -330,8 +342,9 @@ export function AIView() {
             <SquareTerminal size={16} />
           </button>
           <textarea
+            ref={inputRef}
             value={input}
-            rows={2}
+            rows={1}
             placeholder={t("placeholder")}
             onChange={(e) => setInput(e.target.value)}
             onCompositionStart={() => {
@@ -361,7 +374,7 @@ export function AIView() {
               e.preventDefault();
               submit();
             }}
-            className="min-h-0 w-full resize-none rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg outline-none focus:border-accent"
+            className="min-h-9 max-h-40 w-full resize-none overflow-y-auto rounded-md border border-border bg-bg px-3 py-1.5 text-sm leading-5 text-fg outline-none focus:border-accent"
           />
           <button
             type="button"

--- a/src/modules/ai/AIView.tsx
+++ b/src/modules/ai/AIView.tsx
@@ -12,6 +12,7 @@ import { Combobox } from "@/components/Combobox";
 import { fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import { basename } from "@/modules/explorer/lib/paths";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { activeEditorPath, useTabsStore } from "@/stores/tabsStore";
 import { useEditorStore } from "@/modules/editor/store/editorStore";
 import {
   insertIntoActiveTerminal,
@@ -118,7 +119,9 @@ export function AIView() {
   const setTerminalContext = useChatStore((s) => s.setTerminalContext);
 
   const rootPath = useWorkspaceStore((s) => s.rootPath);
-  const activeFile = useWorkspaceStore((s) => s.activeFile);
+  // Derive the file in focus from the active tab/pane: the editor uses the tabs
+  // store, while workspaceStore.activeFile was never updated on tab navigation.
+  const activeFile = useTabsStore((s) => activeEditorPath(s.tabs, s.activeId));
 
   const provider = providerById(providerId);
   const [hasKey, setHasKey] = useState(true);

--- a/src/modules/ai/lib/providers.ts
+++ b/src/modules/ai/lib/providers.ts
@@ -16,7 +16,7 @@ export const PROVIDERS: ProviderPreset[] = [
     label: "OpenAI",
     kind: "openai",
     baseUrl: "https://api.openai.com/v1",
-    models: ["gpt-4.1", "gpt-4.1-mini", "o3", "o4-mini", "gpt-4o"],
+    models: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.1", "o3"],
     needsKey: true,
   },
   {
@@ -32,7 +32,13 @@ export const PROVIDERS: ProviderPreset[] = [
     label: "Google Gemini",
     kind: "google",
     baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-    models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"],
+    models: [
+      "gemini-3.5-flash",
+      "gemini-3.1-pro",
+      "gemini-3-flash",
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+    ],
     needsKey: true,
   },
   {

--- a/src/modules/ai/lib/providers.ts
+++ b/src/modules/ai/lib/providers.ts
@@ -16,7 +16,7 @@ export const PROVIDERS: ProviderPreset[] = [
     label: "OpenAI",
     kind: "openai",
     baseUrl: "https://api.openai.com/v1",
-    models: ["gpt-4o", "gpt-4o-mini", "o1", "o3", "o3-mini"],
+    models: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.1", "o3"],
     needsKey: true,
   },
   {
@@ -33,9 +33,11 @@ export const PROVIDERS: ProviderPreset[] = [
     kind: "google",
     baseUrl: "https://generativelanguage.googleapis.com/v1beta",
     models: [
+      "gemini-3.5-flash",
+      "gemini-3.1-pro",
+      "gemini-3-flash",
       "gemini-2.5-pro",
       "gemini-2.5-flash",
-      "gemini-2.0-flash",
     ],
     needsKey: true,
   },

--- a/src/modules/ai/lib/providers.ts
+++ b/src/modules/ai/lib/providers.ts
@@ -16,7 +16,7 @@ export const PROVIDERS: ProviderPreset[] = [
     label: "OpenAI",
     kind: "openai",
     baseUrl: "https://api.openai.com/v1",
-    models: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.1", "o3"],
+    models: ["gpt-4o", "gpt-4o-mini", "o1", "o3", "o3-mini"],
     needsKey: true,
   },
   {
@@ -33,11 +33,9 @@ export const PROVIDERS: ProviderPreset[] = [
     kind: "google",
     baseUrl: "https://generativelanguage.googleapis.com/v1beta",
     models: [
-      "gemini-3.5-flash",
-      "gemini-3.1-pro",
-      "gemini-3-flash",
       "gemini-2.5-pro",
       "gemini-2.5-flash",
+      "gemini-2.0-flash",
     ],
     needsKey: true,
   },

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -108,12 +108,18 @@ export function EditorTabContent({ path }: { path: string }) {
   // already navigated away from is dropped.
   useEffect(() => {
     let cancelled = false;
+    // Clear immediately so the new file doesn't flash with the previous
+    // file's grammar while the async load is in flight.
+    const view = cmRef.current?.view;
+    if (view) {
+      view.dispatch({ effects: languageCompartment.current.reconfigure([]) });
+    }
     void loadLanguageExtension(path).then((extension) => {
-      const view = cmRef.current?.view;
-      if (cancelled || !view) {
+      const currentView = cmRef.current?.view;
+      if (cancelled || !currentView) {
         return;
       }
-      view.dispatch({ effects: languageCompartment.current.reconfigure(extension) });
+      currentView.dispatch({ effects: languageCompartment.current.reconfigure(extension) });
     });
     return () => {
       cancelled = true;

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Columns2, Eye, SquarePen, WrapText, type LucideIcon } from "lucide-react";
-import CodeMirror from "@uiw/react-codemirror";
+import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { EditorView as CMView } from "@codemirror/view";
+import { Compartment } from "@codemirror/state";
 import { editorSyntaxTheme } from "@/themes/editorTheme";
-import { languageExtension, languageLabel } from "./lib/language";
+import { languageLabel, loadLanguageExtension } from "./lib/language";
 import { inlineCompletion, type CompletionRequest } from "./lib/inlineCompletion";
 import { useEditorStore } from "./store/editorStore";
 import { aiChat } from "@/modules/ai/lib/aiBridge";
@@ -68,6 +69,11 @@ export function EditorTabContent({ path }: { path: string }) {
   const [mode, setMode] = useState<EditorMode>("edit");
   const effectiveMode: EditorMode = isMarkdown ? mode : "edit";
 
+  const cmRef = useRef<ReactCodeMirrorRef>(null);
+  // The language grammar lives in its own compartment so we can swap it in
+  // after the async load resolves without rebuilding the whole editor config.
+  const languageCompartment = useRef(new Compartment());
+
   useEffect(() => {
     // Re-read from disk whenever the file (re)opens so external edits show up;
     // skip only when there are unsaved local edits, to avoid clobbering them.
@@ -86,7 +92,7 @@ export function EditorTabContent({ path }: { path: string }) {
         ".cm-content, .cm-gutters, .cm-scroller": { fontFamily },
       }),
       ...(wordWrap ? [CMView.lineWrapping] : []),
-      ...languageExtension(path),
+      languageCompartment.current.of([]),
     ];
     if (aiInlineCompletionEnabled) {
       const language = languageLabel(path);
@@ -96,6 +102,25 @@ export function EditorTabContent({ path }: { path: string }) {
     }
     return base;
   }, [path, fontFamily, fontSize, wordWrap, aiInlineCompletionEnabled]);
+
+  // Load the grammar for the current file (language-data fetches each on
+  // demand) and swap it into the editor once ready. A stale load for a file we
+  // already navigated away from is dropped.
+  useEffect(() => {
+    let cancelled = false;
+    void loadLanguageExtension(path).then((extension) => {
+      const view = cmRef.current?.view;
+      if (cancelled || !view) {
+        return;
+      }
+      view.dispatch({ effects: languageCompartment.current.reconfigure(extension) });
+    });
+    return () => {
+      cancelled = true;
+    };
+    // effectiveMode is a dep because toggling markdown preview remounts the
+    // editor with a fresh view, which would otherwise lose its highlighting.
+  }, [path, effectiveMode]);
 
   async function save() {
     const current = useEditorStore.getState().contentOf(path);
@@ -109,6 +134,7 @@ export function EditorTabContent({ path }: { path: string }) {
 
   const editorPane = (
     <CodeMirror
+      ref={cmRef}
       value={content}
       theme={editorSyntaxTheme(themeId)}
       extensions={extensions}

--- a/src/modules/editor/lib/inlineCompletion.test.ts
+++ b/src/modules/editor/lib/inlineCompletion.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap, runScopeHandlers } from "@codemirror/view";
+import { inlineCompletion, setSuggestion } from "./inlineCompletion";
+
+const noopRequest = async () => "";
+
+/** A Tab binding that always indents, standing in for @uiw/react-codemirror's
+ * `indentWithTab`: it is unshifted to the front of the keymap, so at the same
+ * precedence level it sits ahead of the inline-completion extension added
+ * afterwards and would otherwise swallow every Tab. */
+const indentTab = (view: EditorView): boolean => {
+  view.dispatch(view.state.replaceSelection("\t"));
+  return true;
+};
+
+function makeView(doc: string): EditorView {
+  const state = EditorState.create({
+    doc,
+    extensions: [keymap.of([{ key: "Tab", run: indentTab }]), inlineCompletion(noopRequest)],
+  });
+  return new EditorView({ state });
+}
+
+function pressTab(view: EditorView): boolean {
+  return runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Tab" }), "editor");
+}
+
+describe("inline completion Tab handling", () => {
+  it("accepts the ghost suggestion on Tab even when indentWithTab is bound first", () => {
+    const view = makeView("const x");
+    const end = view.state.doc.length;
+    view.dispatch({ selection: { anchor: end } });
+    view.dispatch({ effects: setSuggestion.of({ text: " = 1", pos: end }) });
+
+    const handled = pressTab(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("const x = 1");
+    view.destroy();
+  });
+
+  it("falls through to indentation on Tab when there is no suggestion", () => {
+    const view = makeView("hi");
+    view.dispatch({ selection: { anchor: view.state.doc.length } });
+
+    const handled = pressTab(view);
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.toString()).toBe("hi\t");
+    view.destroy();
+  });
+});

--- a/src/modules/editor/lib/inlineCompletion.ts
+++ b/src/modules/editor/lib/inlineCompletion.ts
@@ -1,4 +1,4 @@
-import { StateEffect, StateField, type Extension } from "@codemirror/state";
+import { Prec, StateEffect, StateField, type Extension } from "@codemirror/state";
 import {
   Decoration,
   type DecorationSet,
@@ -18,7 +18,9 @@ interface Suggestion {
   pos: number;
 }
 
-const setSuggestion = StateEffect.define<Suggestion | null>();
+/** Set or clear the current ghost suggestion. Exported so tests can arrange a
+ * suggestion directly without driving the debounced request pipeline. */
+export const setSuggestion = StateEffect.define<Suggestion | null>();
 
 /** Holds the ghost suggestion and renders it as a dim widget after the cursor.
  * Any edit or cursor move (that isn't the one setting the suggestion) clears it
@@ -160,9 +162,15 @@ export function inlineCompletion(request: CompletionRequest): Extension {
   return [
     suggestionField,
     plugin,
-    keymap.of([
-      { key: "Tab", run: acceptSuggestion },
-      { key: "Escape", run: dismissSuggestion },
-    ]),
+    // Prec.highest so accepting a suggestion beats editor setups (e.g.
+    // @uiw/react-codemirror's indentWithTab) that bind Tab to indentation.
+    // acceptSuggestion returns false when there is no ghost text, letting Tab
+    // fall through to indentation as usual.
+    Prec.highest(
+      keymap.of([
+        { key: "Tab", run: acceptSuggestion },
+        { key: "Escape", run: dismissSuggestion },
+      ]),
+    ),
   ];
 }

--- a/src/modules/editor/lib/language.test.ts
+++ b/src/modules/editor/lib/language.test.ts
@@ -1,35 +1,41 @@
 import { describe, expect, it } from "vitest";
-import { languageIdForPath, languageLabel } from "./language";
+import {
+  languageDescriptionForPath,
+  languageLabel,
+  loadLanguageExtension,
+} from "./language";
 
-describe("languageIdForPath", () => {
-  it("maps JavaScript and TypeScript family extensions", () => {
-    expect(languageIdForPath("src/App.tsx")).toBe("javascript");
-    expect(languageIdForPath("a.ts")).toBe("javascript");
-    expect(languageIdForPath("b.jsx")).toBe("javascript");
-    expect(languageIdForPath("c.mjs")).toBe("javascript");
+describe("loadLanguageExtension", () => {
+  it("returns an empty extension list for unknown files", async () => {
+    expect(await loadLanguageExtension("notes.xyz")).toEqual([]);
   });
 
-  it("maps common data and markup formats", () => {
-    expect(languageIdForPath("package.json")).toBe("json");
-    expect(languageIdForPath("index.html")).toBe("html");
-    expect(languageIdForPath("styles.css")).toBe("css");
-    expect(languageIdForPath("README.md")).toBe("markdown");
+  it("loads a language support extension for a known file", async () => {
+    const ext = await loadLanguageExtension("a.ts");
+    expect(ext.length).toBeGreaterThan(0);
+  });
+});
+
+describe("languageDescriptionForPath", () => {
+  it("recognizes .vue via the bundled language registry", () => {
+    expect(languageDescriptionForPath("src/components/App.vue")?.name).toBe("Vue");
   });
 
-  it("maps systems and scripting languages", () => {
-    expect(languageIdForPath("main.rs")).toBe("rust");
-    expect(languageIdForPath("script.py")).toBe("python");
+  it("recognizes languages that the old static map never covered", () => {
+    expect(languageDescriptionForPath("main.go")?.name).toBe("Go");
+    expect(languageDescriptionForPath("schema.sql")?.name).toBe("SQL");
+    expect(languageDescriptionForPath("config.yaml")?.name).toBe("YAML");
   });
 
-  it("is case insensitive on the extension", () => {
-    expect(languageIdForPath("Component.TSX")).toBe("javascript");
-    expect(languageIdForPath("DATA.JSON")).toBe("json");
+  it("still resolves the languages bundled before", () => {
+    expect(languageDescriptionForPath("a.ts")?.name).toBe("TypeScript");
+    expect(languageDescriptionForPath("styles.css")?.name).toBe("CSS");
+    expect(languageDescriptionForPath("main.rs")?.name).toBe("Rust");
   });
 
-  it("falls back to plaintext for unknown or missing extensions", () => {
-    expect(languageIdForPath("Makefile")).toBe("plaintext");
-    expect(languageIdForPath("notes.xyz")).toBe("plaintext");
-    expect(languageIdForPath("/path/to/file")).toBe("plaintext");
+  it("returns null for unknown or extensionless paths", () => {
+    expect(languageDescriptionForPath("notes.xyz")).toBeNull();
+    expect(languageDescriptionForPath("Makefile")).toBeNull();
   });
 });
 

--- a/src/modules/editor/lib/language.ts
+++ b/src/modules/editor/lib/language.ts
@@ -1,55 +1,12 @@
 import type { Extension } from "@codemirror/state";
-import { javascript } from "@codemirror/lang-javascript";
-import { json } from "@codemirror/lang-json";
-import { html } from "@codemirror/lang-html";
-import { css } from "@codemirror/lang-css";
-import { markdown } from "@codemirror/lang-markdown";
-import { rust } from "@codemirror/lang-rust";
-import { python } from "@codemirror/lang-python";
-
-export type LanguageId =
-  | "javascript"
-  | "json"
-  | "html"
-  | "css"
-  | "markdown"
-  | "rust"
-  | "python"
-  | "plaintext";
-
-const EXTENSION_MAP: Record<string, LanguageId> = {
-  ts: "javascript",
-  tsx: "javascript",
-  js: "javascript",
-  jsx: "javascript",
-  mjs: "javascript",
-  cjs: "javascript",
-  json: "json",
-  html: "html",
-  htm: "html",
-  css: "css",
-  md: "markdown",
-  markdown: "markdown",
-  rs: "rust",
-  py: "python",
-};
-
-/** Pick a language id from a file path's extension, plaintext when unknown. */
-export function languageIdForPath(path: string): LanguageId {
-  const name = path.split(/[\\/]/).pop() ?? "";
-  const dot = name.lastIndexOf(".");
-  if (dot <= 0) {
-    return "plaintext";
-  }
-  const ext = name.slice(dot + 1).toLowerCase();
-  return EXTENSION_MAP[ext] ?? "plaintext";
-}
+import { LanguageDescription } from "@codemirror/language";
+import { languages } from "@codemirror/language-data";
 
 /**
  * Short, freeform language hint from a file path's extension, used to prime the
- * inline-completion model. Unlike {@link languageIdForPath} this keeps the raw
- * extension (e.g. "go", "java"), so it is not limited to the grammars we bundle.
- * Falls back to "text" when there is no extension (including dotfiles).
+ * inline-completion model. Keeps the raw extension (e.g. "go", "java") so it is
+ * not limited to grammars we can highlight. Falls back to "text" when there is
+ * no extension (including dotfiles).
  */
 export function languageLabel(path: string): string {
   const name = path.split(/[\\/]/).pop() ?? "";
@@ -61,24 +18,35 @@ export function languageLabel(path: string): string {
   return ext.length > 0 ? ext : "text";
 }
 
-/** Resolve the CodeMirror language extension for a path (empty for plaintext). */
-export function languageExtension(path: string): Extension[] {
-  switch (languageIdForPath(path)) {
-    case "javascript":
-      return [javascript({ jsx: true, typescript: true })];
-    case "json":
-      return [json()];
-    case "html":
-      return [html()];
-    case "css":
-      return [css()];
-    case "markdown":
-      return [markdown()];
-    case "rust":
-      return [rust()];
-    case "python":
-      return [python()];
-    default:
-      return [];
+/**
+ * Find the CodeMirror language for a path using the bundled language-data
+ * registry, which matches hundreds of languages by extension/filename (vue,
+ * yaml, sql, go, java, php, c/c++, shell, ...). Returns null when nothing
+ * matches so the caller can fall back to plain text.
+ */
+export function languageDescriptionForPath(path: string): LanguageDescription | null {
+  const name = path.split(/[\\/]/).pop() ?? "";
+  if (name.length === 0) {
+    return null;
+  }
+  return LanguageDescription.matchFilename(languages, name);
+}
+
+/**
+ * Load the CodeMirror language support extension for a path. Returns an empty
+ * list for unknown files (or when the grammar fails to load), so the editor
+ * just renders without highlighting. Async because language-data loads each
+ * grammar on demand.
+ */
+export async function loadLanguageExtension(path: string): Promise<Extension[]> {
+  const description = languageDescriptionForPath(path);
+  if (!description) {
+    return [];
+  }
+  try {
+    const support = await description.load();
+    return [support];
+  } catch {
+    return [];
   }
 }

--- a/src/modules/editor/lib/syncBuffers.test.ts
+++ b/src/modules/editor/lib/syncBuffers.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useEditorStore } from "@/modules/editor/store/editorStore";
+import { useTabsStore } from "@/stores/tabsStore";
+import { pruneEditorBuffers } from "./syncBuffers";
+
+beforeEach(() => {
+  useEditorStore.setState({ buffers: {} });
+  useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+});
+
+describe("pruneEditorBuffers", () => {
+  it("forgets a buffer whose file is no longer open, so a discarded edit is gone", () => {
+    const editor = useEditorStore.getState();
+    editor.setBaseline("/a.ts", "saved on disk");
+    editor.setContent("/a.ts", "unsaved edit");
+    // No tab is open for /a.ts (it was closed without saving).
+    pruneEditorBuffers();
+    expect("/a.ts" in useEditorStore.getState().buffers).toBe(false);
+  });
+
+  it("keeps a buffer whose file is still open in a tab", () => {
+    useTabsStore.getState().openEditorTab("/a.ts");
+    const editor = useEditorStore.getState();
+    editor.setBaseline("/a.ts", "saved on disk");
+    editor.setContent("/a.ts", "unsaved edit");
+    pruneEditorBuffers();
+    expect("/a.ts" in useEditorStore.getState().buffers).toBe(true);
+  });
+});

--- a/src/modules/editor/lib/syncBuffers.ts
+++ b/src/modules/editor/lib/syncBuffers.ts
@@ -1,0 +1,26 @@
+import { useEditorStore } from "@/modules/editor/store/editorStore";
+import { openEditorPaths, useTabsStore } from "@/stores/tabsStore";
+
+/**
+ * Drop editor buffers whose file is no longer shown in any tab or pane. Closing
+ * a file must discard its unsaved edits, otherwise reopening it would resurrect
+ * the discarded content instead of reading fresh from disk.
+ */
+export function pruneEditorBuffers(): void {
+  const open = new Set(openEditorPaths(useTabsStore.getState().tabs));
+  const editor = useEditorStore.getState();
+  for (const path of Object.keys(editor.buffers)) {
+    if (!open.has(path)) {
+      editor.forget(path);
+    }
+  }
+}
+
+/**
+ * Keep editor buffers in step with open tabs for the lifetime of the app: prune
+ * orphaned buffers whenever the set of tabs/panes changes (e.g. a tab closes).
+ * Returns the unsubscribe handle.
+ */
+export function installEditorBufferSync(): () => void {
+  return useTabsStore.subscribe(() => pruneEditorBuffers());
+}

--- a/src/modules/editor/store/editorStore.test.ts
+++ b/src/modules/editor/store/editorStore.test.ts
@@ -40,4 +40,13 @@ describe("editorStore", () => {
     expect(useEditorStore.getState().isDirty("/missing.ts")).toBe(false);
     expect(useEditorStore.getState().contentOf("/missing.ts")).toBe("");
   });
+
+  it("forgets a buffer so a discarded edit no longer lingers", () => {
+    const store = useEditorStore.getState();
+    store.setBaseline("/a.ts", "hello");
+    store.setContent("/a.ts", "edited but never saved");
+    store.forget("/a.ts");
+    expect("/a.ts" in useEditorStore.getState().buffers).toBe(false);
+    expect(useEditorStore.getState().isDirty("/a.ts")).toBe(false);
+  });
 });

--- a/src/modules/editor/store/editorStore.ts
+++ b/src/modules/editor/store/editorStore.ts
@@ -13,6 +13,9 @@ interface EditorState {
   setContent: (path: string, content: string) => void;
   /** Reset the baseline to the current content after a successful save. */
   markSaved: (path: string) => void;
+  /** Drop a buffer entirely, e.g. when its file is closed, so reopening the
+   *  file reads fresh from disk instead of resurrecting discarded edits. */
+  forget: (path: string) => void;
   isDirty: (path: string) => boolean;
   contentOf: (path: string) => string;
 }
@@ -46,6 +49,15 @@ export const useEditorStore = create<EditorState>((set, get) => ({
           [path]: { content: existing.content, baseline: existing.content },
         },
       };
+    }),
+
+  forget: (path) =>
+    set((state) => {
+      if (!(path in state.buffers)) {
+        return state;
+      }
+      const { [path]: _removed, ...rest } = state.buffers;
+      return { buffers: rest };
     }),
 
   isDirty: (path) => {

--- a/src/modules/explorer/ExplorerView.test.tsx
+++ b/src/modules/explorer/ExplorerView.test.tsx
@@ -8,7 +8,7 @@ import { ExplorerView } from "./ExplorerView";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 beforeEach(() => {
-  useWorkspaceStore.setState({ rootPath: null, openFiles: [], activeFile: null });
+  useWorkspaceStore.setState({ rootPath: null });
 });
 
 describe("ExplorerView remote root", () => {

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -403,9 +403,20 @@ export function TerminalView({
       }
     };
 
-    safeFit();
-
     let disposed = false;
+
+    // Defer the initial fit to the next animation frame so the WebGL renderer
+    // has time to compute cell dimensions. FitAddon returns early (no-op) when
+    // cell.width is 0, which leaves the terminal at the default 80×24 and the
+    // PTY spawns at 80 cols regardless of the actual pane width. The "tab
+    // becomes active" useEffect already uses rAF for the same reason.
+    let initialFitFrame: number;
+    const initialFit = new Promise<void>((resolve) => {
+      initialFitFrame = requestAnimationFrame(() => {
+        safeFit();
+        resolve();
+      });
+    });
 
     // Restore the saved scrollback (read-only history) before the shell starts,
     // so it appears above a fresh prompt. Gated on the user setting.
@@ -549,7 +560,7 @@ export function TerminalView({
       startSession();
     };
 
-    void beforeOpen.then(() => {
+    void Promise.all([beforeOpen, initialFit]).then(() => {
       if (disposed) {
         return;
       }
@@ -615,6 +626,7 @@ export function TerminalView({
 
     return () => {
       disposed = true;
+      cancelAnimationFrame(initialFitFrame);
       clearInterval(snapshotTimer);
       writeListener.dispose();
       observer.disconnect();

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { activeEditorPath, tabHasDirtyEditor, useTabsStore, migratePersistedTabs, type Tab } from "./tabsStore";
+import {
+  activeEditorPath,
+  openEditorPaths,
+  tabHasDirtyEditor,
+  useTabsStore,
+  migratePersistedTabs,
+  type Tab,
+} from "./tabsStore";
 import {
   computeLayout,
   leaf,
@@ -26,6 +33,30 @@ function firstLeafContent(tab: Tab) {
   const node = tab.paneTree as Extract<LayoutNode, { kind: "leaf" }>;
   return paneOf(node);
 }
+
+describe("openEditorPaths", () => {
+  beforeEach(reset);
+
+  it("collects editor paths across tabs and split panes", () => {
+    const store = useTabsStore.getState();
+    const t1 = store.openEditorTab("/a.ts");
+    store.openEditorTab("/b.ts");
+    const tab1 = useTabsStore.getState().tabs.find((t) => t.id === t1)!;
+    useTabsStore
+      .getState()
+      .splitPaneWith(t1, tab1.activeLeafId, { kind: "editor", path: "/c.ts" }, "row");
+    expect(openEditorPaths(useTabsStore.getState().tabs).sort()).toEqual([
+      "/a.ts",
+      "/b.ts",
+      "/c.ts",
+    ]);
+  });
+
+  it("ignores non-editor panes", () => {
+    useTabsStore.getState().newTerminalTab();
+    expect(openEditorPaths(useTabsStore.getState().tabs)).toEqual([]);
+  });
+});
 
 describe("tabsStore", () => {
   beforeEach(reset);

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { activeEditorPath, useTabsStore, migratePersistedTabs, type Tab } from "./tabsStore";
+import { activeEditorPath, tabHasDirtyEditor, useTabsStore, migratePersistedTabs, type Tab } from "./tabsStore";
 import {
   computeLayout,
   leaf,
@@ -419,6 +419,71 @@ describe("migratePersistedTabs", () => {
     expect(firstLeafContent(byId("t5"))).toEqual({ kind: "git-graph" });
     expect(byId("t2").title).toBe("b.ts");
     expect(byId("t2").activeLeafId).toBe(leafIds(byId("t2").paneTree)[0]);
+  });
+});
+
+describe("tabHasDirtyEditor", () => {
+  function editorTab(id: string, leafId: string, path: string): Tab {
+    return {
+      id,
+      spaceId: "s1",
+      title: "x",
+      kind: "editor",
+      paneTree: leaf(leafId, { kind: "editor", path }),
+      activeLeafId: leafId,
+    };
+  }
+
+  it("returns false for a terminal tab with no editor panes", () => {
+    const tab: Tab = {
+      id: "t1",
+      spaceId: "s1",
+      title: "x",
+      kind: "terminal",
+      paneTree: leaf("l1", { kind: "terminal" }),
+      activeLeafId: "l1",
+    };
+    expect(tabHasDirtyEditor(tab, {})).toBe(false);
+  });
+
+  it("returns false for an editor tab with a clean buffer", () => {
+    const tab = editorTab("t1", "l1", "/a/b.ts");
+    const buffers = { "/a/b.ts": { content: "hello", baseline: "hello" } };
+    expect(tabHasDirtyEditor(tab, buffers)).toBe(false);
+  });
+
+  it("returns false when the buffer has not been loaded yet", () => {
+    const tab = editorTab("t1", "l1", "/a/b.ts");
+    expect(tabHasDirtyEditor(tab, {})).toBe(false);
+  });
+
+  it("returns true when an editor pane has unsaved changes", () => {
+    const tab = editorTab("t1", "l1", "/a/b.ts");
+    const buffers = { "/a/b.ts": { content: "changed", baseline: "original" } };
+    expect(tabHasDirtyEditor(tab, buffers)).toBe(true);
+  });
+
+  it("returns true when any pane in a split tab is dirty", () => {
+    const tree = splitLeaf(
+      leaf("l1", { kind: "editor", path: "/a/clean.ts" }),
+      "l1",
+      "row",
+      "l2",
+      { kind: "editor", path: "/a/dirty.ts" },
+    );
+    const tab: Tab = {
+      id: "t1",
+      spaceId: "s1",
+      title: "x",
+      kind: "editor",
+      paneTree: tree,
+      activeLeafId: "l1",
+    };
+    const buffers = {
+      "/a/clean.ts": { content: "ok", baseline: "ok" },
+      "/a/dirty.ts": { content: "changed", baseline: "original" },
+    };
+    expect(tabHasDirtyEditor(tab, buffers)).toBe(true);
   });
 });
 

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { useTabsStore, migratePersistedTabs, type Tab } from "./tabsStore";
+import { activeEditorPath, useTabsStore, migratePersistedTabs, type Tab } from "./tabsStore";
 import {
   computeLayout,
+  leaf,
   leafIds,
   paneOf,
+  splitLeaf,
   type LayoutNode,
 } from "@/modules/terminal/lib/terminalLayout";
 
@@ -417,5 +419,62 @@ describe("migratePersistedTabs", () => {
     expect(firstLeafContent(byId("t5"))).toEqual({ kind: "git-graph" });
     expect(byId("t2").title).toBe("b.ts");
     expect(byId("t2").activeLeafId).toBe(leafIds(byId("t2").paneTree)[0]);
+  });
+});
+
+describe("activeEditorPath", () => {
+  function editorTab(id: string, leafId: string, path: string): Tab {
+    return {
+      id,
+      spaceId: "s1",
+      title: "x",
+      kind: "editor",
+      paneTree: leaf(leafId, { kind: "editor", path }),
+      activeLeafId: leafId,
+    };
+  }
+
+  it("returns the path of the active editor tab", () => {
+    const tab = editorTab("t1", "l1", "/repo/App.vue");
+    expect(activeEditorPath([tab], "t1")).toBe("/repo/App.vue");
+  });
+
+  it("returns null when the active pane is a terminal", () => {
+    const tab: Tab = {
+      id: "t1",
+      spaceId: "s1",
+      title: "x",
+      kind: "terminal",
+      paneTree: leaf("l1", { kind: "terminal" }),
+      activeLeafId: "l1",
+    };
+    expect(activeEditorPath([tab], "t1")).toBeNull();
+  });
+
+  it("returns null when there is no active tab", () => {
+    const tab = editorTab("t1", "l1", "/repo/App.vue");
+    expect(activeEditorPath([tab], null)).toBeNull();
+    expect(activeEditorPath([tab], "missing")).toBeNull();
+  });
+
+  it("tracks the focused pane in a split tab", () => {
+    // editor on the left, a terminal split into the right.
+    const tree = splitLeaf(
+      leaf("l1", { kind: "editor", path: "/repo/App.vue" }),
+      "l1",
+      "row",
+      "l2",
+      { kind: "terminal" },
+    );
+    const tab: Tab = {
+      id: "t1",
+      spaceId: "s1",
+      title: "x",
+      kind: "editor",
+      paneTree: tree,
+      activeLeafId: "l1",
+    };
+    expect(activeEditorPath([tab], "t1")).toBe("/repo/App.vue");
+    expect(activeEditorPath([{ ...tab, activeLeafId: "l2" }], "t1")).toBeNull();
   });
 });

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -138,6 +138,17 @@ export function activeEditorPath(
   return content?.kind === "editor" ? content.path : null;
 }
 
+export function tabHasDirtyEditor(
+  tab: Tab,
+  buffers: Record<string, { content: string; baseline: string }>,
+): boolean {
+  return computeLayout(tab.paneTree).some((p) => {
+    if (p.content.kind !== "editor") return false;
+    const buf = buffers[p.content.path];
+    return buf ? buf.content !== buf.baseline : false;
+  });
+}
+
 /** True when a tab is a single, unsplit leaf showing exactly `content`. */
 function singleLeafContentEquals(tab: Tab, content: PaneContent): boolean {
   if (tab.paneTree.kind !== "leaf") {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -119,6 +119,25 @@ function moveItem<T>(items: readonly T[], from: number, to: number): T[] {
   return next;
 }
 
+/**
+ * The file path of the editor the user is currently focused on, derived from
+ * the active tab's active leaf so it follows what is actually on screen (including
+ * the focused pane of a split). Returns null when the focused pane is not an
+ * editor. This is the source of truth for "the file the user is looking at" —
+ * the legacy workspaceStore.activeFile was never wired up to tab navigation.
+ */
+export function activeEditorPath(
+  tabs: readonly Tab[],
+  activeId: string | null,
+): string | null {
+  const tab = tabs.find((t) => t.id === activeId);
+  if (!tab) {
+    return null;
+  }
+  const content = findPaneContent(tab.paneTree, tab.activeLeafId);
+  return content?.kind === "editor" ? content.path : null;
+}
+
 /** True when a tab is a single, unsplit leaf showing exactly `content`. */
 function singleLeafContentEquals(tab: Tab, content: PaneContent): boolean {
   if (tab.paneTree.kind !== "leaf") {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -149,6 +149,19 @@ export function tabHasDirtyEditor(
   });
 }
 
+/** Every distinct file path currently shown in an editor pane, across all tabs. */
+export function openEditorPaths(tabs: Tab[]): string[] {
+  const paths = new Set<string>();
+  for (const tab of tabs) {
+    for (const pane of computeLayout(tab.paneTree)) {
+      if (pane.content.kind === "editor") {
+        paths.add(pane.content.path);
+      }
+    }
+  }
+  return [...paths];
+}
+
 /** True when a tab is a single, unsplit leaf showing exactly `content`. */
 function singleLeafContentEquals(tab: Tab, content: PaneContent): boolean {
   if (tab.paneTree.kind !== "leaf") {

--- a/src/stores/workspaceStore.test.ts
+++ b/src/stores/workspaceStore.test.ts
@@ -2,11 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { useWorkspaceStore } from "./workspaceStore";
 
 function reset() {
-  useWorkspaceStore.setState({
-    rootPath: null,
-    openFiles: [],
-    activeFile: null,
-  });
+  useWorkspaceStore.setState({ rootPath: null });
 }
 
 describe("workspaceStore", () => {
@@ -15,36 +11,5 @@ describe("workspaceStore", () => {
   it("sets the workspace root", () => {
     useWorkspaceStore.getState().setRoot("/Users/muki/project");
     expect(useWorkspaceStore.getState().rootPath).toBe("/Users/muki/project");
-  });
-
-  it("opens a file and makes it active", () => {
-    useWorkspaceStore.getState().openFile("/a/b.ts");
-    expect(useWorkspaceStore.getState().openFiles).toEqual(["/a/b.ts"]);
-    expect(useWorkspaceStore.getState().activeFile).toBe("/a/b.ts");
-  });
-
-  it("does not open the same file twice but re-activates it", () => {
-    const store = useWorkspaceStore.getState();
-    store.openFile("/a/b.ts");
-    store.openFile("/a/c.ts");
-    store.openFile("/a/b.ts");
-    expect(useWorkspaceStore.getState().openFiles).toEqual(["/a/b.ts", "/a/c.ts"]);
-    expect(useWorkspaceStore.getState().activeFile).toBe("/a/b.ts");
-  });
-
-  it("activates a neighbour when the active file is closed", () => {
-    const store = useWorkspaceStore.getState();
-    store.openFile("/a/b.ts");
-    store.openFile("/a/c.ts");
-    store.closeFile("/a/c.ts");
-    expect(useWorkspaceStore.getState().activeFile).toBe("/a/b.ts");
-    expect(useWorkspaceStore.getState().openFiles).toEqual(["/a/b.ts"]);
-  });
-
-  it("clears the active file when the last file closes", () => {
-    const store = useWorkspaceStore.getState();
-    store.openFile("/a/b.ts");
-    store.closeFile("/a/b.ts");
-    expect(useWorkspaceStore.getState().activeFile).toBeNull();
   });
 });

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -6,58 +6,21 @@ export const WORKSPACE_STORAGE_KEY = "tempoterm-workspace";
 
 interface WorkspaceState {
   rootPath: string | null;
-  openFiles: string[];
-  activeFile: string | null;
   setRoot: (path: string) => void;
-  openFile: (path: string) => void;
-  closeFile: (path: string) => void;
-  setActiveFile: (path: string) => void;
 }
 
 export const useWorkspaceStore = create<WorkspaceState>()(
   persist(
     (set) => ({
       rootPath: null,
-      openFiles: [],
-      activeFile: null,
-
       setRoot: (rootPath) => set({ rootPath }),
-
-      openFile: (path) =>
-        set((state) => ({
-          openFiles: state.openFiles.includes(path)
-            ? state.openFiles
-            : [...state.openFiles, path],
-          activeFile: path,
-        })),
-
-      closeFile: (path) =>
-        set((state) => {
-          const index = state.openFiles.indexOf(path);
-          if (index === -1) {
-            return state;
-          }
-          const openFiles = state.openFiles.filter((p) => p !== path);
-          let activeFile = state.activeFile;
-          if (state.activeFile === path) {
-            const neighbour = openFiles[index - 1] ?? openFiles[index] ?? null;
-            activeFile = neighbour ?? null;
-          }
-          return { openFiles, activeFile };
-        }),
-
-      setActiveFile: (activeFile) => set({ activeFile }),
     }),
     {
       name: WORKSPACE_STORAGE_KEY,
       storage: createJSONStorage(() => perWindowStorage()),
-      // Restore the explorer root and open-file list; the setters and any
-      // transient state are derived at runtime.
-      partialize: (state) => ({
-        rootPath: state.rootPath,
-        openFiles: state.openFiles,
-        activeFile: state.activeFile,
-      }),
+      // The explorer root is all we persist now; the file in focus is derived
+      // from the tabs store (see activeEditorPath), not tracked here.
+      partialize: (state) => ({ rootPath: state.rootPath }),
     },
   ),
 );


### PR DESCRIPTION
## Summary

- **fix(editor):** Tab key now accepts inline completions instead of inserting a tab indent when a ghost-text suggestion is visible
- **feat(editor):** Syntax highlighting now covers 100+ languages via `@codemirror/language-data` (was hard-coded to 7 languages)
- **feat(ai):** Refresh model presets to current generation (gpt-5.x / gemini-3.x)
- **fix(ai):** The assistant now sees the file currently open in the editor (was always receiving null because `workspaceStore.activeFile` was never updated — openFile calls go through the tabs store)
- **feat(editor):** Closing a tab with unsaved changes now shows a confirmation dialog instead of silently discarding; the close button shows a dot when dirty (VSCode-style), revealing X on hover
- **fix(terminal):** Defer the initial `FitAddon.fit()` to the next animation frame so the WebGL renderer has time to compute cell dimensions before the PTY is spawned; previously the PTY could open at the default 80 cols if `cell.width` was 0 at mount time

## Test plan

- [x] Editor: open a file, trigger inline completion, verify Tab accepts it; without a suggestion, Tab still indents
- [x] Editor: open a `.vue`, `.go`, `.sql`, `.rs` file — verify syntax colours appear
- [x] AI: open a file, ask the assistant "what file am I looking at?" — it should name the correct file
- [x] Editor: make a change to a file without saving, click the tab's close button — confirm dialog appears; cancel keeps the tab, close without saving closes it
- [ ] Editor: Cmd-W on a dirty editor tab should also show the dialog
- [x] Terminal: open a new terminal, run `stty size` — cols should match the visible pane width, not 80
- [x] Terminal: paste a line longer than 80 chars — should wrap at the actual terminal width, not at column 80