### PR TITLE
feat(settings): give terminal options a top-level section

### DIFF
--- a/src/modules/settings/SettingsView.tsx
+++ b/src/modules/settings/SettingsView.tsx
@@ -11,8 +11,8 @@ import { WorkspaceSettingsSection } from "./WorkspaceSettingsSection";
 import { ShortcutsSettingsSection } from "./ShortcutsSettingsSection";
 import { AboutSettingsSection } from "./AboutSettingsSection";
 
-type SectionId = "appearance" | "terminal" | "ai" | "workspace" | "shortcuts" | "about";
-const SECTIONS: SectionId[] = ["appearance", "terminal", "ai", "workspace", "shortcuts", "about"];
+const SECTIONS = ["appearance", "terminal", "ai", "workspace", "shortcuts", "about"] as const;
+type SectionId = typeof SECTIONS[number];
 
 /**
  * A read-only code snippet painted in the active theme's own colours, so its

--- a/src/modules/settings/SettingsView.tsx
+++ b/src/modules/settings/SettingsView.tsx
@@ -11,8 +11,8 @@ import { WorkspaceSettingsSection } from "./WorkspaceSettingsSection";
 import { ShortcutsSettingsSection } from "./ShortcutsSettingsSection";
 import { AboutSettingsSection } from "./AboutSettingsSection";
 
-type SectionId = "appearance" | "ai" | "workspace" | "shortcuts" | "about";
-const SECTIONS: SectionId[] = ["appearance", "ai", "workspace", "shortcuts", "about"];
+type SectionId = "appearance" | "terminal" | "ai" | "workspace" | "shortcuts" | "about";
+const SECTIONS: SectionId[] = ["appearance", "terminal", "ai", "workspace", "shortcuts", "about"];
 
 /**
  * A read-only code snippet painted in the active theme's own colours, so its
@@ -146,14 +146,10 @@ function AppearanceSection() {
         ))}
       </div>
 
-      {/* Fonts and terminal display settings now live under Appearance so the
-          sidebar stays a short list of top-level areas. */}
+      {/* Font settings stay under Appearance; terminal behaviour now has its
+          own top-level section in the sidebar. */}
       <div className="mt-8 border-t border-border pt-8">
         <FontsSettingsSection />
-      </div>
-
-      <div className="mt-8 border-t border-border pt-8">
-        <TerminalSettingsSection />
       </div>
     </section>
   );
@@ -199,6 +195,7 @@ export function SettingsView() {
           }
         >
           {section === "appearance" && <AppearanceSection />}
+          {section === "terminal" && <TerminalSettingsSection />}
           {section === "ai" && <AiSettingsSection />}
           {section === "workspace" && <WorkspaceSettingsSection />}
           {section === "shortcuts" && <ShortcutsSettingsSection />}


### PR DESCRIPTION
## Summary

Terminal settings used to be tucked under the Appearance section. This promotes them to their own top-level entry in the settings sidebar, so the sidebar reads as a flat list of distinct areas (Appearance, Terminal, AI, Workspace, Shortcuts, About).

- Add `terminal` to `SectionId` and the `SECTIONS` list, between `appearance` and `ai`
- Render `TerminalSettingsSection` for the new `terminal` section instead of inside `AppearanceSection`
- Keep font settings under Appearance; update the explanatory comment accordingly

## Test plan

- [x] Open Settings and confirm a `Terminal` entry appears in the sidebar between Appearance and AI
- [x] Selecting `Terminal` shows the terminal behaviour settings
- [x] Appearance no longer renders the terminal section, but still shows fonts