### PR TITLE
fix(terminal): open file paths hard-wrapped across two lines

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -4,6 +4,7 @@
 - 編輯器檔案重新整理：開啟的檔案被外部或 AI 改動後不用關掉重開，工具列多了一個重新整理鈕可隨時載入最新內容，若有未存修改會先確認；編輯器也會自動偵測磁碟變更，沒有未存修改時自動重載，有的話跳出提示讓你選要用磁碟版本還是保留自己的
 
 ### fix
+- 終端機裡被程式（例如 AI agent）折成兩行的長檔案路徑，現在點上下任一段都打得開，會自動把被斷開的路徑接回來再開
 
 ## English
 
@@ -11,3 +12,4 @@
 - Editor file reload: when an open file changes on disk (e.g. an AI agent edits it), pick up the new content without closing and reopening the tab. A toolbar refresh button reloads on demand (confirming first if you have unsaved edits), and the editor also watches the file: a clean buffer reloads automatically, while unsaved edits raise a banner to choose between the disk version and your own
 
 ### fix
+- File paths that a program (e.g. an AI agent) hard-wraps across two lines in the terminal are now clickable: clicking either half opens the rejoined path

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -66,7 +66,7 @@ import {
   shouldAttachImage,
   shellQuotePath,
 } from "./lib/terminalClipboard";
-import { buildFileLink, findFilePaths, resolveFilePath } from "./lib/fileLinks";
+import { buildFileLink, findFilePaths, resolveFilePath, wrappedPathCandidates } from "./lib/fileLinks";
 import { actionsFor, findActionLinks, type TerminalAction } from "./lib/actionLinks";
 import { ActionCard } from "./ActionCard";
 import { buildCellPositions, gatherLogicalLine } from "./lib/cellPositions";
@@ -519,8 +519,9 @@ export function TerminalView({
 
     term.registerLinkProvider({
       provideLinks(lineNumber, callback) {
+        const buffer = term.buffer.active;
         // Resolve the logical line (handles wrapped paths) and read its cells.
-        const rows = gatherLogicalLine(term.buffer.active, lineNumber);
+        const rows = gatherLogicalLine(buffer, lineNumber);
         if (!rows) {
           callback(undefined);
           return;
@@ -534,10 +535,6 @@ export function TerminalView({
         const matches = findFilePaths(text).filter(
           (f) => !actionMatches.some((a) => f.start < a.end && f.end > a.start),
         );
-        if (matches.length === 0 && actionMatches.length === 0) {
-          callback(undefined);
-          return;
-        }
         const lastSpan = spans[spans.length - 1];
         // Map a string index back to a buffer cell (1-based x/y). start uses the
         // glyph's first column; end uses its last, so wide glyphs are covered.
@@ -558,6 +555,56 @@ export function TerminalView({
             onOpen: (raw) => void openFromTerminal(raw),
           }),
         );
+
+        // A program (e.g. an AI coding agent) can hard-wrap a long absolute path
+        // across logical lines: the first ends mid-path, the next continues it
+        // after indentation. Offer a link on each half that opens the rejoined
+        // path. We avoid a cross-line range (an xterm minefield) by giving each
+        // half its own single-line link pointing at the same rejoined path;
+        // openFromTerminal validates existence on click, so a wrong join (this
+        // joins broadly) simply won't open.
+        const logicalText = (start: number): string | null => {
+          const r = gatherLogicalLine(buffer, start);
+          return r ? buildCellPositions(r).text : null;
+        };
+        const wrappedLinks: ReturnType<typeof buildFileLink>[] = [];
+        const nextText = logicalText(rows[rows.length - 1].y + 1);
+        if (nextText !== null) {
+          for (const cand of wrappedPathCandidates(text, nextText)) {
+            const tailIdx = text.search(/\/\S*$/);
+            if (tailIdx >= 0) {
+              wrappedLinks.push(
+                buildFileLink({
+                  text: cand,
+                  range: { start: startCell(tailIdx), end: endCell(text.length - 1) },
+                  hint: linkHintRef.current,
+                  isMac: IS_MAC,
+                  onOpen: (raw) => void openFromTerminal(raw),
+                }),
+              );
+            }
+          }
+        }
+        const prevText = logicalText(rows[0].y - 1);
+        if (prevText !== null) {
+          for (const cand of wrappedPathCandidates(prevText, text)) {
+            const lead = text.match(/^(\s*)([\p{L}\p{N}_.\-/]+)/u);
+            if (lead) {
+              const leadStart = lead[1].length;
+              const leadEnd = leadStart + lead[2].length;
+              wrappedLinks.push(
+                buildFileLink({
+                  text: cand,
+                  range: { start: startCell(leadStart), end: endCell(leadEnd - 1) },
+                  hint: linkHintRef.current,
+                  isMac: IS_MAC,
+                  onOpen: (raw) => void openFromTerminal(raw),
+                }),
+              );
+            }
+          }
+        }
+
         const actionLinks = actionMatches.map((m) => ({
           text: m.text,
           range: { start: startCell(m.start), end: endCell(m.end - 1) },
@@ -571,7 +618,11 @@ export function TerminalView({
             scheduleActionCardHide();
           },
         }));
-        callback([...fileLinks, ...actionLinks]);
+        if (fileLinks.length === 0 && wrappedLinks.length === 0 && actionLinks.length === 0) {
+          callback(undefined);
+          return;
+        }
+        callback([...fileLinks, ...wrappedLinks, ...actionLinks]);
       },
     });
 

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -66,7 +66,13 @@ import {
   shouldAttachImage,
   shellQuotePath,
 } from "./lib/terminalClipboard";
-import { buildFileLink, findFilePaths, resolveFilePath, wrappedPathCandidates } from "./lib/fileLinks";
+import {
+  buildFileLink,
+  findFilePaths,
+  resolveFilePath,
+  wrappedPathCandidates,
+  TRAILING_PATH_RE,
+} from "./lib/fileLinks";
 import { actionsFor, findActionLinks, type TerminalAction } from "./lib/actionLinks";
 import { ActionCard } from "./ActionCard";
 import { buildCellPositions, gatherLogicalLine } from "./lib/cellPositions";
@@ -571,12 +577,12 @@ export function TerminalView({
         const nextText = logicalText(rows[rows.length - 1].y + 1);
         if (nextText !== null) {
           for (const cand of wrappedPathCandidates(text, nextText)) {
-            const tailIdx = text.search(/\/\S*$/);
-            if (tailIdx >= 0) {
+            const tailMatch = text.match(TRAILING_PATH_RE);
+            if (tailMatch && tailMatch.index !== undefined) {
               wrappedLinks.push(
                 buildFileLink({
                   text: cand,
-                  range: { start: startCell(tailIdx), end: endCell(text.length - 1) },
+                  range: { start: startCell(tailMatch.index), end: endCell(text.length - 1) },
                   hint: linkHintRef.current,
                   isMac: IS_MAC,
                   onOpen: (raw) => void openFromTerminal(raw),

--- a/src/modules/terminal/lib/fileLinks.test.ts
+++ b/src/modules/terminal/lib/fileLinks.test.ts
@@ -95,6 +95,14 @@ describe("wrappedPathCandidates", () => {
     ).toContain("/private/tmp/proj/scratchpad/history.html");
   });
 
+  it("rejoins a relative path too, keeping the leading directory segments", () => {
+    // The whole path-like suffix must be kept, not just the last "/seg", so a
+    // relative path stays relative instead of collapsing to "/inalView.tsx".
+    expect(
+      wrappedPathCandidates("● Write(src/modules/terminal/Term", "      inalView.tsx)"),
+    ).toContain("src/modules/terminal/TerminalView.tsx");
+  });
+
   it("returns nothing when the first line does not end mid-path", () => {
     expect(wrappedPathCandidates("just some prose ending in a word", "  more prose")).toEqual([]);
   });

--- a/src/modules/terminal/lib/fileLinks.test.ts
+++ b/src/modules/terminal/lib/fileLinks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { findFilePaths, resolveFilePath, buildFileLink } from "./fileLinks";
+import { findFilePaths, resolveFilePath, wrappedPathCandidates, buildFileLink } from "./fileLinks";
 import { showLinkTooltip, hideLinkTooltip } from "./linkTooltip";
 
 vi.mock("./linkTooltip", () => ({
@@ -82,6 +82,25 @@ describe("resolveFilePath", () => {
 
   it("expands a leading ~ when home is known", () => {
     expect(resolveFilePath("~/notes/a.md", null, "/Users/me")).toBe("/Users/me/notes/a.md");
+  });
+});
+
+describe("wrappedPathCandidates", () => {
+  it("rejoins an absolute path a program hard-wrapped across two lines", () => {
+    // The first line ends mid-path with no trailing space; the next continues it
+    // after indentation. "scr" + "atchpad" rejoins to "scratchpad". The caller
+    // still validates the result exists, since this can also join unrelated lines.
+    expect(
+      wrappedPathCandidates("● Write(/private/tmp/proj/scr", "      atchpad/history.html)"),
+    ).toContain("/private/tmp/proj/scratchpad/history.html");
+  });
+
+  it("returns nothing when the first line does not end mid-path", () => {
+    expect(wrappedPathCandidates("just some prose ending in a word", "  more prose")).toEqual([]);
+  });
+
+  it("returns nothing when the next line is not a path continuation", () => {
+    expect(wrappedPathCandidates("/abs/path/scr", ")not a path")).toEqual([]);
   });
 });
 

--- a/src/modules/terminal/lib/fileLinks.ts
+++ b/src/modules/terminal/lib/fileLinks.ts
@@ -78,17 +78,26 @@ export function resolveFilePath(
 }
 
 /**
- * Candidate absolute paths formed when a program hard-wraps a long path across
- * two lines: the first line ends mid-path (an absolute fragment running to the
+ * The trailing path-like fragment of a line: a run of path characters that
+ * contains at least one slash and reaches the end of the line. Matching the
+ * whole suffix (not just the last slash) keeps a relative path like
+ * `src/modules/x` intact instead of collapsing it to `/x`. Shared so the link
+ * range and the rejoin agree on where the fragment starts.
+ */
+export const TRAILING_PATH_RE = /[\p{L}\p{N}_.\-/~]*\/[\p{L}\p{N}_.\-/~]*$/u;
+
+/**
+ * Candidate paths (absolute or relative) formed when a program hard-wraps a long
+ * path across two lines: the first line ends mid-path (a fragment reaching the
  * line end with no trailing space) and the next line continues it after
  * indentation. The caller MUST validate each candidate against the filesystem,
  * since this also joins unrelated lines — that validation is what keeps the
  * broad join safe (a wrong join simply won't exist, so it never becomes a link).
  */
 export function wrappedPathCandidates(firstLine: string, nextLine: string): string[] {
-  // First line must end with an absolute path fragment: a "/" run reaching the
-  // end of the line with no trailing whitespace.
-  const tail = firstLine.match(/\/\S*$/);
+  // First line must end with a path fragment that contains at least one slash,
+  // reaching the end of the line with no trailing whitespace.
+  const tail = firstLine.match(TRAILING_PATH_RE);
   if (!tail) {
     return [];
   }

--- a/src/modules/terminal/lib/fileLinks.ts
+++ b/src/modules/terminal/lib/fileLinks.ts
@@ -77,6 +77,30 @@ export function resolveFilePath(
   return base ? `${base}/${rel}` : rel;
 }
 
+/**
+ * Candidate absolute paths formed when a program hard-wraps a long path across
+ * two lines: the first line ends mid-path (an absolute fragment running to the
+ * line end with no trailing space) and the next line continues it after
+ * indentation. The caller MUST validate each candidate against the filesystem,
+ * since this also joins unrelated lines — that validation is what keeps the
+ * broad join safe (a wrong join simply won't exist, so it never becomes a link).
+ */
+export function wrappedPathCandidates(firstLine: string, nextLine: string): string[] {
+  // First line must end with an absolute path fragment: a "/" run reaching the
+  // end of the line with no trailing whitespace.
+  const tail = firstLine.match(/\/\S*$/);
+  if (!tail) {
+    return [];
+  }
+  // The continuation is the next line's leading path-like run, after dropping
+  // its indentation; it stops at the first non-path char (e.g. a closing paren).
+  const cont = nextLine.replace(/^\s+/, "").match(/^[\p{L}\p{N}_.\-/]+/u);
+  if (!cont) {
+    return [];
+  }
+  return [tail[0] + cont[0]];
+}
+
 interface BuildFileLinkParams {
   text: string;
   range: IBufferRange;


### PR DESCRIPTION
Closes #73.

## Problem

When a program (e.g. an AI coding agent) hard-wraps a long absolute path across two lines — the first ends mid-path, the next continues it after indentation — the path was not clickable. It's a hard wrap (`\n` + indent), so the two halves are separate logical lines and `gatherLogicalLine` (soft-wrap only) can't rejoin them; `findFilePaths` saw half a path per line.

## Approach

Checked against Warp (via DeepWiki): it detects paths by regex + filesystem validation as the gatekeeper. Applied here:

- `wrappedPathCandidates(firstLine, nextLine)` (pure, tested) rejoins the two halves of a hard-wrapped absolute path.
- The link provider feeds the previous/next logical line into it and, for each half, adds a **single-line** link pointing at the rejoined path.
- **No cross-line range** (an xterm minefield): each half is its own link. `openFromTerminal` validates the rejoined path exists on click, so a broad/wrong join simply won't open.

## Scope

In: the hard-wrapped absolute path case (image 1). Out: bare filenames in prose with no path and living outside the cwd (image 2) — no info to resolve.

## Test plan

- [x] `wrappedPathCandidates` unit tests (rejoin, reject non-path lines)
- [x] fileLinks suite + full frontend suite — 794 passed
- [x] `tsc --noEmit` passes
- [ ] Manual: the xterm cross-line wiring (clicking either half) needs an in-app click test — flagging for review since unit tests can't cover the link provider's xterm integration.