### PR TITLE
feat(tabs): add right-click menu to rename and close tabs

### DIFF
--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import "@/i18n";
+import { TabBar } from "./TabBar";
+import { useTabsStore } from "@/stores/tabsStore";
+import { leaf } from "@/modules/terminal/lib/terminalLayout";
+
+beforeEach(() => {
+  useTabsStore.setState({
+    spaces: [{ id: "s1", name: "One" }],
+    activeSpaceId: "s1",
+    tabs: [
+      {
+        id: "t1",
+        spaceId: "s1",
+        title: "Terminal 1",
+        kind: "terminal",
+        paneTree: leaf("p1", { kind: "terminal" }),
+        activeLeafId: "p1",
+      },
+    ],
+    activeId: "t1",
+  });
+});
+
+describe("TabBar tab context menu", () => {
+  it("opens a context menu with a rename item on right-click", () => {
+    render(<TabBar />);
+    const tab = screen.getByRole("tab");
+    fireEvent.contextMenu(tab);
+    expect(
+      screen.getByRole("menuitem", { name: "Rename Tab" }),
+    ).toBeInTheDocument();
+  });
+
+  it("starts inline editing with the current title when rename is clicked", () => {
+    render(<TabBar />);
+    fireEvent.contextMenu(screen.getByRole("tab"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename Tab" }));
+    expect(screen.getByRole("textbox")).toHaveValue("Terminal 1");
+  });
+
+  it("closes the tab when the close item is clicked (no unsaved changes)", () => {
+    render(<TabBar />);
+    fireEvent.contextMenu(screen.getByRole("tab"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Close Tab" }));
+    expect(useTabsStore.getState().tabs).toHaveLength(0);
+  });
+});

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -46,4 +46,14 @@ describe("TabBar tab context menu", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Close Tab" }));
     expect(useTabsStore.getState().tabs).toHaveLength(0);
   });
+
+  it("does not open a context menu when right-clicking the rename input", () => {
+    render(<TabBar />);
+    fireEvent.contextMenu(screen.getByRole("tab"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename Tab" }));
+    // Right-clicking the rename field must not bubble up and open a fresh tab
+    // menu over the input being edited.
+    fireEvent.contextMenu(screen.getByRole("textbox"));
+    expect(screen.queryByRole("menuitem")).toBeNull();
+  });
 });

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -83,6 +83,9 @@ function TabItem({ id }: { id: string }) {
   const Icon = tabIcon(tab.kind);
 
   function startRename() {
+    // `tab` is narrowed at line 80, but TS does not carry that into this
+    // closure, so the guard is required to compile (same reason `commit` below
+    // uses `tab &&`).
     if (!tab) {
       return;
     }
@@ -139,6 +142,7 @@ function TabItem({ id }: { id: string }) {
           onBlur={commit}
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
+          onContextMenu={(e) => e.stopPropagation()}
           onKeyDown={(e) => {
             if (e.key === "Enter") commit();
             if (e.key === "Escape") setEditing(false);

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -7,6 +7,7 @@ import {
   Globe,
   LayoutGrid,
   PanelLeft,
+  Pencil,
   Plus,
   SquareTerminal,
   X,
@@ -32,6 +33,7 @@ import { useEditorStore } from "@/modules/editor/store/editorStore";
 import { useUiStore } from "@/stores/uiStore";
 import { SpaceDropdown } from "./SpaceDropdown";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { ContextMenu } from "./ContextMenu";
 
 // Module-level so the reference stays stable across renders. Passing an inline
 // options object would make useSensor/useSensors return a new sensors array on
@@ -73,17 +75,37 @@ function TabItem({ id }: { id: string }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [confirmClose, setConfirmClose] = useState(false);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   if (!tab) {
     return null;
   }
   const active = tab.id === activeId;
   const Icon = tabIcon(tab.kind);
 
+  function startRename() {
+    if (!tab) {
+      return;
+    }
+    setDraft(tab.title);
+    setEditing(true);
+  }
+
   function commit() {
     if (tab && draft.trim()) {
       setTabTitle(tab.id, draft.trim());
     }
     setEditing(false);
+  }
+
+  function requestClose() {
+    if (!tab) {
+      return;
+    }
+    if (dirty) {
+      setConfirmClose(true);
+    } else {
+      closeTab(tab.id);
+    }
   }
 
   return (
@@ -98,9 +120,10 @@ function TabItem({ id }: { id: string }) {
       role="tab"
       aria-selected={active}
       onClick={() => setActive(tab.id)}
-      onDoubleClick={() => {
-        setDraft(tab.title);
-        setEditing(true);
+      onDoubleClick={startRename}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setMenu({ x: e.clientX, y: e.clientY });
       }}
       title={tab.title}
       className={`group flex h-7 cursor-pointer items-center gap-2 rounded-md px-3 text-xs transition-colors ${
@@ -131,11 +154,7 @@ function TabItem({ id }: { id: string }) {
         onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.stopPropagation();
-          if (dirty) {
-            setConfirmClose(true);
-          } else {
-            closeTab(tab.id);
-          }
+          requestClose();
         }}
         className="group/close rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
       >
@@ -165,6 +184,30 @@ function TabItem({ id }: { id: string }) {
             closeTab(tab.id);
           }}
           onCancel={() => setConfirmClose(false)}
+        />
+      )}
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          onClose={() => setMenu(null)}
+          items={[
+            {
+              id: "rename",
+              label: t("actions.renameTab"),
+              icon: Pencil,
+              group: 0,
+              onSelect: startRename,
+            },
+            {
+              id: "close",
+              label: t("actions.closeTab"),
+              icon: X,
+              group: 1,
+              danger: true,
+              onSelect: requestClose,
+            },
+          ]}
         />
       )}
     </div>

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -58,6 +58,7 @@
   "actions": {
     "newTab": "New Tab",
     "closeTab": "Close Tab",
+    "renameTab": "Rename Tab",
     "split": "Split",
     "search": "Search",
     "cancel": "Cancel",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -58,6 +58,7 @@
   "actions": {
     "newTab": "新增分頁",
     "closeTab": "關閉分頁",
+    "renameTab": "重新命名分頁",
     "split": "分割",
     "search": "搜尋",
     "cancel": "取消",


### PR DESCRIPTION
## Summary

Adds a right-click context menu to tabs in the tab bar. Part of #58.

- **Rename Tab** — enters the existing inline-edit flow, pre-filled with the current title. Double-click still works as before.
- **Close Tab** — reuses the same `requestClose` path as the close button, so the unsaved-changes confirm dialog still fires for dirty editor tabs.

The store side (`setTabTitle`, `renamed` guard against cwd auto-sync) was already in place; this only wires up the right-click entry point.

## Changes

- `TabBar.tsx`: extract `startRename` / `requestClose`, add `onContextMenu` + `ContextMenu` with rename/close items
- `TabBar.test.tsx` (new): 3 behavior tests covering menu open, rename → inline edit, close → tab removed
- `common.json` (en + zh-Hant): add `actions.renameTab`

## Test plan

- [x] `pnpm test` — 757 passed
- [x] `tsc --noEmit` — clean
- [ ] Manual: right-click a tab, confirm Rename enters inline edit and Close removes the tab (and prompts when an editor pane is dirty)