### PR TITLE
feat(editor): reload open files when they change on disk

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -1,11 +1,13 @@
 ## 正體中文
 
 ### feat
+- 編輯器檔案重新整理：開啟的檔案被外部或 AI 改動後不用關掉重開，工具列多了一個重新整理鈕可隨時載入最新內容，若有未存修改會先確認；編輯器也會自動偵測磁碟變更，沒有未存修改時自動重載，有的話跳出提示讓你選要用磁碟版本還是保留自己的
 
 ### fix
 
 ## English
 
 ### feat
+- Editor file reload: when an open file changes on disk (e.g. an AI agent edits it), pick up the new content without closing and reopening the tab. A toolbar refresh button reloads on demand (confirming first if you have unsaved edits), and the editor also watches the file: a clean buffer reloads automatically, while unsaved edits raise a banner to choose between the disk version and your own
 
 ### fix

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,7 @@ use modules::terminal_history::{
     terminal_history_prune, terminal_history_save,
 };
 use modules::sysmon::{system_stats, SysinfoState};
+use modules::editor_watch::{editor_watch_set, EditorWatchState};
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -90,6 +91,7 @@ pub fn run() {
         .manage(CodexProgressState::new())
         .manage(NotesWatchState::new())
         .manage(SysinfoState::new())
+        .manage(EditorWatchState::new())
         .setup(|app| {
             // window-state restores the last size/position, but it can persist a
             // corrupt tiny / off-screen value (observed 360x240 at a negative
@@ -219,7 +221,8 @@ pub fn run() {
             sftp_close,
             ssh_secret_set,
             ssh_secret_delete,
-            system_stats
+            system_stats,
+            editor_watch_set
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/editor_watch/mod.rs
+++ b/src-tauri/src/modules/editor_watch/mod.rs
@@ -116,9 +116,9 @@ pub fn editor_watch_set(
         }
     }
     for dir in dirs {
-        watcher
-            .watch(&dir, RecursiveMode::NonRecursive)
-            .map_err(|e| e.to_string())?;
+        // Ignore individual watch errors (permission denied, deleted directory,
+        // disconnected drive) so the remaining open files are still watched.
+        let _ = watcher.watch(&dir, RecursiveMode::NonRecursive);
     }
     *state.watcher.lock().unwrap() = Some(watcher);
     Ok(())

--- a/src-tauri/src/modules/editor_watch/mod.rs
+++ b/src-tauri/src/modules/editor_watch/mod.rs
@@ -1,0 +1,150 @@
+//! Watches the files open in editor tabs and tells the frontend when one
+//! changes on disk (e.g. an AI agent edits it), so the editor can reload without
+//! the user closing and reopening the tab.
+//!
+//! Unlike the notes watcher (a single recursive folder), this tracks an
+//! arbitrary set of open files. It subscribes to each file's parent directory
+//! (non-recursive) — atomic saves (write temp + rename) surface as directory
+//! events a per-file watch would miss — then filters events down to exactly the
+//! tracked paths before notifying the frontend.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use notify::event::{EventKind, ModifyKind};
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+
+const EDITOR_FILE_CHANGED_EVENT: &str = "editor-file-changed";
+
+/// Payload emitted to the frontend: the absolute path that changed.
+#[derive(Clone, Serialize)]
+struct EditorFileChanged {
+    path: String,
+}
+
+/// Whether a filesystem event should trigger a reload. We react to
+/// content/structure changes but skip access and metadata-only events: reading a
+/// file to reload it emits an access event, which would otherwise loop, and
+/// mtime/atime touches are not real content changes.
+fn is_interesting_change(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(_) | EventKind::Remove(_) | EventKind::Modify(_)
+    ) && !matches!(kind, EventKind::Modify(ModifyKind::Metadata(_)))
+}
+
+/// Holds the active watcher and the set of files it should report. Dropping the
+/// watcher stops the OS-level subscription.
+pub struct EditorWatchState {
+    watcher: Mutex<Option<RecommendedWatcher>>,
+    watched: Arc<Mutex<HashSet<PathBuf>>>,
+}
+
+impl EditorWatchState {
+    pub fn new() -> Self {
+        Self {
+            watcher: Mutex::new(None),
+            watched: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+impl Default for EditorWatchState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn build_watcher(
+    app: &AppHandle,
+    watched: Arc<Mutex<HashSet<PathBuf>>>,
+) -> Result<RecommendedWatcher, String> {
+    let app_cb = app.clone();
+    notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        let event = match res {
+            Ok(event) => event,
+            Err(_) => return,
+        };
+        if !is_interesting_change(&event.kind) {
+            return;
+        }
+        let set = watched.lock().unwrap();
+        for path in &event.paths {
+            if set.contains(path) {
+                if let Some(s) = path.to_str() {
+                    let _ = app_cb.emit(
+                        EDITOR_FILE_CHANGED_EVENT,
+                        EditorFileChanged {
+                            path: s.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+    })
+    .map_err(|e| e.to_string())
+}
+
+/// Replace the set of watched editor files. Subscribes to each file's parent
+/// directory (non-recursive) and filters events down to these paths. An empty
+/// list drops the watcher entirely.
+#[tauri::command]
+pub fn editor_watch_set(
+    app: AppHandle,
+    state: State<EditorWatchState>,
+    paths: Vec<String>,
+) -> Result<(), String> {
+    let path_bufs: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
+    {
+        let mut set = state.watched.lock().unwrap();
+        set.clear();
+        set.extend(path_bufs.iter().cloned());
+    }
+    if path_bufs.is_empty() {
+        *state.watcher.lock().unwrap() = None;
+        return Ok(());
+    }
+    let mut watcher = build_watcher(&app, state.watched.clone())?;
+    // Distinct parent dirs, so two files in the same folder share one watch.
+    let mut dirs: HashSet<PathBuf> = HashSet::new();
+    for path in &path_bufs {
+        if let Some(dir) = path.parent() {
+            dirs.insert(dir.to_path_buf());
+        }
+    }
+    for dir in dirs {
+        watcher
+            .watch(&dir, RecursiveMode::NonRecursive)
+            .map_err(|e| e.to_string())?;
+    }
+    *state.watcher.lock().unwrap() = Some(watcher);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::event::{AccessKind, CreateKind, DataChange, MetadataKind, RemoveKind};
+
+    #[test]
+    fn reacts_to_content_and_structure_changes() {
+        assert!(is_interesting_change(&EventKind::Create(CreateKind::Any)));
+        assert!(is_interesting_change(&EventKind::Remove(RemoveKind::Any)));
+        assert!(is_interesting_change(&EventKind::Modify(ModifyKind::Data(
+            DataChange::Any
+        ))));
+    }
+
+    #[test]
+    fn ignores_access_and_metadata_events() {
+        // Access events fire when we read the file to reload it; reacting loops.
+        assert!(!is_interesting_change(&EventKind::Access(AccessKind::Any)));
+        // Metadata-only touches (mtime/atime) are not real content changes.
+        assert!(!is_interesting_change(&EventKind::Modify(
+            ModifyKind::Metadata(MetadataKind::Any)
+        )));
+    }
+}

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -6,6 +6,7 @@ pub mod claude_status_hook;
 pub mod codex_progress;
 pub mod codex_status_hook;
 pub mod clipboard;
+pub mod editor_watch;
 pub mod fonts;
 pub mod fs;
 pub mod git;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { useSettingsStore } from "@/stores/settingsStore";
 import { useTabsStore, tabHasDirtyEditor } from "@/stores/tabsStore";
 import { useEditorStore } from "@/modules/editor/store/editorStore";
 import { installEditorBufferSync } from "@/modules/editor/lib/syncBuffers";
+import { installEditorWatchSync } from "@/modules/editor/lib/editorWatch";
 import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { pruneTerminalHistory } from "@/modules/terminal/lib/terminalHistory";
@@ -113,6 +114,10 @@ function App() {
   // Forget an editor buffer once its file leaves every tab/pane, so closing a
   // file without saving discards the edit instead of resurrecting it on reopen.
   useEffect(() => installEditorBufferSync(), []);
+
+  // Watch the files open in editor tabs so external edits (e.g. an AI agent
+  // editing a file) can reload it without closing and reopening the tab.
+  useEffect(() => installEditorWatchSync(), []);
 
   // In a secondary window, close this window's PTY sessions before it is
   // destroyed so no background shells leak. No-op in the main window.

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -11,6 +11,9 @@
   "reloadUnsavedTitle": "Unsaved changes",
   "reloadUnsavedMessage": "This file has unsaved changes. Reload from disk and discard them?",
   "discardReload": "Reload and discard",
+  "externalChanged": "This file changed on disk while you were editing.",
+  "useDiskVersion": "Use disk version",
+  "keepMine": "Keep mine",
   "wrap": "Word wrap",
   "mode": {
     "edit": "Edit",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -7,6 +7,10 @@
   "closeUnsavedTitle": "Unsaved changes",
   "closeUnsavedMessage": "This tab has unsaved changes. Close without saving?",
   "discardClose": "Close without saving",
+  "refresh": "Reload from disk",
+  "reloadUnsavedTitle": "Unsaved changes",
+  "reloadUnsavedMessage": "This file has unsaved changes. Reload from disk and discard them?",
+  "discardReload": "Reload and discard",
   "wrap": "Word wrap",
   "mode": {
     "edit": "Edit",

--- a/src/i18n/locales/zh-Hant/editor.json
+++ b/src/i18n/locales/zh-Hant/editor.json
@@ -7,6 +7,10 @@
   "closeUnsavedTitle": "尚未儲存的變更",
   "closeUnsavedMessage": "這個分頁有未儲存的變更，確定要關閉嗎？",
   "discardClose": "不儲存直接關閉",
+  "refresh": "從磁碟重新整理",
+  "reloadUnsavedTitle": "尚未儲存的變更",
+  "reloadUnsavedMessage": "這個檔案有未儲存的變更，要從磁碟重新載入並捨棄它們嗎？",
+  "discardReload": "重新載入並捨棄",
   "wrap": "自動換行",
   "mode": {
     "edit": "編輯",

--- a/src/i18n/locales/zh-Hant/editor.json
+++ b/src/i18n/locales/zh-Hant/editor.json
@@ -11,6 +11,9 @@
   "reloadUnsavedTitle": "尚未儲存的變更",
   "reloadUnsavedMessage": "這個檔案有未儲存的變更，要從磁碟重新載入並捨棄它們嗎？",
   "discardReload": "重新載入並捨棄",
+  "externalChanged": "編輯期間，這個檔案在磁碟上被改動了",
+  "useDiskVersion": "使用磁碟版本",
+  "keepMine": "保留我的",
   "wrap": "自動換行",
   "mode": {
     "edit": "編輯",

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -139,12 +139,15 @@ export function EditorTabContent({ path }: { path: string }) {
 
   async function save() {
     const current = useEditorStore.getState().contentOf(path);
+    // Mark our own write BEFORE the async write: the OS watcher event can arrive
+    // before fsWriteFile resolves, so setting the marker afterwards would race and
+    // let our own save be mistaken for an external change.
+    selfWrite.current = { path, at: Date.now() };
     try {
       await fsWriteFile(path, current);
       markSaved(path);
-      // Mark our own write so the watcher echo for it is ignored.
-      selfWrite.current = { path, at: Date.now() };
     } catch {
+      selfWrite.current = null;
       // a toast surface comes later
     }
   }

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Columns2, Eye, SquarePen, WrapText, type LucideIcon } from "lucide-react";
+import { Columns2, Eye, RefreshCw, SquarePen, WrapText, type LucideIcon } from "lucide-react";
 import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { EditorView as CMView } from "@codemirror/view";
 import { Compartment } from "@codemirror/state";
@@ -12,11 +12,12 @@ import { aiChat } from "@/modules/ai/lib/aiBridge";
 import { providerById } from "@/modules/ai/lib/providers";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 import { buildCompletionMessages, cleanCompletion } from "@/modules/ai/lib/completion";
-import { shouldReloadFromDisk } from "./lib/reload";
+import { manualReloadAction, shouldReloadFromDisk } from "./lib/reload";
 import { fsReadFile, fsWriteFile } from "@/modules/explorer/lib/fsBridge";
 import { basename } from "@/modules/explorer/lib/paths";
 import { MarkdownView } from "@/components/MarkdownView";
 import { Tooltip } from "@/components/Tooltip";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { selectTerminalFontFamily, useFontStore } from "@/stores/fontStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 
@@ -67,6 +68,7 @@ export function EditorTabContent({ path }: { path: string }) {
 
   const isMarkdown = isMarkdownPath(path);
   const [mode, setMode] = useState<EditorMode>("edit");
+  const [confirmReload, setConfirmReload] = useState(false);
   const effectiveMode: EditorMode = isMarkdown ? mode : "edit";
 
   const cmRef = useRef<ReactCodeMirrorRef>(null);
@@ -138,6 +140,25 @@ export function EditorTabContent({ path }: { path: string }) {
     }
   }
 
+  // Re-read the file from disk into the buffer (content + baseline → clean), so
+  // external edits (e.g. an AI agent editing the file) show up without closing
+  // and reopening the tab.
+  function reloadFromDisk() {
+    fsReadFile(path)
+      .then((text) => setBaseline(path, text))
+      .catch(() => {});
+  }
+
+  // The refresh button: reload immediately when there is nothing to lose, but
+  // confirm first when the buffer has unsaved edits.
+  function handleRefresh() {
+    if (manualReloadAction(useEditorStore.getState().buffers[path]) === "confirm") {
+      setConfirmReload(true);
+    } else {
+      reloadFromDisk();
+    }
+  }
+
   const editorPane = (
     <CodeMirror
       ref={cmRef}
@@ -170,6 +191,16 @@ export function EditorTabContent({ path }: { path: string }) {
           {basename(path)}
         </span>
         <div className="flex shrink-0 items-center gap-0.5">
+        <Tooltip label={t("refresh")}>
+          <button
+            type="button"
+            aria-label={t("refresh")}
+            onClick={handleRefresh}
+            className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+          >
+            <RefreshCw size={14} />
+          </button>
+        </Tooltip>
         <Tooltip label={t("wrap")}>
           <button
             type="button"
@@ -220,6 +251,20 @@ export function EditorTabContent({ path }: { path: string }) {
           editorPane
         )}
       </div>
+
+      {confirmReload && (
+        <ConfirmDialog
+          title={t("reloadUnsavedTitle")}
+          message={t("reloadUnsavedMessage")}
+          confirmLabel={t("discardReload")}
+          cancelLabel={t("common:actions.cancel")}
+          onConfirm={() => {
+            setConfirmReload(false);
+            reloadFromDisk();
+          }}
+          onCancel={() => setConfirmReload(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -12,7 +12,8 @@ import { aiChat } from "@/modules/ai/lib/aiBridge";
 import { providerById } from "@/modules/ai/lib/providers";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 import { buildCompletionMessages, cleanCompletion } from "@/modules/ai/lib/completion";
-import { manualReloadAction, shouldReloadFromDisk } from "./lib/reload";
+import { externalChangeAction, manualReloadAction, shouldReloadFromDisk } from "./lib/reload";
+import { onEditorFileChanged } from "./lib/editorWatch";
 import { fsReadFile, fsWriteFile } from "@/modules/explorer/lib/fsBridge";
 import { basename } from "@/modules/explorer/lib/paths";
 import { MarkdownView } from "@/components/MarkdownView";
@@ -32,6 +33,10 @@ const MODES: { key: EditorMode; icon: LucideIcon }[] = [
 function isMarkdownPath(path: string): boolean {
   return /\.(md|markdown|mdx)$/i.test(path);
 }
+
+// After we save, the watcher reports our own write back as a change. Ignore
+// those echoes for a short window so a save never bounces back as a reload.
+const SELF_WRITE_WINDOW_MS = 2000;
 
 /** Ask the active chat provider to complete the code around the cursor. */
 async function requestCompletion(
@@ -69,6 +74,8 @@ export function EditorTabContent({ path }: { path: string }) {
   const isMarkdown = isMarkdownPath(path);
   const [mode, setMode] = useState<EditorMode>("edit");
   const [confirmReload, setConfirmReload] = useState(false);
+  const [externalChanged, setExternalChanged] = useState(false);
+  const selfWrite = useRef<{ path: string; at: number } | null>(null);
   const effectiveMode: EditorMode = isMarkdown ? mode : "edit";
 
   const cmRef = useRef<ReactCodeMirrorRef>(null);
@@ -135,6 +142,8 @@ export function EditorTabContent({ path }: { path: string }) {
     try {
       await fsWriteFile(path, current);
       markSaved(path);
+      // Mark our own write so the watcher echo for it is ignored.
+      selfWrite.current = { path, at: Date.now() };
     } catch {
       // a toast surface comes later
     }
@@ -145,7 +154,10 @@ export function EditorTabContent({ path }: { path: string }) {
   // and reopening the tab.
   function reloadFromDisk() {
     fsReadFile(path)
-      .then((text) => setBaseline(path, text))
+      .then((text) => {
+        setBaseline(path, text);
+        setExternalChanged(false);
+      })
       .catch(() => {});
   }
 
@@ -158,6 +170,48 @@ export function EditorTabContent({ path }: { path: string }) {
       reloadFromDisk();
     }
   }
+
+  const keepMine = () => setExternalChanged(false);
+
+  // A path switch on the same component instance starts fresh: drop any pending
+  // conflict flag and the stale self-write marker.
+  useEffect(() => {
+    setExternalChanged(false);
+    selfWrite.current = null;
+  }, [path]);
+
+  // React to the watcher reporting this file changed on disk (e.g. an AI agent
+  // edited it). Ignore the echo of our own save; reload a clean buffer silently;
+  // raise the conflict banner when there are unsaved edits so they are kept.
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+    void onEditorFileChanged((changedPath) => {
+      if (changedPath !== path) {
+        return;
+      }
+      const sw = selfWrite.current;
+      const isSelfSave = sw?.path === path && Date.now() - sw.at < SELF_WRITE_WINDOW_MS;
+      const action = externalChangeAction(useEditorStore.getState().buffers[path], isSelfSave);
+      if (action === "reload") {
+        reloadFromDisk();
+      } else if (action === "flag") {
+        setExternalChanged(true);
+      }
+    }).then((fn) => {
+      if (disposed) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+    // reloadFromDisk closes over `path` and stable setters; re-subscribe on path.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [path]);
 
   const editorPane = (
     <CodeMirror
@@ -236,6 +290,28 @@ export function EditorTabContent({ path }: { path: string }) {
           })}
         </div>
       </div>
+
+      {externalChanged && (
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-warning/10 px-3 py-1.5 text-xs text-fg">
+          <span>{t("externalChanged")}</span>
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              type="button"
+              onClick={reloadFromDisk}
+              className="rounded border border-border-strong px-2 py-0.5 hover:bg-border-strong"
+            >
+              {t("useDiskVersion")}
+            </button>
+            <button
+              type="button"
+              onClick={keepMine}
+              className="rounded border border-border-strong px-2 py-0.5 hover:bg-border-strong"
+            >
+              {t("keepMine")}
+            </button>
+          </div>
+        </div>
+      )}
 
       <div className="min-h-0 flex-1 overflow-hidden">
         {effectiveMode === "split" ? (

--- a/src/modules/editor/lib/editorWatch.ts
+++ b/src/modules/editor/lib/editorWatch.ts
@@ -23,8 +23,19 @@ export function onEditorFileChanged(handler: (path: string) => void): Promise<Un
  * Returns the unsubscribe handle.
  */
 export function installEditorWatchSync(): () => void {
+  // The tabs store fires on every change (active tab, pane resize, cwd polls),
+  // but the watcher only needs rebuilding when the SET of open files changes.
+  // Skip the backend call when the path set is unchanged so dragging a pane
+  // resizer doesn't tear down and rebuild the OS watcher dozens of times a second.
+  let lastPathsKey = "";
   const sync = () => {
-    void setWatchedEditorFiles(openEditorPaths(useTabsStore.getState().tabs)).catch(() => {});
+    const paths = openEditorPaths(useTabsStore.getState().tabs).sort();
+    const pathsKey = paths.join("\n");
+    if (pathsKey === lastPathsKey) {
+      return;
+    }
+    lastPathsKey = pathsKey;
+    void setWatchedEditorFiles(paths).catch(() => {});
   };
   sync();
   return useTabsStore.subscribe(sync);

--- a/src/modules/editor/lib/editorWatch.ts
+++ b/src/modules/editor/lib/editorWatch.ts
@@ -1,0 +1,31 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { openEditorPaths, useTabsStore } from "@/stores/tabsStore";
+
+/**
+ * Frontend wrappers around the Rust editor file watcher. The backend watches the
+ * given files (by their parent directories) and emits `editor-file-changed` with
+ * the affected path whenever one changes on disk, so an open editor tab can
+ * reload without the user closing and reopening it.
+ */
+
+export function setWatchedEditorFiles(paths: string[]): Promise<void> {
+  return invoke("editor_watch_set", { paths });
+}
+
+export function onEditorFileChanged(handler: (path: string) => void): Promise<UnlistenFn> {
+  return listen<{ path: string }>("editor-file-changed", (event) => handler(event.payload.path));
+}
+
+/**
+ * Keep the backend watcher's file set in step with the editor tabs that are
+ * open: push the current set once, then again whenever tabs/panes change.
+ * Returns the unsubscribe handle.
+ */
+export function installEditorWatchSync(): () => void {
+  const sync = () => {
+    void setWatchedEditorFiles(openEditorPaths(useTabsStore.getState().tabs)).catch(() => {});
+  };
+  sync();
+  return useTabsStore.subscribe(sync);
+}

--- a/src/modules/editor/lib/reload.test.ts
+++ b/src/modules/editor/lib/reload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldReloadFromDisk } from "./reload";
+import { manualReloadAction, shouldReloadFromDisk } from "./reload";
 
 describe("shouldReloadFromDisk", () => {
   it("reloads when no buffer is open yet", () => {
@@ -12,5 +12,19 @@ describe("shouldReloadFromDisk", () => {
 
   it("keeps a dirty buffer so unsaved edits are not clobbered", () => {
     expect(shouldReloadFromDisk({ content: "edited", baseline: "v1" })).toBe(false);
+  });
+});
+
+describe("manualReloadAction", () => {
+  it("reloads straight away when no buffer is open", () => {
+    expect(manualReloadAction(undefined)).toBe("reload");
+  });
+
+  it("reloads a clean buffer without prompting", () => {
+    expect(manualReloadAction({ content: "v1", baseline: "v1" })).toBe("reload");
+  });
+
+  it("confirms first when the buffer has unsaved edits, so they are not silently discarded", () => {
+    expect(manualReloadAction({ content: "edited", baseline: "v1" })).toBe("confirm");
   });
 });

--- a/src/modules/editor/lib/reload.test.ts
+++ b/src/modules/editor/lib/reload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { manualReloadAction, shouldReloadFromDisk } from "./reload";
+import { externalChangeAction, manualReloadAction, shouldReloadFromDisk } from "./reload";
 
 describe("shouldReloadFromDisk", () => {
   it("reloads when no buffer is open yet", () => {
@@ -26,5 +26,21 @@ describe("manualReloadAction", () => {
 
   it("confirms first when the buffer has unsaved edits, so they are not silently discarded", () => {
     expect(manualReloadAction({ content: "edited", baseline: "v1" })).toBe("confirm");
+  });
+});
+
+describe("externalChangeAction", () => {
+  it("ignores a change caused by our own save, even on a clean or dirty buffer", () => {
+    expect(externalChangeAction({ content: "v1", baseline: "v1" }, true)).toBe("ignore");
+    expect(externalChangeAction({ content: "edited", baseline: "v1" }, true)).toBe("ignore");
+  });
+
+  it("auto-reloads a clean (or not-yet-open) buffer changed by something else", () => {
+    expect(externalChangeAction({ content: "v1", baseline: "v1" }, false)).toBe("reload");
+    expect(externalChangeAction(undefined, false)).toBe("reload");
+  });
+
+  it("flags a conflict when a dirty buffer changes on disk, so unsaved edits are kept", () => {
+    expect(externalChangeAction({ content: "edited", baseline: "v1" }, false)).toBe("flag");
   });
 });

--- a/src/modules/editor/lib/reload.ts
+++ b/src/modules/editor/lib/reload.ts
@@ -16,3 +16,16 @@ export function shouldReloadFromDisk(buffer: BufferSnapshot | undefined): boolea
   }
   return buffer.content === buffer.baseline;
 }
+
+export type ManualReloadAction = "reload" | "confirm";
+
+/**
+ * What a user-initiated refresh should do. A clean (or not-yet-open) buffer
+ * reloads straight from disk; a buffer with unsaved edits must confirm first so
+ * the user's work is never silently discarded. This differs from the on-open
+ * path (`shouldReloadFromDisk`), where a dirty buffer is silently kept rather
+ * than prompting — a manual refresh is an explicit user action, so it asks.
+ */
+export function manualReloadAction(buffer: BufferSnapshot | undefined): ManualReloadAction {
+  return shouldReloadFromDisk(buffer) ? "reload" : "confirm";
+}

--- a/src/modules/editor/lib/reload.ts
+++ b/src/modules/editor/lib/reload.ts
@@ -29,3 +29,22 @@ export type ManualReloadAction = "reload" | "confirm";
 export function manualReloadAction(buffer: BufferSnapshot | undefined): ManualReloadAction {
   return shouldReloadFromDisk(buffer) ? "reload" : "confirm";
 }
+
+export type ExternalChangeAction = "ignore" | "reload" | "flag";
+
+/**
+ * How to react when the watcher reports the open file changed on disk. A change
+ * we caused ourselves (a save just happened) is ignored, so writing the file
+ * doesn't bounce back as a reload. Otherwise a clean buffer reloads silently; a
+ * dirty buffer flags a conflict so the user's unsaved edits are kept and they
+ * can reload when ready.
+ */
+export function externalChangeAction(
+  buffer: BufferSnapshot | undefined,
+  isSelfSave: boolean,
+): ExternalChangeAction {
+  if (isSelfSave) {
+    return "ignore";
+  }
+  return shouldReloadFromDisk(buffer) ? "reload" : "flag";
+}


### PR DESCRIPTION
Closes #70. Pick up on-disk changes to an open file without closing/reopening the tab — both manually and automatically.

## What's in it

- **Manual refresh button** (toolbar): reloads the file from disk. A clean buffer reloads immediately; unsaved edits confirm first (`manualReloadAction`).
- **File watcher** (backend, `notify`): `editor_watch_set(paths)` subscribes to each open file's parent directory (non-recursive, so atomic temp+rename saves are seen) and emits `editor-file-changed`. Reuses the notes watcher's event filter (skip access / metadata to avoid reload loops).
- **Auto-reload + conflict banner** (frontend): a clean buffer reloads silently; unsaved edits raise a non-destructive banner to pick the disk version or keep yours (`externalChangeAction`). The echo of our own save is ignored via a 2s self-write window. `installEditorWatchSync` keeps the watched set in step with the open editor tabs.

Layered exactly as discussed on the issue: watcher detects → clean auto-reloads → dirty is never clobbered.

## Test plan

- [x] New pure-logic tests: `manualReloadAction`, `externalChangeAction` (reload.test.ts), `is_interesting_change` (Rust)
- [x] Full frontend suite — 791 passed
- [x] Full Rust lib tests — 174 passed
- [x] `tsc --noEmit` typecheck passes

## Notes

- The CodeMirror component itself isn't unit-tested (project convention is to test the lib logic); the decision functions are fully covered.
- Cursor/scroll preservation on auto-reload is best-effort for now and can be refined if needed.