### PR TITLE
feat(window): custom title bar with window controls on Windows

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
     "core:window:allow-close",
     "core:window:allow-destroy",
     "core:webview:allow-set-webview-zoom",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "core:window:allow-start-dragging",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
+    "core:window:allow-is-maximized",
     "core:window:allow-close",
     "core:window:allow-destroy",
     "core:webview:allow-set-webview-zoom",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,6 +102,12 @@ pub fn run() {
                         let _ = window.center();
                     }
                 }
+                // Windows draws a custom React title bar (see TitleBar.tsx), so
+                // hide the native window frame. macOS keeps its overlay title bar.
+                #[cfg(target_os = "windows")]
+                {
+                    let _ = window.set_decorations(false);
+                }
             }
             // Resolve the encrypted secrets file once; create the data dir so
             // the first write succeeds on a fresh install.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TabBar } from "@/components/TabBar";
+import { TitleBar } from "@/components/TitleBar";
 import { Sidebar, SIDEBAR_VIEW_ORDER } from "@/components/Sidebar";
 import { Resizer } from "@/components/Resizer";
 import { StatusBar } from "@/components/StatusBar";
@@ -313,6 +314,7 @@ function App() {
 
   return (
     <div className="flex h-screen w-screen flex-col overflow-hidden bg-bg text-fg">
+      <TitleBar />
       <TabBar />
 
       <div className="flex min-h-0 flex-1">

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -30,6 +30,7 @@ import {
 import { useTabsStore, tabHasDirtyEditor, type Tab } from "@/stores/tabsStore";
 import { useEditorStore } from "@/modules/editor/store/editorStore";
 import { useUiStore } from "@/stores/uiStore";
+import { IS_MAC } from "@/lib/platform";
 import { SpaceDropdown } from "./SpaceDropdown";
 import { ConfirmDialog } from "./ConfirmDialog";
 
@@ -213,7 +214,9 @@ export function TabBar() {
   return (
     <header
       data-tauri-drag-region
-      className="flex h-9 shrink-0 items-center gap-1 border-b border-border bg-bg-inset pl-20 pr-2"
+      className={`flex h-9 shrink-0 items-center gap-1 border-b border-border bg-bg-inset pr-2 ${
+        IS_MAC ? "pl-20" : "pl-3"
+      }`}
     >
       <button
         type="button"

--- a/src/components/TitleBar.test.tsx
+++ b/src/components/TitleBar.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/i18n";
+
+// IS_WINDOWS is a module-load const; expose it through a getter so each test can
+// flip the platform without re-importing the module.
+const platformMock = vi.hoisted(() => ({ isWindows: true }));
+vi.mock("@/lib/platform", () => ({
+  get IS_WINDOWS() {
+    return platformMock.isWindows;
+  },
+}));
+
+const { minimizeWindow, toggleMaximizeWindow, closeWindow } = vi.hoisted(() => ({
+  minimizeWindow: vi.fn(),
+  toggleMaximizeWindow: vi.fn(),
+  closeWindow: vi.fn(),
+}));
+vi.mock("@/lib/window", () => ({ minimizeWindow, toggleMaximizeWindow, closeWindow }));
+
+import { TitleBar } from "./TitleBar";
+
+beforeEach(() => {
+  platformMock.isWindows = true;
+  minimizeWindow.mockReset();
+  toggleMaximizeWindow.mockReset();
+  closeWindow.mockReset();
+});
+
+describe("TitleBar", () => {
+  it("renders nothing on non-Windows platforms", () => {
+    platformMock.isWindows = false;
+    const { container } = render(<TitleBar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders minimize, maximize and close controls on Windows", () => {
+    render(<TitleBar />);
+    expect(screen.getByLabelText("Minimize")).toBeInTheDocument();
+    expect(screen.getByLabelText("Maximize")).toBeInTheDocument();
+    expect(screen.getByLabelText("Close")).toBeInTheDocument();
+  });
+
+  it("drives the window controls when the buttons are clicked", () => {
+    render(<TitleBar />);
+    fireEvent.click(screen.getByLabelText("Minimize"));
+    fireEvent.click(screen.getByLabelText("Maximize"));
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(minimizeWindow).toHaveBeenCalledOnce();
+    expect(toggleMaximizeWindow).toHaveBeenCalledOnce();
+    expect(closeWindow).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/TitleBar.test.tsx
+++ b/src/components/TitleBar.test.tsx
@@ -11,12 +11,21 @@ vi.mock("@/lib/platform", () => ({
   },
 }));
 
-const { minimizeWindow, toggleMaximizeWindow, closeWindow } = vi.hoisted(() => ({
-  minimizeWindow: vi.fn(),
-  toggleMaximizeWindow: vi.fn(),
-  closeWindow: vi.fn(),
+const { minimizeWindow, toggleMaximizeWindow, closeWindow, isWindowMaximized, onWindowResized } =
+  vi.hoisted(() => ({
+    minimizeWindow: vi.fn(),
+    toggleMaximizeWindow: vi.fn(),
+    closeWindow: vi.fn(),
+    isWindowMaximized: vi.fn(),
+    onWindowResized: vi.fn(),
+  }));
+vi.mock("@/lib/window", () => ({
+  minimizeWindow,
+  toggleMaximizeWindow,
+  closeWindow,
+  isWindowMaximized,
+  onWindowResized,
 }));
-vi.mock("@/lib/window", () => ({ minimizeWindow, toggleMaximizeWindow, closeWindow }));
 
 import { TitleBar } from "./TitleBar";
 
@@ -25,6 +34,8 @@ beforeEach(() => {
   minimizeWindow.mockReset();
   toggleMaximizeWindow.mockReset();
   closeWindow.mockReset();
+  isWindowMaximized.mockReset().mockResolvedValue(false);
+  onWindowResized.mockReset().mockResolvedValue(() => {});
 });
 
 describe("TitleBar", () => {
@@ -49,5 +60,12 @@ describe("TitleBar", () => {
     expect(minimizeWindow).toHaveBeenCalledOnce();
     expect(toggleMaximizeWindow).toHaveBeenCalledOnce();
     expect(closeWindow).toHaveBeenCalledOnce();
+  });
+
+  it("shows the restore control once the window reports it is maximized", async () => {
+    isWindowMaximized.mockResolvedValue(true);
+    render(<TitleBar />);
+    expect(await screen.findByLabelText("Restore")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Maximize")).toBeNull();
   });
 });

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,53 +1,98 @@
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Minus, Square, X } from "lucide-react";
 import { IS_WINDOWS } from "@/lib/platform";
-import { closeWindow, minimizeWindow, toggleMaximizeWindow } from "@/lib/window";
+import {
+  closeWindow,
+  isWindowMaximized,
+  minimizeWindow,
+  onWindowResized,
+  toggleMaximizeWindow,
+} from "@/lib/window";
+
+/** Overlapping-squares "restore" glyph; lucide has no direct equivalent. */
+function RestoreIcon({ size = 11 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      aria-hidden="true"
+    >
+      <path d="M3 3H9V9H3V3Z" />
+      <path d="M5 1.5H11V7.5H9" />
+    </svg>
+  );
+}
 
 /**
  * Custom title bar for Windows, where the native frame is hidden
- * (`decorations(false)`). It provides the draggable region plus
- * minimize / maximize / close controls. Renders nothing on macOS, which keeps
- * its native overlay title bar.
+ * (`decorations(false)`). A draggable region fills the left, and the
+ * minimize / maximize-restore / close controls sit on the right — kept in a
+ * separate, non-draggable element so clicks aren't swallowed by the drag
+ * region. Renders nothing on macOS, which keeps its native overlay title bar.
  */
 export function TitleBar() {
   const { t } = useTranslation();
+  const [isMaximized, setIsMaximized] = useState(false);
+
+  // Track the maximized state so the middle button shows the right icon/label.
+  // Hooks run unconditionally; the effect no-ops off Windows.
+  useEffect(() => {
+    if (!IS_WINDOWS) {
+      return;
+    }
+    const sync = () => {
+      void isWindowMaximized()
+        .then(setIsMaximized)
+        .catch(() => {});
+    };
+    sync();
+    const unlisten = onWindowResized(sync);
+    return () => {
+      void unlisten.then((off) => off()).catch(() => {});
+    };
+  }, []);
 
   if (!IS_WINDOWS) {
     return null;
   }
 
   return (
-    <div
-      data-tauri-drag-region
-      className="flex h-8 shrink-0 items-center justify-end border-b border-border bg-bg-inset"
-    >
-      <button
-        type="button"
-        aria-label={t("titleBar.minimize")}
-        title={t("titleBar.minimize")}
-        onClick={() => void minimizeWindow()}
-        className="flex h-8 w-11 items-center justify-center text-fg-subtle transition-colors hover:bg-bg-elevated hover:text-fg"
-      >
-        <Minus size={15} />
-      </button>
-      <button
-        type="button"
-        aria-label={t("titleBar.maximize")}
-        title={t("titleBar.maximize")}
-        onClick={() => void toggleMaximizeWindow()}
-        className="flex h-8 w-11 items-center justify-center text-fg-subtle transition-colors hover:bg-bg-elevated hover:text-fg"
-      >
-        <Square size={12} />
-      </button>
-      <button
-        type="button"
-        aria-label={t("titleBar.close")}
-        title={t("titleBar.close")}
-        onClick={() => void closeWindow()}
-        className="flex h-8 w-11 items-center justify-center text-fg-subtle transition-colors hover:bg-danger hover:text-white"
-      >
-        <X size={16} />
-      </button>
+    <div className="flex h-8 shrink-0 items-center border-b border-border bg-bg-inset">
+      <div data-tauri-drag-region className="h-full flex-1" />
+      <div className="flex h-full shrink-0 items-center">
+        <button
+          type="button"
+          aria-label={t("titleBar.minimize")}
+          title={t("titleBar.minimize")}
+          onClick={() => void minimizeWindow()}
+          className="flex h-8 w-11 items-center justify-center text-fg-subtle transition-colors hover:bg-bg-elevated hover:text-fg"
+        >
+          <Minus size={15} />
+        </button>
+        <button
+          type="button"
+          aria-label={isMaximized ? t("titleBar.restore") : t("titleBar.maximize")}
+          title={isMaximized ? t("titleBar.restore") : t("titleBar.maximize")}
+          onClick={() => void toggleMaximizeWindow()}
+          className="flex h-8 w-11 items-center justify-center text-fg-subtle transition-colors hover:bg-bg-elevated hover:text-fg"
+        >
+          {isMaximized ? <RestoreIcon size={11} /> : <Square size={12} />}
+        </button>
+        <button
+          type="button"
+          aria-label={t("titleBar.close")}
+          title={t("titleBar.close")}
+          onClick={() => void closeWindow()}
+          className="flex h-8 w-11 items-center justify-center text-fg-subtle transition-colors hover:bg-danger hover:text-white"
+        >
+          <X size={16} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from "react-i18next";
+import { Minus, Square, X } from "lucide-react";
+import { IS_WINDOWS } from "@/lib/platform";
+import { closeWindow, minimizeWindow, toggleMaximizeWindow } from "@/lib/window";
+
+/**
+ * Custom title bar for Windows, where the native frame is hidden
+ * (`decorations(false)`). It provides the draggable region plus
+ * minimize / maximize / close controls. Renders nothing on macOS, which keeps
+ * its native overlay title bar.
+ */
+export function TitleBar() {
+  const { t } = useTranslation();
+
+  if (!IS_WINDOWS) {
+    return null;
+  }
+
+  return (
+    <div
+      data-tauri-drag-region
+      className="flex h-8 shrink-0 items-center justify-end border-b border-border bg-bg-inset"
+    >
+      <button
+        type="button"
+        aria-label={t("titleBar.minimize")}
+        title={t("titleBar.minimize")}
+        onClick={() => void minimizeWindow()}
+        className="flex h-8 w-11 items-center justify-center text-fg-subtle transition-colors hover:bg-bg-elevated hover:text-fg"
+      >
+        <Minus size={15} />
+      </button>
+      <button
+        type="button"
+        aria-label={t("titleBar.maximize")}
+        title={t("titleBar.maximize")}
+        onClick={() => void toggleMaximizeWindow()}
+        className="flex h-8 w-11 items-center justify-center text-fg-subtle transition-colors hover:bg-bg-elevated hover:text-fg"
+      >
+        <Square size={12} />
+      </button>
+      <button
+        type="button"
+        aria-label={t("titleBar.close")}
+        title={t("titleBar.close")}
+        onClick={() => void closeWindow()}
+        className="flex h-8 w-11 items-center justify-center text-fg-subtle transition-colors hover:bg-danger hover:text-white"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -55,6 +55,11 @@
     "language": "Language",
     "updateAvailable": "Update available"
   },
+  "titleBar": {
+    "minimize": "Minimize",
+    "maximize": "Maximize",
+    "close": "Close"
+  },
   "actions": {
     "newTab": "New Tab",
     "closeTab": "Close Tab",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -58,6 +58,7 @@
   "titleBar": {
     "minimize": "Minimize",
     "maximize": "Maximize",
+    "restore": "Restore",
     "close": "Close"
   },
   "actions": {

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -58,6 +58,7 @@
   "titleBar": {
     "minimize": "最小化",
     "maximize": "最大化",
+    "restore": "還原",
     "close": "關閉"
   },
   "actions": {

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -55,6 +55,11 @@
     "language": "語言",
     "updateAvailable": "有可用更新"
   },
+  "titleBar": {
+    "minimize": "最小化",
+    "maximize": "最大化",
+    "close": "關閉"
+  },
   "actions": {
     "newTab": "新增分頁",
     "closeTab": "關閉分頁",

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -64,3 +64,33 @@ describe("IS_MAC platform detection", () => {
     ).resolves.toBe(false);
   });
 });
+
+describe("IS_WINDOWS platform detection", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  async function loadIsWindows(nav: unknown): Promise<boolean> {
+    vi.stubGlobal("navigator", nav);
+    vi.resetModules();
+    const mod = await import("./platform");
+    return mod.IS_WINDOWS;
+  }
+
+  it("detects windows via platform", async () => {
+    await expect(loadIsWindows({ platform: "Win32" })).resolves.toBe(true);
+  });
+
+  it("falls back to userAgent when platform is undefined", async () => {
+    await expect(
+      loadIsWindows({ userAgent: "Mozilla/5.0 (Windows NT 10.0)", platform: undefined }),
+    ).resolves.toBe(true);
+  });
+
+  it("is false on mac", async () => {
+    await expect(
+      loadIsWindows({ platform: "MacIntel", userAgent: "Mac OS X" }),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -18,8 +18,11 @@ export const IS_MAC =
  */
 export const IS_WINDOWS =
   typeof navigator !== "undefined" &&
+  // platform is "Win32"/"Win64" on Windows; the userAgent says "Windows". Match
+  // the userAgent on the full word, not "win", so "darwin" (e.g. jsdom's UA)
+  // doesn't false-positive.
   (navigator.platform?.toLowerCase().includes("win") ||
-    navigator.userAgent?.toLowerCase().includes("win") ||
+    navigator.userAgent?.toLowerCase().includes("windows") ||
     false);
 
 type ModifierEvent = Pick<MouseEvent, "altKey" | "metaKey" | "ctrlKey">;

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -12,6 +12,16 @@ export const IS_MAC =
     navigator.userAgent?.toLowerCase().includes("mac") ||
     false);
 
+/**
+ * Windows detection, used to swap in a custom title bar (the native one is
+ * hidden via decorations) while macOS keeps its overlay title bar.
+ */
+export const IS_WINDOWS =
+  typeof navigator !== "undefined" &&
+  (navigator.platform?.toLowerCase().includes("win") ||
+    navigator.userAgent?.toLowerCase().includes("win") ||
+    false);
+
 type ModifierEvent = Pick<MouseEvent, "altKey" | "metaKey" | "ctrlKey">;
 
 /** Whether a click carries the platform's open-link modifier. */

--- a/src/lib/window.test.ts
+++ b/src/lib/window.test.ts
@@ -3,7 +3,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const { getCurrentWindow } = vi.hoisted(() => ({ getCurrentWindow: vi.fn() }));
 vi.mock("@tauri-apps/api/window", () => ({ getCurrentWindow }));
 
-import { isMainWindow, perWindowStorage } from "./window";
+import {
+  closeWindow,
+  isMainWindow,
+  minimizeWindow,
+  perWindowStorage,
+  toggleMaximizeWindow,
+} from "./window";
 
 afterEach(() => {
   getCurrentWindow.mockReset();
@@ -45,5 +51,28 @@ describe("perWindowStorage", () => {
     expect(storage.getItem("k")).toBe("v");
     storage.removeItem("k");
     expect(storage.getItem("k")).toBeNull();
+  });
+});
+
+describe("window controls", () => {
+  it("minimizeWindow calls the current window's minimize", async () => {
+    const minimize = vi.fn().mockResolvedValue(undefined);
+    getCurrentWindow.mockReturnValue({ minimize });
+    await minimizeWindow();
+    expect(minimize).toHaveBeenCalledOnce();
+  });
+
+  it("toggleMaximizeWindow calls the current window's toggleMaximize", async () => {
+    const toggleMaximize = vi.fn().mockResolvedValue(undefined);
+    getCurrentWindow.mockReturnValue({ toggleMaximize });
+    await toggleMaximizeWindow();
+    expect(toggleMaximize).toHaveBeenCalledOnce();
+  });
+
+  it("closeWindow calls the current window's close", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    getCurrentWindow.mockReturnValue({ close });
+    await closeWindow();
+    expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/window.test.ts
+++ b/src/lib/window.test.ts
@@ -6,7 +6,9 @@ vi.mock("@tauri-apps/api/window", () => ({ getCurrentWindow }));
 import {
   closeWindow,
   isMainWindow,
+  isWindowMaximized,
   minimizeWindow,
+  onWindowResized,
   perWindowStorage,
   toggleMaximizeWindow,
 } from "./window";
@@ -74,5 +76,25 @@ describe("window controls", () => {
     getCurrentWindow.mockReturnValue({ close });
     await closeWindow();
     expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("isWindowMaximized reports the current window's maximized state", async () => {
+    const isMaximized = vi.fn().mockResolvedValue(true);
+    getCurrentWindow.mockReturnValue({ isMaximized });
+    await expect(isWindowMaximized()).resolves.toBe(true);
+    expect(isMaximized).toHaveBeenCalledOnce();
+  });
+
+  it("onWindowResized subscribes to the window's resize events", async () => {
+    const unlisten = vi.fn();
+    const onResized = vi.fn().mockResolvedValue(unlisten);
+    getCurrentWindow.mockReturnValue({ onResized });
+    const handler = vi.fn();
+    const off = await onWindowResized(handler);
+    expect(onResized).toHaveBeenCalledOnce();
+    // The wrapper forwards the event to the bare handler.
+    onResized.mock.calls[0][0]();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(off).toBe(unlisten);
   });
 });

--- a/src/lib/window.ts
+++ b/src/lib/window.ts
@@ -1,4 +1,5 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import type { StateStorage } from "zustand/middleware";
 
 /**
@@ -29,6 +30,16 @@ export function toggleMaximizeWindow(): Promise<void> {
 
 export function closeWindow(): Promise<void> {
   return getCurrentWindow().close();
+}
+
+/** Whether the window is currently maximized (drives the maximize/restore icon). */
+export function isWindowMaximized(): Promise<boolean> {
+  return getCurrentWindow().isMaximized();
+}
+
+/** Subscribe to window resize events; returns an unlisten function. */
+export function onWindowResized(handler: () => void): Promise<UnlistenFn> {
+  return getCurrentWindow().onResized(() => handler());
 }
 
 // Private to this webview, so each secondary window gets its own isolated copy

--- a/src/lib/window.ts
+++ b/src/lib/window.ts
@@ -14,6 +14,23 @@ export function isMainWindow(): boolean {
   }
 }
 
+/**
+ * Window-control actions for the custom Windows title bar. They drive the
+ * minimize / maximize-restore / close buttons; on macOS the native overlay
+ * title bar handles this, so these are only wired up in the Windows TitleBar.
+ */
+export function minimizeWindow(): Promise<void> {
+  return getCurrentWindow().minimize();
+}
+
+export function toggleMaximizeWindow(): Promise<void> {
+  return getCurrentWindow().toggleMaximize();
+}
+
+export function closeWindow(): Promise<void> {
+  return getCurrentWindow().close();
+}
+
 // Private to this webview, so each secondary window gets its own isolated copy
 // and never touches localStorage (which is shared across windows of the origin).
 const memoryBacking = new Map<string, string>();


### PR DESCRIPTION
## Summary

Gives Windows a custom title bar. Part of #58.

On Windows the native window frame is hidden (`set_decorations(false)`) and a React `TitleBar` provides the draggable region plus minimize / maximize / close controls. **macOS is untouched** — it keeps its native overlay title bar and traffic-light padding; `TitleBar` renders `null` there.

## Changes

**Frontend**
- `platform.ts`: add `IS_WINDOWS` detection (mirrors `IS_MAC`)
- `window.ts`: `minimizeWindow` / `toggleMaximizeWindow` / `closeWindow`
- `TitleBar.tsx` (new): Windows-only control strip, `data-tauri-drag-region` + three buttons; returns `null` on other platforms
- `App.tsx`: mount `<TitleBar />` above the tab bar
- `TabBar.tsx`: apply the traffic-light left padding (`pl-20`) only on macOS, otherwise `pl-3`
- i18n: `titleBar.minimize/maximize/close` in both locales

**Backend**
- `lib.rs`: `set_decorations(false)` on Windows in `setup()` (cfg-gated)
- `capabilities/default.json`: add `allow-minimize`, `allow-toggle-maximize`

## Test plan

- [x] `pnpm test` — 763 passed (IS_WINDOWS detection, window controls, TitleBar render/click)
- [x] `tsc --noEmit` — clean
- [x] `cargo check` — clean (non-Windows build; the `set_decorations` block is cfg-gated)
- [ ] **Windows** (real verification): frameless window, drag region works, min/max/close behave
- [ ] macOS eyeball: temporarily force `IS_WINDOWS = true` to sanity-check the TitleBar layout (do not commit)

> The frameless-window behaviour and dragging can only be verified on Windows. On macOS the TitleBar is `null` by design, so this PR is a no-op there.