### PR TITLE
feat(terminal): add custom shell path override

### DIFF
--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -16,10 +16,20 @@ pub fn pty_open(
     rows: u16,
     cwd: Option<String>,
     suggestions: bool,
+    shell_override: Option<String>,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
-    session::spawn(&state, cols, rows, cwd, suggestions, on_data, on_exit)
+    session::spawn(
+        &state,
+        cols,
+        rows,
+        cwd,
+        suggestions,
+        shell_override,
+        on_data,
+        on_exit,
+    )
 }
 
 #[tauri::command]

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtyPair, PtySize};
 use tauri::ipc::{Channel, Response};
 
-use super::shell::{autosuggest_env, login_args, resolve_shell, terminal_env, usable_cwd};
+use super::shell::{autosuggest_env, login_args, resolve_shell_with, terminal_env, usable_cwd};
 
 /// A single live terminal session.
 pub struct Session {
@@ -58,8 +58,12 @@ fn pty_size(cols: u16, rows: u16) -> PtySize {
 /// Build the shell command and its display name from the live environment.
 /// `suggestions` is the user's "suggest previous commands" setting, passed per
 /// spawn so a freshly opened (or restored) session reflects the current value.
-fn build_shell_command(cwd: Option<String>, suggestions: bool) -> (CommandBuilder, String) {
-    let shell = resolve_shell();
+fn build_shell_command(
+    cwd: Option<String>,
+    suggestions: bool,
+    shell_override: Option<String>,
+) -> (CommandBuilder, String) {
+    let shell = resolve_shell_with(shell_override);
     let mut cmd = CommandBuilder::new(&shell);
     // Run as a login shell so it sources the user's profile and inherits the
     // full PATH (Homebrew etc.); a GUI-launched non-login shell misses those.
@@ -159,10 +163,11 @@ pub fn spawn(
     rows: u16,
     cwd: Option<String>,
     suggestions: bool,
+    shell_override: Option<String>,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
-    let (cmd, shell_name) = build_shell_command(cwd, suggestions);
+    let (cmd, shell_name) = build_shell_command(cwd, suggestions, shell_override);
     spawn_with_sinks(
         state,
         cols,

--- a/src-tauri/src/modules/pty/shell.rs
+++ b/src-tauri/src/modules/pty/shell.rs
@@ -125,18 +125,20 @@ fn is_zsh(shell: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Pick the shell program. A non-empty `$SHELL` wins, otherwise fall back to a
-/// sensible per-platform default.
-pub fn resolve_shell_from(shell_env: Option<String>) -> String {
-    match shell_env {
-        Some(s) if !s.trim().is_empty() => s,
-        _ => default_shell(),
-    }
+/// Pick the shell program. A non-empty `shell_override` (the user's custom
+/// shell-path setting) wins, then a non-empty `$SHELL`, otherwise a sensible
+/// per-platform default.
+pub fn resolve_shell_from(shell_override: Option<String>, shell_env: Option<String>) -> String {
+    let non_empty = |v: Option<String>| v.filter(|s| !s.trim().is_empty());
+    non_empty(shell_override)
+        .or_else(|| non_empty(shell_env))
+        .unwrap_or_else(default_shell)
 }
 
-/// Resolve the shell from the live environment.
-pub fn resolve_shell() -> String {
-    resolve_shell_from(std::env::var("SHELL").ok())
+/// Resolve the shell from the live environment, honouring an optional user
+/// override (the custom shell-path setting, passed per spawn).
+pub fn resolve_shell_with(shell_override: Option<String>) -> String {
+    resolve_shell_from(shell_override, std::env::var("SHELL").ok())
 }
 
 #[cfg(not(windows))]
@@ -249,17 +251,36 @@ mod tests {
     #[test]
     fn uses_shell_env_when_set() {
         assert_eq!(
-            resolve_shell_from(Some("/usr/bin/fish".to_string())),
+            resolve_shell_from(None, Some("/usr/bin/fish".to_string())),
             "/usr/bin/fish"
         );
     }
 
     #[test]
     fn falls_back_to_default_when_shell_env_missing_or_blank() {
-        let from_none = resolve_shell_from(None);
-        let from_blank = resolve_shell_from(Some("   ".to_string()));
+        let from_none = resolve_shell_from(None, None);
+        let from_blank = resolve_shell_from(None, Some("   ".to_string()));
         assert_eq!(from_none, from_blank);
         assert!(from_none.starts_with('/') || from_none.ends_with(".exe"));
+    }
+
+    #[test]
+    fn custom_override_wins_over_shell_env() {
+        assert_eq!(
+            resolve_shell_from(
+                Some("/opt/homebrew/bin/pwsh".to_string()),
+                Some("/bin/zsh".to_string()),
+            ),
+            "/opt/homebrew/bin/pwsh"
+        );
+    }
+
+    #[test]
+    fn blank_override_falls_through_to_shell_env() {
+        assert_eq!(
+            resolve_shell_from(Some("   ".to_string()), Some("/bin/zsh".to_string())),
+            "/bin/zsh"
+        );
     }
 
     #[test]

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -97,6 +97,9 @@
     "suggestionsHint": "Show a dim completion from your shell history as you type; press → to accept",
     "actionLinks": "Hover action cards",
     "actionLinksHint": "Hover an IP, host:port or archive in the output to get quick commands (ping, curl, extract…)",
+    "customShell": "Custom shell path",
+    "customShellHint": "Shell executable to spawn instead of the auto-detected default; leave empty for your system $SHELL, or point at pwsh / PowerShell 7 on Windows",
+    "customShellPlaceholder": "/opt/homebrew/bin/pwsh",
     "clearHistory": "Clear saved history",
     "historyCleared": "Cleared"
   },

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -97,6 +97,9 @@
     "suggestionsHint": "輸入時根據 shell 歷史以灰色顯示補完建議，按 → 接受",
     "actionLinks": "滑鼠懸停動作卡片",
     "actionLinksHint": "滑鼠移到輸出中的 IP、host:port 或壓縮檔，跳出可執行的快速指令（ping、curl、解壓縮等）",
+    "customShell": "自訂 shell 路徑",
+    "customShellHint": "要啟動的 shell 執行檔路徑，取代自動偵測的預設值；留空就用系統的 $SHELL，Windows 上可以指向 pwsh 或 PowerShell 7",
+    "customShellPlaceholder": "/opt/homebrew/bin/pwsh",
     "clearHistory": "清除已儲存的歷史",
     "historyCleared": "已清除"
   },

--- a/src/modules/settings/TerminalSettingsSection.test.tsx
+++ b/src/modules/settings/TerminalSettingsSection.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/i18n";
+import { TerminalSettingsSection } from "./TerminalSettingsSection";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+vi.mock("@/modules/terminal/lib/terminalHistory", () => ({
+  clearTerminalHistory: vi.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(() => {
+  useSettingsStore.setState({ customShellPath: "" });
+});
+
+describe("TerminalSettingsSection custom shell", () => {
+  it("shows the stored custom shell path and writes edits back to the store", () => {
+    useSettingsStore.setState({ customShellPath: "/bin/zsh" });
+    render(<TerminalSettingsSection />);
+    const input = screen.getByLabelText("Custom shell path");
+    expect(input).toHaveValue("/bin/zsh");
+    fireEvent.change(input, { target: { value: "/opt/homebrew/bin/pwsh" } });
+    expect(useSettingsStore.getState().customShellPath).toBe("/opt/homebrew/bin/pwsh");
+  });
+});

--- a/src/modules/settings/TerminalSettingsSection.test.tsx
+++ b/src/modules/settings/TerminalSettingsSection.test.tsx
@@ -8,8 +8,12 @@ vi.mock("@/modules/terminal/lib/terminalHistory", () => ({
   clearTerminalHistory: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Snapshot the store (actions included) at load so each test starts from a
+// complete, clean state rather than only resetting one field.
+const initialState = useSettingsStore.getState();
+
 beforeEach(() => {
-  useSettingsStore.setState({ customShellPath: "" });
+  useSettingsStore.setState(initialState, true);
 });
 
 describe("TerminalSettingsSection custom shell", () => {

--- a/src/modules/settings/TerminalSettingsSection.tsx
+++ b/src/modules/settings/TerminalSettingsSection.tsx
@@ -16,6 +16,8 @@ export function TerminalSettingsSection() {
   const setRestoreTerminalHistory = useSettingsStore((s) => s.setRestoreTerminalHistory);
   const terminalSuggestions = useSettingsStore((s) => s.terminalSuggestions);
   const setTerminalSuggestions = useSettingsStore((s) => s.setTerminalSuggestions);
+  const customShellPath = useSettingsStore((s) => s.customShellPath);
+  const setCustomShellPath = useSettingsStore((s) => s.setCustomShellPath);
   const actionLinksEnabled = useSettingsStore((s) => s.actionLinksEnabled);
   const setActionLinksEnabled = useSettingsStore((s) => s.setActionLinksEnabled);
   const themeId = useSettingsStore((s) => s.themeId);
@@ -60,6 +62,21 @@ export function TerminalSettingsSection() {
             {t("terminalSettings.previewText")}
           </pre>
         </div>
+      </div>
+
+      <div className="mb-6">
+        <label htmlFor="custom-shell-path" className="mb-2 block text-sm font-medium text-fg">
+          {t("terminalSettings.customShell")}
+        </label>
+        <input
+          id="custom-shell-path"
+          type="text"
+          value={customShellPath}
+          placeholder={t("terminalSettings.customShellPlaceholder")}
+          onChange={(e) => setCustomShellPath(e.target.value)}
+          className="w-full max-w-md rounded-md border border-border bg-bg px-2 py-1 font-mono text-sm text-fg outline-none focus:border-accent"
+        />
+        <p className="mt-1 text-xs text-fg-muted">{t("terminalSettings.customShellHint")}</p>
       </div>
 
       <div className="mb-6">

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -671,6 +671,7 @@ export function TerminalView({
         // Read the setting at spawn time so a restored pane reflects the current
         // value, instead of racing a global flag set after mount.
         suggestions: useSettingsStore.getState().terminalSuggestions,
+        shellOverride: useSettingsStore.getState().customShellPath,
         onData: (bytes) => outputWriter.push(bytes),
         // Only treat an exit as user-facing when we did not tear the session
         // down ourselves (e.g. React StrictMode's mount/unmount/remount in dev).

--- a/src/modules/terminal/lib/pty-bridge.test.ts
+++ b/src/modules/terminal/lib/pty-bridge.test.ts
@@ -25,6 +25,16 @@ describe("pty-bridge session registry", () => {
     expect((open?.[1] as { suggestions: boolean }).suggestions).toBe(true);
   });
 
+  it("forwards the shell override to pty_open so the backend can spawn it", async () => {
+    invoke.mockResolvedValueOnce(1);
+    await openPty({ ...opts, shellOverride: "/opt/homebrew/bin/pwsh" });
+
+    const open = invoke.mock.calls.find(([cmd]) => cmd === "pty_open");
+    expect((open?.[1] as { shellOverride?: string }).shellOverride).toBe(
+      "/opt/homebrew/bin/pwsh",
+    );
+  });
+
   it("closeLocalSessions closes every open session, then clears", async () => {
     invoke.mockResolvedValueOnce(1).mockResolvedValueOnce(2); // two pty_open ids
     await openPty(opts);

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -20,6 +20,12 @@ export interface OpenPtyOptions {
    * always reflects the current setting, with no startup race against a global.
    */
   suggestions: boolean;
+  /**
+   * Custom shell executable to spawn instead of the auto-detected one. Undefined
+   * or empty keeps the backend's `$SHELL` / per-platform default. Tauri maps this
+   * camelCase key onto the Rust command's `shell_override` argument.
+   */
+  shellOverride?: string;
   onData: (bytes: Uint8Array) => void;
   onExit: (code: number) => void;
 }
@@ -45,6 +51,7 @@ export async function openPty(opts: OpenPtyOptions): Promise<PtySession> {
     rows: opts.rows,
     cwd: opts.cwd,
     suggestions: opts.suggestions,
+    shellOverride: opts.shellOverride,
     onData,
     onExit,
   });

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -21,6 +21,7 @@ describe("settingsStore", () => {
       prSource: "auto",
       claudeFlags: initialState.claudeFlags,
       codexFlags: initialState.codexFlags,
+      customShellPath: initialState.customShellPath,
     });
   });
 
@@ -123,5 +124,11 @@ describe("settingsStore", () => {
     useSettingsStore.getState().setClaudeFlags("--model opus");
     const persisted = localStorage.getItem("tempoterm-settings");
     expect(persisted).toContain("--model opus");
+  });
+
+  it("defaults the custom shell path empty and updates it", () => {
+    expect(useSettingsStore.getState().customShellPath).toBe("");
+    useSettingsStore.getState().setCustomShellPath("/opt/homebrew/bin/pwsh");
+    expect(useSettingsStore.getState().customShellPath).toBe("/opt/homebrew/bin/pwsh");
   });
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -61,6 +61,12 @@ interface SettingsState {
   aiTerminalContext: boolean;
   /** Suggest previously-run commands as ghost text in the terminal. */
   terminalSuggestions: boolean;
+  /**
+   * Custom shell executable to spawn instead of the auto-detected one (`$SHELL`,
+   * or the per-platform default). Empty string keeps the default. Lets Windows
+   * users point at pwsh / PowerShell 7, for example.
+   */
+  customShellPath: string;
   /** Show the hover action card (ping/curl/extract) over IPs, host:port and archives. */
   actionLinksEnabled: boolean;
   /** Webview zoom factor for the whole UI (1 = 100%); driven by ⌘+ / ⌘-. */
@@ -80,6 +86,7 @@ interface SettingsState {
   setAiInlineCompletion: (value: boolean) => void;
   setAiTerminalContext: (value: boolean) => void;
   setTerminalSuggestions: (value: boolean) => void;
+  setCustomShellPath: (path: string) => void;
   setActionLinksEnabled: (value: boolean) => void;
   zoomIn: () => void;
   zoomOut: () => void;
@@ -124,6 +131,7 @@ export const useSettingsStore = create<SettingsState>()(
       aiInlineCompletion: false,
       aiTerminalContext: true,
       terminalSuggestions: true,
+      customShellPath: "",
       actionLinksEnabled: true,
       uiZoom: DEFAULT_UI_ZOOM,
       setLanguage: (language) => set({ language }),
@@ -142,6 +150,7 @@ export const useSettingsStore = create<SettingsState>()(
       setAiInlineCompletion: (value) => set({ aiInlineCompletion: value }),
       setAiTerminalContext: (value) => set({ aiTerminalContext: value }),
       setTerminalSuggestions: (value) => set({ terminalSuggestions: value }),
+      setCustomShellPath: (customShellPath) => set({ customShellPath }),
       setActionLinksEnabled: (value) => set({ actionLinksEnabled: value }),
       zoomIn: () => set((s) => ({ uiZoom: clampZoom(s.uiZoom + UI_ZOOM_STEP) })),
       zoomOut: () => set((s) => ({ uiZoom: clampZoom(s.uiZoom - UI_ZOOM_STEP) })),


### PR DESCRIPTION
## Summary

Adds a **Custom shell path** setting under Settings → Terminal. Part of #58.

When set, the backend spawns that shell executable instead of the auto-detected one. Empty keeps the existing behaviour (`$SHELL`, then a per-platform default). The main motivation is letting Windows users point at pwsh / PowerShell 7, but it works on any platform.

The path is read **per spawn** and threaded through `pty_open` → `spawn` → `build_shell_command`, mirroring how the existing `suggestions` flag flows — so a restored pane reflects the current setting with no startup race.

## Changes

**Backend**
- `shell.rs`: `resolve_shell_from(override, env)` — a non-empty override beats `$SHELL`; add `resolve_shell_with` as the live-env entry point
- `session.rs` / `mod.rs`: thread `shell_override` through `spawn` and the `pty_open` command

**Frontend**
- `settingsStore`: `customShellPath` state + setter (defaults to `""`)
- `pty-bridge`: forward `shellOverride` to `pty_open` (Tauri maps the camelCase key onto the Rust `shell_override` arg, same as `onData`/`on_data`)
- `TerminalView`: read the setting at spawn time
- `TerminalSettingsSection`: text input bound to the setting
- i18n: `customShell` label/hint/placeholder in `en` + `zh-Hant`

## Test plan

- [x] `cargo test` — 168 passed (incl. new `resolve_shell_from` override cases)
- [x] `pnpm test` — 757 passed (settingsStore, pty-bridge, TerminalSettingsSection)
- [x] `tsc --noEmit` — clean
- [ ] Manual (macOS): set the path to a different shell (e.g. `/bin/bash`), open a new terminal, confirm it spawns; clear it, confirm it falls back to `$SHELL`
- [ ] Manual (Windows): set to a pwsh path, confirm PowerShell 7 spawns