### PR TITLE
feat(terminal): large-output protection (batched writer + overload notice)

### DIFF
--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -2,6 +2,7 @@
   "appName": "TempoTerm",
   "tagline": "AI-powered terminal workspace",
   "terminalConnecting": "Starting shell…",
+  "outputThrottled": "Output throttled, skipped {{size}} to keep the UI responsive",
   "openLinkHint": "{{mods}}-click to open",
   "actionLinks": {
     "hoverHint": "Hover for actions",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -2,6 +2,7 @@
   "appName": "TempoTerm",
   "tagline": "AI 驅動的終端機工作區",
   "terminalConnecting": "啟動中…",
+  "outputThrottled": "輸出太快，已略過 {{size}} 以維持介面流暢",
   "openLinkHint": "{{mods}} + 點擊開啟",
   "actionLinks": {
     "hoverHint": "可執行的動作",

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Loader2, WifiOff } from "lucide-react";
 import { consumeFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/createTerminal";
+import { createOutputWriter } from "./lib/outputWriter";
 import { SearchBar } from "./SearchBar";
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import { openSsh, type SshSession } from "@/modules/ssh/lib/ssh-bridge";
@@ -243,6 +244,11 @@ export function TerminalView({
     // DOM renderer on its own if WebGL is unavailable; term.dispose() (cleanup
     // below) tears the addon down with the terminal.
     enableWebglRenderer(term);
+
+    // Batch live PTY/SSH output through a frame-scheduled writer so a flood
+    // (cat a huge file, runaway logs) can't block the UI thread. One-shot writes
+    // (restored history, error notices) still go straight to the terminal.
+    const outputWriter = createOutputWriter({ write: (chunk) => term.write(chunk) });
 
     // The session-status hook (see claude_status_hook) emits OSC 6973 on this
     // pane's tty when Claude changes state. Capture it here, where we know the
@@ -595,7 +601,7 @@ export function TerminalView({
           cols: term.cols,
           rows: term.rows,
           forwards,
-          onData: (bytes) => term.write(bytes),
+          onData: (bytes) => outputWriter.push(bytes),
           // Only treat an exit as user-facing when we did not tear the session
           // down ourselves (e.g. React StrictMode's mount/unmount/remount in dev).
           onExit: (_code) => {
@@ -621,7 +627,7 @@ export function TerminalView({
         // Read the setting at spawn time so a restored pane reflects the current
         // value, instead of racing a global flag set after mount.
         suggestions: useSettingsStore.getState().terminalSuggestions,
-        onData: (bytes) => term.write(bytes),
+        onData: (bytes) => outputWriter.push(bytes),
         // Only treat an exit as user-facing when we did not tear the session
         // down ourselves (e.g. React StrictMode's mount/unmount/remount in dev).
         onExit: () => {
@@ -761,6 +767,7 @@ export function TerminalView({
 
     return () => {
       disposed = true;
+      outputWriter.dispose();
       cancelAnimationFrame(initialFitFrame);
       clearInterval(snapshotTimer);
       writeListener.dispose();

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -188,7 +188,11 @@ export function TerminalView({
   // Skipped-bytes total shown in the overload notice, or null when hidden. The
   // refs throttle visible updates during a flood and auto-hide once it settles.
   const [outputSkipped, setOutputSkipped] = useState<number | null>(null);
+  // The writer reports a lifetime cumulative dropped total; the baseline marks
+  // the total when the last notice closed, so each notice shows just this
+  // overload event's skipped bytes rather than an ever-growing lifetime sum.
   const skippedTotalRef = useRef(0);
+  const skippedBaselineRef = useRef(0);
   const skippedShowTimer = useRef<number | null>(null);
   const skippedHideTimer = useRef<number | null>(null);
   const dragDepthRef = useRef(0);
@@ -237,7 +241,7 @@ export function TerminalView({
     if (skippedShowTimer.current === null) {
       skippedShowTimer.current = window.setTimeout(() => {
         skippedShowTimer.current = null;
-        setOutputSkipped(skippedTotalRef.current);
+        setOutputSkipped(skippedTotalRef.current - skippedBaselineRef.current);
       }, 250);
     }
     if (skippedHideTimer.current !== null) {
@@ -245,7 +249,7 @@ export function TerminalView({
     }
     skippedHideTimer.current = window.setTimeout(() => {
       setOutputSkipped(null);
-      skippedTotalRef.current = 0;
+      skippedBaselineRef.current = skippedTotalRef.current;
     }, 2500);
   };
 

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -105,6 +105,17 @@ async function getHomeDir(): Promise<string | null> {
   return homeDirCache;
 }
 
+/** Human-readable byte size for the overload notice (e.g. 12 KB, 3.4 MB). */
+function formatSkipped(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${bytes} B`;
+}
+
 interface TerminalViewProps {
   active: boolean;
   /** When true, this pane drives the file explorer root from its shell CWD. */
@@ -174,6 +185,12 @@ export function TerminalView({
   const [reconnectTrigger, setReconnectTrigger] = useState(0);
   const [externalFileDragging, setExternalFileDragging] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+  // Skipped-bytes total shown in the overload notice, or null when hidden. The
+  // refs throttle visible updates during a flood and auto-hide once it settles.
+  const [outputSkipped, setOutputSkipped] = useState<number | null>(null);
+  const skippedTotalRef = useRef(0);
+  const skippedShowTimer = useRef<number | null>(null);
+  const skippedHideTimer = useRef<number | null>(null);
   const dragDepthRef = useRef(0);
   const nativeDragPathsRef = useRef<string[]>([]);
   // The hover action card (IP / host:port / archive quick commands), positioned
@@ -212,6 +229,26 @@ export function TerminalView({
     setActionCard(null);
   };
 
+  // Surface the overload notice when the output writer sheds data. Visible
+  // updates are throttled so a sustained flood doesn't itself thrash React, and
+  // the notice auto-hides once output stops being dropped.
+  const noteDroppedOutput = (total: number) => {
+    skippedTotalRef.current = total;
+    if (skippedShowTimer.current === null) {
+      skippedShowTimer.current = window.setTimeout(() => {
+        skippedShowTimer.current = null;
+        setOutputSkipped(skippedTotalRef.current);
+      }, 250);
+    }
+    if (skippedHideTimer.current !== null) {
+      clearTimeout(skippedHideTimer.current);
+    }
+    skippedHideTimer.current = window.setTimeout(() => {
+      setOutputSkipped(null);
+      skippedTotalRef.current = 0;
+    }, 2500);
+  };
+
   // Clear any pending action-card hide timer when the pane unmounts so it can't
   // fire a state update on a gone component.
   useEffect(() => {
@@ -248,7 +285,10 @@ export function TerminalView({
     // Batch live PTY/SSH output through a frame-scheduled writer so a flood
     // (cat a huge file, runaway logs) can't block the UI thread. One-shot writes
     // (restored history, error notices) still go straight to the terminal.
-    const outputWriter = createOutputWriter({ write: (chunk) => term.write(chunk) });
+    const outputWriter = createOutputWriter({
+      write: (chunk) => term.write(chunk),
+      onDrop: (total) => noteDroppedOutput(total),
+    });
 
     // The session-status hook (see claude_status_hook) emits OSC 6973 on this
     // pane's tty when Claude changes state. Capture it here, where we know the
@@ -768,6 +808,8 @@ export function TerminalView({
     return () => {
       disposed = true;
       outputWriter.dispose();
+      if (skippedShowTimer.current !== null) clearTimeout(skippedShowTimer.current);
+      if (skippedHideTimer.current !== null) clearTimeout(skippedHideTimer.current);
       cancelAnimationFrame(initialFitFrame);
       clearInterval(snapshotTimer);
       writeListener.dispose();
@@ -1182,6 +1224,11 @@ export function TerminalView({
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-2 text-fg-subtle">
           <Loader2 size={15} className="animate-spin" />
           <span className="text-xs">{t("terminalConnecting")}</span>
+        </div>
+      )}
+      {outputSkipped !== null && (
+        <div className="pointer-events-none absolute left-1/2 top-3 -translate-x-1/2 rounded-md border border-border-strong bg-bg-elevated px-3 py-1 text-xs text-fg-muted shadow-lg">
+          {t("outputThrottled", { size: formatSkipped(outputSkipped) })}
         </div>
       )}
       {sshDisconnected && !connecting && (

--- a/src/modules/terminal/lib/outputWriter.test.ts
+++ b/src/modules/terminal/lib/outputWriter.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOutputWriter } from "./outputWriter";
+
+/** A scheduler whose frames fire only when the test calls runAll(). */
+function fakeScheduler() {
+  let pending: Array<() => void> = [];
+  return {
+    schedule: (cb: () => void): number => {
+      pending.push(cb);
+      return pending.length;
+    },
+    cancel: (): void => {},
+    runAll: (): void => {
+      const cbs = pending;
+      pending = [];
+      for (const cb of cbs) cb();
+    },
+  };
+}
+
+describe("createOutputWriter", () => {
+  it("buffers a pushed chunk and writes it on the next scheduled flush", () => {
+    const sched = fakeScheduler();
+    const write = vi.fn();
+    const writer = createOutputWriter({ write, schedule: sched.schedule, cancel: sched.cancel });
+
+    writer.push("hello");
+    expect(write).not.toHaveBeenCalled();
+
+    sched.runAll();
+    expect(write).toHaveBeenCalledWith("hello");
+  });
+
+  it("writes at most maxBytesPerFlush per frame and reschedules the rest", () => {
+    const sched = fakeScheduler();
+    const write = vi.fn();
+    const writer = createOutputWriter({
+      write,
+      schedule: sched.schedule,
+      cancel: sched.cancel,
+      maxBytesPerFlush: 5,
+    });
+
+    writer.push("aaa"); // 3 bytes
+    writer.push("bbb"); // 3 bytes — together 6 > 5
+
+    sched.runAll();
+    expect(write.mock.calls.map((c) => c[0])).toEqual(["aaa"]);
+
+    sched.runAll();
+    expect(write.mock.calls.map((c) => c[0])).toEqual(["aaa", "bbb"]);
+  });
+
+  it("drops the oldest queued bytes when the backlog exceeds the cap", () => {
+    const sched = fakeScheduler();
+    const write = vi.fn();
+    const writer = createOutputWriter({
+      write,
+      schedule: sched.schedule,
+      cancel: sched.cancel,
+      backlogCap: 5,
+    });
+
+    writer.push("aaa"); // 3 bytes, within cap
+    writer.push("bbb"); // total 6 > 5 — oldest "aaa" is dropped
+
+    expect(writer.droppedBytes).toBe(3);
+
+    sched.runAll();
+    expect(write.mock.calls.map((c) => c[0])).toEqual(["bbb"]);
+  });
+
+  it("does not write anything once disposed, even if a flush was pending", () => {
+    const sched = fakeScheduler();
+    const write = vi.fn();
+    const writer = createOutputWriter({ write, schedule: sched.schedule, cancel: sched.cancel });
+
+    writer.push("x");
+    writer.dispose();
+    sched.runAll();
+
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/terminal/lib/outputWriter.test.ts
+++ b/src/modules/terminal/lib/outputWriter.test.ts
@@ -70,6 +70,24 @@ describe("createOutputWriter", () => {
     expect(write.mock.calls.map((c) => c[0])).toEqual(["bbb"]);
   });
 
+  it("reports the running dropped total via onDrop when it sheds output", () => {
+    const sched = fakeScheduler();
+    const seen: number[] = [];
+    const writer = createOutputWriter({
+      write: vi.fn(),
+      schedule: sched.schedule,
+      cancel: sched.cancel,
+      backlogCap: 5,
+      onDrop: (total) => seen.push(total),
+    });
+
+    writer.push("aaa"); // within cap, no drop
+    writer.push("bbb"); // total 6 > 5 — drops "aaa" (3 bytes)
+
+    expect(seen).toEqual([3]);
+    expect(writer.droppedBytes).toBe(3);
+  });
+
   it("does not write anything once disposed, even if a flush was pending", () => {
     const sched = fakeScheduler();
     const write = vi.fn();

--- a/src/modules/terminal/lib/outputWriter.ts
+++ b/src/modules/terminal/lib/outputWriter.ts
@@ -1,0 +1,102 @@
+/** A chunk xterm's `term.write` accepts. Both forms expose `.length`. */
+export type WriteChunk = string | Uint8Array;
+
+export interface OutputWriterOptions {
+  /** Sink for batched output (typically `term.write`). */
+  write: (chunk: WriteChunk) => void;
+  /** Schedule a flush on the next frame. Injectable for tests. */
+  schedule?: (cb: () => void) => number;
+  /** Cancel a scheduled flush. */
+  cancel?: (handle: number) => void;
+  /** Max bytes written to the sink per frame; the rest waits for the next frame. */
+  maxBytesPerFlush?: number;
+  /** Max bytes allowed to sit in the queue; older bytes are dropped past this. */
+  backlogCap?: number;
+}
+
+/** nyaterm's writeChunkChars: a comfortable per-frame write budget. */
+const DEFAULT_MAX_BYTES_PER_FLUSH = 32 * 1024;
+/** nyaterm's visibleBacklogCap: how much unwritten output we keep before dropping. */
+const DEFAULT_BACKLOG_CAP = 1_000_000;
+
+export interface TerminalOutputWriter {
+  /** Queue a chunk to be written on the next flush. */
+  push(chunk: WriteChunk): void;
+  /** Cancel any pending flush; no further writes happen. */
+  dispose(): void;
+  /** Total bytes dropped from the queue under overload. */
+  readonly droppedBytes: number;
+}
+
+/**
+ * Batches terminal output and flushes it on animation frames instead of writing
+ * synchronously on every PTY/SSH data event, so a flood of output can't block
+ * the UI thread.
+ */
+export function createOutputWriter(options: OutputWriterOptions): TerminalOutputWriter {
+  const schedule = options.schedule ?? ((cb) => requestAnimationFrame(cb));
+  const maxBytesPerFlush = options.maxBytesPerFlush ?? DEFAULT_MAX_BYTES_PER_FLUSH;
+  const backlogCap = options.backlogCap ?? DEFAULT_BACKLOG_CAP;
+  const cancel = options.cancel ?? ((h) => cancelAnimationFrame(h));
+  const queue: WriteChunk[] = [];
+  let queuedBytes = 0;
+  let droppedBytes = 0;
+  let handle: number | null = null;
+  let disposed = false;
+
+  // Keep the queue under the cap by dropping the oldest chunks. Always keep the
+  // most recent chunk so the newest output survives even a single huge write.
+  function trim(): void {
+    while (queue.length > 1 && queuedBytes > backlogCap) {
+      const dropped = queue.shift() as WriteChunk;
+      queuedBytes -= dropped.length;
+      droppedBytes += dropped.length;
+    }
+  }
+
+  function flush(): void {
+    handle = null;
+    if (disposed) {
+      return;
+    }
+    let written = 0;
+    // Always write at least one chunk so a single oversized chunk can't stall
+    // forever; otherwise stop once the next chunk would blow the frame budget.
+    while (queue.length > 0) {
+      if (written > 0 && written + queue[0].length > maxBytesPerFlush) {
+        break;
+      }
+      const chunk = queue.shift() as WriteChunk;
+      queuedBytes -= chunk.length;
+      options.write(chunk);
+      written += chunk.length;
+    }
+    if (queue.length > 0) {
+      handle = schedule(flush);
+    }
+  }
+
+  return {
+    push(chunk) {
+      if (disposed) {
+        return;
+      }
+      queue.push(chunk);
+      queuedBytes += chunk.length;
+      trim();
+      if (handle === null) {
+        handle = schedule(flush);
+      }
+    },
+    dispose() {
+      disposed = true;
+      if (handle !== null) {
+        cancel(handle);
+        handle = null;
+      }
+    },
+    get droppedBytes() {
+      return droppedBytes;
+    },
+  };
+}

--- a/src/modules/terminal/lib/outputWriter.ts
+++ b/src/modules/terminal/lib/outputWriter.ts
@@ -12,6 +12,8 @@ export interface OutputWriterOptions {
   maxBytesPerFlush?: number;
   /** Max bytes allowed to sit in the queue; older bytes are dropped past this. */
   backlogCap?: number;
+  /** Called after output is dropped under overload, with the running dropped total. */
+  onDrop?: (droppedBytes: number) => void;
 }
 
 /** nyaterm's writeChunkChars: a comfortable per-frame write budget. */
@@ -47,10 +49,14 @@ export function createOutputWriter(options: OutputWriterOptions): TerminalOutput
   // Keep the queue under the cap by dropping the oldest chunks. Always keep the
   // most recent chunk so the newest output survives even a single huge write.
   function trim(): void {
+    const before = droppedBytes;
     while (queue.length > 1 && queuedBytes > backlogCap) {
       const dropped = queue.shift() as WriteChunk;
       queuedBytes -= dropped.length;
       droppedBytes += dropped.length;
+    }
+    if (droppedBytes > before) {
+      options.onDrop?.(droppedBytes);
     }
   }
 


### PR DESCRIPTION
## Summary

Terminal output was written to xterm synchronously on every PTY/SSH data event (`onData → term.write`), so a flood (cat a huge file, runaway logs, `yes`) could block the UI thread and freeze the window. This routes live output through a frame-scheduled writer with overload protection, inspired by nyaterm's pipeline.

Built in three slices:

1. **Batched output writer** (`terminal/lib/outputWriter.ts`) — queues chunks and flushes on `requestAnimationFrame` in bounded per-frame chunks (32 KB), dropping the oldest bytes once the backlog passes a cap (1 MB). `requestAnimationFrame`/`cancel` are injectable, so the queue/throttle/drop logic is fully unit-tested.
2. **Wiring** — both PTY and SSH `onData` paths push into the writer; it's disposed on pane teardown. Restored-history and error notices still write directly, so their ordering is unchanged.
3. **Overload notice** — the writer reports a running dropped-bytes total via `onDrop`; a transient notice (throttled to avoid render churn during a flood, auto-hiding once output settles) tells the user how much was skipped.

Constants follow nyaterm's validated values: 32 KB per frame, 1 MB backlog cap.

## Test plan

- [x] `outputWriter.test.ts` — buffers + flushes on frame, per-frame byte budget + reschedule, drop-oldest past the cap, `onDrop` running total, no writes after dispose
- [x] Full suite green (738), `tsc --noEmit` clean, `vite build` clean
- [x] Manual: normal interaction (typing, vim/htop) feels unchanged; a flood (`yes | head -n 5000000`, big `cat`) keeps the UI responsive instead of freezing
- [ ] Manual: the overload notice appears during a flood showing the skipped amount and auto-hides once output settles