### PR TITLE
feat(terminal): hover action cards for IPs, host:port and archives

### DIFF
--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -3,6 +3,21 @@
   "tagline": "AI-powered terminal workspace",
   "terminalConnecting": "Starting shell…",
   "openLinkHint": "{{mods}}-click to open",
+  "actionLinks": {
+    "hoverHint": "Hover for actions",
+    "ping": "Ping",
+    "traceroute": "Traceroute",
+    "ssh": "SSH",
+    "curl": "curl (HTTP)",
+    "curlHttps": "curl (HTTPS)",
+    "nc": "Netcat",
+    "telnet": "Telnet",
+    "extract": "Extract",
+    "list": "List contents",
+    "dangerWarning": "This command looks destructive.",
+    "runAnyway": "Run anyway",
+    "cancel": "Cancel"
+  },
   "ssh": {
     "disconnected": "Disconnected — click to reconnect",
     "reconnect": "Reconnect"

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -5,6 +5,7 @@
   "openLinkHint": "{{mods}}-click to open",
   "actionLinks": {
     "hoverHint": "Hover for actions",
+    "preview": "Open in preview",
     "ping": "Ping",
     "traceroute": "Traceroute",
     "ssh": "SSH",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -87,6 +87,8 @@
     "restoreHistoryHint": "Reopen each terminal with its previous output (read-only), unless its shell was exited or the pane was closed",
     "suggestions": "Suggest previous commands",
     "suggestionsHint": "Show a dim completion from your shell history as you type; press → to accept",
+    "actionLinks": "Hover action cards",
+    "actionLinksHint": "Hover an IP, host:port or archive in the output to get quick commands (ping, curl, extract…)",
     "clearHistory": "Clear saved history",
     "historyCleared": "Cleared"
   },

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -5,6 +5,7 @@
   "openLinkHint": "{{mods}} + 點擊開啟",
   "actionLinks": {
     "hoverHint": "可執行的動作",
+    "preview": "用網頁預覽開啟",
     "ping": "Ping",
     "traceroute": "Traceroute",
     "ssh": "SSH",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -3,6 +3,21 @@
   "tagline": "AI 驅動的終端機工作區",
   "terminalConnecting": "啟動中…",
   "openLinkHint": "{{mods}} + 點擊開啟",
+  "actionLinks": {
+    "hoverHint": "可執行的動作",
+    "ping": "Ping",
+    "traceroute": "Traceroute",
+    "ssh": "SSH",
+    "curl": "curl（HTTP）",
+    "curlHttps": "curl（HTTPS）",
+    "nc": "Netcat",
+    "telnet": "Telnet",
+    "extract": "解壓縮",
+    "list": "列出內容",
+    "dangerWarning": "這個指令看起來具破壞性",
+    "runAnyway": "仍要執行",
+    "cancel": "取消"
+  },
   "ssh": {
     "disconnected": "已斷線，點擊重新連線",
     "reconnect": "重新連線"

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -87,6 +87,8 @@
     "restoreHistoryHint": "重開時把每個終端機的上次輸出以唯讀方式還原,除非該 shell 已結束或分頁已關閉",
     "suggestions": "提示曾經輸入過的指令",
     "suggestionsHint": "輸入時根據 shell 歷史以灰色顯示補完建議，按 → 接受",
+    "actionLinks": "滑鼠懸停動作卡片",
+    "actionLinksHint": "滑鼠移到輸出中的 IP、host:port 或壓縮檔，跳出可執行的快速指令（ping、curl、解壓縮等）",
     "clearHistory": "清除已儲存的歷史",
     "historyCleared": "已清除"
   },

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isWebUrl } from "./url";
+import { isLocalUrl, isWebUrl } from "./url";
 
 describe("isWebUrl", () => {
   it("treats an https URL as a web URL", () => {
@@ -18,5 +18,24 @@ describe("isWebUrl", () => {
     expect(isWebUrl("notes/a.md")).toBe(false);
     expect(isWebUrl("file:///Users/me/a.txt")).toBe(false);
     expect(isWebUrl("")).toBe(false);
+  });
+});
+
+describe("isLocalUrl", () => {
+  it("treats localhost and loopback/IP URLs as local (keeping the path)", () => {
+    expect(isLocalUrl("http://localhost:3030/gomoku/scene-1")).toBe(true);
+    expect(isLocalUrl("http://127.0.0.1:8080")).toBe(true);
+    expect(isLocalUrl("http://192.168.1.5/admin")).toBe(true);
+    expect(isLocalUrl("https://localhost")).toBe(true);
+  });
+
+  it("treats public hosts as not local", () => {
+    expect(isLocalUrl("https://example.com")).toBe(false);
+    expect(isLocalUrl("https://github.com/foo")).toBe(false);
+  });
+
+  it("returns false for non-URLs", () => {
+    expect(isLocalUrl("not a url")).toBe(false);
+    expect(isLocalUrl("")).toBe(false);
   });
 });

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -5,3 +5,22 @@
 export function isWebUrl(href: string): boolean {
   return /^(https?|mailto):/i.test(href.trim());
 }
+
+/**
+ * True when `href` is an http(s) URL pointing at the local machine (localhost,
+ * loopback, or any IPv4 host). These are the URLs worth opening in the in-app
+ * preview rather than the system browser, and which allow being framed.
+ */
+export function isLocalUrl(href: string): boolean {
+  try {
+    const { hostname } = new URL(href.trim());
+    return (
+      hostname === "localhost" ||
+      hostname === "0.0.0.0" ||
+      hostname === "::1" ||
+      /^(?:\d{1,3}\.){3}\d{1,3}$/.test(hostname)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/modules/settings/TerminalSettingsSection.tsx
+++ b/src/modules/settings/TerminalSettingsSection.tsx
@@ -16,6 +16,8 @@ export function TerminalSettingsSection() {
   const setRestoreTerminalHistory = useSettingsStore((s) => s.setRestoreTerminalHistory);
   const terminalSuggestions = useSettingsStore((s) => s.terminalSuggestions);
   const setTerminalSuggestions = useSettingsStore((s) => s.setTerminalSuggestions);
+  const actionLinksEnabled = useSettingsStore((s) => s.actionLinksEnabled);
+  const setActionLinksEnabled = useSettingsStore((s) => s.setActionLinksEnabled);
   const themeId = useSettingsStore((s) => s.themeId);
   const terminal = getTheme(themeId).terminal;
   const [cleared, setCleared] = useState(false);
@@ -71,6 +73,19 @@ export function TerminalSettingsSection() {
           {t("terminalSettings.suggestions")}
         </label>
         <p className="mt-1 text-xs text-fg-muted">{t("terminalSettings.suggestionsHint")}</p>
+      </div>
+
+      <div className="mb-6">
+        <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg">
+          <input
+            type="checkbox"
+            checked={actionLinksEnabled}
+            onChange={(e) => setActionLinksEnabled(e.target.checked)}
+            className="accent-accent"
+          />
+          {t("terminalSettings.actionLinks")}
+        </label>
+        <p className="mt-1 text-xs text-fg-muted">{t("terminalSettings.actionLinksHint")}</p>
       </div>
 
       <div className="mb-6">

--- a/src/modules/terminal/ActionCard.test.tsx
+++ b/src/modules/terminal/ActionCard.test.tsx
@@ -18,6 +18,29 @@ describe("ActionCard", () => {
     expect(onRun).toHaveBeenCalledWith("ping 1.2.3.4");
   });
 
+  it("opens the in-app preview instead of running a shell command for a preview action", () => {
+    const onRun = vi.fn();
+    const onOpenPreview = vi.fn();
+    render(
+      <ActionCard
+        actions={[
+          {
+            labelKey: "actionLinks.preview",
+            command: "http://localhost:3000",
+            previewUrl: "http://localhost:3000",
+          },
+        ]}
+        onRun={onRun}
+        onOpenPreview={onOpenPreview}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /http:\/\/localhost:3000/ }));
+
+    expect(onOpenPreview).toHaveBeenCalledWith("http://localhost:3000");
+    expect(onRun).not.toHaveBeenCalled();
+  });
+
   it("tints the command on hover via mouse events (not CSS :hover)", () => {
     render(
       <ActionCard actions={[{ labelKey: "actionLinks.ping", command: "ping 1.2.3.4" }]} onRun={vi.fn()} />,

--- a/src/modules/terminal/ActionCard.test.tsx
+++ b/src/modules/terminal/ActionCard.test.tsx
@@ -18,6 +18,24 @@ describe("ActionCard", () => {
     expect(onRun).toHaveBeenCalledWith("ping 1.2.3.4");
   });
 
+  it("tints the command on hover via mouse events (not CSS :hover)", () => {
+    render(
+      <ActionCard actions={[{ labelKey: "actionLinks.ping", command: "ping 1.2.3.4" }]} onRun={vi.fn()} />,
+    );
+    const row = screen.getByRole("button", { name: /ping 1\.2\.3\.4/ });
+    const command = screen.getByText("ping 1.2.3.4");
+
+    expect(command.className).toContain("text-fg-subtle");
+    expect(command.className).not.toContain("text-accent");
+
+    fireEvent.mouseEnter(row);
+    expect(command.className).toContain("text-accent");
+    expect(command.className).not.toContain("text-fg-subtle");
+
+    fireEvent.mouseLeave(row);
+    expect(command.className).toContain("text-fg-subtle");
+  });
+
   it("asks for confirmation before running a dangerous command", () => {
     const onRun = vi.fn();
     render(

--- a/src/modules/terminal/ActionCard.test.tsx
+++ b/src/modules/terminal/ActionCard.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ActionCard } from "./ActionCard";
+import "../../i18n";
+
+describe("ActionCard", () => {
+  it("runs a safe action immediately when its button is clicked", () => {
+    const onRun = vi.fn();
+    render(
+      <ActionCard
+        actions={[{ labelKey: "actionLinks.ping", command: "ping 1.2.3.4" }]}
+        onRun={onRun}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /ping 1\.2\.3\.4/ }));
+
+    expect(onRun).toHaveBeenCalledWith("ping 1.2.3.4");
+  });
+
+  it("asks for confirmation before running a dangerous command", () => {
+    const onRun = vi.fn();
+    render(
+      <ActionCard
+        actions={[{ labelKey: "actionLinks.extract", command: "rm -rf /tmp/x" }]}
+        onRun={onRun}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /rm -rf/ }));
+    expect(onRun).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /run anyway/i }));
+    expect(onRun).toHaveBeenCalledWith("rm -rf /tmp/x");
+  });
+
+  it("does not run a dangerous command when the confirmation is cancelled", () => {
+    const onRun = vi.fn();
+    render(
+      <ActionCard
+        actions={[{ labelKey: "actionLinks.extract", command: "rm -rf /tmp/x" }]}
+        onRun={onRun}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /rm -rf/ }));
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(onRun).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/terminal/ActionCard.tsx
+++ b/src/modules/terminal/ActionCard.tsx
@@ -6,9 +6,11 @@ import { isDangerousCommand, type TerminalAction } from "./lib/actionLinks";
 interface ActionCardProps {
   actions: TerminalAction[];
   onRun: (command: string) => void;
+  /** Open a URL in the in-app web preview (for localhost/IP preview actions). */
+  onOpenPreview?: (url: string) => void;
 }
 
-export function ActionCard({ actions, onRun }: ActionCardProps) {
+export function ActionCard({ actions, onRun, onOpenPreview }: ActionCardProps) {
   const { t } = useTranslation();
   // The command awaiting a destructive-action confirmation, or null when the
   // plain action list is showing.
@@ -18,11 +20,13 @@ export function ActionCard({ actions, onRun }: ActionCardProps) {
   // elements that appear under the pointer, though mouse events still fire.
   const [hovered, setHovered] = useState<string | null>(null);
 
-  function handleClick(command: string) {
-    if (isDangerousCommand(command)) {
-      setPending(command);
+  function handleAction(action: TerminalAction) {
+    if (action.previewUrl) {
+      onOpenPreview?.(action.previewUrl);
+    } else if (isDangerousCommand(action.command)) {
+      setPending(action.command);
     } else {
-      onRun(command);
+      onRun(action.command);
     }
   }
 
@@ -74,7 +78,7 @@ export function ActionCard({ actions, onRun }: ActionCardProps) {
             className={`flex items-center gap-2 px-2.5 py-1 text-left text-xs ${
               isHovered ? "bg-border" : ""
             }`}
-            onClick={() => handleClick(action.command)}
+            onClick={() => handleAction(action)}
             onMouseEnter={() => setHovered(action.command)}
             onMouseLeave={() => setHovered((h) => (h === action.command ? null : h))}
           >

--- a/src/modules/terminal/ActionCard.tsx
+++ b/src/modules/terminal/ActionCard.tsx
@@ -13,6 +13,10 @@ export function ActionCard({ actions, onRun }: ActionCardProps) {
   // The command awaiting a destructive-action confirmation, or null when the
   // plain action list is showing.
   const [pending, setPending] = useState<string | null>(null);
+  // Hover is tracked with JS mouse events rather than CSS :hover: this card pops
+  // up dynamically and Tauri's WKWebview doesn't reliably recompute :hover for
+  // elements that appear under the pointer, though mouse events still fire.
+  const [hovered, setHovered] = useState<string | null>(null);
 
   function handleClick(command: string) {
     if (isDangerousCommand(command)) {
@@ -58,25 +62,28 @@ export function ActionCard({ actions, onRun }: ActionCardProps) {
 
   return (
     <div className="flex flex-col rounded-md border border-border-strong bg-bg-elevated py-1 shadow-lg">
-      {actions.map((action) => (
-        <button
-          key={action.command}
-          type="button"
-          className="group flex items-center gap-2 px-2.5 py-1 text-left text-xs hover:bg-border"
-          onClick={() => handleClick(action.command)}
-        >
-          <span className="min-w-16 font-medium text-fg">{t(action.labelKey)}</span>
-          {/* command + arrow turn accent while the row is hovered, signalling it
-              is the runnable target */}
-          <code className="font-mono text-fg-subtle group-hover:text-accent">
-            {action.command}
-          </code>
-          <ArrowRight
-            size={13}
-            className="ml-auto shrink-0 text-fg-subtle group-hover:text-accent"
-          />
-        </button>
-      ))}
+      {actions.map((action) => {
+        // command + arrow turn accent while the row is hovered, signalling it is
+        // the runnable target.
+        const isHovered = hovered === action.command;
+        const accent = isHovered ? "text-accent" : "text-fg-subtle";
+        return (
+          <button
+            key={action.command}
+            type="button"
+            className={`flex items-center gap-2 px-2.5 py-1 text-left text-xs ${
+              isHovered ? "bg-border" : ""
+            }`}
+            onClick={() => handleClick(action.command)}
+            onMouseEnter={() => setHovered(action.command)}
+            onMouseLeave={() => setHovered((h) => (h === action.command ? null : h))}
+          >
+            <span className="min-w-16 font-medium text-fg">{t(action.labelKey)}</span>
+            <code className={`font-mono ${accent}`}>{action.command}</code>
+            <ArrowRight size={13} className={`ml-auto shrink-0 ${accent}`} />
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/modules/terminal/ActionCard.tsx
+++ b/src/modules/terminal/ActionCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, ArrowRight } from "lucide-react";
 import { isDangerousCommand, type TerminalAction } from "./lib/actionLinks";
 
 interface ActionCardProps {
@@ -62,11 +62,19 @@ export function ActionCard({ actions, onRun }: ActionCardProps) {
         <button
           key={action.command}
           type="button"
-          className="flex items-center gap-2 px-2.5 py-1 text-left text-xs hover:bg-border"
+          className="group flex items-center gap-2 px-2.5 py-1 text-left text-xs hover:bg-border"
           onClick={() => handleClick(action.command)}
         >
           <span className="min-w-16 font-medium text-fg">{t(action.labelKey)}</span>
-          <code className="font-mono text-fg-subtle">{action.command}</code>
+          {/* command + arrow turn accent the moment the row is pressed, so the
+              click clearly registers before the card closes and the command runs */}
+          <code className="font-mono text-fg-subtle group-active:text-accent">
+            {action.command}
+          </code>
+          <ArrowRight
+            size={13}
+            className="ml-auto shrink-0 text-fg-subtle group-active:text-accent"
+          />
         </button>
       ))}
     </div>

--- a/src/modules/terminal/ActionCard.tsx
+++ b/src/modules/terminal/ActionCard.tsx
@@ -66,14 +66,14 @@ export function ActionCard({ actions, onRun }: ActionCardProps) {
           onClick={() => handleClick(action.command)}
         >
           <span className="min-w-16 font-medium text-fg">{t(action.labelKey)}</span>
-          {/* command + arrow turn accent the moment the row is pressed, so the
-              click clearly registers before the card closes and the command runs */}
-          <code className="font-mono text-fg-subtle group-active:text-accent">
+          {/* command + arrow turn accent while the row is hovered, signalling it
+              is the runnable target */}
+          <code className="font-mono text-fg-subtle group-hover:text-accent">
             {action.command}
           </code>
           <ArrowRight
             size={13}
-            className="ml-auto shrink-0 text-fg-subtle group-active:text-accent"
+            className="ml-auto shrink-0 text-fg-subtle group-hover:text-accent"
           />
         </button>
       ))}

--- a/src/modules/terminal/ActionCard.tsx
+++ b/src/modules/terminal/ActionCard.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { AlertTriangle } from "lucide-react";
+import { isDangerousCommand, type TerminalAction } from "./lib/actionLinks";
+
+interface ActionCardProps {
+  actions: TerminalAction[];
+  onRun: (command: string) => void;
+}
+
+export function ActionCard({ actions, onRun }: ActionCardProps) {
+  const { t } = useTranslation();
+  // The command awaiting a destructive-action confirmation, or null when the
+  // plain action list is showing.
+  const [pending, setPending] = useState<string | null>(null);
+
+  function handleClick(command: string) {
+    if (isDangerousCommand(command)) {
+      setPending(command);
+    } else {
+      onRun(command);
+    }
+  }
+
+  if (pending) {
+    return (
+      <div className="flex max-w-xs flex-col gap-2 rounded-md border border-danger/60 bg-bg-elevated p-2 shadow-lg">
+        <div className="flex items-center gap-1.5 text-xs text-danger">
+          <AlertTriangle size={13} className="shrink-0" />
+          <span>{t("actionLinks.dangerWarning")}</span>
+        </div>
+        <code className="block truncate rounded bg-bg-inset px-1.5 py-1 font-mono text-xs text-fg">
+          {pending}
+        </code>
+        <div className="flex justify-end gap-1.5">
+          <button
+            type="button"
+            className="rounded px-2 py-0.5 text-xs text-fg-muted hover:bg-border hover:text-fg"
+            onClick={() => setPending(null)}
+          >
+            {t("actionLinks.cancel")}
+          </button>
+          <button
+            type="button"
+            className="rounded border border-danger/60 px-2 py-0.5 text-xs font-medium text-danger hover:bg-danger/10"
+            onClick={() => {
+              const command = pending;
+              setPending(null);
+              onRun(command);
+            }}
+          >
+            {t("actionLinks.runAnyway")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col rounded-md border border-border-strong bg-bg-elevated py-1 shadow-lg">
+      {actions.map((action) => (
+        <button
+          key={action.command}
+          type="button"
+          className="flex items-center gap-2 px-2.5 py-1 text-left text-xs hover:bg-border"
+          onClick={() => handleClick(action.command)}
+        >
+          <span className="min-w-16 font-medium text-fg">{t(action.labelKey)}</span>
+          <code className="font-mono text-fg-subtle">{action.command}</code>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/modules/terminal/ActionCard.tsx
+++ b/src/modules/terminal/ActionCard.tsx
@@ -29,7 +29,7 @@ export function ActionCard({ actions, onRun }: ActionCardProps) {
           <AlertTriangle size={13} className="shrink-0" />
           <span>{t("actionLinks.dangerWarning")}</span>
         </div>
-        <code className="block truncate rounded bg-bg-inset px-1.5 py-1 font-mono text-xs text-fg">
+        <code className="block max-h-24 overflow-y-auto whitespace-pre-wrap break-all rounded bg-bg-inset px-1.5 py-1 font-mono text-xs text-fg">
           {pending}
         </code>
         <div className="flex justify-end gap-1.5">

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -280,6 +280,9 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                     onOpenFile={(absolutePath) =>
                       splitPaneWith(tab.id, pane.id, { kind: "editor", path: absolutePath }, "row")
                     }
+                    onOpenPreview={(url) =>
+                      splitPaneWith(tab.id, pane.id, { kind: "preview", url }, "row")
+                    }
                   />
                 )}
               </Suspense>

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -65,6 +65,8 @@ import {
   shellQuotePath,
 } from "./lib/terminalClipboard";
 import { buildFileLink, findFilePaths, resolveFilePath } from "./lib/fileLinks";
+import { actionsFor, findActionLinks, type TerminalAction } from "./lib/actionLinks";
+import { ActionCard } from "./ActionCard";
 import { buildCellPositions, gatherLogicalLine } from "./lib/cellPositions";
 import { terminalKeySequence } from "./lib/terminalKeymap";
 import { shouldCdToRoot } from "./lib/cwdSync";
@@ -166,6 +168,36 @@ export function TerminalView({
   const [externalFileDragging, setExternalFileDragging] = useState(false);
   const dragDepthRef = useRef(0);
   const nativeDragPathsRef = useRef<string[]>([]);
+  // The hover action card (IP / host:port / archive quick commands), positioned
+  // at the cursor. A short hide delay lets the pointer travel from the link into
+  // the card without it vanishing.
+  const [actionCard, setActionCard] = useState<{
+    actions: TerminalAction[];
+    x: number;
+    y: number;
+  } | null>(null);
+  const actionCardTimer = useRef<number | null>(null);
+
+  const cancelActionCardHide = () => {
+    if (actionCardTimer.current !== null) {
+      clearTimeout(actionCardTimer.current);
+      actionCardTimer.current = null;
+    }
+  };
+  const showActionCard = (actions: TerminalAction[], x: number, y: number) => {
+    cancelActionCardHide();
+    setActionCard({ actions, x, y });
+  };
+  const scheduleActionCardHide = () => {
+    cancelActionCardHide();
+    actionCardTimer.current = window.setTimeout(() => setActionCard(null), 180);
+  };
+  const runActionCommand = (command: string) => {
+    void sessionRef.current?.write(`${command}\r`);
+    cancelActionCardHide();
+    setActionCard(null);
+    handleRef.current?.term.focus();
+  };
 
   useEffect(() => {
     const container = containerRef.current;
@@ -391,8 +423,15 @@ export function TerminalView({
           return;
         }
         const { text, spans } = buildCellPositions(rows);
-        const matches = findFilePaths(text);
-        if (matches.length === 0) {
+        const actionsEnabled = useSettingsStore.getState().actionLinksEnabled;
+        const actionMatches = actionsEnabled ? findActionLinks(text) : [];
+        // An archive filename also matches as a file path; drop the overlapping
+        // file link so the action card wins (opening a binary archive as a file
+        // is not useful anyway).
+        const matches = findFilePaths(text).filter(
+          (f) => !actionMatches.some((a) => f.start < a.end && f.end > a.start),
+        );
+        if (matches.length === 0 && actionMatches.length === 0) {
           callback(undefined);
           return;
         }
@@ -407,17 +446,29 @@ export function TerminalView({
           const span = spans[index] ?? lastSpan;
           return { x: span?.endX ?? 1, y: span?.y ?? lineNumber };
         };
-        callback(
-          matches.map((m) =>
-            buildFileLink({
-              text: m.text,
-              range: { start: startCell(m.start), end: endCell(m.end - 1) },
-              hint: linkHintRef.current,
-              isMac: IS_MAC,
-              onOpen: (raw) => void openFromTerminal(raw),
-            }),
-          ),
+        const fileLinks = matches.map((m) =>
+          buildFileLink({
+            text: m.text,
+            range: { start: startCell(m.start), end: endCell(m.end - 1) },
+            hint: linkHintRef.current,
+            isMac: IS_MAC,
+            onOpen: (raw) => void openFromTerminal(raw),
+          }),
         );
+        const actionLinks = actionMatches.map((m) => ({
+          text: m.text,
+          range: { start: startCell(m.start), end: endCell(m.end - 1) },
+          // Interaction happens through the hover card's buttons, so a click on
+          // the link itself does nothing.
+          activate: () => {},
+          hover: (event: MouseEvent) => {
+            showActionCard(actionsFor(m), event.clientX, event.clientY);
+          },
+          leave: () => {
+            scheduleActionCardHide();
+          },
+        }));
+        callback([...fileLinks, ...actionLinks]);
       },
     });
 
@@ -1044,6 +1095,16 @@ export function TerminalView({
       }}
     >
       {externalFileDragging && <div className={dropOverlayClassName(true)} />}
+      {actionCard && (
+        <div
+          className="fixed z-30"
+          style={{ left: actionCard.x, top: actionCard.y + 14 }}
+          onMouseEnter={cancelActionCardHide}
+          onMouseLeave={() => setActionCard(null)}
+        >
+          <ActionCard actions={actionCard.actions} onRun={runActionCommand} />
+        </div>
+      )}
       {connecting && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-2 text-fg-subtle">
           <Loader2 size={15} className="animate-spin" />

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -118,6 +118,8 @@ interface TerminalViewProps {
   onCwdChange?: (cwd: string) => void;
   /** Alt+click on a file path in the output opens it (with the resolved abs path). */
   onOpenFile?: (absolutePath: string) => void;
+  /** Open a localhost/IP URL from a terminal action card in the in-app preview. */
+  onOpenPreview?: (url: string) => void;
 }
 
 export function TerminalView({
@@ -129,6 +131,7 @@ export function TerminalView({
   onExit,
   onCwdChange,
   onOpenFile,
+  onOpenPreview,
 }: TerminalViewProps) {
   const leafIdRef = useRef(leafId);
   leafIdRef.current = leafId;
@@ -147,6 +150,8 @@ export function TerminalView({
   onCwdChangeRef.current = onCwdChange;
   const onOpenFileRef = useRef(onOpenFile);
   onOpenFileRef.current = onOpenFile;
+  const onOpenPreviewRef = useRef(onOpenPreview);
+  onOpenPreviewRef.current = onOpenPreview;
   // Holds a deferred "start the SSH session now" function that is set inside the
   // main mount effect and called by the reconnect button for restored panes.
   const connectNowRef = useRef<(() => void) | null>(null);
@@ -197,6 +202,11 @@ export function TerminalView({
     cancelActionCardHide();
     setActionCard(null);
     handleRef.current?.term.focus();
+  };
+  const openActionPreview = (url: string) => {
+    onOpenPreviewRef.current?.(url);
+    cancelActionCardHide();
+    setActionCard(null);
   };
 
   // Clear any pending action-card hide timer when the pane unmounts so it can't
@@ -1112,7 +1122,11 @@ export function TerminalView({
           onMouseEnter={cancelActionCardHide}
           onMouseLeave={() => setActionCard(null)}
         >
-          <ActionCard actions={actionCard.actions} onRun={runActionCommand} />
+          <ActionCard
+            actions={actionCard.actions}
+            onRun={runActionCommand}
+            onOpenPreview={openActionPreview}
+          />
         </div>
       )}
       {connecting && (

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -232,6 +232,7 @@ export function TerminalView({
       fontSize: initial.fontSize,
       theme: getTheme(useSettingsStore.getState().themeId).terminal,
       linkHint: linkHintRef.current,
+      onOpenLocalUrl: (url) => onOpenPreviewRef.current?.(url),
     });
     handleRef.current = handle;
     const { term, fit } = handle;

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -199,6 +199,16 @@ export function TerminalView({
     handleRef.current?.term.focus();
   };
 
+  // Clear any pending action-card hide timer when the pane unmounts so it can't
+  // fire a state update on a gone component.
+  useEffect(() => {
+    return () => {
+      if (actionCardTimer.current !== null) {
+        clearTimeout(actionCardTimer.current);
+      }
+    };
+  }, []);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container) {

--- a/src/modules/terminal/lib/actionLinks.test.ts
+++ b/src/modules/terminal/lib/actionLinks.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  actionsFor,
+  findActionLinks,
+  isDangerousCommand,
+  type ActionLinkMatch,
+} from "./actionLinks";
+
+function match(text: string, kind: ActionLinkMatch["kind"]): ActionLinkMatch {
+  return { text, start: 0, end: text.length, kind };
+}
+
+describe("findActionLinks", () => {
+  it("detects an IPv4 address", () => {
+    const matches = findActionLinks("trying 192.168.1.1 now");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({ text: "192.168.1.1", kind: "ip" });
+  });
+
+  it("detects a host:port pair", () => {
+    const matches = findActionLinks("curl example.com:8080/health");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({ text: "example.com:8080", kind: "host-port" });
+  });
+
+  it("does not treat key:number pairs like error:42 as host:port", () => {
+    expect(findActionLinks("error:42 occurred")).toHaveLength(0);
+  });
+
+  it("treats an IP with a port as a single host:port, not a bare IP", () => {
+    const matches = findActionLinks("listening on 192.168.1.1:8080");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({ text: "192.168.1.1:8080", kind: "host-port" });
+  });
+
+  it("detects archive filenames", () => {
+    expect(findActionLinks("got backup.tar.gz here")[0]).toMatchObject({
+      text: "backup.tar.gz",
+      kind: "archive",
+    });
+    expect(findActionLinks("data.zip")[0]).toMatchObject({ text: "data.zip", kind: "archive" });
+  });
+});
+
+describe("actionsFor", () => {
+  it("offers network actions for an IP", () => {
+    const cmds = actionsFor(match("10.0.0.1", "ip")).map((a) => a.command);
+    expect(cmds).toContain("ping 10.0.0.1");
+    expect(cmds).toContain("ssh 10.0.0.1");
+  });
+
+  it("offers connection actions for a host:port, splitting host and port for nc", () => {
+    const cmds = actionsFor(match("example.com:8080", "host-port")).map((a) => a.command);
+    expect(cmds).toContain("curl http://example.com:8080");
+    expect(cmds).toContain("nc example.com 8080");
+  });
+
+  it("offers the right extract command per archive type", () => {
+    const extract = (f: string) => actionsFor(match(f, "archive")).map((a) => a.command);
+    expect(extract("data.zip")).toContain("unzip data.zip");
+    expect(extract("backup.tar.gz")).toContain("tar -xzf backup.tar.gz");
+    expect(extract("photos.tgz")).toContain("tar -xzf photos.tgz");
+    expect(extract("logs.tar")).toContain("tar -xf logs.tar");
+    expect(extract("blob.7z")).toContain("7z x blob.7z");
+  });
+
+  it("offers a list-contents action for archives", () => {
+    expect(actionsFor(match("data.zip", "archive")).map((a) => a.command)).toContain(
+      "unzip -l data.zip",
+    );
+    expect(actionsFor(match("backup.tar.gz", "archive")).map((a) => a.command)).toContain(
+      "tar -tzf backup.tar.gz",
+    );
+  });
+});
+
+describe("isDangerousCommand", () => {
+  it("flags destructive commands", () => {
+    expect(isDangerousCommand("rm -rf /")).toBe(true);
+    expect(isDangerousCommand("sudo rm -rf node_modules")).toBe(true);
+    expect(isDangerousCommand("dd if=/dev/zero of=/dev/sda")).toBe(true);
+    expect(isDangerousCommand("mkfs.ext4 /dev/sda1")).toBe(true);
+    expect(isDangerousCommand("curl http://get.example.sh | sh")).toBe(true);
+  });
+
+  it("treats the safe action commands as not dangerous", () => {
+    expect(isDangerousCommand("ping 1.2.3.4")).toBe(false);
+    expect(isDangerousCommand("unzip data.zip")).toBe(false);
+    expect(isDangerousCommand("tar -xzf backup.tar.gz")).toBe(false);
+    expect(isDangerousCommand("curl http://example.com:8080")).toBe(false);
+  });
+});

--- a/src/modules/terminal/lib/actionLinks.test.ts
+++ b/src/modules/terminal/lib/actionLinks.test.ts
@@ -40,6 +40,12 @@ describe("findActionLinks", () => {
     });
     expect(findActionLinks("data.zip")[0]).toMatchObject({ text: "data.zip", kind: "archive" });
   });
+
+  it("keeps only the longest match when entities overlap (e.g. 1.2.3.4.zip)", () => {
+    const matches = findActionLinks("downloaded 1.2.3.4.zip ok");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({ text: "1.2.3.4.zip", kind: "archive" });
+  });
 });
 
 describe("actionsFor", () => {
@@ -55,21 +61,21 @@ describe("actionsFor", () => {
     expect(cmds).toContain("nc example.com 8080");
   });
 
-  it("offers the right extract command per archive type", () => {
+  it("offers the right extract command per archive type, with the filename quoted", () => {
     const extract = (f: string) => actionsFor(match(f, "archive")).map((a) => a.command);
-    expect(extract("data.zip")).toContain("unzip data.zip");
-    expect(extract("backup.tar.gz")).toContain("tar -xzf backup.tar.gz");
-    expect(extract("photos.tgz")).toContain("tar -xzf photos.tgz");
-    expect(extract("logs.tar")).toContain("tar -xf logs.tar");
-    expect(extract("blob.7z")).toContain("7z x blob.7z");
+    expect(extract("data.zip")).toContain("unzip 'data.zip'");
+    expect(extract("backup.tar.gz")).toContain("tar -xzf 'backup.tar.gz'");
+    expect(extract("photos.tgz")).toContain("tar -xzf 'photos.tgz'");
+    expect(extract("logs.tar")).toContain("tar -xf 'logs.tar'");
+    expect(extract("blob.7z")).toContain("7z x 'blob.7z'");
   });
 
   it("offers a list-contents action for archives", () => {
     expect(actionsFor(match("data.zip", "archive")).map((a) => a.command)).toContain(
-      "unzip -l data.zip",
+      "unzip -l 'data.zip'",
     );
     expect(actionsFor(match("backup.tar.gz", "archive")).map((a) => a.command)).toContain(
-      "tar -tzf backup.tar.gz",
+      "tar -tzf 'backup.tar.gz'",
     );
   });
 });
@@ -81,6 +87,7 @@ describe("isDangerousCommand", () => {
     expect(isDangerousCommand("dd if=/dev/zero of=/dev/sda")).toBe(true);
     expect(isDangerousCommand("mkfs.ext4 /dev/sda1")).toBe(true);
     expect(isDangerousCommand("curl http://get.example.sh | sh")).toBe(true);
+    expect(isDangerousCommand("rm --recursive --force /tmp/x")).toBe(true);
   });
 
   it("treats the safe action commands as not dangerous", () => {

--- a/src/modules/terminal/lib/actionLinks.test.ts
+++ b/src/modules/terminal/lib/actionLinks.test.ts
@@ -78,6 +78,20 @@ describe("actionsFor", () => {
       "tar -tzf 'backup.tar.gz'",
     );
   });
+
+  it("offers an in-app preview action for localhost and IP web servers", () => {
+    const preview = (m: ActionLinkMatch) =>
+      actionsFor(m).find((a) => a.labelKey === "actionLinks.preview")?.previewUrl;
+
+    expect(preview(match("localhost:3000", "host-port"))).toBe("http://localhost:3000");
+    expect(preview(match("192.168.1.1:8080", "host-port"))).toBe("http://192.168.1.1:8080");
+    expect(preview(match("192.168.1.1", "ip"))).toBe("http://192.168.1.1");
+  });
+
+  it("does not offer preview for a public domain (the iframe would be blocked)", () => {
+    const actions = actionsFor(match("example.com:8000", "host-port"));
+    expect(actions.find((a) => a.labelKey === "actionLinks.preview")).toBeUndefined();
+  });
 });
 
 describe("isDangerousCommand", () => {

--- a/src/modules/terminal/lib/actionLinks.ts
+++ b/src/modules/terminal/lib/actionLinks.ts
@@ -55,10 +55,16 @@ export interface TerminalAction {
   command: string;
 }
 
+/** Single-quote a filename for safe use in a shell command. */
+function shellQuote(file: string): string {
+  return `'${file.replace(/'/g, "'\\''")}'`;
+}
+
 /** The extract and list commands appropriate for an archive's extension. */
 function archiveCommands(file: string): { extract: string; list: string | null } {
   const lower = file.toLowerCase();
-  const tar = (flags: string) => `tar -${flags} ${file}`;
+  const q = shellQuote(file);
+  const tar = (flags: string) => `tar -${flags} ${q}`;
   if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) {
     return { extract: tar("xzf"), list: tar("tzf") };
   }
@@ -72,22 +78,22 @@ function archiveCommands(file: string): { extract: string; list: string | null }
     return { extract: tar("xf"), list: tar("tf") };
   }
   if (lower.endsWith(".zip")) {
-    return { extract: `unzip ${file}`, list: `unzip -l ${file}` };
+    return { extract: `unzip ${q}`, list: `unzip -l ${q}` };
   }
   if (lower.endsWith(".gz")) {
-    return { extract: `gunzip ${file}`, list: null };
+    return { extract: `gunzip ${q}`, list: null };
   }
   if (lower.endsWith(".bz2")) {
-    return { extract: `bunzip2 ${file}`, list: null };
+    return { extract: `bunzip2 ${q}`, list: null };
   }
   if (lower.endsWith(".xz")) {
-    return { extract: `unxz ${file}`, list: null };
+    return { extract: `unxz ${q}`, list: null };
   }
   if (lower.endsWith(".7z")) {
-    return { extract: `7z x ${file}`, list: `7z l ${file}` };
+    return { extract: `7z x ${q}`, list: `7z l ${q}` };
   }
   if (lower.endsWith(".rar")) {
-    return { extract: `unrar x ${file}`, list: `unrar l ${file}` };
+    return { extract: `unrar x ${q}`, list: `unrar l ${q}` };
   }
   return { extract: tar("xf"), list: tar("tf") };
 }
@@ -96,7 +102,7 @@ function archiveCommands(file: string): { extract: string; list: string | null }
 // None of the built-in actions hit these; this is a safety net for destructive
 // commands so the run-on-click gesture can't silently do real damage.
 const DANGEROUS_COMMAND_RES: RegExp[] = [
-  /\brm\s+-[a-z]*[rf]/i, // rm -rf / rm -r / rm -f
+  /\brm\s+(?:-[a-z]*[rf]|--recursive|--force)\b/i, // rm -rf / -r / -f / --recursive / --force
   /\bdd\b[^\n]*\bof=/i, // dd writing to a device/file
   /\bmkfs\b/i, // formatting a filesystem
   /\|\s*(?:sudo\s+)?(?:sh|bash|zsh|fish)\b/i, // piping a download into a shell
@@ -144,12 +150,21 @@ export function actionsFor(match: ActionLinkMatch): TerminalAction[] {
 }
 
 export function findActionLinks(line: string): ActionLinkMatch[] {
-  // host:port is matched first; an IP that sits inside a host:port match (e.g.
-  // `1.2.3.4:80`) is dropped so the two matchers don't overlap.
-  const hostPorts = collect(line, HOST_PORT_RE, "host-port");
-  const ips = collect(line, IPV4_RE, "ip").filter(
-    (ip) => !hostPorts.some((hp) => ip.start < hp.end && ip.end > hp.start),
-  );
-  const archives = collect(line, ARCHIVE_RE, "archive");
-  return [...hostPorts, ...ips, ...archives].sort((a, b) => a.start - b.start);
+  // Collect every candidate, then resolve overlaps generically: sort by start
+  // (and longest-first on ties) and keep a match only when it doesn't overlap
+  // one already kept. This drops the IP inside `1.2.3.4:80` and the IP inside an
+  // archive name like `1.2.3.4.zip`, always preferring the longer entity.
+  const all = [
+    ...collect(line, HOST_PORT_RE, "host-port"),
+    ...collect(line, IPV4_RE, "ip"),
+    ...collect(line, ARCHIVE_RE, "archive"),
+  ].sort((a, b) => a.start - b.start || b.end - b.start - (a.end - a.start));
+
+  const out: ActionLinkMatch[] = [];
+  for (const m of all) {
+    if (!out.some((kept) => m.start < kept.end && m.end > kept.start)) {
+      out.push(m);
+    }
+  }
+  return out;
 }

--- a/src/modules/terminal/lib/actionLinks.ts
+++ b/src/modules/terminal/lib/actionLinks.ts
@@ -1,0 +1,155 @@
+/**
+ * Detect actionable entities in a line of terminal output — IP addresses,
+ * host:port pairs, and archive filenames — so the terminal can offer quick
+ * commands (ping, curl, unzip, …) on hover. This is the matcher half; the
+ * command/menu logic lives alongside it.
+ */
+
+export type ActionLinkKind = "ip" | "host-port" | "archive";
+
+export interface ActionLinkMatch {
+  /** The raw matched text. */
+  text: string;
+  /** Zero-based start index within the line. */
+  start: number;
+  /** Exclusive end index within the line. */
+  end: number;
+  /** Which kind of entity matched, so the caller can offer the right actions. */
+  kind: ActionLinkKind;
+}
+
+/** A single dotted-decimal octet, 0-255. */
+const OCTET = "(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)";
+const IPV4_RE = new RegExp(`\\b(?:${OCTET}\\.){3}${OCTET}\\b`, "g");
+
+// host:port — the host must be a dotted name (domain or IP) or exactly
+// `localhost`, which keeps `error:42`-style key:number pairs out.
+const HOST_PORT_RE = /\b((?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+|localhost):(\d{1,5})\b/g;
+
+// Archive filenames. The double extensions (.tar.gz, …) come first in the
+// alternation so the whole suffix is captured rather than just the trailing
+// .gz. Greedy name matching keeps the full `backup.tar.gz`.
+const ARCHIVE_RE =
+  /\b\w[\w.-]*\.(?:tar\.(?:gz|bz2|xz)|tgz|tbz2?|txz|tar|zip|gz|bz2|xz|7z|rar)\b/g;
+
+function collect(line: string, re: RegExp, kind: ActionLinkKind): ActionLinkMatch[] {
+  const out: ActionLinkMatch[] = [];
+  re.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(line)) !== null) {
+    out.push({
+      text: match[0],
+      start: match.index,
+      end: match.index + match[0].length,
+      kind,
+    });
+  }
+  return out;
+}
+
+/** A command the user can run against a matched entity. */
+export interface TerminalAction {
+  /** i18n key for the menu label (e.g. "actionLinks.ping"). */
+  labelKey: string;
+  /** The shell command to run. */
+  command: string;
+}
+
+/** The extract and list commands appropriate for an archive's extension. */
+function archiveCommands(file: string): { extract: string; list: string | null } {
+  const lower = file.toLowerCase();
+  const tar = (flags: string) => `tar -${flags} ${file}`;
+  if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) {
+    return { extract: tar("xzf"), list: tar("tzf") };
+  }
+  if (lower.endsWith(".tar.bz2") || lower.endsWith(".tbz2") || lower.endsWith(".tbz")) {
+    return { extract: tar("xjf"), list: tar("tjf") };
+  }
+  if (lower.endsWith(".tar.xz") || lower.endsWith(".txz")) {
+    return { extract: tar("xJf"), list: tar("tJf") };
+  }
+  if (lower.endsWith(".tar")) {
+    return { extract: tar("xf"), list: tar("tf") };
+  }
+  if (lower.endsWith(".zip")) {
+    return { extract: `unzip ${file}`, list: `unzip -l ${file}` };
+  }
+  if (lower.endsWith(".gz")) {
+    return { extract: `gunzip ${file}`, list: null };
+  }
+  if (lower.endsWith(".bz2")) {
+    return { extract: `bunzip2 ${file}`, list: null };
+  }
+  if (lower.endsWith(".xz")) {
+    return { extract: `unxz ${file}`, list: null };
+  }
+  if (lower.endsWith(".7z")) {
+    return { extract: `7z x ${file}`, list: `7z l ${file}` };
+  }
+  if (lower.endsWith(".rar")) {
+    return { extract: `unrar x ${file}`, list: `unrar l ${file}` };
+  }
+  return { extract: tar("xf"), list: tar("tf") };
+}
+
+// Patterns that make a command worth a confirmation prompt before it runs.
+// None of the built-in actions hit these; this is a safety net for destructive
+// commands so the run-on-click gesture can't silently do real damage.
+const DANGEROUS_COMMAND_RES: RegExp[] = [
+  /\brm\s+-[a-z]*[rf]/i, // rm -rf / rm -r / rm -f
+  /\bdd\b[^\n]*\bof=/i, // dd writing to a device/file
+  /\bmkfs\b/i, // formatting a filesystem
+  /\|\s*(?:sudo\s+)?(?:sh|bash|zsh|fish)\b/i, // piping a download into a shell
+  /:\(\)\s*\{.*\|.*&\s*\}\s*;/, // fork bomb
+  />\s*\/dev\/[sh]d/i, // overwriting a raw disk device
+];
+
+/** True when a command is destructive enough to warrant a confirmation prompt. */
+export function isDangerousCommand(command: string): boolean {
+  return DANGEROUS_COMMAND_RES.some((re) => re.test(command));
+}
+
+/** Build the list of quick commands offered for a matched entity. */
+export function actionsFor(match: ActionLinkMatch): TerminalAction[] {
+  if (match.kind === "ip") {
+    const ip = match.text;
+    return [
+      { labelKey: "actionLinks.ping", command: `ping ${ip}` },
+      { labelKey: "actionLinks.traceroute", command: `traceroute ${ip}` },
+      { labelKey: "actionLinks.ssh", command: `ssh ${ip}` },
+      { labelKey: "actionLinks.curl", command: `curl http://${ip}` },
+    ];
+  }
+  if (match.kind === "host-port") {
+    const hostPort = match.text;
+    const lastColon = hostPort.lastIndexOf(":");
+    const host = hostPort.slice(0, lastColon);
+    const port = hostPort.slice(lastColon + 1);
+    return [
+      { labelKey: "actionLinks.curl", command: `curl http://${hostPort}` },
+      { labelKey: "actionLinks.curlHttps", command: `curl https://${hostPort}` },
+      { labelKey: "actionLinks.nc", command: `nc ${host} ${port}` },
+      { labelKey: "actionLinks.telnet", command: `telnet ${host} ${port}` },
+    ];
+  }
+  if (match.kind === "archive") {
+    const { extract, list } = archiveCommands(match.text);
+    const actions: TerminalAction[] = [{ labelKey: "actionLinks.extract", command: extract }];
+    if (list) {
+      actions.push({ labelKey: "actionLinks.list", command: list });
+    }
+    return actions;
+  }
+  return [];
+}
+
+export function findActionLinks(line: string): ActionLinkMatch[] {
+  // host:port is matched first; an IP that sits inside a host:port match (e.g.
+  // `1.2.3.4:80`) is dropped so the two matchers don't overlap.
+  const hostPorts = collect(line, HOST_PORT_RE, "host-port");
+  const ips = collect(line, IPV4_RE, "ip").filter(
+    (ip) => !hostPorts.some((hp) => ip.start < hp.end && ip.end > hp.start),
+  );
+  const archives = collect(line, ARCHIVE_RE, "archive");
+  return [...hostPorts, ...ips, ...archives].sort((a, b) => a.start - b.start);
+}

--- a/src/modules/terminal/lib/actionLinks.ts
+++ b/src/modules/terminal/lib/actionLinks.ts
@@ -51,8 +51,25 @@ function collect(line: string, re: RegExp, kind: ActionLinkKind): ActionLinkMatc
 export interface TerminalAction {
   /** i18n key for the menu label (e.g. "actionLinks.ping"). */
   labelKey: string;
-  /** The shell command to run. */
+  /** Shell command to run, or the URL shown for a preview action. */
   command: string;
+  /**
+   * When set, the action opens this URL in the in-app web preview instead of
+   * running `command` in the shell.
+   */
+  previewUrl?: string;
+}
+
+/** Matches a whole string that is exactly a dotted-decimal IPv4 address. */
+const IPV4_HOST_RE = new RegExp(`^(?:${OCTET}\\.){3}${OCTET}$`);
+
+/**
+ * Whether a host should offer the in-app preview. Limited to localhost and IPs:
+ * those are local servers that allow being framed, whereas public sites usually
+ * block embedding (X-Frame-Options/CSP) and would render blank.
+ */
+function isPreviewableHost(host: string): boolean {
+  return host === "localhost" || IPV4_HOST_RE.test(host);
 }
 
 /** Single-quote a filename for safe use in a shell command. */
@@ -119,7 +136,9 @@ export function isDangerousCommand(command: string): boolean {
 export function actionsFor(match: ActionLinkMatch): TerminalAction[] {
   if (match.kind === "ip") {
     const ip = match.text;
+    const url = `http://${ip}`;
     return [
+      { labelKey: "actionLinks.preview", command: url, previewUrl: url },
       { labelKey: "actionLinks.ping", command: `ping ${ip}` },
       { labelKey: "actionLinks.traceroute", command: `traceroute ${ip}` },
       { labelKey: "actionLinks.ssh", command: `ssh ${ip}` },
@@ -131,12 +150,18 @@ export function actionsFor(match: ActionLinkMatch): TerminalAction[] {
     const lastColon = hostPort.lastIndexOf(":");
     const host = hostPort.slice(0, lastColon);
     const port = hostPort.slice(lastColon + 1);
-    return [
+    const actions: TerminalAction[] = [];
+    if (isPreviewableHost(host)) {
+      const url = `http://${hostPort}`;
+      actions.push({ labelKey: "actionLinks.preview", command: url, previewUrl: url });
+    }
+    actions.push(
       { labelKey: "actionLinks.curl", command: `curl http://${hostPort}` },
       { labelKey: "actionLinks.curlHttps", command: `curl https://${hostPort}` },
       { labelKey: "actionLinks.nc", command: `nc ${host} ${port}` },
       { labelKey: "actionLinks.telnet", command: `telnet ${host} ${port}` },
-    ];
+    );
+    return actions;
   }
   if (match.kind === "archive") {
     const { extract, list } = archiveCommands(match.text);

--- a/src/modules/terminal/lib/createTerminal.ts
+++ b/src/modules/terminal/lib/createTerminal.ts
@@ -5,7 +5,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { buildTerminalFontFamily } from "@/modules/fonts/lib/fontChain";
-import { isWebUrl } from "@/lib/url";
+import { isLocalUrl, isWebUrl } from "@/lib/url";
 import { IS_MAC, matchesOpenModifier } from "@/lib/platform";
 import { hideLinkTooltip, showLinkTooltip } from "./linkTooltip";
 import "@xterm/xterm/css/xterm.css";
@@ -29,6 +29,12 @@ export interface CreateTerminalOptions {
   theme?: ITheme;
   /** Hover hint shown over web links (e.g. "Cmd / Ctrl-click to open"). */
   linkHint?: string;
+  /**
+   * Open a localhost/IP web URL in the in-app preview. When provided, local
+   * URLs route here on modifier-click instead of opening the system browser;
+   * external URLs always go to the browser.
+   */
+  onOpenLocalUrl?: (url: string) => void;
 }
 
 export function createTerminal(options: CreateTerminalOptions = {}): TerminalHandle {
@@ -48,13 +54,19 @@ export function createTerminal(options: CreateTerminalOptions = {}): TerminalHan
 
   const fit = new FitAddon();
   term.loadAddon(fit);
-  // Open web links in the system browser (not the in-app webview) on a
-  // modifier-click, matching the file-link gesture (Alt/Cmd) plus Ctrl for
-  // non-mac. A plain click is left for text selection. Hover shows a hint.
+  // Open web links on a modifier-click, matching the file-link gesture (Alt/Cmd)
+  // plus Ctrl for non-mac. A plain click is left for text selection. Local
+  // (localhost/IP) URLs go to the in-app preview when a handler is wired;
+  // everything else opens in the system browser. Hover shows a hint.
   term.loadAddon(
     new WebLinksAddon(
       (event, uri) => {
-        if (matchesOpenModifier(event, IS_MAC) && isWebUrl(uri)) {
+        if (!matchesOpenModifier(event, IS_MAC) || !isWebUrl(uri)) {
+          return;
+        }
+        if (options.onOpenLocalUrl && isLocalUrl(uri)) {
+          options.onOpenLocalUrl(uri);
+        } else {
           void openUrl(uri);
         }
       },

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -50,6 +50,8 @@ interface SettingsState {
   aiInlineCompletion: boolean;
   /** Suggest previously-run commands as ghost text in the terminal. */
   terminalSuggestions: boolean;
+  /** Show the hover action card (ping/curl/extract) over IPs, host:port and archives. */
+  actionLinksEnabled: boolean;
   /** Webview zoom factor for the whole UI (1 = 100%); driven by ⌘+ / ⌘-. */
   uiZoom: number;
   setLanguage: (language: SupportedLanguage) => void;
@@ -63,6 +65,7 @@ interface SettingsState {
   setClaudeStatusTracking: (value: boolean) => void;
   setAiInlineCompletion: (value: boolean) => void;
   setTerminalSuggestions: (value: boolean) => void;
+  setActionLinksEnabled: (value: boolean) => void;
   zoomIn: () => void;
   zoomOut: () => void;
   resetZoom: () => void;
@@ -102,6 +105,7 @@ export const useSettingsStore = create<SettingsState>()(
       claudeStatusTracking: true,
       aiInlineCompletion: false,
       terminalSuggestions: true,
+      actionLinksEnabled: true,
       uiZoom: DEFAULT_UI_ZOOM,
       setLanguage: (language) => set({ language }),
       setThemeId: (themeId) => set({ themeId }),
@@ -115,6 +119,7 @@ export const useSettingsStore = create<SettingsState>()(
       setClaudeStatusTracking: (value) => set({ claudeStatusTracking: value }),
       setAiInlineCompletion: (value) => set({ aiInlineCompletion: value }),
       setTerminalSuggestions: (value) => set({ terminalSuggestions: value }),
+      setActionLinksEnabled: (value) => set({ actionLinksEnabled: value }),
       zoomIn: () => set((s) => ({ uiZoom: clampZoom(s.uiZoom + UI_ZOOM_STEP) })),
       zoomOut: () => set((s) => ({ uiZoom: clampZoom(s.uiZoom - UI_ZOOM_STEP) })),
       resetZoom: () => set({ uiZoom: DEFAULT_UI_ZOOM }),


### PR DESCRIPTION
## Summary

Hovering an entity in terminal output now pops a small card of quick commands you can run with one click — inspired by nyaterm's ActionLinks.

| Entity | Actions |
|---|---|
| IPv4 (`10.0.0.1`) | `ping` · `traceroute` · `ssh` · `curl http://…` |
| host:port (`example.com:8080`, `192.168.1.1:8080`) | `curl http://…` · `curl https://…` · `nc host port` · `telnet host port` |
| archive (`backup.tar.gz`, `data.zip`, `blob.7z`, …) | extension-correct **extract** + **list** (`unzip` / `tar -xzf` / `7z x` / …) |

**Clicking an action runs it directly** in the focused terminal. As a safety net, a command that looks destructive (`rm -rf`, `dd … of=`, `mkfs`, pipe-to-shell, fork bomb, raw-disk overwrite) shows a **red confirmation** before running. A settings toggle (`Hover action cards`, on by default) turns the whole thing off.

## Implementation

| Piece | File | Tested |
|---|---|---|
| Matchers (IP / host:port / archive) with overlap resolution | `terminal/lib/actionLinks.ts` | ✅ pure unit tests |
| Per-entity command builders | same | ✅ |
| Destructive-command detection | same | ✅ |
| Hover card UI + red confirm flow | `terminal/ActionCard.tsx` | ✅ RTL |
| Link-provider wiring + hover show/hide + run | `terminal/TerminalView.tsx` | glue |
| Setting + toggle | `stores/settingsStore.ts`, `settings/TerminalSettingsSection.tsx` | — |
| Strings | `i18n/locales/{en,zh-Hant}/{common,settings}.json` | — |

Notes:
- host:port deliberately requires a dotted host or `localhost`, so `error:42`-style key:number pairs are not matched.
- An archive filename also matches as a file path; the overlapping file link is dropped so the action card wins (opening a binary archive as a file isn't useful).
- The card escapes the pane via `position: fixed`; a short hide delay + cancel-on-card-enter lets the pointer travel from the link into the card.

## Test plan

- [x] `actionLinks.test.ts` — 11 cases: each matcher, IP-with-port precedence, `error:42` rejection, per-extension extract/list, danger detection, safe-command pass
- [x] `ActionCard.test.tsx` — safe action runs immediately; dangerous action requires confirm; cancel does not run
- [x] Full suite green (701 tests), `tsc --noEmit` clean, `vite build` clean
- [ ] Manual smoke test in the running app: hover an IP / archive in real output, run an action, confirm the destructive-command warning