### PR TITLE
feat(ai): redact secrets from scraped context before sending to LLM

### DIFF
--- a/src/modules/ai/lib/attachments.test.ts
+++ b/src/modules/ai/lib/attachments.test.ts
@@ -45,4 +45,12 @@ describe("buildAttachmentsBlock", () => {
     ]);
     expect(block).toContain("[truncated]");
   });
+
+  it("redacts secrets from attached files before they reach the model", () => {
+    const block = buildAttachmentsBlock([
+      { path: "/app/.env", contents: "TOKEN=ghp_16C7e42F292c6912E7710c838347Ae178B4a01" },
+    ]);
+    expect(block).toContain("[REDACTED]");
+    expect(block).not.toContain("ghp_16C7e42F292c6912");
+  });
 });

--- a/src/modules/ai/lib/attachments.ts
+++ b/src/modules/ai/lib/attachments.ts
@@ -1,3 +1,5 @@
+import { redactSecrets } from "./redact";
+
 /** A file the user attached to the assistant's context. */
 export interface AttachedFile {
   path: string;
@@ -32,7 +34,7 @@ export function buildAttachmentsBlock(files: AttachedFile[]): string {
     return "";
   }
   const sections = files.map((file) => {
-    const body = truncateContents(file.contents);
+    const body = redactSecrets(truncateContents(file.contents));
     return `--- ${file.path} ---\n${body}`;
   });
   return ["The user attached these files for reference:", ...sections].join("\n\n");

--- a/src/modules/ai/lib/context.test.ts
+++ b/src/modules/ai/lib/context.test.ts
@@ -23,6 +23,12 @@ describe("buildActiveFileBlock", () => {
     expect(block).toContain("[truncated]");
     expect(block.length).toBeLessThan(20000);
   });
+
+  it("redacts secrets from the active file before they reach the model", () => {
+    const block = buildActiveFileBlock("/app/.env", "API_KEY=sk-abc123DEF456ghi789jkl012mno345");
+    expect(block).toContain("[REDACTED]");
+    expect(block).not.toContain("sk-abc123DEF456");
+  });
 });
 
 describe("buildTerminalBlock", () => {
@@ -43,5 +49,11 @@ describe("buildTerminalBlock", () => {
     const block = buildTerminalBlock(lines, 100);
     expect(block).toContain("line 499");
     expect(block).not.toContain("line 0\n");
+  });
+
+  it("redacts secrets from terminal output before they reach the model", () => {
+    const block = buildTerminalBlock("$ echo $TOKEN\nsk-abc123DEF456ghi789jkl012mno345");
+    expect(block).toContain("[REDACTED]");
+    expect(block).not.toContain("sk-abc123DEF456");
   });
 });

--- a/src/modules/ai/lib/context.ts
+++ b/src/modules/ai/lib/context.ts
@@ -1,4 +1,5 @@
 import { truncateContents } from "./attachments";
+import { redactSecrets } from "./redact";
 
 /** Budget for the active-file context block — larger than a casual attachment
  * because it is the primary thing the user is looking at. */
@@ -18,7 +19,7 @@ export function buildActiveFileBlock(
     return "";
   }
   const body = truncateContents(content, ACTIVE_FILE_MAX_BYTES);
-  return `The file the user is currently viewing (${path}):\n${body}`;
+  return `The file the user is currently viewing (${path}):\n${redactSecrets(body)}`;
 }
 
 /** Default number of trailing terminal lines to keep as context. */
@@ -39,5 +40,5 @@ export function buildTerminalBlock(
   }
   const lines = trimmed.split("\n");
   const tail = lines.length > maxLines ? lines.slice(lines.length - maxLines) : lines;
-  return `Recent output from the user's active terminal:\n${tail.join("\n")}`;
+  return `Recent output from the user's active terminal:\n${redactSecrets(tail.join("\n"))}`;
 }

--- a/src/modules/ai/lib/redact.test.ts
+++ b/src/modules/ai/lib/redact.test.ts
@@ -74,4 +74,27 @@ describe("redactSecrets", () => {
     const input = "PWD=/Users/muki/Documents/project";
     expect(redactSecrets(input)).toBe(input);
   });
+
+  it("redacts a private key block even when the closing marker was truncated away", () => {
+    const input = [
+      "-----BEGIN OPENSSH PRIVATE KEY-----",
+      "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAAB",
+      "AAAAMwb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAA",
+      "…[truncated]",
+    ].join("\n");
+
+    const output = redactSecrets(input);
+
+    expect(output).toContain("[REDACTED]");
+    expect(output).not.toContain("b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQ");
+  });
+
+  it("redacts the whole of a quoted password that contains spaces", () => {
+    const output = redactSecrets('mysql --password="super secret value" -u root');
+
+    expect(output).not.toContain("super secret value");
+    expect(output).not.toContain("secret value");
+    expect(output).toContain("[REDACTED]");
+    expect(output).toContain("-u root");
+  });
 });

--- a/src/modules/ai/lib/redact.test.ts
+++ b/src/modules/ai/lib/redact.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { redactSecrets } from "./redact";
+
+describe("redactSecrets", () => {
+  it("redacts a private key block so the key material never reaches the model", () => {
+    const input = [
+      "$ cat id_rsa",
+      "-----BEGIN OPENSSH PRIVATE KEY-----",
+      "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAAB",
+      "AAAAMwb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAA",
+      "-----END OPENSSH PRIVATE KEY-----",
+    ].join("\n");
+
+    const output = redactSecrets(input);
+
+    expect(output).toContain("[REDACTED]");
+    expect(output).not.toContain("b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQ");
+    expect(output).not.toContain("BEGIN OPENSSH PRIVATE KEY");
+    // surrounding non-secret context is preserved
+    expect(output).toContain("$ cat id_rsa");
+  });
+
+  it("redacts API tokens (OpenAI sk- and GitHub gh* tokens)", () => {
+    const openai = redactSecrets("OPENAI_API_KEY=sk-abc123DEF456ghi789jkl012mno345");
+    expect(openai).toContain("[REDACTED]");
+    expect(openai).not.toContain("sk-abc123DEF456");
+
+    const github = redactSecrets("token: ghp_16C7e42F292c6912E7710c838347Ae178B4a01");
+    expect(github).toContain("[REDACTED]");
+    expect(github).not.toContain("ghp_16C7e42F292c6912");
+  });
+
+  it("redacts AWS access key ids", () => {
+    const out = redactSecrets("aws_access_key_id = AKIAIOSFODNN7EXAMPLE");
+    expect(out).toContain("[REDACTED]");
+    expect(out).not.toContain("AKIAIOSFODNN7EXAMPLE");
+  });
+
+  it("redacts bearer tokens but keeps the scheme word so the line stays readable", () => {
+    const out = redactSecrets("Authorization: Bearer eyJhbGciOiJIUzI1Ni.secret.Token123456");
+    expect(out).toContain("Bearer");
+    expect(out).toContain("[REDACTED]");
+    expect(out).not.toContain("eyJhbGciOiJIUzI1Ni.secret.Token123456");
+  });
+
+  it("redacts password assignments but keeps the key name", () => {
+    const out = redactSecrets("mysql -u root --password=Sup3rS3cret!Value");
+    expect(out).toContain("password=");
+    expect(out).toContain("[REDACTED]");
+    expect(out).not.toContain("Sup3rS3cret!Value");
+  });
+
+  it("redacts the password inside a connection string url but keeps the host", () => {
+    const out = redactSecrets("DATABASE_URL=postgres://admin:Hunter2Pass@db.example.com:5432/app");
+    expect(out).toContain("[REDACTED]");
+    expect(out).not.toContain("Hunter2Pass");
+    expect(out).toContain("db.example.com");
+  });
+
+  it("leaves ordinary terminal output untouched (no false positives)", () => {
+    const input = [
+      "$ npm test",
+      "  ✓ builds the project (1.2s)",
+      "Listening on http://localhost:3000",
+      "commit a1b2c3d  fix: handle empty input",
+      "export PATH=/usr/local/bin:$PATH",
+      "$ ssh deploy@prod.example.com",
+      "$ git remote add origin git@github.com:acme/app.git",
+    ].join("\n");
+    expect(redactSecrets(input)).toBe(input);
+  });
+
+  it("does not treat the PWD environment variable as a password", () => {
+    const input = "PWD=/Users/muki/Documents/project";
+    expect(redactSecrets(input)).toBe(input);
+  });
+});

--- a/src/modules/ai/lib/redact.ts
+++ b/src/modules/ai/lib/redact.ts
@@ -1,0 +1,36 @@
+/** Placeholder substituted for any detected secret. */
+const REDACTED = "[REDACTED]";
+
+/**
+ * Ordered list of redaction rules. Each rule is a global regex and its
+ * replacement; a replacement may reference capture groups (`$1`, `$2`, ...) to
+ * keep the non-secret parts of a match (a scheme word, a key name, a host) so
+ * the surrounding context stays useful to the model.
+ */
+const RULES: ReadonlyArray<readonly [RegExp, string]> = [
+  // PEM / OpenSSH key blocks, e.g. `-----BEGIN OPENSSH PRIVATE KEY----- ... -----END ...-----`.
+  [/-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/g, REDACTED],
+  // OpenAI-style secret keys, e.g. `sk-...` and `sk-proj-...`.
+  [/\bsk-[A-Za-z0-9_-]{20,}/g, REDACTED],
+  // GitHub personal/OAuth/app tokens, e.g. `ghp_...`, `gho_...`.
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}/g, REDACTED],
+  // AWS access key ids, e.g. `AKIA...` (long-lived) and `ASIA...` (temporary).
+  [/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, REDACTED],
+  // `Bearer <token>` auth headers — keep the scheme word, drop the token.
+  [/\bBearer\s+[A-Za-z0-9._~+/=-]+/g, `Bearer ${REDACTED}`],
+  // `password=...` / `passwd:...` assignments — keep the key, drop the value.
+  // `pwd` is deliberately excluded: it collides with the very common `PWD`
+  // working-directory environment variable, which is not a secret.
+  [/\b(password|passwd)(\s*[=:]\s*)(\S+)/gi, `$1$2${REDACTED}`],
+  // Credentials embedded in a URL, e.g. `postgres://user:pass@host` — keep user and host, drop the password.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:@/]+):([^\s:@/]+)@/gi, `$1:${REDACTED}@`],
+];
+
+/**
+ * Strip credentials and key material out of text before it is sent to an LLM.
+ * Matches are replaced with `[REDACTED]`; everything else is left untouched so
+ * the surrounding context stays useful to the model.
+ */
+export function redactSecrets(text: string): string {
+  return RULES.reduce((acc, [pattern, replacement]) => acc.replace(pattern, replacement), text);
+}

--- a/src/modules/ai/lib/redact.ts
+++ b/src/modules/ai/lib/redact.ts
@@ -9,7 +9,10 @@ const REDACTED = "[REDACTED]";
  */
 const RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // PEM / OpenSSH key blocks, e.g. `-----BEGIN OPENSSH PRIVATE KEY----- ... -----END ...-----`.
-  [/-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/g, REDACTED],
+  // The end alternates between the closing marker and end-of-string so a key
+  // whose tail was truncated away (context blocks are truncated before
+  // redaction) is still scrubbed instead of leaking.
+  [/-----BEGIN [^-]+-----[\s\S]*?(?:-----END [^-]+-----|$)/g, REDACTED],
   // OpenAI-style secret keys, e.g. `sk-...` and `sk-proj-...`.
   [/\bsk-[A-Za-z0-9_-]{20,}/g, REDACTED],
   // GitHub personal/OAuth/app tokens, e.g. `ghp_...`, `gho_...`.
@@ -19,9 +22,14 @@ const RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // `Bearer <token>` auth headers — keep the scheme word, drop the token.
   [/\bBearer\s+[A-Za-z0-9._~+/=-]+/g, `Bearer ${REDACTED}`],
   // `password=...` / `passwd:...` assignments — keep the key, drop the value.
-  // `pwd` is deliberately excluded: it collides with the very common `PWD`
-  // working-directory environment variable, which is not a secret.
-  [/\b(password|passwd)(\s*[=:]\s*)(\S+)/gi, `$1$2${REDACTED}`],
+  // The value may be a single/double-quoted string (so spaces inside quotes are
+  // covered) or an unquoted run of non-space chars. `pwd` is deliberately
+  // excluded: it collides with the very common `PWD` working-directory
+  // environment variable, which is not a secret.
+  [
+    /\b(password|passwd)(\s*[=:]\s*)("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S+)/gi,
+    `$1$2${REDACTED}`,
+  ],
   // Credentials embedded in a URL, e.g. `postgres://user:pass@host` — keep user and host, drop the password.
   [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:@/]+):([^\s:@/]+)@/gi, `$1:${REDACTED}@`],
 ];

--- a/src/modules/git-graph/lib/explainDiff.test.ts
+++ b/src/modules/git-graph/lib/explainDiff.test.ts
@@ -31,4 +31,10 @@ describe("buildExplainPrompt", () => {
     const out = buildExplainPrompt("short", "f.ts", "en", 100);
     expect(out).not.toContain("[truncated]");
   });
+
+  it("redacts secrets from the diff before it reaches the model", () => {
+    const out = buildExplainPrompt("+API_KEY=sk-abc123DEF456ghi789jkl012mno345", "f.ts", "en");
+    expect(out).toContain("[REDACTED]");
+    expect(out).not.toContain("sk-abc123DEF456");
+  });
 });

--- a/src/modules/git-graph/lib/explainDiff.ts
+++ b/src/modules/git-graph/lib/explainDiff.ts
@@ -1,6 +1,7 @@
 import { aiChat } from "@/modules/ai/lib/aiBridge";
 import { composeMessages } from "@/modules/ai/lib/chat";
 import { providerById } from "@/modules/ai/lib/providers";
+import { redactSecrets } from "@/modules/ai/lib/redact";
 
 export const EXPLAIN_SYSTEM_PROMPT =
   "You are a senior software engineer. Explain a git diff in simple, scannable terms: " +
@@ -14,8 +15,9 @@ export function buildExplainPrompt(
   lang: string,
   maxChars = 12000,
 ): string {
-  const body =
-    diff.length > maxChars ? `${diff.slice(0, maxChars)}\n...[truncated]` : diff;
+  const body = redactSecrets(
+    diff.length > maxChars ? `${diff.slice(0, maxChars)}\n...[truncated]` : diff,
+  );
   const language = lang.startsWith("zh")
     ? "Respond in 正體中文 (Traditional Chinese)."
     : "Respond in English.";

--- a/src/modules/source-control/lib/aiCommit.test.ts
+++ b/src/modules/source-control/lib/aiCommit.test.ts
@@ -12,6 +12,12 @@ describe("buildCommitPrompt", () => {
     expect(prompt.length).toBeLessThan(2000);
     expect(prompt).toContain("truncated");
   });
+
+  it("redacts secrets from the diff before it reaches the model", () => {
+    const prompt = buildCommitPrompt("+API_KEY=sk-abc123DEF456ghi789jkl012mno345");
+    expect(prompt).toContain("[REDACTED]");
+    expect(prompt).not.toContain("sk-abc123DEF456");
+  });
 });
 
 describe("sanitizeCommitMessage", () => {

--- a/src/modules/source-control/lib/aiCommit.ts
+++ b/src/modules/source-control/lib/aiCommit.ts
@@ -1,6 +1,7 @@
 import { aiChat } from "@/modules/ai/lib/aiBridge";
 import { composeMessages } from "@/modules/ai/lib/chat";
 import { providerById } from "@/modules/ai/lib/providers";
+import { redactSecrets } from "@/modules/ai/lib/redact";
 
 const SYSTEM_PROMPT =
   "You are a git commit message generator. Given a staged diff, write a single " +
@@ -12,7 +13,7 @@ const SYSTEM_PROMPT =
 export function buildCommitPrompt(diff: string, maxChars = 12000): string {
   const body =
     diff.length > maxChars ? `${diff.slice(0, maxChars)}\n...[truncated]` : diff;
-  return `Write a conventional commit message for this staged diff:\n\n${body}`;
+  return `Write a conventional commit message for this staged diff:\n\n${redactSecrets(body)}`;
 }
 
 /** Strip code fences and surrounding whitespace from a model's reply. */


### PR DESCRIPTION
## Summary

Terminal output, files, and diffs were sent to the configured LLM verbatim, so a visible password, API key, or private key could leak to a third-party provider. This adds a redaction layer that masks secrets before any scraped content leaves the app.

A new `redactSecrets()` utility (`src/modules/ai/lib/redact.ts`) replaces the following with `[REDACTED]`:

- PEM / OpenSSH private-key blocks
- OpenAI-style keys (`sk-…`) and GitHub tokens (`ghp_/gho_/…`)
- AWS access key ids (`AKIA…` / `ASIA…`)
- `Bearer <token>` auth headers (keeps the scheme word)
- `password=` / `passwd:` assignments (keeps the key name)
- credentials embedded in URLs, e.g. `postgres://user:pass@host` (keeps user + host)

It is applied at every point where scraped content is assembled into a prompt:

| Entry point | File |
|---|---|
| Active terminal output | `ai/lib/context.ts` → `buildTerminalBlock` |
| Active file block | `ai/lib/context.ts` → `buildActiveFileBlock` |
| Attached files | `ai/lib/attachments.ts` → `buildAttachmentsBlock` |
| Commit-message prompt | `source-control/lib/aiCommit.ts` → `buildCommitPrompt` |
| Diff-explanation prompt | `git-graph/lib/explainDiff.ts` → `buildExplainPrompt` |

The user's own typed chat messages and inline code completion are intentionally **not** redacted, so they keep full fidelity.

## Notes

- `pwd` is deliberately excluded from the password matcher because it collides with the very common `PWD` working-directory environment variable (covered by a regression test).
- Redaction is conservative on the "don't break context" side: it keeps hosts, key names, and scheme words so the model still has useful surrounding context.

## Test plan

- [x] `redact.test.ts` — 8 behaviors: each secret type + a no-false-positive guard (ordinary output, `ssh user@host`, `git@github.com:…`, `PWD=`)
- [x] Integration tests on all 5 entry points assert secrets are stripped
- [x] Full suite green (700 tests), `tsc --noEmit` clean