### PR TITLE
feat: 鍵盤快捷鍵、Claude Code/Codex 啟動器與 session 系統通知

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@lezer/highlight": "^1.2.3",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
+      '@tauri-apps/plugin-notification':
+        specifier: ^2.3.3
+        version: 2.3.3
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.4
@@ -1086,6 +1089,9 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -3433,6 +3439,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
   '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-notification@2.3.3':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3047,6 +3047,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "machine-uid"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3260,6 +3274,20 @@ dependencies = [
  "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -3917,7 +3945,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -4127,6 +4155,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5688,6 +5725,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5868,6 +5924,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5905,6 +5973,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ git2 = "0.19"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "rt", "io-util", "net", "time"] }
 tauri-plugin-dialog = "2.7.1"
+tauri-plugin-notification = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-window-state = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,9 @@
     "core:webview:allow-set-webview-zoom",
     "opener:default",
     "dialog:default",
+    "notification:allow-notify",
+    "notification:allow-request-permission",
+    "notification:allow-is-permission-granted",
     "updater:default",
     "process:default"
   ]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         // Persist and restore window size and position across launches. Only

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,7 +5,7 @@ import "./i18n";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useUiStore } from "@/stores/uiStore";
 import { useTabsStore } from "@/stores/tabsStore";
-import { leaf } from "@/modules/terminal/lib/terminalLayout";
+import { leaf, splitLeaf } from "@/modules/terminal/lib/terminalLayout";
 
 describe("App shell", () => {
   beforeEach(() => {
@@ -60,6 +60,35 @@ describe("App shell", () => {
     // A digit past the last tab is a no-op rather than clearing the selection.
     fireEvent.keyDown(window, { code: "Digit9", key: "9", metaKey: true });
     expect(useTabsStore.getState().activeId).toBe("b");
+  });
+
+  it("closes the focused pane with Cmd+W, not the bottom-right one", () => {
+    // Two launcher panes (left + right); focus the left one. Cmd+W must peel
+    // away the focused pane, leaving the right pane behind.
+    const paneTree = splitLeaf(leaf("left-leaf", { kind: "launcher" }), "left-leaf", "row", "right-leaf", {
+      kind: "launcher",
+    });
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space 1" }],
+      activeSpaceId: "s1",
+      tabs: [
+        {
+          id: "a",
+          spaceId: "s1",
+          title: "a",
+          kind: "launcher" as const,
+          paneTree,
+          activeLeafId: "left-leaf",
+        },
+      ],
+      activeId: "a",
+    });
+    render(<App />);
+
+    fireEvent.keyDown(window, { code: "KeyW", key: "w", metaKey: true });
+
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
+    expect(tab?.paneTree).toEqual(leaf("right-leaf", { kind: "launcher" }));
   });
 
   it("selects the Nth sidebar panel with Option+digit", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,8 @@ import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useProgressStore } from "@/modules/claude-progress/lib/progressStore";
 import { useWatchSessions } from "@/modules/claude-progress/lib/useWatchSessions";
 import { installStatusHook, installCodexStatusHook } from "@/modules/claude-progress/lib/statusHookBridge";
+import { installSessionNotifications } from "@/modules/claude-progress/lib/sessionNotifications";
+import { ensureNotificationPermission } from "@/modules/claude-progress/lib/notify";
 import { useWatchNotes } from "@/modules/notes/lib/useWatchNotes";
 import { registerSecondaryWindowCleanup } from "@/lib/windowLifecycle";
 import { SshPromptDialog } from "@/modules/ssh/SshPromptDialog";
@@ -136,6 +138,16 @@ function App() {
       void installStatusHook().catch(() => {});
       void installCodexStatusHook().catch(() => {});
     }
+  }, []);
+
+  // Raise a desktop notification when a tracked agent needs approval or finishes
+  // while the window is unfocused. Prime the OS permission up front so the first
+  // real notification isn't swallowed by a permission prompt.
+  useEffect(() => {
+    if (useSettingsStore.getState().claudeNotifications) {
+      void ensureNotificationPermission();
+    }
+    return installSessionNotifications();
   }, []);
 
   // Quietly check for a new release a few seconds after launch; the modal only
@@ -263,18 +275,21 @@ function App() {
             tabsState.closePaneOrTab();
           }
         } else {
-          // Closing the bottom-right pane (same selection as closePaneOrTab).
-          const target = panes.reduce((a, b) => {
-            if (b.rect.top !== a.rect.top) return b.rect.top > a.rect.top ? b : a;
-            return b.rect.left > a.rect.left ? b : a;
-          });
+          // Close the currently focused pane; fall back to the bottom-right
+          // pane if the active leaf is somehow stale.
+          const target =
+            panes.find((p) => p.id === tab.activeLeafId) ??
+            panes.reduce((a, b) => {
+              if (b.rect.top !== a.rect.top) return b.rect.top > a.rect.top ? b : a;
+              return b.rect.left > a.rect.left ? b : a;
+            });
           const targetBuf =
             target.content.kind === "editor" ? buffers[target.content.path] : undefined;
           const targetDirty = targetBuf ? targetBuf.content !== targetBuf.baseline : false;
           if (targetDirty) {
             setPendingCloseAction(() => () => tabsState.closePane(tab.id, target.id));
           } else {
-            tabsState.closePaneOrTab();
+            tabsState.closePane(tab.id, target.id);
           }
         }
       } else if (key === "p") {

--- a/src/components/LauncherPanel.tsx
+++ b/src/components/LauncherPanel.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  Bot,
   FilePlus,
   FileText,
   FolderOpen,
   Globe,
   Server,
+  Sparkles,
   SquareTerminal,
   Waypoints,
   type LucideIcon,
@@ -16,6 +18,7 @@ import { useUiStore } from "@/stores/uiStore";
 import { useNotesStore } from "@/stores/notesStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { pickNotesFolder } from "@/modules/notes/lib/pickNotesFolder";
+import { writeToTerminal } from "@/modules/terminal/lib/terminalBus";
 import { pickFile, pickFolder } from "@/lib/dialog";
 import { IS_MAC } from "@/lib/platform";
 import type { PaneContent } from "@/modules/terminal/lib/terminalLayout";
@@ -115,6 +118,26 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
     }
   }
 
+  // Open a terminal and auto-run a CLI command in it (e.g. `claude`, `codex`).
+  // The command is queued via writeToTerminal until the freshly spawned shell
+  // registers, so it runs once the prompt is ready.
+  function openTerminalWithCommand(command: string) {
+    const line = command.endsWith("\n") ? command : `${command}\n`;
+    if (resolved.mode === "replacePane") {
+      setPaneContent(resolved.tabId, resolved.leafId, { kind: "terminal" });
+      writeToTerminal(resolved.leafId, line);
+      return;
+    }
+    const tabId = newTerminalTab(useWorkspaceStore.getState().rootPath ?? undefined);
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId);
+    if (tab && tab.kind === "terminal") {
+      writeToTerminal(tab.activeLeafId, line);
+    }
+    if (resolved.closeTabId) {
+      closeTab(resolved.closeTabId);
+    }
+  }
+
   const showShortcuts = resolved.mode === "newTab";
 
   const groups: LauncherGroup[] = [
@@ -122,6 +145,18 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
       key: "workspace",
       label: t("workspace.launcherGroup.workspace"),
       actions: [
+        {
+          key: "claude-code",
+          label: t("workspace.claudeCode"),
+          icon: Sparkles,
+          run: () => openTerminalWithCommand("claude"),
+        },
+        {
+          key: "codex",
+          label: t("workspace.codex"),
+          icon: Bot,
+          run: () => openTerminalWithCommand("codex"),
+        },
         {
           key: "terminal",
           label: t("workspace.terminal"),

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -161,6 +161,8 @@
     "note": "Note",
     "newTerminal": "New terminal",
     "connectSsh": "Connect SSH",
+    "claudeCode": "Claude Code",
+    "codex": "Codex",
     "launcherHint": "Choose what to open",
     "launcherGroup": {
       "workspace": "Workspace",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -25,6 +25,11 @@
     "previous": "Find previous",
     "close": "Close search"
   },
+  "notify": {
+    "agentFallback": "Agent",
+    "needPermission": "{{agent}} needs permission",
+    "finished": "{{agent}} finished"
+  },
   "ssh": {
     "disconnected": "Disconnected — click to reconnect",
     "reconnect": "Reconnect"

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -19,6 +19,8 @@
     "statusTrackingTitle": "Claude session status",
     "statusTrackingDescription": "Installs a Claude Code hook so cards show live status (running, thinking, needs approval) only while Claude runs in a tempo-term terminal. Other terminals are unaffected.",
     "statusTrackingLabel": "Track Claude session status",
+    "notificationsLabel": "Desktop notification when an agent needs approval or finishes (only while the window is unfocused)",
+    "notificationsRequiresTracking": "Turn on session-status tracking to enable notifications.",
     "prTitle": "Pull request source",
     "prDescription": "Where PR status is fetched from. gh is detected automatically.",
     "prAuto": "Auto",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -25,6 +25,11 @@
     "previous": "上一個",
     "close": "關閉搜尋"
   },
+  "notify": {
+    "agentFallback": "工作階段",
+    "needPermission": "{{agent}} 需要權限",
+    "finished": "{{agent}} 已完成"
+  },
   "ssh": {
     "disconnected": "已斷線，點擊重新連線",
     "reconnect": "重新連線"

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -161,6 +161,8 @@
     "note": "筆記",
     "newTerminal": "新增終端機",
     "connectSsh": "SSH 連線",
+    "claudeCode": "Claude Code",
+    "codex": "Codex",
     "launcherHint": "選擇要開啟的內容",
     "launcherGroup": {
       "workspace": "工作區",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -19,6 +19,8 @@
     "statusTrackingTitle": "Claude session 狀態",
     "statusTrackingDescription": "安裝一個 Claude Code hook，讓卡片只在 Claude 跑於 tempo-term 終端機時顯示即時狀態（執行中、思考中、等待批准）。其他終端機不受影響。",
     "statusTrackingLabel": "追蹤 Claude session 狀態",
+    "notificationsLabel": "工作階段需要批准或完成時跳出桌面通知（僅在視窗未聚焦時）",
+    "notificationsRequiresTracking": "需先開啟 session 狀態追蹤才能使用通知。",
     "prTitle": "Pull request 來源",
     "prDescription": "PR 狀態的查詢來源，gh 會自動偵測。",
     "prAuto": "自動",

--- a/src/modules/claude-progress/lib/notify.ts
+++ b/src/modules/claude-progress/lib/notify.ts
@@ -1,0 +1,44 @@
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
+
+/** Cached once granted, so repeat sends skip the permission IPC round-trip. */
+let permissionGranted = false;
+
+/**
+ * Ask the OS for notification permission if we don't already have it. Safe to
+ * call repeatedly; returns whether notifications may now be sent. Swallows
+ * errors (e.g. no backend in tests/web preview) and reports no permission.
+ */
+export async function ensureNotificationPermission(): Promise<boolean> {
+  if (permissionGranted) {
+    return true;
+  }
+  try {
+    if (await isPermissionGranted()) {
+      permissionGranted = true;
+      return true;
+    }
+    permissionGranted = (await requestPermission()) === "granted";
+    return permissionGranted;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fire one OS desktop notification, requesting permission first if needed. A
+ * thin wrapper over the Tauri plugin so callers stay testable and never throw.
+ */
+export async function notifyDesktop(title: string, body: string): Promise<void> {
+  try {
+    if (!(await ensureNotificationPermission())) {
+      return;
+    }
+    sendNotification({ title, body });
+  } catch {
+    // Notifications are best-effort; never let a failure bubble into the app.
+  }
+}

--- a/src/modules/claude-progress/lib/sessionNotifications.test.ts
+++ b/src/modules/claude-progress/lib/sessionNotifications.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { notificationForTransition } from "./sessionNotifications";
+
+describe("notificationForTransition", () => {
+  it("notifies on entering waiting-approval from any prior state", () => {
+    expect(notificationForTransition(undefined, "waiting-approval")).toBe("approval");
+    expect(notificationForTransition("active", "waiting-approval")).toBe("approval");
+    expect(notificationForTransition("thinking", "waiting-approval")).toBe("approval");
+    expect(notificationForTransition("idle", "waiting-approval")).toBe("approval");
+  });
+
+  it("does not re-notify while already waiting-approval", () => {
+    expect(notificationForTransition("waiting-approval", "waiting-approval")).toBeNull();
+  });
+
+  it("notifies done when active work returns to idle", () => {
+    expect(notificationForTransition("active", "idle")).toBe("done");
+    expect(notificationForTransition("thinking", "idle")).toBe("done");
+  });
+
+  it("stays quiet on the SessionStart idle (no prior work)", () => {
+    expect(notificationForTransition(undefined, "idle")).toBeNull();
+    expect(notificationForTransition("idle", "idle")).toBeNull();
+  });
+
+  it("does not notify on resuming work or approval clearing to idle", () => {
+    expect(notificationForTransition("thinking", "active")).toBeNull();
+    expect(notificationForTransition("waiting-approval", "active")).toBeNull();
+    expect(notificationForTransition("waiting-approval", "idle")).toBeNull();
+  });
+
+  it("treats a cleared status (next undefined) as no notification", () => {
+    expect(notificationForTransition("active", undefined)).toBeNull();
+    expect(notificationForTransition("waiting-approval", undefined)).toBeNull();
+  });
+});

--- a/src/modules/claude-progress/lib/sessionNotifications.ts
+++ b/src/modules/claude-progress/lib/sessionNotifications.ts
@@ -1,0 +1,109 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import i18n from "@/i18n";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useTabsStore } from "@/stores/tabsStore";
+import { findPaneContent } from "@/modules/terminal/lib/terminalLayout";
+import { basename } from "@/modules/explorer/lib/paths";
+import { agentLabel } from "@/modules/workspace/lib/agentLabel";
+import { progressKey } from "./progressStore";
+import { useTitlesStore } from "@/modules/workspace/lib/titlesStore";
+import type { AgentKind } from "./codexNormalize";
+import { useSessionStatusStore } from "./sessionStatusStore";
+import type { SessionStatus } from "./sessionStatus";
+import { notifyDesktop } from "./notify";
+
+/** The kinds of OS notification a status transition can warrant. */
+export type NotificationKind = "approval" | "done";
+
+/**
+ * Decide whether a per-pane status change should raise a desktop notification.
+ *
+ * - Entering `waiting-approval` (from anything else) → "approval": the agent is
+ *   blocked on the user allowing a tool.
+ * - Returning to `idle` from active work (`active`/`thinking`) → "done": the
+ *   task just finished and is waiting for the next message. Crucially, the
+ *   `SessionStart` idle (prev `undefined`) is NOT a finish, so it stays quiet.
+ *
+ * Re-emitting the same status (prev === next) never notifies, so a stream of
+ * repeated `waiting-approval` events can't spam the user.
+ */
+export function notificationForTransition(
+  prev: SessionStatus | undefined,
+  next: SessionStatus | undefined,
+): NotificationKind | null {
+  if (next === "waiting-approval" && prev !== "waiting-approval") {
+    return "approval";
+  }
+  if (next === "idle" && (prev === "active" || prev === "thinking")) {
+    return "done";
+  }
+  return null;
+}
+
+/**
+ * A short label for the pane a notification is about: the session's transcript
+ * title if known, else its directory name, else the tab title. Searches the
+ * active space's tabs for the leaf; returns "" when it can't be located.
+ */
+function leafContextName(leafId: string, agent: AgentKind | undefined): string {
+  for (const tab of useTabsStore.getState().tabs) {
+    const content = findPaneContent(tab.paneTree, leafId);
+    if (!content || content.kind !== "terminal") {
+      continue;
+    }
+    const cwd = content.cwd ?? tab.cwd ?? null;
+    if (cwd && agent) {
+      const title = useTitlesStore.getState().titles[progressKey(cwd, agent)];
+      if (title) {
+        return title;
+      }
+    }
+    return cwd ? basename(cwd) : tab.title;
+  }
+  return "";
+}
+
+async function dispatch(
+  leafId: string,
+  kind: NotificationKind,
+  agent: AgentKind | undefined,
+): Promise<void> {
+  try {
+    // Only nudge the user when they're looking elsewhere; a focused window
+    // already shows the live badge, so a system toast would just be noise.
+    if (await getCurrentWindow().isFocused()) {
+      return;
+    }
+    const label = agentLabel(agent) ?? i18n.t("notify.agentFallback");
+    const title =
+      kind === "approval"
+        ? i18n.t("notify.needPermission", { agent: label })
+        : i18n.t("notify.finished", { agent: label });
+    await notifyDesktop(title, leafContextName(leafId, agent));
+  } catch {
+    // Best-effort: a missing window/permission must never break status updates.
+  }
+}
+
+/**
+ * Subscribe to the per-pane session status store and raise desktop
+ * notifications on the transitions that warrant the user's attention. Returns
+ * an unsubscribe function for an effect cleanup. No-op while the
+ * `claudeNotifications` setting is off.
+ */
+export function installSessionNotifications(): () => void {
+  return useSessionStatusStore.subscribe((state, prev) => {
+    if (state.statuses === prev.statuses) {
+      return; // An agent-only change; no status moved.
+    }
+    if (!useSettingsStore.getState().claudeNotifications) {
+      return;
+    }
+    for (const leafId of Object.keys(state.statuses)) {
+      const kind = notificationForTransition(prev.statuses[leafId], state.statuses[leafId]);
+      if (kind) {
+        void dispatch(leafId, kind, state.agents[leafId]);
+      }
+    }
+  });
+}

--- a/src/modules/claude-progress/lib/sessionStatusStore.ts
+++ b/src/modules/claude-progress/lib/sessionStatusStore.ts
@@ -20,20 +20,33 @@ export const useSessionStatusStore = create<SessionStatusState>((set) => ({
   statuses: {},
   agents: {},
   setStatus: (leafId, status) =>
-    set((s) => ({ statuses: { ...s.statuses, [leafId]: status } })),
+    set((s) =>
+      s.statuses[leafId] === status ? s : { statuses: { ...s.statuses, [leafId]: status } },
+    ),
   setAgent: (leafId, agent) =>
     set((s) =>
       s.agents[leafId] === agent ? s : { agents: { ...s.agents, [leafId]: agent } },
     ),
   clear: (leafId) =>
     set((s) => {
-      if (!(leafId in s.statuses) && !(leafId in s.agents)) {
+      const hasStatus = leafId in s.statuses;
+      const hasAgent = leafId in s.agents;
+      if (!hasStatus && !hasAgent) {
         return s;
       }
-      const statuses = { ...s.statuses };
-      delete statuses[leafId];
-      const agents = { ...s.agents };
-      delete agents[leafId];
-      return { statuses, agents };
+      // Only rebuild the map the leaf is actually in, so clearing an
+      // agent-only leaf doesn't churn the statuses ref the notifier watches.
+      const next: Partial<SessionStatusState> = {};
+      if (hasStatus) {
+        const statuses = { ...s.statuses };
+        delete statuses[leafId];
+        next.statuses = statuses;
+      }
+      if (hasAgent) {
+        const agents = { ...s.agents };
+        delete agents[leafId];
+        next.agents = agents;
+      }
+      return next;
     }),
 }));

--- a/src/modules/settings/WorkspaceSettingsSection.tsx
+++ b/src/modules/settings/WorkspaceSettingsSection.tsx
@@ -14,6 +14,7 @@ import {
   installCodexStatusHook,
   uninstallCodexStatusHook,
 } from "@/modules/claude-progress/lib/statusHookBridge";
+import { ensureNotificationPermission } from "@/modules/claude-progress/lib/notify";
 
 /** Keychain account the GitHub API token is stored under (matches the backend). */
 const GITHUB_PROVIDER = "github";
@@ -100,6 +101,8 @@ export function WorkspaceSettingsSection() {
   const setPrSource = useSettingsStore((s) => s.setPrSource);
   const statusTracking = useSettingsStore((s) => s.claudeStatusTracking);
   const setStatusTracking = useSettingsStore((s) => s.setClaudeStatusTracking);
+  const notifications = useSettingsStore((s) => s.claudeNotifications);
+  const setNotifications = useSettingsStore((s) => s.setClaudeNotifications);
   const [ghReady, setGhReady] = useState<boolean | null>(null);
 
   async function toggleStatusTracking(checked: boolean) {
@@ -116,6 +119,15 @@ export function WorkspaceSettingsSection() {
       // Keep the toggle in sync with the real system state: if install or
       // uninstall failed, the hook is in the opposite state from what we set.
       setStatusTracking(!checked);
+    }
+  }
+
+  async function toggleNotifications(checked: boolean) {
+    setNotifications(checked);
+    if (checked) {
+      // Prompt for OS permission the moment the user opts in, so the first real
+      // notification fires without a permission dialog racing it.
+      await ensureNotificationPermission();
     }
   }
 
@@ -151,7 +163,7 @@ export function WorkspaceSettingsSection() {
         {t("workspace.statusTrackingTitle")}
       </label>
       <p className="mb-2 text-xs text-fg-muted">{t("workspace.statusTrackingDescription")}</p>
-      <label className="mb-6 flex items-center gap-2 text-sm text-fg">
+      <label className="mb-3 flex items-center gap-2 text-sm text-fg">
         <input
           type="checkbox"
           checked={statusTracking}
@@ -159,6 +171,21 @@ export function WorkspaceSettingsSection() {
           className="h-4 w-4 accent-accent"
         />
         {t("workspace.statusTrackingLabel")}
+      </label>
+      <label
+        className={`mb-6 flex items-center gap-2 text-sm ${
+          statusTracking ? "text-fg" : "text-fg-subtle"
+        }`}
+        title={statusTracking ? undefined : t("workspace.notificationsRequiresTracking")}
+      >
+        <input
+          type="checkbox"
+          checked={notifications}
+          disabled={!statusTracking}
+          onChange={(e) => void toggleNotifications(e.target.checked)}
+          className="h-4 w-4 accent-accent disabled:opacity-50"
+        />
+        {t("workspace.notificationsLabel")}
       </label>
 
       <label className="mb-1 block text-sm font-medium text-fg">{t("workspace.prTitle")}</label>

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -866,7 +866,11 @@ export function TerminalView({
       return;
     }
     let cancelled = false;
-    let last = "";
+    // Seed with the shell's starting dir so the mount-time setRoot (which fires
+    // with this same dir) does not echo a redundant `cd` back into the shell.
+    // Without this, a freshly opened pane that auto-runs a CLI (e.g. claude,
+    // codex) gets the `cd` typed into that program's prompt instead.
+    let last = cwdRef.current ?? "";
     const poll = async () => {
       const raw = sessionRef.current;
       const session = raw && isPtySession(raw) ? raw : null;

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -46,6 +46,11 @@ interface SettingsState {
   prSource: WorkspacePrSource;
   /** Install the Claude Code hook that reports live session status to cards. */
   claudeStatusTracking: boolean;
+  /**
+   * Raise an OS desktop notification when a tracked agent needs approval or
+   * finishes, but only while the window is unfocused. Depends on status tracking.
+   */
+  claudeNotifications: boolean;
   /** Show AI ghost-text completions while typing in the code editor. */
   aiInlineCompletion: boolean;
   /** Suggest previously-run commands as ghost text in the terminal. */
@@ -63,6 +68,7 @@ interface SettingsState {
   setWorkspaceCardBlock: (key: keyof WorkspaceCardBlocks, value: boolean) => void;
   setPrSource: (source: WorkspacePrSource) => void;
   setClaudeStatusTracking: (value: boolean) => void;
+  setClaudeNotifications: (value: boolean) => void;
   setAiInlineCompletion: (value: boolean) => void;
   setTerminalSuggestions: (value: boolean) => void;
   setActionLinksEnabled: (value: boolean) => void;
@@ -103,6 +109,7 @@ export const useSettingsStore = create<SettingsState>()(
       workspaceCard: DEFAULT_WORKSPACE_CARD,
       prSource: "auto",
       claudeStatusTracking: true,
+      claudeNotifications: true,
       aiInlineCompletion: false,
       terminalSuggestions: true,
       actionLinksEnabled: true,
@@ -117,6 +124,7 @@ export const useSettingsStore = create<SettingsState>()(
         set((state) => ({ workspaceCard: { ...state.workspaceCard, [key]: value } })),
       setPrSource: (prSource) => set({ prSource }),
       setClaudeStatusTracking: (value) => set({ claudeStatusTracking: value }),
+      setClaudeNotifications: (value) => set({ claudeNotifications: value }),
       setAiInlineCompletion: (value) => set({ aiInlineCompletion: value }),
       setTerminalSuggestions: (value) => set({ terminalSuggestions: value }),
       setActionLinksEnabled: (value) => set({ actionLinksEnabled: value }),


### PR DESCRIPTION
## 概述

整合一系列終端工作流改善，涵蓋快捷鍵、啟動器與系統通知。

## 變更內容

- **feat(shortcuts)** — 新增分頁/面板/縮放快捷鍵與焦點提示。
- **feat(terminal)** — 整合 zsh-autosuggestions 提供指令 ghost text 提示。
- **fix(shortcuts)** — ⌘W 改為關閉「目前焦點」的分割面板，而非一律從右下角面板開始關。
- **feat(launcher)** — launcher 面板新增 Claude Code 與 Codex 兩個選項，選擇後自動於終端機進入對應 CLI 工具（預設不帶入路徑）。
- **feat(notification)** — 整合 `tauri-plugin-notification`，當 Claude/Codex session 狀態變化且視窗未聚焦時發送系統通知，並提供 workspace 設定開關。權限採最小授權（僅 notify / request-permission / is-permission-granted）。

## 測試

- `pnpm typecheck` 通過
- `pnpm test`（App / tabsStore / sessionNotifications）通過
- Tauri security review：PASS（notification 權限最小化，無 IPC 信任邊界問題）

🤖 Generated with [Claude Code](https://claude.com/claude-code)