### PR TITLE
feat(terminal): add in-terminal search (find next/previous)

### DIFF
--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -3,6 +3,12 @@
   "tagline": "AI-powered terminal workspace",
   "terminalConnecting": "Starting shell…",
   "openLinkHint": "{{mods}}-click to open",
+  "terminalSearch": {
+    "placeholder": "Find in terminal",
+    "next": "Find next",
+    "previous": "Find previous",
+    "close": "Close search"
+  },
   "ssh": {
     "disconnected": "Disconnected — click to reconnect",
     "reconnect": "Reconnect"

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -134,6 +134,7 @@
     "splitRight": "Split left / right",
     "splitDown": "Split top / bottom",
     "cyclePane": "Cycle split panes",
+    "searchTerminal": "Search terminal output",
     "lineStart": "Jump to line start",
     "lineEnd": "Jump to line end",
     "wordBack": "Jump word left",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -3,6 +3,12 @@
   "tagline": "AI 驅動的終端機工作區",
   "terminalConnecting": "啟動中…",
   "openLinkHint": "{{mods}} + 點擊開啟",
+  "terminalSearch": {
+    "placeholder": "在終端機中搜尋",
+    "next": "下一個",
+    "previous": "上一個",
+    "close": "關閉搜尋"
+  },
   "ssh": {
     "disconnected": "已斷線，點擊重新連線",
     "reconnect": "重新連線"

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -134,6 +134,7 @@
     "splitRight": "左右分割面板",
     "splitDown": "上下分割面板",
     "cyclePane": "循環切換分割視窗",
+    "searchTerminal": "搜尋終端機輸出",
     "lineStart": "跳到行首",
     "lineEnd": "跳到行尾",
     "wordBack": "跳上一個單字",

--- a/src/modules/settings/ShortcutsSettingsSection.tsx
+++ b/src/modules/settings/ShortcutsSettingsSection.tsx
@@ -39,6 +39,10 @@ const GROUPS: ShortcutGroup[] = [
       { labelKey: "shortcutsList.splitRight", keys: `${MOD} D` },
       { labelKey: "shortcutsList.splitDown", keys: `${MOD} ${SHIFT} D` },
       { labelKey: "shortcutsList.cyclePane", keys: `${MOD} \`` },
+      {
+        labelKey: "shortcutsList.searchTerminal",
+        keys: IS_MAC ? `${MOD} F` : `${MOD} ${SHIFT} F`,
+      },
     ],
   },
   {

--- a/src/modules/terminal/SearchBar.test.tsx
+++ b/src/modules/terminal/SearchBar.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SearchBar } from "./SearchBar";
+import "../../i18n";
+
+function makeController() {
+  return {
+    findNext: vi.fn(() => true),
+    findPrevious: vi.fn(() => true),
+    clearDecorations: vi.fn(),
+  };
+}
+
+describe("SearchBar", () => {
+  it("searches forward when the user types a query and presses Enter", () => {
+    const search = makeController();
+    render(<SearchBar search={search} onClose={() => {}} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "needle" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(search.findNext).toHaveBeenCalledWith("needle");
+  });
+
+  it("searches backward when the user presses Shift+Enter", () => {
+    const search = makeController();
+    render(<SearchBar search={search} onClose={() => {}} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "needle" } });
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+
+    expect(search.findPrevious).toHaveBeenCalledWith("needle");
+    expect(search.findNext).not.toHaveBeenCalled();
+  });
+
+  it("closes when the user presses Escape", () => {
+    const search = makeController();
+    const onClose = vi.fn();
+    render(<SearchBar search={search} onClose={onClose} />);
+
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("clears the search highlight when it unmounts", () => {
+    const search = makeController();
+    const { unmount } = render(<SearchBar search={search} onClose={() => {}} />);
+
+    unmount();
+
+    expect(search.clearDecorations).toHaveBeenCalled();
+  });
+
+  it("searches forward and backward from the next/previous buttons", () => {
+    const search = makeController();
+    render(<SearchBar search={search} onClose={() => {}} />);
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "needle" } });
+    fireEvent.click(screen.getByLabelText("Find next"));
+    fireEvent.click(screen.getByLabelText("Find previous"));
+
+    expect(search.findNext).toHaveBeenCalledWith("needle");
+    expect(search.findPrevious).toHaveBeenCalledWith("needle");
+  });
+});

--- a/src/modules/terminal/SearchBar.test.tsx
+++ b/src/modules/terminal/SearchBar.test.tsx
@@ -45,6 +45,18 @@ describe("SearchBar", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("clears the highlight as soon as the query is emptied", () => {
+    const search = makeController();
+    render(<SearchBar search={search} onClose={() => {}} />);
+    const input = screen.getByRole("textbox");
+
+    fireEvent.change(input, { target: { value: "needle" } });
+    search.clearDecorations.mockClear();
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(search.clearDecorations).toHaveBeenCalled();
+  });
+
   it("clears the search highlight when it unmounts", () => {
     const search = makeController();
     const { unmount } = render(<SearchBar search={search} onClose={() => {}} />);

--- a/src/modules/terminal/SearchBar.test.tsx
+++ b/src/modules/terminal/SearchBar.test.tsx
@@ -1,12 +1,13 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import type { ISearchOptions } from "@xterm/addon-search";
 import { SearchBar } from "./SearchBar";
 import "../../i18n";
 
 function makeController() {
   return {
-    findNext: vi.fn(() => true),
-    findPrevious: vi.fn(() => true),
+    findNext: vi.fn((_query: string, _options?: ISearchOptions) => true),
+    findPrevious: vi.fn((_query: string, _options?: ISearchOptions) => true),
     clearDecorations: vi.fn(),
   };
 }
@@ -20,7 +21,23 @@ describe("SearchBar", () => {
     fireEvent.change(input, { target: { value: "needle" } });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    expect(search.findNext).toHaveBeenCalledWith("needle");
+    expect(search.findNext).toHaveBeenCalledWith(
+      "needle",
+      expect.objectContaining({ decorations: expect.anything() }),
+    );
+  });
+
+  it("highlights matches with a visible decoration background", () => {
+    const search = makeController();
+    render(<SearchBar search={search} onClose={() => {}} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "needle" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const options = search.findNext.mock.calls[0]?.[1];
+    expect(options?.decorations?.matchBackground).toBeTruthy();
+    expect(options?.decorations?.activeMatchBackground).toBeTruthy();
   });
 
   it("searches backward when the user presses Shift+Enter", () => {
@@ -31,7 +48,10 @@ describe("SearchBar", () => {
     fireEvent.change(input, { target: { value: "needle" } });
     fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
 
-    expect(search.findPrevious).toHaveBeenCalledWith("needle");
+    expect(search.findPrevious).toHaveBeenCalledWith(
+      "needle",
+      expect.objectContaining({ decorations: expect.anything() }),
+    );
     expect(search.findNext).not.toHaveBeenCalled();
   });
 
@@ -74,7 +94,7 @@ describe("SearchBar", () => {
     fireEvent.click(screen.getByLabelText("Find next"));
     fireEvent.click(screen.getByLabelText("Find previous"));
 
-    expect(search.findNext).toHaveBeenCalledWith("needle");
-    expect(search.findPrevious).toHaveBeenCalledWith("needle");
+    expect(search.findNext).toHaveBeenCalledWith("needle", expect.anything());
+    expect(search.findPrevious).toHaveBeenCalledWith("needle", expect.anything());
   });
 });

--- a/src/modules/terminal/SearchBar.tsx
+++ b/src/modules/terminal/SearchBar.tsx
@@ -15,19 +15,20 @@ export interface TerminalSearchController {
 }
 
 /**
- * Bright match colours. Decorations only set the cell background (xterm can't
- * recolour the matched text), so a bright fill is what keeps dark/dim terminal
- * text readable and makes the hit obvious: amber for every match, a stronger
- * orange for the currently focused one.
+ * Muted gold match colours. Decorations only set the cell background (xterm
+ * can't recolour the matched text), so the fill is kept a desaturated mid-tone
+ * gold: bright enough to spot, dark enough that light terminal text stays
+ * readable on top, and easy on the eyes. The active match is a lighter gold so
+ * the focused hit still stands out from the rest.
  */
 const SEARCH_OPTIONS: ISearchOptions = {
   decorations: {
-    matchBackground: "#fbbf24",
-    matchBorder: "#fbbf24",
-    matchOverviewRuler: "#fbbf24",
-    activeMatchBackground: "#f97316",
-    activeMatchBorder: "#fdba74",
-    activeMatchColorOverviewRuler: "#fdba74",
+    matchBackground: "#9d8136",
+    matchBorder: "#b59a45",
+    matchOverviewRuler: "#b59a45",
+    activeMatchBackground: "#c0a046",
+    activeMatchBorder: "#d8b65e",
+    activeMatchColorOverviewRuler: "#d8b65e",
   },
 };
 

--- a/src/modules/terminal/SearchBar.tsx
+++ b/src/modules/terminal/SearchBar.tsx
@@ -22,11 +22,24 @@ export function SearchBar({ search, onClose }: SearchBarProps) {
   const { t } = useTranslation();
   const [query, setQuery] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const initialMount = useRef(true);
 
   // Focus the field as soon as the bar opens so the user can type immediately.
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  // Clear stale highlights the moment the query is emptied, rather than leaving
+  // them on screen until the bar closes. Skips the initial empty mount.
+  useEffect(() => {
+    if (initialMount.current) {
+      initialMount.current = false;
+      return;
+    }
+    if (!query) {
+      search.clearDecorations();
+    }
+  }, [query, search]);
 
   // Drop the match highlight when the bar goes away, so closing search leaves
   // the terminal clean.

--- a/src/modules/terminal/SearchBar.tsx
+++ b/src/modules/terminal/SearchBar.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown, ChevronUp, X } from "lucide-react";
+
+/**
+ * Minimal slice of the xterm SearchAddon the search bar drives. Keeping it to
+ * these three methods lets tests pass a fake and lets the real addon satisfy it
+ * structurally.
+ */
+export interface TerminalSearchController {
+  findNext(query: string): boolean;
+  findPrevious(query: string): boolean;
+  clearDecorations(): void;
+}
+
+interface SearchBarProps {
+  search: TerminalSearchController;
+  onClose: () => void;
+}
+
+export function SearchBar({ search, onClose }: SearchBarProps) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the field as soon as the bar opens so the user can type immediately.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Drop the match highlight when the bar goes away, so closing search leaves
+  // the terminal clean.
+  useEffect(() => () => search.clearDecorations(), [search]);
+
+  const buttonClass = "rounded p-0.5 text-fg-muted hover:bg-border hover:text-fg";
+
+  return (
+    <div className="absolute right-3 top-3 z-20 flex items-center gap-1 rounded-md border border-border-strong bg-bg-elevated px-2 py-1 shadow-lg">
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        placeholder={t("terminalSearch.placeholder")}
+        className="w-44 bg-transparent text-sm text-fg placeholder-fg-subtle focus:outline-none"
+        onChange={(event) => setQuery(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            if (event.shiftKey) {
+              search.findPrevious(query);
+            } else {
+              search.findNext(query);
+            }
+          } else if (event.key === "Escape") {
+            onClose();
+          }
+        }}
+      />
+      <button
+        type="button"
+        aria-label={t("terminalSearch.previous")}
+        className={buttonClass}
+        onClick={() => search.findPrevious(query)}
+      >
+        <ChevronUp size={14} />
+      </button>
+      <button
+        type="button"
+        aria-label={t("terminalSearch.next")}
+        className={buttonClass}
+        onClick={() => search.findNext(query)}
+      >
+        <ChevronDown size={14} />
+      </button>
+      <button type="button" aria-label={t("terminalSearch.close")} className={buttonClass} onClick={onClose}>
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/modules/terminal/SearchBar.tsx
+++ b/src/modules/terminal/SearchBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, ChevronUp, X } from "lucide-react";
+import type { ISearchOptions } from "@xterm/addon-search";
 
 /**
  * Minimal slice of the xterm SearchAddon the search bar drives. Keeping it to
@@ -8,10 +9,26 @@ import { ChevronDown, ChevronUp, X } from "lucide-react";
  * structurally.
  */
 export interface TerminalSearchController {
-  findNext(query: string): boolean;
-  findPrevious(query: string): boolean;
+  findNext(query: string, options?: ISearchOptions): boolean;
+  findPrevious(query: string, options?: ISearchOptions): boolean;
   clearDecorations(): void;
 }
+
+/**
+ * High-contrast match colours so hits stand out on the dark terminal while the
+ * light terminal text stays readable: a blue fill for every match and a warm
+ * amber for the currently focused one.
+ */
+const SEARCH_OPTIONS: ISearchOptions = {
+  decorations: {
+    matchBackground: "#3b5e8c",
+    matchBorder: "#5e8cd1",
+    matchOverviewRuler: "#5e8cd1",
+    activeMatchBackground: "#d7831e",
+    activeMatchBorder: "#ffb454",
+    activeMatchColorOverviewRuler: "#ffb454",
+  },
+};
 
 interface SearchBarProps {
   search: TerminalSearchController;
@@ -59,9 +76,9 @@ export function SearchBar({ search, onClose }: SearchBarProps) {
         onKeyDown={(event) => {
           if (event.key === "Enter") {
             if (event.shiftKey) {
-              search.findPrevious(query);
+              search.findPrevious(query, SEARCH_OPTIONS);
             } else {
-              search.findNext(query);
+              search.findNext(query, SEARCH_OPTIONS);
             }
           } else if (event.key === "Escape") {
             onClose();
@@ -72,7 +89,7 @@ export function SearchBar({ search, onClose }: SearchBarProps) {
         type="button"
         aria-label={t("terminalSearch.previous")}
         className={buttonClass}
-        onClick={() => search.findPrevious(query)}
+        onClick={() => search.findPrevious(query, SEARCH_OPTIONS)}
       >
         <ChevronUp size={14} />
       </button>
@@ -80,7 +97,7 @@ export function SearchBar({ search, onClose }: SearchBarProps) {
         type="button"
         aria-label={t("terminalSearch.next")}
         className={buttonClass}
-        onClick={() => search.findNext(query)}
+        onClick={() => search.findNext(query, SEARCH_OPTIONS)}
       >
         <ChevronDown size={14} />
       </button>

--- a/src/modules/terminal/SearchBar.tsx
+++ b/src/modules/terminal/SearchBar.tsx
@@ -15,18 +15,19 @@ export interface TerminalSearchController {
 }
 
 /**
- * High-contrast match colours so hits stand out on the dark terminal while the
- * light terminal text stays readable: a blue fill for every match and a warm
- * amber for the currently focused one.
+ * Bright match colours. Decorations only set the cell background (xterm can't
+ * recolour the matched text), so a bright fill is what keeps dark/dim terminal
+ * text readable and makes the hit obvious: amber for every match, a stronger
+ * orange for the currently focused one.
  */
 const SEARCH_OPTIONS: ISearchOptions = {
   decorations: {
-    matchBackground: "#3b5e8c",
-    matchBorder: "#5e8cd1",
-    matchOverviewRuler: "#5e8cd1",
-    activeMatchBackground: "#d7831e",
-    activeMatchBorder: "#ffb454",
-    activeMatchColorOverviewRuler: "#ffb454",
+    matchBackground: "#fbbf24",
+    matchBorder: "#fbbf24",
+    matchOverviewRuler: "#fbbf24",
+    activeMatchBackground: "#f97316",
+    activeMatchBorder: "#fdba74",
+    activeMatchColorOverviewRuler: "#fdba74",
   },
 };
 

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Loader2, WifiOff } from "lucide-react";
 import { consumeFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/createTerminal";
+import { SearchBar } from "./SearchBar";
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import { openSsh, type SshSession } from "@/modules/ssh/lib/ssh-bridge";
 import { useForwardStatusStore } from "@/modules/ssh/lib/forwardStatusStore";
@@ -164,6 +165,7 @@ export function TerminalView({
   // effect for restored SSH panes without touching any other path.
   const [reconnectTrigger, setReconnectTrigger] = useState(0);
   const [externalFileDragging, setExternalFileDragging] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   const dragDepthRef = useRef(0);
   const nativeDragPathsRef = useRef<string[]>([]);
 
@@ -321,6 +323,20 @@ export function TerminalView({
       if (event.type === "keydown" && isAppShortcut(event)) {
         event.preventDefault();
         return false;
+      }
+      // Open the in-terminal search bar. On mac Cmd+F is free; on other
+      // platforms Ctrl+F is readline's forward-char, so use Ctrl+Shift+F to
+      // avoid clobbering it.
+      if (event.type === "keydown") {
+        const isF = event.code === "KeyF" || event.key.toLowerCase() === "f";
+        const findCombo = IS_MAC
+          ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+          : event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
+        if (isF && findCombo) {
+          event.preventDefault();
+          setSearchOpen(true);
+          return false;
+        }
       }
       // Standard terminal editing shortcuts (Shift+Enter, word/line nav, word
       // and line delete), matching common terminals so muscle memory carries over.
@@ -1044,6 +1060,15 @@ export function TerminalView({
       }}
     >
       {externalFileDragging && <div className={dropOverlayClassName(true)} />}
+      {searchOpen && handleRef.current && (
+        <SearchBar
+          search={handleRef.current.search}
+          onClose={() => {
+            setSearchOpen(false);
+            handleRef.current?.term.focus();
+          }}
+        />
+      )}
       {connecting && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-2 text-fg-subtle">
           <Loader2 size={15} className="animate-spin" />

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -277,6 +277,11 @@ export function TerminalView({
         return false;
       }
       const target = event.target;
+      // Let inputs inside the pane (e.g. the search bar) handle their own paste
+      // rather than redirecting it into the shell.
+      if (target instanceof HTMLInputElement) {
+        return false;
+      }
       if (target instanceof Node && !containerEl.contains(target)) {
         return false;
       }
@@ -298,6 +303,10 @@ export function TerminalView({
 
     const onPasteCapture = (event: ClipboardEvent) => {
       const target = event.target;
+      // Let inputs inside the pane (e.g. the search bar) keep their own paste.
+      if (target instanceof HTMLInputElement) {
+        return;
+      }
       if (!activeRef.current || (target instanceof Node && !containerEl.contains(target))) {
         return;
       }
@@ -335,6 +344,13 @@ export function TerminalView({
         if (isF && findCombo) {
           event.preventDefault();
           setSearchOpen(true);
+          // If the bar is already open (just unfocused), refocus and select it
+          // so the shortcut is never a no-op.
+          const input = containerEl.querySelector("input");
+          if (input) {
+            input.focus();
+            input.select();
+          }
           return false;
         }
       }

--- a/src/modules/terminal/lib/createTerminal.test.ts
+++ b/src/modules/terminal/lib/createTerminal.test.ts
@@ -1,6 +1,23 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { createTerminal, enableWebglRenderer } from "./createTerminal";
 
+describe("createTerminal search", () => {
+  it("exposes a search addon that finds text already in the buffer", async () => {
+    const { term, search } = createTerminal();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    term.open(container);
+
+    await new Promise<void>((resolve) => term.write("the quick brown fox\r\n", resolve));
+
+    expect(search.findNext("brown")).toBe(true);
+    expect(search.findNext("zebra")).toBe(false);
+
+    term.dispose();
+    container.remove();
+  });
+});
+
 describe("enableWebglRenderer", () => {
   const containers: HTMLDivElement[] = [];
 

--- a/src/modules/terminal/lib/createTerminal.ts
+++ b/src/modules/terminal/lib/createTerminal.ts
@@ -1,5 +1,6 @@
 import { Terminal, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
@@ -21,6 +22,7 @@ export const DEFAULT_TERMINAL_FONT_FAMILY = buildTerminalFontFamily({});
 export interface TerminalHandle {
   term: Terminal;
   fit: FitAddon;
+  search: SearchAddon;
 }
 
 export interface CreateTerminalOptions {
@@ -48,6 +50,9 @@ export function createTerminal(options: CreateTerminalOptions = {}): TerminalHan
 
   const fit = new FitAddon();
   term.loadAddon(fit);
+
+  const search = new SearchAddon();
+  term.loadAddon(search);
   // Open web links in the system browser (not the in-app webview) on a
   // modifier-click, matching the file-link gesture (Alt/Cmd) plus Ctrl for
   // non-mac. A plain click is left for text selection. Hover shows a hint.
@@ -75,7 +80,7 @@ export function createTerminal(options: CreateTerminalOptions = {}): TerminalHan
   // cells and the cursor never drifts out of alignment.
   term.unicode.activeVersion = "11";
 
-  return { term, fit };
+  return { term, fit, search };
 }
 
 /**


### PR DESCRIPTION
## Summary

The terminal had no way to search its scrollback — `@xterm/addon-search` was already a dependency but was never wired up. This adds a search bar.

- **Open**: `Cmd+F` (macOS) / `Ctrl+Shift+F` (other platforms). `Ctrl+F` is intentionally avoided off-mac because it is readline's forward-char binding.
- **Navigate**: `Enter` next, `Shift+Enter` previous; the up/down buttons do the same.
- **Close**: `Escape` or the close button — also clears the match highlight.
- Scoped to the focused pane; opening only affects the terminal that has focus.

## Implementation

| Change | File |
|---|---|
| Load `SearchAddon`, expose it on `TerminalHandle` | `terminal/lib/createTerminal.ts` |
| Search bar component (input + prev/next/close, autofocus, i18n) | `terminal/SearchBar.tsx` |
| `Cmd/Ctrl+Shift+F` interception + overlay render | `terminal/TerminalView.tsx` |
| Shortcut entry | `settings/ShortcutsSettingsSection.tsx` |
| Strings | `i18n/locales/{en,zh-Hant}/{common,settings}.json` |

`SearchBar` depends on a minimal `TerminalSearchController` interface (`findNext` / `findPrevious` / `clearDecorations`) that the real `SearchAddon` satisfies structurally, which keeps the component unit-testable with a fake.

Match highlighting currently uses xterm's native selection (the found text is selected and scrolled into view). Persistent multi-match decoration coloring is a possible follow-up.

## Test plan

- [x] `createTerminal.test.ts` — the handle exposes a working search addon (finds present text, misses absent text)
- [x] `SearchBar.test.tsx` — Enter→next, Shift+Enter→previous, Escape→close, unmount→clear highlight, next/previous buttons
- [x] Full suite green (693 tests), `tsc --noEmit` clean
- [ ] Manual smoke test of the `Cmd+F` interaction in the running app