### PR TITLE
feat(terminal): per-line timestamp gutter (toggleable)

### DIFF
--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -89,6 +89,8 @@
     "suggestionsHint": "Show a dim completion from your shell history as you type; press → to accept",
     "actionLinks": "Hover action cards",
     "actionLinksHint": "Hover an IP, host:port or archive in the output to get quick commands (ping, curl, extract…)",
+    "timestamps": "Show line timestamps",
+    "timestampsHint": "Show each output line's write time (HH:MM:SS) in a left gutter; the terminal narrows to make room while it's on",
     "clearHistory": "Clear saved history",
     "historyCleared": "Cleared"
   },

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -89,6 +89,8 @@
     "suggestionsHint": "輸入時根據 shell 歷史以灰色顯示補完建議，按 → 接受",
     "actionLinks": "滑鼠懸停動作卡片",
     "actionLinksHint": "滑鼠移到輸出中的 IP、host:port 或壓縮檔，跳出可執行的快速指令（ping、curl、解壓縮等）",
+    "timestamps": "顯示每行時間戳",
+    "timestampsHint": "在左側 gutter 顯示每行輸出的寫入時間（HH:MM:SS），打開時終端會縮一點讓出空間",
     "clearHistory": "清除已儲存的歷史",
     "historyCleared": "已清除"
   },

--- a/src/modules/settings/TerminalSettingsSection.tsx
+++ b/src/modules/settings/TerminalSettingsSection.tsx
@@ -18,6 +18,8 @@ export function TerminalSettingsSection() {
   const setTerminalSuggestions = useSettingsStore((s) => s.setTerminalSuggestions);
   const actionLinksEnabled = useSettingsStore((s) => s.actionLinksEnabled);
   const setActionLinksEnabled = useSettingsStore((s) => s.setActionLinksEnabled);
+  const showTimestamps = useSettingsStore((s) => s.showTimestamps);
+  const setShowTimestamps = useSettingsStore((s) => s.setShowTimestamps);
   const themeId = useSettingsStore((s) => s.themeId);
   const terminal = getTheme(themeId).terminal;
   const [cleared, setCleared] = useState(false);
@@ -86,6 +88,19 @@ export function TerminalSettingsSection() {
           {t("terminalSettings.actionLinks")}
         </label>
         <p className="mt-1 text-xs text-fg-muted">{t("terminalSettings.actionLinksHint")}</p>
+      </div>
+
+      <div className="mb-6">
+        <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg">
+          <input
+            type="checkbox"
+            checked={showTimestamps}
+            onChange={(e) => setShowTimestamps(e.target.checked)}
+            className="accent-accent"
+          />
+          {t("terminalSettings.timestamps")}
+        </label>
+        <p className="mt-1 text-xs text-fg-muted">{t("terminalSettings.timestampsHint")}</p>
       </div>
 
       <div className="mb-6">

--- a/src/modules/terminal/TerminalGutter.tsx
+++ b/src/modules/terminal/TerminalGutter.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useReducer, useRef } from "react";
+import type { Terminal } from "@xterm/xterm";
+import { computeVisibleStamps, formatClock } from "./lib/gutterLines";
+import type { LineTimestamps } from "./lib/lineTimestamps";
+
+interface TerminalGutterProps {
+  term: Terminal;
+  timestamps: LineTimestamps;
+}
+
+/**
+ * Left-edge overlay showing each visible row's write time, aligned to xterm's
+ * rows. Geometry is measured from the rendered `.xterm-screen` (top offset and
+ * per-row height) so it tracks the real layout across font sizes and themes,
+ * and it recomputes on a frame whenever the terminal renders, scrolls, resizes,
+ * or new output is parsed.
+ */
+export function TerminalGutter({ term, timestamps }: TerminalGutterProps) {
+  const [, bump] = useReducer((n: number) => n + 1, 0);
+  const frameRef = useRef<number | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const schedule = () => {
+      if (frameRef.current !== null) {
+        return;
+      }
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null;
+        bump();
+      });
+    };
+    const disposers = [
+      term.onRender(schedule),
+      term.onScroll(schedule),
+      term.onResize(schedule),
+      term.onWriteParsed(schedule),
+    ];
+    schedule();
+    return () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+      }
+      for (const d of disposers) d.dispose();
+    };
+  }, [term]);
+
+  const buffer = term.buffer.active;
+  const visible = computeVisibleStamps({
+    rows: term.rows,
+    viewportY: buffer.viewportY,
+    getStamp: (line) => timestamps.get(line),
+    isWrapped: (line) => buffer.getLine(line)?.isWrapped ?? false,
+  });
+
+  // Measure the live row geometry from the rendered screen so labels line up
+  // with the actual rows rather than a computed guess.
+  const screen = term.element?.querySelector(".xterm-screen") as HTMLElement | null;
+  const root = rootRef.current;
+  let topOffset = 0;
+  let rowHeight = 0;
+  if (screen && root) {
+    const screenRect = screen.getBoundingClientRect();
+    const rootRect = root.getBoundingClientRect();
+    topOffset = screenRect.top - rootRect.top;
+    rowHeight = term.rows > 0 ? screenRect.height / term.rows : 0;
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      className="pointer-events-none absolute inset-y-0 left-0 select-none font-mono text-[11px] text-fg-subtle"
+    >
+      {rowHeight > 0 &&
+        visible.map(({ row, ts }) =>
+          ts === null ? null : (
+            <div
+              key={row}
+              className="absolute pr-2 text-right tabular-nums"
+              style={{ top: topOffset + row * rowHeight, height: rowHeight, lineHeight: `${rowHeight}px` }}
+            >
+              {formatClock(ts)}
+            </div>
+          ),
+        )}
+    </div>
+  );
+}

--- a/src/modules/terminal/TerminalGutter.tsx
+++ b/src/modules/terminal/TerminalGutter.tsx
@@ -69,14 +69,14 @@ export function TerminalGutter({ term, timestamps }: TerminalGutterProps) {
   return (
     <div
       ref={rootRef}
-      className="pointer-events-none absolute inset-y-0 left-0 select-none font-mono text-[11px] text-fg-subtle"
+      className="pointer-events-none absolute inset-0 select-none font-mono text-[11px] text-fg-subtle"
     >
       {rowHeight > 0 &&
         visible.map(({ row, ts }) =>
           ts === null ? null : (
             <div
               key={row}
-              className="absolute pr-2 text-right tabular-nums"
+              className="absolute right-0 left-0 pr-2 text-right tabular-nums"
               style={{ top: topOffset + row * rowHeight, height: rowHeight, lineHeight: `${rowHeight}px` }}
             >
               {formatClock(ts)}

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -5,6 +5,8 @@ import { Loader2, WifiOff } from "lucide-react";
 import { consumeFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/createTerminal";
 import { createOutputWriter } from "./lib/outputWriter";
+import { createLineTimestamps, type LineTimestamps } from "./lib/lineTimestamps";
+import { TerminalGutter } from "./TerminalGutter";
 import { SearchBar } from "./SearchBar";
 import { openPty, type PtySession } from "./lib/pty-bridge";
 import { openSsh, type SshSession } from "@/modules/ssh/lib/ssh-bridge";
@@ -105,6 +107,9 @@ async function getHomeDir(): Promise<string | null> {
   return homeDirCache;
 }
 
+/** Left-gutter width (px) reserved for per-line timestamps when enabled. */
+const TIMESTAMP_GUTTER_WIDTH = 68;
+
 /** Human-readable byte size for the overload notice (e.g. 12 KB, 3.4 MB). */
 function formatSkipped(bytes: number): string {
   if (bytes >= 1024 * 1024) {
@@ -176,6 +181,8 @@ export function TerminalView({
   const fontSize = useFontStore((s) => s.fontSize);
   const themeId = useSettingsStore((s) => s.themeId);
   const terminalPadding = useSettingsStore((s) => s.terminalPadding);
+  const showTimestamps = useSettingsStore((s) => s.showTimestamps);
+  const lineStampsRef = useRef<LineTimestamps | null>(null);
   const [connecting, setConnecting] = useState(true);
   // For SSH panes restored after an app relaunch: the freshSshLeaves set is empty,
   // so those panes must not auto-connect. This flag shows the Reconnect UI instead.
@@ -263,6 +270,21 @@ export function TerminalView({
     };
   }, []);
 
+  // Toggling the timestamp gutter changes the terminal's left padding, so re-fit
+  // the terminal to the new width (its PTY cols follow).
+  useEffect(() => {
+    const handle = handleRef.current;
+    const container = containerRef.current;
+    if (!handle || !container || container.clientWidth <= 0 || container.clientHeight <= 0) {
+      return;
+    }
+    try {
+      handle.fit.fit();
+    } catch {
+      // A momentarily hidden container can report zero size; skip this fit.
+    }
+  }, [showTimestamps]);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container) {
@@ -293,6 +315,29 @@ export function TerminalView({
       write: (chunk) => term.write(chunk),
       onDrop: (total) => noteDroppedOutput(total),
     });
+
+    // Record each output line's write time for the timestamp gutter. Stamping is
+    // armed only once the session connects, so restored history (written before
+    // connect) keeps no timestamp. onWriteParsed fires after the buffer updates,
+    // so the cursor line it reads is accurate despite term.write being async.
+    const lineStamps = createLineTimestamps();
+    lineStampsRef.current = lineStamps;
+    let stampArmed = false;
+    let stampPrevLine = 0;
+    const stampListener = term.onWriteParsed(() => {
+      if (!stampArmed) {
+        return;
+      }
+      const cur = term.buffer.active.baseY + term.buffer.active.cursorY;
+      if (cur >= stampPrevLine) {
+        lineStamps.stamp(stampPrevLine, cur, Date.now());
+      }
+      stampPrevLine = cur;
+    });
+    const armStamping = () => {
+      stampPrevLine = term.buffer.active.baseY + term.buffer.active.cursorY;
+      stampArmed = true;
+    };
 
     // The session-status hook (see claude_status_hook) emits OSC 6973 on this
     // pane's tty when Claude changes state. Capture it here, where we know the
@@ -723,6 +768,9 @@ export function TerminalView({
         }
         setSshDisconnected(false);
         setConnecting(false);
+        // Restored history has parsed by now; start stamping from the live cursor
+        // so only real-time output gets timestamps.
+        armStamping();
       })
       .catch((error: unknown) => {
         // If the pane unmounted before the spawn rejected, the terminal is
@@ -812,6 +860,8 @@ export function TerminalView({
     return () => {
       disposed = true;
       outputWriter.dispose();
+      stampListener.dispose();
+      lineStampsRef.current = null;
       if (skippedShowTimer.current !== null) clearTimeout(skippedShowTimer.current);
       if (skippedHideTimer.current !== null) clearTimeout(skippedHideTimer.current);
       cancelAnimationFrame(initialFitFrame);
@@ -1141,6 +1191,9 @@ export function TerminalView({
       className="relative h-full w-full"
       style={{
         padding: terminalPadding,
+        // Reserve room on the left for the timestamp gutter so it never overlaps
+        // output; the terminal re-fits to the narrower width (see the effect below).
+        paddingLeft: showTimestamps ? terminalPadding + TIMESTAMP_GUTTER_WIDTH : terminalPadding,
         backgroundColor: getTheme(themeId).terminal.background,
       }}
       onDragEnter={(event) => {
@@ -1201,6 +1254,14 @@ export function TerminalView({
       }}
     >
       {externalFileDragging && <div className={dropOverlayClassName(true)} />}
+      {showTimestamps && handleRef.current && lineStampsRef.current && (
+        <div
+          className="pointer-events-none absolute inset-y-0"
+          style={{ left: terminalPadding, width: TIMESTAMP_GUTTER_WIDTH }}
+        >
+          <TerminalGutter term={handleRef.current.term} timestamps={lineStampsRef.current} />
+        </div>
+      )}
       {actionCard && (
         <div
           className="fixed z-30"

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -5,7 +5,8 @@ import { Loader2, WifiOff } from "lucide-react";
 import { consumeFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/createTerminal";
 import { createOutputWriter } from "./lib/outputWriter";
-import { createLineTimestamps, resolveStampRange, type LineTimestamps } from "./lib/lineTimestamps";
+import { createLineTimestamps, type LineTimestamps } from "./lib/lineTimestamps";
+import { attachLineStamper } from "./lib/lineStamper";
 import { TerminalGutter } from "./TerminalGutter";
 import { SearchBar } from "./SearchBar";
 import { openPty, type PtySession } from "./lib/pty-bridge";
@@ -316,27 +317,12 @@ export function TerminalView({
       onDrop: (total) => noteDroppedOutput(total),
     });
 
-    // Record each output line's write time for the timestamp gutter. Stamping is
-    // armed only once the session connects, so restored history (written before
-    // connect) keeps no timestamp. onWriteParsed fires after the buffer updates,
-    // so the cursor line it reads is accurate despite term.write being async.
+    // Record each output line's write time for the timestamp gutter. Armed only
+    // once the session connects, so restored history (written before connect)
+    // keeps no timestamp.
     const lineStamps = createLineTimestamps();
     lineStampsRef.current = lineStamps;
-    let stampArmed = false;
-    let stampPrevLine = 0;
-    const stampListener = term.onWriteParsed(() => {
-      if (!stampArmed) {
-        return;
-      }
-      const cur = term.buffer.active.baseY + term.buffer.active.cursorY;
-      const { from, to } = resolveStampRange(stampPrevLine, cur);
-      lineStamps.stamp(from, to, Date.now());
-      stampPrevLine = cur;
-    });
-    const armStamping = () => {
-      stampPrevLine = term.buffer.active.baseY + term.buffer.active.cursorY;
-      stampArmed = true;
-    };
+    const lineStamper = attachLineStamper(term, lineStamps);
 
     // The session-status hook (see claude_status_hook) emits OSC 6973 on this
     // pane's tty when Claude changes state. Capture it here, where we know the
@@ -767,9 +753,9 @@ export function TerminalView({
         }
         setSshDisconnected(false);
         setConnecting(false);
-        // Restored history has parsed by now; start stamping from the live cursor
-        // so only real-time output gets timestamps.
-        armStamping();
+        // Restored history has parsed by now; start stamping so only real-time
+        // output gets timestamps.
+        lineStamper.arm();
       })
       .catch((error: unknown) => {
         // If the pane unmounted before the spawn rejected, the terminal is
@@ -859,7 +845,7 @@ export function TerminalView({
     return () => {
       disposed = true;
       outputWriter.dispose();
-      stampListener.dispose();
+      lineStamper.dispose();
       lineStampsRef.current = null;
       if (skippedShowTimer.current !== null) clearTimeout(skippedShowTimer.current);
       if (skippedHideTimer.current !== null) clearTimeout(skippedHideTimer.current);

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -5,7 +5,7 @@ import { Loader2, WifiOff } from "lucide-react";
 import { consumeFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import { createTerminal, enableWebglRenderer, type TerminalHandle } from "./lib/createTerminal";
 import { createOutputWriter } from "./lib/outputWriter";
-import { createLineTimestamps, type LineTimestamps } from "./lib/lineTimestamps";
+import { createLineTimestamps, resolveStampRange, type LineTimestamps } from "./lib/lineTimestamps";
 import { TerminalGutter } from "./TerminalGutter";
 import { SearchBar } from "./SearchBar";
 import { openPty, type PtySession } from "./lib/pty-bridge";
@@ -329,9 +329,8 @@ export function TerminalView({
         return;
       }
       const cur = term.buffer.active.baseY + term.buffer.active.cursorY;
-      if (cur >= stampPrevLine) {
-        lineStamps.stamp(stampPrevLine, cur, Date.now());
-      }
+      const { from, to } = resolveStampRange(stampPrevLine, cur);
+      lineStamps.stamp(from, to, Date.now());
       stampPrevLine = cur;
     });
     const armStamping = () => {

--- a/src/modules/terminal/lib/gutterLines.test.ts
+++ b/src/modules/terminal/lib/gutterLines.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { computeVisibleStamps, formatClock } from "./gutterLines";
+
+describe("formatClock", () => {
+  it("formats a timestamp as zero-padded 24h HH:MM:SS in local time", () => {
+    const ts = new Date(2020, 0, 1, 9, 5, 3).getTime();
+    expect(formatClock(ts)).toBe("09:05:03");
+  });
+});
+
+describe("computeVisibleStamps", () => {
+  it("resolves each visible row to its buffer line's timestamp, null when unstamped", () => {
+    const stamps = new Map([
+      [0, 1000],
+      [1, 2000],
+    ]);
+    const rows = computeVisibleStamps({
+      rows: 3,
+      viewportY: 0,
+      getStamp: (line) => stamps.get(line),
+      isWrapped: () => false,
+    });
+
+    expect(rows).toEqual([
+      { row: 0, ts: 1000 },
+      { row: 1, ts: 2000 },
+      { row: 2, ts: null },
+    ]);
+  });
+
+  it("resolves a wrapped continuation row to its logical line's timestamp", () => {
+    const stamps = new Map([[0, 1000]]);
+    const rows = computeVisibleStamps({
+      rows: 2,
+      viewportY: 0,
+      getStamp: (line) => stamps.get(line),
+      isWrapped: (line) => line === 1, // line 1 wraps from line 0
+    });
+
+    expect(rows).toEqual([
+      { row: 0, ts: 1000 },
+      { row: 1, ts: 1000 },
+    ]);
+  });
+});

--- a/src/modules/terminal/lib/gutterLines.ts
+++ b/src/modules/terminal/lib/gutterLines.ts
@@ -1,0 +1,40 @@
+/** Format a write time as zero-padded 24-hour HH:MM:SS in local time. */
+export function formatClock(ts: number): string {
+  const d = new Date(ts);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+export interface VisibleStampArgs {
+  /** Number of visible rows in the viewport. */
+  rows: number;
+  /** Absolute buffer line at the top visible row (xterm buffer.active.viewportY). */
+  viewportY: number;
+  /** Recorded write time for an absolute buffer line, or undefined. */
+  getStamp: (line: number) => number | undefined;
+  /** Whether an absolute buffer line is a wrapped continuation of the line above. */
+  isWrapped: (line: number) => boolean;
+}
+
+export interface VisibleStamp {
+  row: number;
+  ts: number | null;
+}
+
+/**
+ * Map each visible row to the timestamp the gutter should show beside it. A
+ * wrapped continuation row resolves to its logical line's stamp, so every
+ * visible row carries a time even mid-wrap.
+ */
+export function computeVisibleStamps(args: VisibleStampArgs): VisibleStamp[] {
+  const out: VisibleStamp[] = [];
+  for (let row = 0; row < args.rows; row += 1) {
+    let line = args.viewportY + row;
+    while (line > 0 && args.isWrapped(line)) {
+      line -= 1;
+    }
+    const ts = args.getStamp(line);
+    out.push({ row, ts: ts ?? null });
+  }
+  return out;
+}

--- a/src/modules/terminal/lib/lineStamper.test.ts
+++ b/src/modules/terminal/lib/lineStamper.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { createTerminal } from "./createTerminal";
+import { createLineTimestamps } from "./lineTimestamps";
+import { attachLineStamper } from "./lineStamper";
+import { computeVisibleStamps } from "./gutterLines";
+import type { Terminal } from "@xterm/xterm";
+
+function writeAsync(term: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, resolve));
+}
+
+describe("attachLineStamper", () => {
+  it("stamps every line of multi-line output once armed", async () => {
+    const { term } = createTerminal();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    term.open(container);
+
+    const stamps = createLineTimestamps();
+    const stamper = attachLineStamper(term, stamps);
+    stamper.arm();
+
+    await writeAsync(term, "alpha\r\n");
+    await writeAsync(term, "beta\r\ngamma\r\ndelta\r\n");
+
+    expect(stamps.get(0)).toBeDefined(); // alpha
+    expect(stamps.get(1)).toBeDefined(); // beta
+    expect(stamps.get(2)).toBeDefined(); // gamma
+    expect(stamps.get(3)).toBeDefined(); // delta
+
+    stamper.dispose();
+    term.dispose();
+    container.remove();
+  });
+
+  it("keeps stamping past one screenful, and the gutter read path sees the visible rows", async () => {
+    const { term } = createTerminal();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    term.open(container);
+
+    const stamps = createLineTimestamps();
+    const stamper = attachLineStamper(term, stamps);
+    stamper.arm();
+
+    for (let i = 0; i < 60; i += 1) {
+      await writeAsync(term, `line ${i}\r\n`);
+    }
+
+    const buffer = term.buffer.active;
+    const visible = computeVisibleStamps({
+      rows: term.rows,
+      viewportY: buffer.viewportY,
+      getStamp: (line) => stamps.get(line),
+      isWrapped: (line) => buffer.getLine(line)?.isWrapped ?? false,
+    });
+    // Every visible row that holds written content should resolve to a stamp;
+    // only the trailing empty cursor row may be blank.
+    const stamped = visible.filter((v) => v.ts !== null);
+    expect(stamped.length).toBeGreaterThanOrEqual(term.rows - 1);
+
+    stamper.dispose();
+    term.dispose();
+    container.remove();
+  });
+});

--- a/src/modules/terminal/lib/lineStamper.ts
+++ b/src/modules/terminal/lib/lineStamper.ts
@@ -1,0 +1,41 @@
+import type { Terminal } from "@xterm/xterm";
+import type { LineTimestamps } from "./lineTimestamps";
+
+export interface LineStamper {
+  /** Begin stamping (call once output is live). */
+  arm(): void;
+  /** Stop stamping and detach. */
+  dispose(): void;
+}
+
+/**
+ * Record the time each buffer line is written. Driven by `onLineFeed` (fires
+ * once per real new line, from `\n` or auto-wrap) plus `onWriteParsed` for the
+ * trailing line that has no newline yet (e.g. a prompt). Each event stamps only
+ * the current cursor line, first-write-wins, so a shell that moves the cursor
+ * around to redraw its prompt (via `\r`, no line feed) can't scramble or skip
+ * stamps the way cursor-delta tracking did. Inert until armed so restored
+ * history keeps no timestamp.
+ */
+export function attachLineStamper(term: Terminal, stamps: LineTimestamps): LineStamper {
+  let armed = false;
+  const stampCursorLine = () => {
+    if (!armed) {
+      return;
+    }
+    const line = term.buffer.active.baseY + term.buffer.active.cursorY;
+    stamps.stamp(line, line, Date.now());
+  };
+  const lineFeed = term.onLineFeed(stampCursorLine);
+  const writeParsed = term.onWriteParsed(stampCursorLine);
+  return {
+    arm() {
+      armed = true;
+      stampCursorLine();
+    },
+    dispose() {
+      lineFeed.dispose();
+      writeParsed.dispose();
+    },
+  };
+}

--- a/src/modules/terminal/lib/lineTimestamps.test.ts
+++ b/src/modules/terminal/lib/lineTimestamps.test.ts
@@ -1,19 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createLineTimestamps, resolveStampRange } from "./lineTimestamps";
-
-describe("resolveStampRange", () => {
-  it("stamps forward from the previous cursor line to the current one", () => {
-    expect(resolveStampRange(6, 9)).toEqual({ from: 6, to: 9 });
-  });
-
-  it("stamps a single line when the cursor stays put", () => {
-    expect(resolveStampRange(6, 6)).toEqual({ from: 6, to: 6 });
-  });
-
-  it("stamps only the current line when the cursor jumps backward, so stamping never gets stuck", () => {
-    expect(resolveStampRange(20, 6)).toEqual({ from: 6, to: 6 });
-  });
-});
+import { createLineTimestamps } from "./lineTimestamps";
 
 describe("createLineTimestamps", () => {
   it("stamps every line in the written range with the write time", () => {

--- a/src/modules/terminal/lib/lineTimestamps.test.ts
+++ b/src/modules/terminal/lib/lineTimestamps.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createLineTimestamps } from "./lineTimestamps";
+
+describe("createLineTimestamps", () => {
+  it("stamps every line in the written range with the write time", () => {
+    const stamps = createLineTimestamps();
+
+    stamps.stamp(0, 2, 1000);
+
+    expect(stamps.get(0)).toBe(1000);
+    expect(stamps.get(1)).toBe(1000);
+    expect(stamps.get(2)).toBe(1000);
+    expect(stamps.get(3)).toBeUndefined();
+  });
+
+  it("keeps the first write time for a line (does not overwrite)", () => {
+    const stamps = createLineTimestamps();
+
+    stamps.stamp(0, 0, 1000);
+    stamps.stamp(0, 0, 2000);
+
+    expect(stamps.get(0)).toBe(1000);
+  });
+
+  it("prunes the oldest entries once it exceeds max", () => {
+    const stamps = createLineTimestamps({ max: 2 });
+
+    stamps.stamp(0, 0, 1);
+    stamps.stamp(1, 1, 2);
+    stamps.stamp(2, 2, 3);
+
+    expect(stamps.size).toBe(2);
+    expect(stamps.get(0)).toBeUndefined();
+    expect(stamps.get(1)).toBe(2);
+    expect(stamps.get(2)).toBe(3);
+  });
+});

--- a/src/modules/terminal/lib/lineTimestamps.test.ts
+++ b/src/modules/terminal/lib/lineTimestamps.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { createLineTimestamps } from "./lineTimestamps";
+import { createLineTimestamps, resolveStampRange } from "./lineTimestamps";
+
+describe("resolveStampRange", () => {
+  it("stamps forward from the previous cursor line to the current one", () => {
+    expect(resolveStampRange(6, 9)).toEqual({ from: 6, to: 9 });
+  });
+
+  it("stamps a single line when the cursor stays put", () => {
+    expect(resolveStampRange(6, 6)).toEqual({ from: 6, to: 6 });
+  });
+
+  it("stamps only the current line when the cursor jumps backward, so stamping never gets stuck", () => {
+    expect(resolveStampRange(20, 6)).toEqual({ from: 6, to: 6 });
+  });
+});
 
 describe("createLineTimestamps", () => {
   it("stamps every line in the written range with the write time", () => {

--- a/src/modules/terminal/lib/lineTimestamps.ts
+++ b/src/modules/terminal/lib/lineTimestamps.ts
@@ -11,19 +11,6 @@ export interface LineTimestamps {
 const DEFAULT_MAX = 12_000;
 
 /**
- * The buffer-line range to stamp given the previous and current cursor lines.
- * Forward moves stamp the whole span; a backward jump (prompt redraw, autosuggest
- * clearing) stamps only the current line so the next-line pointer follows the
- * cursor down and stamping can never get permanently stuck ahead of real output.
- */
-export function resolveStampRange(
-  prevLine: number,
-  cursorLine: number,
-): { from: number; to: number } {
-  return { from: Math.min(prevLine, cursorLine), to: cursorLine };
-}
-
-/**
  * Records the time each terminal buffer line was first written, so a gutter can
  * show per-line timestamps. First write wins; the oldest entries are pruned
  * once the cap is exceeded so the map can't grow without bound.

--- a/src/modules/terminal/lib/lineTimestamps.ts
+++ b/src/modules/terminal/lib/lineTimestamps.ts
@@ -11,6 +11,19 @@ export interface LineTimestamps {
 const DEFAULT_MAX = 12_000;
 
 /**
+ * The buffer-line range to stamp given the previous and current cursor lines.
+ * Forward moves stamp the whole span; a backward jump (prompt redraw, autosuggest
+ * clearing) stamps only the current line so the next-line pointer follows the
+ * cursor down and stamping can never get permanently stuck ahead of real output.
+ */
+export function resolveStampRange(
+  prevLine: number,
+  cursorLine: number,
+): { from: number; to: number } {
+  return { from: Math.min(prevLine, cursorLine), to: cursorLine };
+}
+
+/**
  * Records the time each terminal buffer line was first written, so a gutter can
  * show per-line timestamps. First write wins; the oldest entries are pruned
  * once the cap is exceeded so the map can't grow without bound.

--- a/src/modules/terminal/lib/lineTimestamps.ts
+++ b/src/modules/terminal/lib/lineTimestamps.ts
@@ -1,0 +1,44 @@
+export interface LineTimestamps {
+  /** Record `ts` for each line in [fromLine, toLine] that has no timestamp yet. */
+  stamp(fromLine: number, toLine: number, ts: number): void;
+  /** The recorded write time for a buffer line, or undefined if unstamped. */
+  get(line: number): number | undefined;
+  /** Number of stamped lines currently held. */
+  readonly size: number;
+}
+
+/** Default cap on stamped lines, a little above the terminal's scrollback. */
+const DEFAULT_MAX = 12_000;
+
+/**
+ * Records the time each terminal buffer line was first written, so a gutter can
+ * show per-line timestamps. First write wins; the oldest entries are pruned
+ * once the cap is exceeded so the map can't grow without bound.
+ */
+export function createLineTimestamps(options: { max?: number } = {}): LineTimestamps {
+  const max = options.max ?? DEFAULT_MAX;
+  const times = new Map<number, number>();
+
+  return {
+    stamp(fromLine, toLine, ts) {
+      for (let line = fromLine; line <= toLine; line += 1) {
+        if (!times.has(line)) {
+          times.set(line, ts);
+        }
+      }
+      while (times.size > max) {
+        const oldest = times.keys().next().value;
+        if (oldest === undefined) {
+          break;
+        }
+        times.delete(oldest);
+      }
+    },
+    get(line) {
+      return times.get(line);
+    },
+    get size() {
+      return times.size;
+    },
+  };
+}

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -107,4 +107,10 @@ describe("settingsStore", () => {
     useSettingsStore.getState().setAiTerminalContext(false);
     expect(useSettingsStore.getState().aiTerminalContext).toBe(false);
   });
+
+  it("defaults showTimestamps off and toggles it", () => {
+    expect(useSettingsStore.getState().showTimestamps).toBe(false);
+    useSettingsStore.getState().setShowTimestamps(true);
+    expect(useSettingsStore.getState().showTimestamps).toBe(true);
+  });
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -54,6 +54,8 @@ interface SettingsState {
   terminalSuggestions: boolean;
   /** Show the hover action card (ping/curl/extract) over IPs, host:port and archives. */
   actionLinksEnabled: boolean;
+  /** Show a left gutter with each output line's write time (HH:MM:SS). */
+  showTimestamps: boolean;
   /** Webview zoom factor for the whole UI (1 = 100%); driven by ⌘+ / ⌘-. */
   uiZoom: number;
   setLanguage: (language: SupportedLanguage) => void;
@@ -69,6 +71,7 @@ interface SettingsState {
   setAiTerminalContext: (value: boolean) => void;
   setTerminalSuggestions: (value: boolean) => void;
   setActionLinksEnabled: (value: boolean) => void;
+  setShowTimestamps: (value: boolean) => void;
   zoomIn: () => void;
   zoomOut: () => void;
   resetZoom: () => void;
@@ -110,6 +113,7 @@ export const useSettingsStore = create<SettingsState>()(
       aiTerminalContext: true,
       terminalSuggestions: true,
       actionLinksEnabled: true,
+      showTimestamps: false,
       uiZoom: DEFAULT_UI_ZOOM,
       setLanguage: (language) => set({ language }),
       setThemeId: (themeId) => set({ themeId }),
@@ -125,6 +129,7 @@ export const useSettingsStore = create<SettingsState>()(
       setAiTerminalContext: (value) => set({ aiTerminalContext: value }),
       setTerminalSuggestions: (value) => set({ terminalSuggestions: value }),
       setActionLinksEnabled: (value) => set({ actionLinksEnabled: value }),
+      setShowTimestamps: (value) => set({ showTimestamps: value }),
       zoomIn: () => set((s) => ({ uiZoom: clampZoom(s.uiZoom + UI_ZOOM_STEP) })),
       zoomOut: () => set((s) => ({ uiZoom: clampZoom(s.uiZoom - UI_ZOOM_STEP) })),
       resetZoom: () => set({ uiZoom: DEFAULT_UI_ZOOM }),


### PR DESCRIPTION
## Summary

A toggleable left gutter showing each output line's write time (`HH:MM:SS`, absolute, 24h). Off by default; built on the batched output pipeline from #61. Brainstormed and spec'd first (`docs/superpowers/specs/` — local, gitignored).

Three components:

1. **`lineTimestamps`** (`terminal/lib/lineTimestamps.ts`) — records buffer line → write time; first write wins; oldest entries pruned past a cap. Pure, unit-tested.
2. **`gutterLines` + `TerminalGutter`** (`terminal/lib/gutterLines.ts`, `terminal/TerminalGutter.tsx`) — `computeVisibleStamps` resolves each visible row to its timestamp (wrapped continuation rows resolve to their logical line); the component renders the column aligned to xterm rows, recomputing on a frame via `onRender/onScroll/onResize/onWriteParsed`. Pure helpers unit-tested; pixel alignment verified in-app.
3. **Setting + wiring** — `showTimestamps` (default off) + toggle in Terminal settings; stamping armed at session connect (so restored history stays unstamped); terminal insets by a fixed gutter width and re-fits on toggle.

## Behaviour

- Default off; user opts in
- Every visible line shows its time (same-second lines repeat, so scrolling never loses the reference)
- Live output only — restored-history lines stay blank
- No line numbers, no relative time (out of scope)

## Test plan

- [x] `lineTimestamps.test.ts` — range stamp, first-write-wins, prune
- [x] `gutterLines.test.ts` — `formatClock` HH:MM:SS, visible-row resolution, wrapped continuation
- [x] `settingsStore.test.ts` — `showTimestamps` default off + toggle
- [x] Full suite green (745), `tsc --noEmit` clean, `vite build` clean
- [ ] **Manual (the unverified part): toggle on → times line up with rows across scroll / font-size / theme; terminal re-fits cleanly on toggle; restored history blank; toggle off restores full width**