### PR TITLE
feat(tabs): make add-tab buttons easier to reach

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -2,7 +2,7 @@
 
 ### feat
 - tab 列的新增分頁按鈕改放在最後一個分頁旁邊，不再擠在最右邊看不清楚；側邊欄每個 workspace 也加了新增分頁按鈕，會在該 workspace 開新分頁，同一排的編輯與刪除按鈕也改為固定顯示
-- 側邊欄改版：頂部面板切換列改用底線標示目前面板、不再用整塊底色，每張 tab 卡片左下角顯示序號，方便用 ⌘ 數字快速切換，並移除 workspace 標題列的數量數字
+- 側邊欄改版：頂部面板切換列改用底線標示目前面板、不再用整塊底色，每張 tab 卡片左側顯示序號，方便用 ⌘ 數字快速切換，並移除 workspace 標題列的數量數字
 
 ### fix
 
@@ -10,6 +10,6 @@
 
 ### feat
 - The new-tab button now sits next to the latest tab instead of the far right edge; each workspace in the sidebar also gets a new-tab button that opens a tab in that workspace, and the rename and delete actions on that row are now always visible
-- Sidebar refresh: the top panel switcher marks the current panel with an underline instead of a filled background, each tab card shows a number in its bottom-left for quick ⌘-number switching, and the count number on the workspace header is removed
+- Sidebar refresh: the top panel switcher marks the current panel with an underline instead of a filled background, each tab card shows a number on its left for quick ⌘-number switching, and the count number on the workspace header is removed
 
 ### fix

--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -1,11 +1,13 @@
 ## 正體中文
 
 ### feat
+- tab 列的新增分頁按鈕改放在最後一個分頁旁邊，不再擠在最右邊看不清楚；側邊欄每個 workspace 也加了新增分頁按鈕，會在該 workspace 開新分頁，同一排的編輯與刪除按鈕也改為固定顯示
 
 ### fix
 
 ## English
 
 ### feat
+- The new-tab button now sits next to the latest tab instead of the far right edge; each workspace in the sidebar also gets a new-tab button that opens a tab in that workspace, and the rename and delete actions on that row are now always visible
 
 ### fix

--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -2,6 +2,7 @@
 
 ### feat
 - tab 列的新增分頁按鈕改放在最後一個分頁旁邊，不再擠在最右邊看不清楚；側邊欄每個 workspace 也加了新增分頁按鈕，會在該 workspace 開新分頁，同一排的編輯與刪除按鈕也改為固定顯示
+- 側邊欄改版：頂部面板切換列改用底線標示目前面板、不再用整塊底色，每張 tab 卡片左下角顯示序號，方便用 ⌘ 數字快速切換，並移除 workspace 標題列的數量數字
 
 ### fix
 
@@ -9,5 +10,6 @@
 
 ### feat
 - The new-tab button now sits next to the latest tab instead of the far right edge; each workspace in the sidebar also gets a new-tab button that opens a tab in that workspace, and the rename and delete actions on that row are now always visible
+- Sidebar refresh: the top panel switcher marks the current panel with an underline instead of a filled background, each tab card shows a number in its bottom-left for quick ⌘-number switching, and the count number on the workspace header is removed
 
 ### fix

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -38,7 +38,7 @@ export function Sidebar() {
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden border-r border-border bg-bg-inset">
-      <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border px-1.5">
+      <div className="flex h-9 shrink-0 items-center gap-0.5 border-b border-border px-1.5">
         {SIDEBAR_TABS.map(({ id, icon: Icon, labelKey }) => {
           const active = sidebarView === id;
           return (
@@ -48,8 +48,10 @@ export function Sidebar() {
                 aria-label={t(labelKey)}
                 aria-pressed={active}
                 onClick={() => selectSidebar(id)}
-                className={`flex h-7 w-8 items-center justify-center rounded-md transition-colors ${
-                  active ? "bg-bg-elevated text-fg" : "text-fg-subtle hover:text-fg"
+                className={`flex h-7 w-8 items-center justify-center border-b-2 transition-colors ${
+                  active
+                    ? "border-accent text-fg"
+                    : "border-transparent text-fg-subtle hover:border-border-strong hover:text-fg"
                 }`}
               >
                 <Icon size={15} />

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -298,19 +298,18 @@ export function TabBar() {
               <TabItem key={tab.id} id={tab.id} />
             ))}
           </SortableContext>
+          <button
+            type="button"
+            aria-label={t("workspace.addTab")}
+            title={t("workspace.addTab")}
+            onClick={() => openLauncherTab()}
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-fg-muted hover:bg-bg-elevated hover:text-fg"
+          >
+            <Plus size={16} />
+          </button>
         </div>
         <DragOverlay>{draggingTab ? <TabOverlay tab={draggingTab} /> : null}</DragOverlay>
       </DndContext>
-
-      <button
-        type="button"
-        aria-label={t("workspace.addTab")}
-        title={t("workspace.addTab")}
-        onClick={() => openLauncherTab()}
-        className="flex h-7 w-7 items-center justify-center rounded-md text-fg-muted hover:bg-bg-elevated hover:text-fg"
-      >
-        <Plus size={16} />
-      </button>
     </header>
   );
 }

--- a/src/modules/workspace/WorkspacePanel.test.tsx
+++ b/src/modules/workspace/WorkspacePanel.test.tsx
@@ -232,4 +232,41 @@ describe("WorkspacePanel", () => {
     const card = screen.getByRole("button", { name: /alpha/ });
     expect(within(card).queryByText("/a")).toBeNull();
   });
+
+  it("opens a new launcher tab in the space from its group add button", () => {
+    render(<WorkspacePanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Add tab" }));
+    const added = useTabsStore.getState().tabs.find((tab) => tab.kind === "launcher");
+    expect(added).toBeDefined();
+    expect(added?.spaceId).toBe("s1");
+    expect(useTabsStore.getState().activeId).toBe(added?.id);
+  });
+
+  it("opens the new tab in the clicked group's space, not the active one", () => {
+    useTabsStore.setState({
+      spaces: [
+        { id: "s1", name: "Salon" },
+        { id: "s2", name: "Studio" },
+      ],
+      activeSpaceId: "s1",
+      activeId: "t1",
+      tabs: [
+        {
+          id: "t1",
+          spaceId: "s1",
+          title: "alpha",
+          kind: "terminal",
+          paneTree: leaf("p1", { kind: "terminal", cwd: "/a" }),
+          activeLeafId: "p1",
+        },
+      ],
+    });
+    render(<WorkspacePanel />);
+    // Each group renders its own "Add tab" button; the second one belongs to s2.
+    const addButtons = screen.getAllByRole("button", { name: "Add tab" });
+    fireEvent.click(addButtons[1]);
+    const added = useTabsStore.getState().tabs.find((tab) => tab.kind === "launcher");
+    expect(added?.spaceId).toBe("s2");
+    expect(useTabsStore.getState().activeSpaceId).toBe("s2");
+  });
 });

--- a/src/modules/workspace/WorkspacePanel.test.tsx
+++ b/src/modules/workspace/WorkspacePanel.test.tsx
@@ -269,4 +269,23 @@ describe("WorkspacePanel", () => {
     expect(added?.spaceId).toBe("s2");
     expect(useTabsStore.getState().activeSpaceId).toBe("s2");
   });
+
+  it("shows a 1-based index on each card matching its ⌘-number", () => {
+    render(<WorkspacePanel />);
+    const alpha = screen.getByRole("button", { name: /alpha/ });
+    const beta = screen.getByRole("button", { name: /beta/ });
+    expect(within(alpha).getByText("1")).toBeInTheDocument();
+    expect(within(beta).getByText("2")).toBeInTheDocument();
+  });
+
+  it("keeps the card index tied to the space order under a status filter", () => {
+    // Only beta (the 2nd tab) is active; filtering to running must still show it
+    // as 2, not renumber it to 1, so the number keeps matching ⌘2.
+    useSessionStatusStore.setState({ statuses: { p2: "active" } });
+    render(<WorkspacePanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Running" }));
+    const beta = screen.getByRole("button", { name: /beta/ });
+    expect(within(beta).getByText("2")).toBeInTheDocument();
+    expect(screen.queryByText("alpha")).toBeNull();
+  });
 });

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -251,7 +251,7 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
           : "border-border bg-bg-inset text-fg-muted hover:bg-bg-elevated"
       }`}
     >
-      <span className="flex shrink-0 flex-col items-center justify-center gap-1">
+      <span className="flex shrink-0 flex-col items-center justify-start gap-1">
         <Icon size={14} className="text-fg-subtle" />
         <span className="text-[10px] font-medium leading-none text-fg-subtle">{index}</span>
       </span>

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -214,7 +214,7 @@ function SessionRow({
   );
 }
 
-function TabCard({ tab }: { tab: Tab }) {
+function TabCard({ tab, index }: { tab: Tab; index: number }) {
   const activeId = useTabsStore((s) => s.activeId);
   const setActive = useTabsStore((s) => s.setActive);
   const statuses = useSessionStatusStore((s) => s.statuses);
@@ -245,13 +245,16 @@ function TabCard({ tab }: { tab: Tab }) {
     <button
       type="button"
       onClick={() => setActive(tab.id)}
-      className={`flex w-full items-start gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors ${
+      className={`flex w-full items-stretch gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors ${
         active
           ? "border-accent bg-accent/10 text-fg"
           : "border-border bg-bg-inset text-fg-muted hover:bg-bg-elevated"
       }`}
     >
-      <Icon size={14} className="mt-0.5 shrink-0 text-fg-subtle" />
+      <span className="flex shrink-0 flex-col items-center justify-between py-0.5">
+        <Icon size={14} className="text-fg-subtle" />
+        <span className="text-[10px] font-medium leading-none text-fg-subtle">{index}</span>
+      </span>
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-1.5">
           <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">{title}</span>
@@ -293,9 +296,10 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
   const [collapsed, setCollapsed] = useState(false);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
-  const tabs = useTabsStore((s) => s.tabs)
-    .filter((t) => t.spaceId === id)
-    .filter((t) => filter === "all" || tabSessionStatus(t, statuses) === filter);
+  const allTabs = useTabsStore((s) => s.tabs).filter((t) => t.spaceId === id);
+  // Number cards by their position in the full space list (not the filtered one)
+  // so the badge keeps matching ⌘1-9, which also indexes the unfiltered tabs.
+  const tabs = allTabs.filter((t) => filter === "all" || tabSessionStatus(t, statuses) === filter);
 
   // Under an active filter a group with no matching cards adds only noise.
   if (filter !== "all" && tabs.length === 0) {
@@ -374,14 +378,13 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
               onClick={() => {
                 setActiveSpace(id);
                 openLauncherTab();
+                // Expand the group so the freshly added card is visible.
+                setCollapsed(false);
               }}
               className="shrink-0 rounded p-0.5 text-fg-subtle transition-colors hover:text-fg"
             >
               <Plus size={12} />
             </button>
-            <span className="shrink-0 rounded-full bg-border px-1.5 py-0.5 text-[11px] leading-none text-fg-subtle">
-              {tabs.length}
-            </span>
           </div>
         )}
       </div>
@@ -389,7 +392,7 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
       {!collapsed && (
         <div className="space-y-1.5 pl-2">
           {tabs.map((tab) => (
-            <TabCard key={tab.id} tab={tab} />
+            <TabCard key={tab.id} tab={tab} index={allTabs.indexOf(tab) + 1} />
           ))}
         </div>
       )}

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -289,6 +289,7 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
   const setActiveSpace = useTabsStore((s) => s.setActiveSpace);
   const renameSpace = useTabsStore((s) => s.renameSpace);
   const deleteSpace = useTabsStore((s) => s.deleteSpace);
+  const openLauncherTab = useTabsStore((s) => s.openLauncherTab);
   const [collapsed, setCollapsed] = useState(false);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
@@ -344,7 +345,7 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
         )}
 
         {!editing && (
-          <>
+          <div className="flex shrink-0 items-center gap-0.5">
             <button
               type="button"
               aria-label={t("workspace.renameSpace")}
@@ -353,7 +354,7 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
                 setDraft(name);
                 setEditing(true);
               }}
-              className="shrink-0 rounded p-0.5 text-fg-subtle opacity-0 transition-opacity hover:text-fg group-hover:opacity-100"
+              className="shrink-0 rounded p-0.5 text-fg-subtle transition-colors hover:text-fg"
             >
               <Pencil size={12} />
             </button>
@@ -362,14 +363,26 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
               aria-label={t("workspace.deleteSpace")}
               title={t("workspace.deleteSpace")}
               onClick={() => deleteSpace(id)}
-              className="shrink-0 rounded p-0.5 text-fg-subtle opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
+              className="shrink-0 rounded p-0.5 text-fg-subtle transition-colors hover:text-danger"
             >
               <Trash2 size={12} />
+            </button>
+            <button
+              type="button"
+              aria-label={t("workspace.addTab")}
+              title={t("workspace.addTab")}
+              onClick={() => {
+                setActiveSpace(id);
+                openLauncherTab();
+              }}
+              className="shrink-0 rounded p-0.5 text-fg-subtle transition-colors hover:text-fg"
+            >
+              <Plus size={12} />
             </button>
             <span className="shrink-0 rounded-full bg-border px-1.5 py-0.5 text-[11px] leading-none text-fg-subtle">
               {tabs.length}
             </span>
-          </>
+          </div>
         )}
       </div>
 

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -251,7 +251,7 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
           : "border-border bg-bg-inset text-fg-muted hover:bg-bg-elevated"
       }`}
     >
-      <span className="flex shrink-0 flex-col items-center justify-between py-0.5">
+      <span className="flex shrink-0 flex-col items-center justify-center gap-1">
         <Icon size={14} className="text-fg-subtle" />
         <span className="text-[10px] font-medium leading-none text-fg-subtle">{index}</span>
       </span>


### PR DESCRIPTION
## Summary

A set of sidebar / tab UX tweaks:

- **Tab bar**: the new-tab **+** moved from the far right of the header into the tab strip, right after the last tab, so it follows the latest tab instead of sitting at the far edge where it was easy to miss.
- **Workspace sidebar**: each space group gets its own **+** that opens a new tab in that space (and expands the group if it was collapsed). The rename/delete actions are now always visible, and the action-row gap is tightened.
- **Sidebar nav bar**: the current/hover panel is marked with a bottom underline instead of a filled background, with a tighter gap.
- **Tab cards**: each card shows a 1-based index (matching ⌘1-9) on its left for quick switching, numbered by the *unfiltered* space order so it stays correct under a status filter. The per-space tab-count badge is removed.

## Test plan

- [x] Behavior tests: per-space add button opens a launcher tab in the clicked group's space; card index stays tied to the space order under a status filter
- [x] `WorkspacePanel` + `TabBar` + `Sidebar` suites — 27 passed
- [x] `tsc --noEmit` typecheck passes

## Review

- Addressed the gemini medium suggestion: expand a collapsed group when its add-tab button is used so the new card is visible.