### PR TITLE
feat(logs): per-session terminal logging with a Logs panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,10 @@ use modules::terminal_history::{
     terminal_history_clear, terminal_history_delete, terminal_history_load,
     terminal_history_prune, terminal_history_save,
 };
+use modules::session_log::{
+    session_log_read, session_logs_dir_path, session_logs_enforce_retention, session_logs_list,
+    session_logs_open_dir,
+};
 use modules::sysmon::{system_stats, SysinfoState};
 use modules::editor_watch::{editor_watch_set, EditorWatchState};
 
@@ -196,6 +200,11 @@ pub fn run() {
             terminal_history_delete,
             terminal_history_clear,
             terminal_history_prune,
+            session_logs_list,
+            session_log_read,
+            session_logs_dir_path,
+            session_logs_open_dir,
+            session_logs_enforce_retention,
             claude_progress_watch,
             claude_progress_unwatch,
             claude_session_title,

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -15,6 +15,6 @@ pub mod notes;
 pub mod pr;
 pub mod pty;
 pub mod secrets;
-pub mod sysmon;
 pub mod session_log;
+pub mod sysmon;
 pub mod terminal_history;

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -16,4 +16,5 @@ pub mod pr;
 pub mod pty;
 pub mod secrets;
 pub mod sysmon;
+pub mod session_log;
 pub mod terminal_history;

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -11,12 +11,14 @@ use tauri::State;
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub fn pty_open(
+    app: tauri::AppHandle,
     state: State<'_, PtyState>,
     cols: u16,
     rows: u16,
     cwd: Option<String>,
     suggestions: bool,
     shell_override: Option<String>,
+    log_enabled: bool,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
@@ -27,6 +29,8 @@ pub fn pty_open(
         cwd,
         suggestions,
         shell_override,
+        &app,
+        log_enabled,
         on_data,
         on_exit,
     )

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -156,7 +156,8 @@ pub fn spawn_with_sinks(
 }
 
 /// Spawn the user's shell and bridge its IO to the frontend over Tauri
-/// channels.
+/// channels. When `log_enabled`, every output chunk is also tee'd into a
+/// per-session `.log` file via the session_log writer.
 pub fn spawn(
     state: &PtyState,
     cols: u16,
@@ -164,17 +165,36 @@ pub fn spawn(
     cwd: Option<String>,
     suggestions: bool,
     shell_override: Option<String>,
+    app: &tauri::AppHandle,
+    log_enabled: bool,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
     let (cmd, shell_name) = build_shell_command(cwd, suggestions, shell_override);
+
+    // Best-effort per-session logger; failure to start logging must not block
+    // opening the terminal, so we discard the error and just don't log.
+    let log_tx = if log_enabled {
+        crate::modules::session_log::start_logger(app, &shell_name)
+            .ok()
+            .map(|h| h.tx)
+    } else {
+        None
+    };
+
     spawn_with_sinks(
         state,
         cols,
         rows,
         cmd,
         shell_name,
-        move |bytes| on_data.send(Response::new(bytes)).is_ok(),
+        move |bytes| {
+            if let Some(tx) = &log_tx {
+                // Drop on a full channel rather than stall the reader thread.
+                let _ = tx.try_send(bytes.clone());
+            }
+            on_data.send(Response::new(bytes)).is_ok()
+        },
         move |code| {
             let _ = on_exit.send(code);
         },

--- a/src-tauri/src/modules/session_log/mod.rs
+++ b/src-tauri/src/modules/session_log/mod.rs
@@ -16,18 +16,17 @@ use tauri::{AppHandle, Manager};
 const DIR_NAME: &str = "session-logs";
 /// Bounded so a stuck writer can't grow memory without limit. On overflow the
 /// tee drops the chunk (best-effort logging), never blocking the terminal.
-#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 const CHANNEL_CAPACITY: usize = 256;
 
-#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 pub struct LoggerHandle {
     pub tx: SyncSender<Vec<u8>>,
+    // Exposed for callers that need the log file path (e.g. Task 5 Logs panel).
+    #[allow(dead_code)]
     pub path: PathBuf,
 }
 
 /// Map a session label (shell name or user@host) to a filename-safe form: keep
 /// alphanumerics and `-_.`; everything else becomes `_`.
-#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 fn sanitize(label: &str) -> String {
     label
         .chars()
@@ -39,7 +38,6 @@ fn sanitize(label: &str) -> String {
 }
 
 /// `<YYYYMMDD_HHMMSS>_<label>.log`
-#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 fn log_filename(stamp: &str, label: &str) -> String {
     format!("{}_{}.log", stamp, sanitize(label))
 }
@@ -72,7 +70,6 @@ pub fn logs_dir(app: &AppHandle) -> Result<PathBuf, String> {
 /// Start a per-session logger writing into `dir`. Feed each raw output chunk to
 /// the returned `tx`; dropping every sender closes the file (writes the footer).
 /// Split from `start_logger` so it is testable against a temp dir.
-#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 fn start_logger_in(dir: PathBuf, label: &str) -> Result<LoggerHandle, String> {
     fs::create_dir_all(&dir).map_err(|e| format!("create log dir: {e}"))?;
     let stamp = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
@@ -108,7 +105,6 @@ fn start_logger_in(dir: PathBuf, label: &str) -> Result<LoggerHandle, String> {
 
 /// Start a logger under the app's `session-logs` dir, labelled by shell name or
 /// `user@host`.
-#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 pub fn start_logger(app: &AppHandle, label: &str) -> Result<LoggerHandle, String> {
     start_logger_in(logs_dir(app)?, label)
 }

--- a/src-tauri/src/modules/session_log/mod.rs
+++ b/src-tauri/src/modules/session_log/mod.rs
@@ -66,6 +66,22 @@ fn select_expired(entries: &[(String, i64)], now_ms: i64, retention_days: i64) -
         .collect()
 }
 
+/// Create the logs directory with owner-only permissions (0o700) on Unix.
+/// Falls back to plain `create_dir_all` on other platforms.
+#[cfg(unix)]
+fn ensure_logs_dir(dir: &std::path::Path) -> Result<(), String> {
+    use std::os::unix::fs::DirBuilderExt;
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(dir)
+        .map_err(|e| format!("create log dir: {e}"))
+}
+#[cfg(not(unix))]
+fn ensure_logs_dir(dir: &std::path::Path) -> Result<(), String> {
+    std::fs::create_dir_all(dir).map_err(|e| format!("create log dir: {e}"))
+}
+
 pub fn logs_dir(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(app.path().app_data_dir().map_err(|e| e.to_string())?.join(DIR_NAME))
 }
@@ -74,7 +90,7 @@ pub fn logs_dir(app: &AppHandle) -> Result<PathBuf, String> {
 /// the returned `tx`; dropping every sender closes the file (writes the footer).
 /// Split from `start_logger` so it is testable against a temp dir.
 fn start_logger_in(dir: PathBuf, label: &str) -> Result<LoggerHandle, String> {
-    fs::create_dir_all(&dir).map_err(|e| format!("create log dir: {e}"))?;
+    ensure_logs_dir(&dir)?;
     // Append a process-global sequence number so same-second sessions (e.g. two
     // `zsh` tabs restoring at once) produce distinct filenames and never collide.
     let seq = LOG_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -84,7 +100,14 @@ fn start_logger_in(dir: PathBuf, label: &str) -> Result<LoggerHandle, String> {
     let path_clone = path.clone();
 
     std::thread::spawn(move || {
-        let mut file = match OpenOptions::new().create(true).append(true).open(&path_clone) {
+        let mut opts = OpenOptions::new();
+        opts.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut file = match opts.open(&path_clone) {
             Ok(f) => f,
             Err(_) => return,
         };
@@ -180,7 +203,7 @@ pub fn session_logs_dir_path(app: AppHandle) -> Result<String, String> {
 #[tauri::command]
 pub fn session_logs_open_dir(app: AppHandle) -> Result<(), String> {
     let dir = logs_dir(&app)?;
-    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    ensure_logs_dir(&dir)?;
     let status = if cfg!(target_os = "macos") {
         std::process::Command::new("open").arg(&dir).status()
     } else if cfg!(target_os = "windows") {
@@ -269,6 +292,40 @@ mod tests {
         ];
         let expired = select_expired(&entries, now, 30);
         assert_eq!(expired, vec!["old.log".to_string()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn log_file_and_dir_are_owner_only_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir()
+            .join(format!("ttlog-perms-{}-{:?}", std::process::id(), std::thread::current().id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let handle = start_logger_in(dir.clone(), "zsh").unwrap();
+        handle.tx.send(b"secret token\n".to_vec()).unwrap();
+        drop(handle);
+
+        // Poll for the log file to appear and the writer to finish.
+        let mut log_path = None;
+        for _ in 0..50 {
+            if let Some(entry) = std::fs::read_dir(&dir).ok().and_then(|mut r| r.next()).and_then(|e| e.ok()) {
+                let content = std::fs::read_to_string(entry.path()).unwrap_or_default();
+                if content.contains("Session ended at") {
+                    log_path = Some(entry.path());
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+
+        let log_path = log_path.expect("log file not found");
+        let file_mode = std::fs::metadata(&log_path).unwrap().permissions().mode() & 0o777;
+        let dir_mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(file_mode, 0o600, "log file should be owner-only (0o600), got {file_mode:#o}");
+        assert_eq!(dir_mode, 0o700, "logs dir should be owner-only (0o700), got {dir_mode:#o}");
     }
 
     #[test]

--- a/src-tauri/src/modules/session_log/mod.rs
+++ b/src-tauri/src/modules/session_log/mod.rs
@@ -1,0 +1,290 @@
+//! Per-session terminal logging. Every local PTY and SSH session can tee its
+//! raw output (ANSI included) into its own timestamped `.log` file under the
+//! app data dir, browsable later in the Logs panel. Writing runs on a dedicated
+//! std thread fed by a bounded channel; the tee uses `try_send` so a slow disk
+//! can never stall or break the terminal — a full channel just drops the chunk.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::mpsc::{sync_channel, SyncSender};
+use std::time::UNIX_EPOCH;
+
+use serde::Serialize;
+use tauri::{AppHandle, Manager};
+
+const DIR_NAME: &str = "session-logs";
+/// Bounded so a stuck writer can't grow memory without limit. On overflow the
+/// tee drops the chunk (best-effort logging), never blocking the terminal.
+const CHANNEL_CAPACITY: usize = 256;
+
+pub struct LoggerHandle {
+    pub tx: SyncSender<Vec<u8>>,
+    pub path: PathBuf,
+}
+
+/// Map a session label (shell name or user@host) to a filename-safe form: keep
+/// alphanumerics and `-_.`; everything else becomes `_`.
+fn sanitize(label: &str) -> String {
+    label
+        .chars()
+        .map(|c| match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => c,
+            _ => '_',
+        })
+        .collect()
+}
+
+/// `<YYYYMMDD_HHMMSS>_<label>.log`
+fn log_filename(stamp: &str, label: &str) -> String {
+    format!("{}_{}.log", stamp, sanitize(label))
+}
+
+/// A bare `.log` filename (no separators, no `..`) — the only thing
+/// `session_log_read` accepts, so a crafted name can't escape the logs dir.
+fn is_safe_log_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.contains('/')
+        && !name.contains('\\')
+        && !name.contains("..")
+        && name.ends_with(".log")
+}
+
+/// Names whose mtime is strictly older than `now_ms - retention_days`.
+/// Pure so it can be unit-tested without touching the filesystem.
+fn select_expired(entries: &[(String, i64)], now_ms: i64, retention_days: i64) -> Vec<String> {
+    let cutoff = now_ms - retention_days * 86_400_000;
+    entries
+        .iter()
+        .filter(|(_, mtime)| *mtime < cutoff)
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
+pub fn logs_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(app.path().app_data_dir().map_err(|e| e.to_string())?.join(DIR_NAME))
+}
+
+/// Start a per-session logger writing into `dir`. Feed each raw output chunk to
+/// the returned `tx`; dropping every sender closes the file (writes the footer).
+/// Split from `start_logger` so it is testable against a temp dir.
+fn start_logger_in(dir: PathBuf, label: &str) -> Result<LoggerHandle, String> {
+    fs::create_dir_all(&dir).map_err(|e| format!("create log dir: {e}"))?;
+    let stamp = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
+    let path = dir.join(log_filename(&stamp, label));
+    let (tx, rx) = sync_channel::<Vec<u8>>(CHANNEL_CAPACITY);
+    let path_for_task = path.clone();
+
+    std::thread::spawn(move || {
+        let mut file = match OpenOptions::new().create(true).append(true).open(&path_for_task) {
+            Ok(f) => f,
+            Err(_) => return,
+        };
+        let header = format!(
+            "\n===== Session started at {} =====\n",
+            chrono::Local::now().format("%Y-%m-%d %H:%M:%S")
+        );
+        let _ = file.write_all(header.as_bytes());
+        while let Ok(bytes) = rx.recv() {
+            if file.write_all(&bytes).is_err() {
+                break;
+            }
+        }
+        let footer = format!(
+            "\n===== Session ended at {} =====\n",
+            chrono::Local::now().format("%Y-%m-%d %H:%M:%S")
+        );
+        let _ = file.write_all(footer.as_bytes());
+        let _ = file.flush();
+    });
+
+    Ok(LoggerHandle { tx, path })
+}
+
+/// Start a logger under the app's `session-logs` dir, labelled by shell name or
+/// `user@host`.
+pub fn start_logger(app: &AppHandle, label: &str) -> Result<LoggerHandle, String> {
+    start_logger_in(logs_dir(app)?, label)
+}
+
+#[derive(Debug, Serialize)]
+pub struct LogEntry {
+    pub name: String,
+    pub size: u64,
+    pub modified_unix_ms: i64,
+}
+
+/// List every `.log` in the logs dir, newest first.
+#[tauri::command]
+pub fn session_logs_list(app: AppHandle) -> Result<Vec<LogEntry>, String> {
+    let dir = logs_dir(&app)?;
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(&dir).map_err(|e| e.to_string())?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("log") {
+            continue;
+        }
+        let meta = match entry.metadata() {
+            Ok(m) if m.is_file() => m,
+            _ => continue,
+        };
+        let name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let modified_unix_ms = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        entries.push(LogEntry { name, size: meta.len(), modified_unix_ms });
+    }
+    entries.sort_by(|a, b| b.modified_unix_ms.cmp(&a.modified_unix_ms));
+    Ok(entries)
+}
+
+/// Read one log by bare filename, guarded against path traversal.
+#[tauri::command]
+pub fn session_log_read(app: AppHandle, name: String) -> Result<Vec<u8>, String> {
+    if !is_safe_log_name(&name) {
+        return Err("invalid log name".into());
+    }
+    let dir = logs_dir(&app)?;
+    let path = dir.join(&name);
+    let canon_dir = fs::canonicalize(&dir).map_err(|e| e.to_string())?;
+    let canon_path = fs::canonicalize(&path).map_err(|e| e.to_string())?;
+    if !canon_path.starts_with(&canon_dir) {
+        return Err("path escapes logs directory".into());
+    }
+    fs::read(&canon_path).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn session_logs_dir_path(app: AppHandle) -> Result<String, String> {
+    Ok(logs_dir(&app)?.to_string_lossy().into_owned())
+}
+
+/// Open the logs dir in the OS file manager.
+#[tauri::command]
+pub fn session_logs_open_dir(app: AppHandle) -> Result<(), String> {
+    let dir = logs_dir(&app)?;
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let status = if cfg!(target_os = "macos") {
+        std::process::Command::new("open").arg(&dir).status()
+    } else if cfg!(target_os = "windows") {
+        std::process::Command::new("explorer").arg(&dir).status()
+    } else {
+        std::process::Command::new("xdg-open").arg(&dir).status()
+    };
+    status.map(|_| ()).map_err(|e| e.to_string())
+}
+
+/// Delete logs older than `retention_days`. `None` means keep forever (no-op).
+#[tauri::command]
+pub fn session_logs_enforce_retention(app: AppHandle, retention_days: Option<i64>) -> Result<(), String> {
+    let Some(days) = retention_days else { return Ok(()) };
+    let dir = logs_dir(&app)?;
+    if !dir.exists() {
+        return Ok(());
+    }
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let entries: Vec<(String, i64)> = fs::read_dir(&dir)
+        .map_err(|e| e.to_string())?
+        .flatten()
+        .filter_map(|e| {
+            let path = e.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("log") {
+                return None;
+            }
+            let name = path.file_name()?.to_str()?.to_string();
+            let mtime = e
+                .metadata()
+                .ok()?
+                .modified()
+                .ok()?
+                .duration_since(UNIX_EPOCH)
+                .ok()?
+                .as_millis() as i64;
+            Some((name, mtime))
+        })
+        .collect();
+    for name in select_expired(&entries, now_ms, days) {
+        let _ = fs::remove_file(dir.join(name));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_keeps_safe_chars_and_replaces_others() {
+        assert_eq!(sanitize("zsh"), "zsh");
+        assert_eq!(sanitize("powershell.exe"), "powershell.exe");
+        assert_eq!(sanitize("rd2@10.0.217.54"), "rd2_10.0.217.54");
+        assert_eq!(sanitize("a b/c\\d"), "a_b_c_d");
+    }
+
+    #[test]
+    fn log_filename_is_stamp_underscore_label_dot_log() {
+        assert_eq!(log_filename("20260507_143343", "rd2@10.0.217.54"), "20260507_143343_rd2_10.0.217.54.log");
+    }
+
+    #[test]
+    fn is_safe_log_name_rejects_traversal_and_non_log() {
+        assert!(is_safe_log_name("20260507_143343_zsh.log"));
+        assert!(!is_safe_log_name("../secret.log"));
+        assert!(!is_safe_log_name("a/b.log"));
+        assert!(!is_safe_log_name("a\\b.log"));
+        assert!(!is_safe_log_name("notes.txt"));
+        assert!(!is_safe_log_name(""));
+    }
+
+    #[test]
+    fn select_expired_returns_names_older_than_cutoff() {
+        // now = 100 days in ms; retention 30 days. Anything with mtime older
+        // than now - 30d is expired.
+        let day = 86_400_000_i64;
+        let now = 100 * day;
+        let entries = vec![
+            ("old.log".to_string(), now - 40 * day),
+            ("fresh.log".to_string(), now - 10 * day),
+            ("edge.log".to_string(), now - 30 * day), // exactly at cutoff: keep
+        ];
+        let expired = select_expired(&entries, now, 30);
+        assert_eq!(expired, vec!["old.log".to_string()]);
+    }
+
+    #[test]
+    fn logger_writes_header_payload_and_footer() {
+        let dir = std::env::temp_dir().join(format!("ttlog-{}-{:?}", std::process::id(), std::thread::current().id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let handle = start_logger_in(dir.clone(), "zsh").unwrap();
+        handle.tx.send(b"hello world\n".to_vec()).unwrap();
+        drop(handle); // closes the channel -> writer flushes footer and exits
+
+        // Poll briefly for the writer thread to finish (it has no JoinHandle).
+        let mut content = String::new();
+        for _ in 0..50 {
+            if let Some(entry) = std::fs::read_dir(&dir).ok().and_then(|mut r| r.next()).and_then(|e| e.ok()) {
+                content = std::fs::read_to_string(entry.path()).unwrap_or_default();
+                if content.contains("Session ended at") {
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert!(content.contains("Session started at"), "header missing: {content:?}");
+        assert!(content.contains("hello world"), "payload missing: {content:?}");
+        assert!(content.contains("Session ended at"), "footer missing: {content:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/modules/session_log/mod.rs
+++ b/src-tauri/src/modules/session_log/mod.rs
@@ -7,6 +7,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{sync_channel, SyncSender};
 use std::time::UNIX_EPOCH;
 
@@ -18,11 +19,13 @@ const DIR_NAME: &str = "session-logs";
 /// tee drops the chunk (best-effort logging), never blocking the terminal.
 const CHANNEL_CAPACITY: usize = 256;
 
+/// Monotonically increasing counter appended to each log filename so that two
+/// sessions starting within the same wall-clock second (e.g. several `zsh`
+/// tabs restoring simultaneously) get distinct paths and never collide.
+static LOG_SEQ: AtomicU64 = AtomicU64::new(0);
+
 pub struct LoggerHandle {
     pub tx: SyncSender<Vec<u8>>,
-    // Exposed for callers that need the log file path (e.g. Task 5 Logs panel).
-    #[allow(dead_code)]
-    pub path: PathBuf,
 }
 
 /// Map a session label (shell name or user@host) to a filename-safe form: keep
@@ -72,13 +75,16 @@ pub fn logs_dir(app: &AppHandle) -> Result<PathBuf, String> {
 /// Split from `start_logger` so it is testable against a temp dir.
 fn start_logger_in(dir: PathBuf, label: &str) -> Result<LoggerHandle, String> {
     fs::create_dir_all(&dir).map_err(|e| format!("create log dir: {e}"))?;
-    let stamp = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
+    // Append a process-global sequence number so same-second sessions (e.g. two
+    // `zsh` tabs restoring at once) produce distinct filenames and never collide.
+    let seq = LOG_SEQ.fetch_add(1, Ordering::Relaxed);
+    let stamp = format!("{}_{}", chrono::Local::now().format("%Y%m%d_%H%M%S"), seq);
     let path = dir.join(log_filename(&stamp, label));
     let (tx, rx) = sync_channel::<Vec<u8>>(CHANNEL_CAPACITY);
-    let path_for_task = path.clone();
+    let path_clone = path.clone();
 
     std::thread::spawn(move || {
-        let mut file = match OpenOptions::new().create(true).append(true).open(&path_for_task) {
+        let mut file = match OpenOptions::new().create(true).append(true).open(&path_clone) {
             Ok(f) => f,
             Err(_) => return,
         };
@@ -100,7 +106,7 @@ fn start_logger_in(dir: PathBuf, label: &str) -> Result<LoggerHandle, String> {
         let _ = file.flush();
     });
 
-    Ok(LoggerHandle { tx, path })
+    Ok(LoggerHandle { tx })
 }
 
 /// Start a logger under the app's `session-logs` dir, labelled by shell name or

--- a/src-tauri/src/modules/session_log/mod.rs
+++ b/src-tauri/src/modules/session_log/mod.rs
@@ -179,8 +179,10 @@ pub fn session_logs_list(app: AppHandle) -> Result<Vec<LogEntry>, String> {
 }
 
 /// Read one log by bare filename, guarded against path traversal.
+/// Returns raw binary via `tauri::ipc::Response` to avoid JSON serialization
+/// overhead (a JSON array of numbers is ~3× larger and much slower than raw bytes).
 #[tauri::command]
-pub fn session_log_read(app: AppHandle, name: String) -> Result<Vec<u8>, String> {
+pub fn session_log_read(app: AppHandle, name: String) -> Result<tauri::ipc::Response, String> {
     if !is_safe_log_name(&name) {
         return Err("invalid log name".into());
     }
@@ -191,7 +193,8 @@ pub fn session_log_read(app: AppHandle, name: String) -> Result<Vec<u8>, String>
     if !canon_path.starts_with(&canon_dir) {
         return Err("path escapes logs directory".into());
     }
-    fs::read(&canon_path).map_err(|e| e.to_string())
+    let bytes = fs::read(&canon_path).map_err(|e| e.to_string())?;
+    Ok(tauri::ipc::Response::new(bytes))
 }
 
 #[tauri::command]
@@ -218,6 +221,12 @@ pub fn session_logs_open_dir(app: AppHandle) -> Result<(), String> {
 #[tauri::command]
 pub fn session_logs_enforce_retention(app: AppHandle, retention_days: Option<i64>) -> Result<(), String> {
     let Some(days) = retention_days else { return Ok(()) };
+    // A zero or negative value would make the cutoff >= now and delete ALL logs.
+    // Guard here at the command boundary; `select_expired` itself is pure and
+    // assumes a valid positive day count.
+    if days <= 0 {
+        return Err("retention days must be greater than zero".into());
+    }
     let dir = logs_dir(&app)?;
     if !dir.exists() {
         return Ok(());
@@ -293,6 +302,26 @@ mod tests {
         let expired = select_expired(&entries, now, 30);
         assert_eq!(expired, vec!["old.log".to_string()]);
     }
+
+    #[test]
+    fn select_expired_with_valid_positive_days_uses_correct_cutoff_math() {
+        // Verify cutoff = now_ms - days * 86_400_000.
+        // With retention_days=7, anything strictly older than 7 days ago is expired.
+        let day = 86_400_000_i64;
+        let now = 1_000 * day;
+        let entries = vec![
+            ("week_old.log".to_string(), now - 7 * day),     // exactly at cutoff: keep
+            ("eight_days.log".to_string(), now - 8 * day),   // 1 ms past cutoff: expire
+            ("six_days.log".to_string(), now - 6 * day),     // fresh: keep
+        ];
+        let expired = select_expired(&entries, now, 7);
+        assert_eq!(expired, vec!["eight_days.log".to_string()]);
+    }
+
+    // Note: the `days <= 0` guard lives at the `session_logs_enforce_retention` command
+    // boundary (needs an AppHandle, so not unit-testable here). `select_expired` itself
+    // is a pure function that assumes a positive day count; the guard above prevents it
+    // from ever being called with non-positive values from the public command surface.
 
     #[cfg(unix)]
     #[test]

--- a/src-tauri/src/modules/session_log/mod.rs
+++ b/src-tauri/src/modules/session_log/mod.rs
@@ -16,8 +16,10 @@ use tauri::{AppHandle, Manager};
 const DIR_NAME: &str = "session-logs";
 /// Bounded so a stuck writer can't grow memory without limit. On overflow the
 /// tee drops the chunk (best-effort logging), never blocking the terminal.
+#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 const CHANNEL_CAPACITY: usize = 256;
 
+#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 pub struct LoggerHandle {
     pub tx: SyncSender<Vec<u8>>,
     pub path: PathBuf,
@@ -25,6 +27,7 @@ pub struct LoggerHandle {
 
 /// Map a session label (shell name or user@host) to a filename-safe form: keep
 /// alphanumerics and `-_.`; everything else becomes `_`.
+#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 fn sanitize(label: &str) -> String {
     label
         .chars()
@@ -36,6 +39,7 @@ fn sanitize(label: &str) -> String {
 }
 
 /// `<YYYYMMDD_HHMMSS>_<label>.log`
+#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 fn log_filename(stamp: &str, label: &str) -> String {
     format!("{}_{}.log", stamp, sanitize(label))
 }
@@ -68,6 +72,7 @@ pub fn logs_dir(app: &AppHandle) -> Result<PathBuf, String> {
 /// Start a per-session logger writing into `dir`. Feed each raw output chunk to
 /// the returned `tx`; dropping every sender closes the file (writes the footer).
 /// Split from `start_logger` so it is testable against a temp dir.
+#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 fn start_logger_in(dir: PathBuf, label: &str) -> Result<LoggerHandle, String> {
     fs::create_dir_all(&dir).map_err(|e| format!("create log dir: {e}"))?;
     let stamp = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
@@ -103,6 +108,7 @@ fn start_logger_in(dir: PathBuf, label: &str) -> Result<LoggerHandle, String> {
 
 /// Start a logger under the app's `session-logs` dir, labelled by shell name or
 /// `user@host`.
+#[allow(dead_code)] // wired up by the PTY/SSH logging tee in Task 3/4
 pub fn start_logger(app: &AppHandle, label: &str) -> Result<LoggerHandle, String> {
     start_logger_in(logs_dir(app)?, label)
 }

--- a/src-tauri/src/modules/ssh/mod.rs
+++ b/src-tauri/src/modules/ssh/mod.rs
@@ -51,6 +51,10 @@ pub struct SshOpenRequest {
     /// Defaults to an empty list when the field is absent.
     #[serde(default)]
     pub forwards: Vec<ForwardSpecInput>,
+    /// Tee this session's output to a per-session log file. Defaults to false
+    /// when the frontend omits it.
+    #[serde(default)]
+    pub log_enabled: bool,
 }
 
 #[tauri::command]

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -293,6 +293,17 @@ async fn run_session(
         forwards.insert(fid, tx);
     }
 
+    // Best-effort per-session logger; never let logging failures affect the
+    // session. Dropping `log_tx` at the end of run_session writes the footer.
+    let log_tx = if req.log_enabled {
+        let label = format!("{}@{}", req.user, req.host);
+        crate::modules::session_log::start_logger(&app, &label)
+            .ok()
+            .map(|h| h.tx)
+    } else {
+        None
+    };
+
     loop {
         tokio::select! {
             // Remote → frontend. `wait` polls russh's event loop, which is what
@@ -300,13 +311,23 @@ async fn run_session(
             msg = read_half.wait() => {
                 match msg {
                     Some(russh::ChannelMsg::Data { data }) => {
-                        if on_data.send(Response::new(data.to_vec())).is_err() {
+                        let bytes = data.to_vec();
+                        if let Some(tx) = &log_tx {
+                            // Best-effort: drop chunk if channel is full or writer has exited.
+                            let _ = tx.try_send(bytes.clone());
+                        }
+                        if on_data.send(Response::new(bytes)).is_err() {
                             // Frontend channel gone (pane closed) — stop.
                             break;
                         }
                     }
                     Some(russh::ChannelMsg::ExtendedData { data, .. }) => {
-                        if on_data.send(Response::new(data.to_vec())).is_err() {
+                        let bytes = data.to_vec();
+                        if let Some(tx) = &log_tx {
+                            // Best-effort: drop chunk if channel is full or writer has exited.
+                            let _ = tx.try_send(bytes.clone());
+                        }
+                        if on_data.send(Response::new(bytes)).is_err() {
                             break;
                         }
                     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -208,7 +208,7 @@ function App() {
       // field (the terminal is excluded — see isEditableTarget).
       const editable = isEditableTarget(e.target);
 
-      // ⌥1…⌥6 jump straight to a sidebar panel by its position in the icon bar.
+      // ⌥1…⌥7 jump straight to a sidebar panel by its position in the icon bar.
       if (digit !== null && e.altKey && !e.metaKey && !e.ctrlKey && !editable) {
         const view = SIDEBAR_VIEW_ORDER[digit - 1];
         if (view) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,7 +123,8 @@ function App() {
   // Prune session logs older than the configured retention window once on
   // startup so disk usage stays bounded without waiting for the panel to open.
   useEffect(() => {
-    void enforceLogRetention(useSettingsStore.getState().logRetentionDays);
+    // Best-effort cleanup; a failure here must never surface as an unhandled rejection.
+    void enforceLogRetention(useSettingsStore.getState().logRetentionDays).catch(() => {});
   }, []);
 
   // In a secondary window, close this window's PTY sessions before it is

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { registerSecondaryWindowCleanup } from "@/lib/windowLifecycle";
 import { SshPromptDialog } from "@/modules/ssh/SshPromptDialog";
 import { useForwardStatusListener } from "@/modules/ssh/lib/useForwardStatus";
 import { sftpSessionStore } from "@/modules/ssh/lib/sftpSessionStore";
+import { enforceLogRetention } from "@/modules/logs/lib/sessionLog";
 
 const MIN_SIDEBAR = 180;
 const MAX_SIDEBAR = 640;
@@ -118,6 +119,12 @@ function App() {
   // Watch the files open in editor tabs so external edits (e.g. an AI agent
   // editing a file) can reload it without closing and reopening the tab.
   useEffect(() => installEditorWatchSync(), []);
+
+  // Prune session logs older than the configured retention window once on
+  // startup so disk usage stays bounded without waiting for the panel to open.
+  useEffect(() => {
+    void enforceLogRetention(useSettingsStore.getState().logRetentionDays);
+  }, []);
 
   // In a secondary window, close this window's PTY sessions before it is
   // destroyed so no background shells leak. No-op in the main window.

--- a/src/components/LauncherPanel.tsx
+++ b/src/components/LauncherPanel.tsx
@@ -113,6 +113,9 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
         break;
       case "launcher":
         break;
+      case "log":
+        // Log panes are opened via the Logs sidebar, not the launcher.
+        break;
     }
     if (resolved.closeTabId) {
       closeTab(resolved.closeTabId);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,11 +1,12 @@
 import { useTranslation } from "react-i18next";
-import { Bot, FolderTree, GitBranch, LayoutGrid, NotebookPen, Server, type LucideIcon } from "lucide-react";
+import { Bot, FolderTree, GitBranch, LayoutGrid, NotebookPen, ScrollText, Server, type LucideIcon } from "lucide-react";
 import { ExplorerView } from "@/modules/explorer/ExplorerView";
 import { SourceControlView } from "@/modules/source-control/SourceControlView";
 import { AIView } from "@/modules/ai/AIView";
 import { NotesSidebar } from "@/modules/notes/NotesSidebar";
 import { WorkspacePanel } from "@/modules/workspace/WorkspacePanel";
 import { ConnectionsPanel } from "@/modules/ssh/ConnectionsPanel";
+import { LogsView } from "@/modules/logs/LogsView";
 import { Tooltip } from "@/components/Tooltip";
 import { useUiStore, type SidebarView } from "@/stores/uiStore";
 
@@ -22,6 +23,7 @@ const SIDEBAR_TABS: SidebarTab[] = [
   { id: "notes", icon: NotebookPen, labelKey: "nav.notes" },
   { id: "ai", icon: Bot, labelKey: "nav.ai" },
   { id: "connections", icon: Server, labelKey: "nav.connections" },
+  { id: "logs", icon: ScrollText, labelKey: "nav.logs" },
 ];
 
 /**
@@ -68,6 +70,7 @@ export function Sidebar() {
         {sidebarView === "notes" && <NotesSidebar />}
         {sidebarView === "ai" && <AIView />}
         {sidebarView === "connections" && <ConnectionsPanel />}
+        {sidebarView === "logs" && <LogsView />}
       </div>
     </div>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -27,7 +27,7 @@ const SIDEBAR_TABS: SidebarTab[] = [
 ];
 
 /**
- * The sidebar panels in their displayed left-to-right order, so ⌥1…⌥6 can map a
+ * The sidebar panels in their displayed left-to-right order, so ⌥1…⌥7 can map a
  * number to the matching panel. Kept beside SIDEBAR_TABS so the order never
  * drifts from what the icon bar renders.
  */

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -9,6 +9,7 @@ import {
   PanelLeft,
   Pencil,
   Plus,
+  ScrollText,
   SquareTerminal,
   X,
   type LucideIcon,
@@ -56,6 +57,8 @@ function tabIcon(kind: Tab["kind"]): LucideIcon {
       return GitBranch;
     case "launcher":
       return LayoutGrid;
+    case "log":
+      return ScrollText;
   }
 }
 

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -48,7 +48,8 @@
     "notes": "Notes",
     "gitGraph": "Git Graph",
     "settings": "Settings",
-    "connections": "Connections"
+    "connections": "Connections",
+    "logs": "Logs"
   },
   "statusBar": {
     "ready": "Ready",
@@ -166,6 +167,17 @@
       "destPort": "Destination port",
       "enabled": "Enabled"
     }
+  },
+  "logs": {
+    "title": "Logs",
+    "empty": "No log files yet",
+    "selectHint": "Select a log on the left",
+    "raw": "Raw (ANSI)",
+    "copy": "Copy",
+    "saveAs": "Save As…",
+    "loading": "Loading…",
+    "refresh": "Refresh",
+    "openFolder": "Open logs folder"
   },
   "workspace": {
     "openFolder": "Open Folder",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -177,7 +177,8 @@
     "saveAs": "Save As…",
     "loading": "Loading…",
     "refresh": "Refresh",
-    "openFolder": "Open logs folder"
+    "openFolder": "Open logs folder",
+    "error": "Error"
   },
   "workspace": {
     "openFolder": "Open Folder",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -6,6 +6,7 @@
     "fonts": "Fonts",
     "ai": "AI",
     "workspace": "Workspaces",
+    "logs": "Logs",
     "shortcuts": "Shortcuts",
     "about": "About"
   },
@@ -123,6 +124,17 @@
     "save": "Save",
     "remove": "Remove",
     "localNoKey": "Runs locally, no key needed"
+  },
+  "logsSettings": {
+    "description": "Record each terminal session's output to a log file you can browse in the Logs panel",
+    "enable": "Record session logs",
+    "enableHint": "New sessions write their output to a per-session log file. Turning this off does not stop sessions already running",
+    "retention": "Keep logs for",
+    "retentionForever": "Forever",
+    "retention7": "7 days",
+    "retention30": "30 days",
+    "retention90": "90 days",
+    "openFolder": "Open logs folder"
   },
   "shortcutsList": {
     "description": "Common keyboard shortcuts",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -177,7 +177,8 @@
     "saveAs": "另存為…",
     "loading": "載入中…",
     "refresh": "重新整理",
-    "openFolder": "開啟 log 資料夾"
+    "openFolder": "開啟 log 資料夾",
+    "error": "錯誤"
   },
   "workspace": {
     "openFolder": "開啟資料夾",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -48,7 +48,8 @@
     "notes": "筆記",
     "gitGraph": "Git 線圖",
     "settings": "設定",
-    "connections": "SSH 連線"
+    "connections": "SSH 連線",
+    "logs": "記錄"
   },
   "statusBar": {
     "ready": "就緒",
@@ -166,6 +167,17 @@
       "destPort": "目標埠號",
       "enabled": "啟用"
     }
+  },
+  "logs": {
+    "title": "記錄",
+    "empty": "還沒有 log 檔",
+    "selectHint": "在左邊選一個 log",
+    "raw": "Raw (ANSI)",
+    "copy": "複製",
+    "saveAs": "另存為…",
+    "loading": "載入中…",
+    "refresh": "重新整理",
+    "openFolder": "開啟 log 資料夾"
   },
   "workspace": {
     "openFolder": "開啟資料夾",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -6,6 +6,7 @@
     "fonts": "字體",
     "ai": "AI",
     "workspace": "工作區",
+    "logs": "記錄",
     "shortcuts": "快捷鍵",
     "about": "關於"
   },
@@ -123,6 +124,17 @@
     "save": "儲存",
     "remove": "移除",
     "localNoKey": "本機執行，不需金鑰"
+  },
+  "logsSettings": {
+    "description": "把每個終端機 session 的輸出記錄成檔案，可在 Logs 面板瀏覽",
+    "enable": "記錄 session log",
+    "enableHint": "新開的 session 會把輸出寫進獨立的 log 檔。關掉不會中止已經在跑的 session",
+    "retention": "保留期限",
+    "retentionForever": "永久",
+    "retention7": "7 天",
+    "retention30": "30 天",
+    "retention90": "90 天",
+    "openFolder": "開啟 log 資料夾"
   },
   "shortcutsList": {
     "description": "常用鍵盤快捷鍵",

--- a/src/modules/logs/LogTabContent.test.tsx
+++ b/src/modules/logs/LogTabContent.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const strings: Record<string, string> = {
+        "logs.raw": "Raw (ANSI)",
+        "logs.copy": "Copy",
+        "logs.saveAs": "Save As…",
+        "logs.loading": "Loading…",
+        "logs.error": "Error",
+      };
+      return strings[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock("./lib/sessionLog", () => ({
+  readSessionLog: vi.fn(),
+  saveTextAs: vi.fn(() => Promise.resolve(null)),
+}));
+vi.mock("./lib/renderLog", () => ({
+  renderLogToText: vi.fn(() => Promise.resolve("rendered clean text")),
+}));
+
+import { LogTabContent } from "./LogTabContent";
+import { readSessionLog } from "./lib/sessionLog";
+import { renderLogToText } from "./lib/renderLog";
+
+describe("LogTabContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads and renders clean text for a logName", async () => {
+    (readSessionLog as ReturnType<typeof vi.fn>).mockResolvedValue(new Uint8Array([104, 105]));
+    render(<LogTabContent logName="session.log" />);
+    await waitFor(() => expect(screen.getByText("rendered clean text")).toBeInTheDocument());
+    expect(readSessionLog).toHaveBeenCalledWith("session.log");
+  });
+
+  it("reloads content when logName prop changes", async () => {
+    (readSessionLog as ReturnType<typeof vi.fn>).mockResolvedValue(new Uint8Array([1]));
+    (renderLogToText as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce("first log text")
+      .mockResolvedValueOnce("second log text");
+
+    const { rerender } = render(<LogTabContent logName="first.log" />);
+    await waitFor(() => expect(screen.getByText("first log text")).toBeInTheDocument());
+
+    rerender(<LogTabContent logName="second.log" />);
+    await waitFor(() => expect(screen.getByText("second log text")).toBeInTheDocument());
+    expect(readSessionLog).toHaveBeenCalledWith("second.log");
+  });
+
+  it("switches to raw ANSI text when Raw toggle is checked", async () => {
+    const rawBytes = new TextEncoder().encode("raw ansi text");
+    (readSessionLog as ReturnType<typeof vi.fn>).mockResolvedValue(rawBytes);
+    render(<LogTabContent logName="session.log" />);
+    await waitFor(() => expect(screen.getByText("rendered clean text")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    await waitFor(() => expect(screen.getByText("raw ansi text")).toBeInTheDocument());
+    expect(renderLogToText).toHaveBeenCalledTimes(1); // not called again on raw toggle
+  });
+
+  it("shows loading state while fetching", async () => {
+    let resolveRead!: (v: Uint8Array) => void;
+    (readSessionLog as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<Uint8Array>((r) => {
+        resolveRead = r;
+      }),
+    );
+    render(<LogTabContent logName="pending.log" />);
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    resolveRead(new Uint8Array([1]));
+    await waitFor(() => expect(screen.queryByText("Loading…")).not.toBeInTheDocument());
+  });
+
+  it("handles a missing or unreadable log gracefully", async () => {
+    (readSessionLog as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("file not found"));
+    render(<LogTabContent logName="gone.log" />);
+    await waitFor(() => expect(screen.getByText(/file not found/i)).toBeInTheDocument());
+  });
+});

--- a/src/modules/logs/LogTabContent.tsx
+++ b/src/modules/logs/LogTabContent.tsx
@@ -54,15 +54,16 @@ export function LogTabContent({ logName }: LogTabContentProps) {
     const next = !showRaw;
     setShowRaw(next);
     if (!bytes) return;
+    const name = logName;
     setLoading(true);
     try {
-      if (next) {
-        setContent(new TextDecoder("utf-8", { fatal: false }).decode(bytes));
-      } else {
-        setContent(await renderLogToText(bytes));
-      }
+      const decoded = next
+        ? new TextDecoder("utf-8", { fatal: false }).decode(bytes)
+        : await renderLogToText(bytes);
+      if (requestedRef.current !== name) return;
+      setContent(decoded);
     } finally {
-      setLoading(false);
+      if (requestedRef.current === name) setLoading(false);
     }
   }
 

--- a/src/modules/logs/LogTabContent.tsx
+++ b/src/modules/logs/LogTabContent.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { readSessionLog, saveTextAs } from "./lib/sessionLog";
+import { renderLogToText } from "./lib/renderLog";
+
+interface LogTabContentProps {
+  logName: string;
+}
+
+export function LogTabContent({ logName }: LogTabContentProps) {
+  const { t } = useTranslation();
+  const [content, setContent] = useState("");
+  const [bytes, setBytes] = useState<Uint8Array | null>(null);
+  const [showRaw, setShowRaw] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Tracks the most recently requested log name so that a slow renderLogToText
+  // for an older logName cannot overwrite content after the prop has changed.
+  const requestedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    requestedRef.current = logName;
+    setLoading(true);
+    setError(null);
+    setContent("");
+    setBytes(null);
+    setShowRaw(false);
+
+    void (async () => {
+      try {
+        const raw = await readSessionLog(logName);
+        if (cancelled || requestedRef.current !== logName) return;
+        const text = await renderLogToText(raw);
+        if (cancelled || requestedRef.current !== logName) return;
+        setBytes(raw);
+        setContent(text);
+      } catch (e: unknown) {
+        if (cancelled || requestedRef.current !== logName) return;
+        setError(String(e instanceof Error ? e.message : e));
+      } finally {
+        if (!cancelled && requestedRef.current === logName) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [logName]);
+
+  async function toggleRaw() {
+    const next = !showRaw;
+    setShowRaw(next);
+    if (!bytes) return;
+    setLoading(true);
+    try {
+      if (next) {
+        setContent(new TextDecoder("utf-8", { fatal: false }).decode(bytes));
+      } else {
+        setContent(await renderLogToText(bytes));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSaveAs() {
+    const suggested = logName.replace(/\.log$/, showRaw ? ".raw.log" : ".txt");
+    await saveTextAs(suggested, content);
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="flex h-8 shrink-0 items-center gap-2 border-b border-border px-3 text-xs text-fg-muted">
+        <span className="truncate">{logName}</span>
+        <label className="ml-auto flex cursor-pointer items-center gap-1">
+          <input
+            type="checkbox"
+            checked={showRaw}
+            onChange={() => void toggleRaw().catch(() => {})}
+            disabled={loading || !bytes}
+            className="accent-accent"
+          />
+          {t("logs.raw")}
+        </label>
+        <button
+          type="button"
+          onClick={() => void navigator.clipboard.writeText(content).catch(() => {})}
+          disabled={!content}
+          className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-50"
+        >
+          {t("logs.copy")}
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleSaveAs().catch(() => {})}
+          disabled={!content}
+          className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-50"
+        >
+          {t("logs.saveAs")}
+        </button>
+      </div>
+      {error && <div className="px-3 py-2 text-xs text-danger">{error}</div>}
+      {loading && <div className="px-3 py-2 text-xs text-fg-muted">{t("logs.loading")}</div>}
+      <pre className="m-0 flex-1 overflow-auto whitespace-pre p-3 font-mono text-xs text-fg">
+        {content}
+      </pre>
+    </div>
+  );
+}

--- a/src/modules/logs/LogsView.test.tsx
+++ b/src/modules/logs/LogsView.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("react-i18next", () => ({
@@ -7,11 +7,6 @@ vi.mock("react-i18next", () => ({
       const strings: Record<string, string> = {
         "logs.title": "Logs",
         "logs.empty": "No log files yet",
-        "logs.selectHint": "Select a log on the left",
-        "logs.raw": "Raw (ANSI)",
-        "logs.copy": "Copy",
-        "logs.saveAs": "Save As…",
-        "logs.loading": "Loading…",
         "logs.refresh": "Refresh",
         "logs.openFolder": "Open logs folder",
       };
@@ -22,37 +17,49 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("./lib/sessionLog", () => ({
   listSessionLogs: vi.fn(),
-  readSessionLog: vi.fn(),
   openSessionLogsDir: vi.fn(() => Promise.resolve()),
   enforceLogRetention: vi.fn(() => Promise.resolve()),
-  saveTextAs: vi.fn(() => Promise.resolve(null)),
-}));
-vi.mock("./lib/renderLog", () => ({
-  renderLogToText: vi.fn(() => Promise.resolve("rendered clean text")),
-  collapseBlankRuns: (x: string[]) => x,
 }));
 
+vi.mock("@/stores/tabsStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/stores/tabsStore")>();
+  return {
+    ...actual,
+    useTabsStore: Object.assign(
+      vi.fn((selector: (s: { openLogTab: (n: string) => string }) => unknown) =>
+        selector({ openLogTab: vi.fn(() => "mock-tab-id") }),
+      ),
+      {
+        getState: vi.fn(() => ({
+          openLogTab: openLogTabSpy,
+        })),
+      },
+    ),
+  };
+});
+
+const openLogTabSpy = vi.fn(() => "mock-tab-id");
+
 import { LogsView } from "./LogsView";
-import { listSessionLogs, readSessionLog } from "./lib/sessionLog";
+import { listSessionLogs } from "./lib/sessionLog";
 
 describe("LogsView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    openLogTabSpy.mockReturnValue("mock-tab-id");
   });
 
-  it("lists logs and shows rendered content when one is selected", async () => {
+  it("calls openLogTab when a log row is clicked", async () => {
     (listSessionLogs as ReturnType<typeof vi.fn>).mockResolvedValue([
       { name: "20260507_143343_zsh.log", size: 1024, modified_unix_ms: 1_700_000_000_000 },
     ]);
-    (readSessionLog as ReturnType<typeof vi.fn>).mockResolvedValue(new Uint8Array([104, 105]));
 
     render(<LogsView />);
 
     const item = await screen.findByText("20260507_143343_zsh.log");
     fireEvent.click(item);
 
-    await waitFor(() => expect(screen.getByText("rendered clean text")).toBeInTheDocument());
-    expect(readSessionLog).toHaveBeenCalledWith("20260507_143343_zsh.log");
+    expect(openLogTabSpy).toHaveBeenCalledWith("20260507_143343_zsh.log");
   });
 
   it("shows an empty state when there are no logs", async () => {

--- a/src/modules/logs/LogsView.test.tsx
+++ b/src/modules/logs/LogsView.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const strings: Record<string, string> = {
+        "logs.title": "Logs",
+        "logs.empty": "No log files yet",
+        "logs.selectHint": "Select a log on the left",
+        "logs.raw": "Raw (ANSI)",
+        "logs.copy": "Copy",
+        "logs.saveAs": "Save As…",
+        "logs.loading": "Loading…",
+        "logs.refresh": "Refresh",
+        "logs.openFolder": "Open logs folder",
+      };
+      return strings[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock("./lib/sessionLog", () => ({
+  listSessionLogs: vi.fn(),
+  readSessionLog: vi.fn(),
+  openSessionLogsDir: vi.fn(() => Promise.resolve()),
+  enforceLogRetention: vi.fn(() => Promise.resolve()),
+  saveTextAs: vi.fn(() => Promise.resolve(null)),
+}));
+vi.mock("./lib/renderLog", () => ({
+  renderLogToText: vi.fn(() => Promise.resolve("rendered clean text")),
+  collapseBlankRuns: (x: string[]) => x,
+}));
+
+import { LogsView } from "./LogsView";
+import { listSessionLogs, readSessionLog } from "./lib/sessionLog";
+
+describe("LogsView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists logs and shows rendered content when one is selected", async () => {
+    (listSessionLogs as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { name: "20260507_143343_zsh.log", size: 1024, modified_unix_ms: 1_700_000_000_000 },
+    ]);
+    (readSessionLog as ReturnType<typeof vi.fn>).mockResolvedValue(new Uint8Array([104, 105]));
+
+    render(<LogsView />);
+
+    const item = await screen.findByText("20260507_143343_zsh.log");
+    fireEvent.click(item);
+
+    await waitFor(() => expect(screen.getByText("rendered clean text")).toBeInTheDocument());
+    expect(readSessionLog).toHaveBeenCalledWith("20260507_143343_zsh.log");
+  });
+
+  it("shows an empty state when there are no logs", async () => {
+    (listSessionLogs as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    render(<LogsView />);
+    expect(await screen.findByText(/no log files/i)).toBeInTheDocument();
+  });
+});

--- a/src/modules/logs/LogsView.tsx
+++ b/src/modules/logs/LogsView.tsx
@@ -43,8 +43,8 @@ export function LogsView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  async function decode(raw: Uint8Array, raw_mode: boolean) {
-    if (raw_mode) {
+  async function decode(raw: Uint8Array, rawMode: boolean) {
+    if (rawMode) {
       setContent(new TextDecoder("utf-8", { fatal: false }).decode(raw));
     } else {
       setContent(await renderLogToText(raw));
@@ -144,7 +144,7 @@ export function LogsView() {
                   <input
                     type="checkbox"
                     checked={showRaw}
-                    onChange={() => void toggleRaw()}
+                    onChange={() => void toggleRaw().catch(() => {})}
                     disabled={loading || !bytes}
                     className="accent-accent"
                   />
@@ -152,7 +152,7 @@ export function LogsView() {
                 </label>
                 <button
                   type="button"
-                  onClick={() => void navigator.clipboard.writeText(content)}
+                  onClick={() => void navigator.clipboard.writeText(content).catch(() => {})}
                   disabled={!content}
                   className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-50"
                 >
@@ -160,7 +160,7 @@ export function LogsView() {
                 </button>
                 <button
                   type="button"
-                  onClick={() => void saveAs()}
+                  onClick={() => void saveAs().catch(() => {})}
                   disabled={!content}
                   className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-50"
                 >

--- a/src/modules/logs/LogsView.tsx
+++ b/src/modules/logs/LogsView.tsx
@@ -1,16 +1,14 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FolderOpen, RefreshCw } from "lucide-react";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useTabsStore } from "@/stores/tabsStore";
 import {
   enforceLogRetention,
   listSessionLogs,
   openSessionLogsDir,
-  readSessionLog,
-  saveTextAs,
   type LogEntry,
 } from "./lib/sessionLog";
-import { renderLogToText } from "./lib/renderLog";
 
 function fmtSize(n: number): string {
   if (n < 1024) return `${n} B`;
@@ -22,15 +20,7 @@ export function LogsView() {
   const { t } = useTranslation();
   const retentionDays = useSettingsStore((s) => s.logRetentionDays);
   const [entries, setEntries] = useState<LogEntry[]>([]);
-  const [selected, setSelected] = useState<string | null>(null);
-  const [bytes, setBytes] = useState<Uint8Array | null>(null);
-  const [content, setContent] = useState("");
-  const [showRaw, setShowRaw] = useState(false);
-  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Tracks the most recently requested log name so that a slow renderLogToText
-  // for an older selection cannot overwrite content after the user has moved on.
-  const requestedRef = useRef<string | null>(null);
 
   async function refresh() {
     try {
@@ -46,59 +36,8 @@ export function LogsView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  async function decode(raw: Uint8Array, rawMode: boolean) {
-    if (rawMode) {
-      setContent(new TextDecoder("utf-8", { fatal: false }).decode(raw));
-    } else {
-      setContent(await renderLogToText(raw));
-    }
-  }
-
-  async function select(name: string) {
-    // Record this as the latest request before any await so the stale-check
-    // below can detect if the user selected a different file while we waited.
-    requestedRef.current = name;
-    setSelected(name);
-    setLoading(true);
-    setError(null);
-    setContent("");
-    setBytes(null);
-    try {
-      const raw = await readSessionLog(name);
-      // Bail if the user selected a different file while we were fetching.
-      if (requestedRef.current !== name) return;
-      const text = showRaw
-        ? new TextDecoder("utf-8", { fatal: false }).decode(raw)
-        : await renderLogToText(raw);
-      // Bail again after the potentially slow renderLogToText.
-      if (requestedRef.current !== name) return;
-      setBytes(raw);
-      setContent(text);
-    } catch (e: unknown) {
-      if (requestedRef.current !== name) return;
-      setError(`read: ${String(e)}`);
-    } finally {
-      // Only clear the loading spinner when this is still the current request.
-      if (requestedRef.current === name) setLoading(false);
-    }
-  }
-
-  async function toggleRaw() {
-    const next = !showRaw;
-    setShowRaw(next);
-    if (!bytes) return;
-    setLoading(true);
-    try {
-      await decode(bytes, next);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function saveAs() {
-    if (!selected) return;
-    const suggested = selected.replace(/\.log$/, showRaw ? ".raw.log" : ".txt");
-    await saveTextAs(suggested, content);
+  function handleLogClick(name: string) {
+    useTabsStore.getState().openLogTab(name);
   }
 
   return (
@@ -125,73 +64,28 @@ export function LogsView() {
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1">
-        <div className="w-56 shrink-0 overflow-auto border-r border-border p-1">
-          {entries.length === 0 ? (
-            <div className="p-4 text-center text-xs text-fg-muted">{t("logs.empty")}</div>
-          ) : (
-            entries.map((e) => (
-              <button
-                key={e.name}
-                type="button"
-                onClick={() => void select(e.name)}
-                className={`flex w-full flex-col gap-0.5 rounded px-2 py-1.5 text-left ${
-                  selected === e.name ? "bg-accent/15 text-accent" : "text-fg hover:bg-bg-elevated"
-                }`}
-                title={e.name}
-              >
-                <span className="truncate text-xs">{e.name}</span>
-                <span className="flex justify-between text-[10px] text-fg-muted">
-                  <span>{new Date(e.modified_unix_ms).toLocaleString()}</span>
-                  <span>{fmtSize(e.size)}</span>
-                </span>
-              </button>
-            ))
-          )}
-        </div>
+      {error && <div className="px-3 py-2 text-xs text-danger">{error}</div>}
 
-        <div className="flex min-w-0 flex-1 flex-col">
-          <div className="flex h-8 shrink-0 items-center gap-2 border-b border-border px-3 text-xs text-fg-muted">
-            {selected ? (
-              <>
-                <span className="truncate">{selected}</span>
-                <label className="ml-auto flex cursor-pointer items-center gap-1">
-                  <input
-                    type="checkbox"
-                    checked={showRaw}
-                    onChange={() => void toggleRaw().catch(() => {})}
-                    disabled={loading || !bytes}
-                    className="accent-accent"
-                  />
-                  {t("logs.raw")}
-                </label>
-                <button
-                  type="button"
-                  onClick={() => void navigator.clipboard.writeText(content).catch(() => {})}
-                  disabled={!content}
-                  className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-50"
-                >
-                  {t("logs.copy")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void saveAs().catch(() => {})}
-                  disabled={!content}
-                  className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-50"
-                >
-                  {t("logs.saveAs")}
-                </button>
-              </>
-            ) : (
-              <span>{t("logs.selectHint")}</span>
-            )}
-          </div>
-          {error && <div className="px-3 py-2 text-xs text-danger">{error}</div>}
-          {loading && <div className="px-3 py-2 text-xs text-fg-muted">{t("logs.loading")}</div>}
-          <pre className="m-0 flex-1 overflow-auto whitespace-pre p-3 font-mono text-xs text-fg">
-            {content}
-          </pre>
-        </div>
+      <div className="flex-1 overflow-auto p-1">
+        {entries.length === 0 ? (
+          <div className="p-4 text-center text-xs text-fg-muted">{t("logs.empty")}</div>
+        ) : (
+          entries.map((e) => (
+            <button
+              key={e.name}
+              type="button"
+              onClick={() => handleLogClick(e.name)}
+              className="flex w-full flex-col gap-0.5 rounded px-2 py-1.5 text-left text-fg hover:bg-bg-elevated"
+              title={e.name}
+            >
+              <span className="truncate text-xs">{e.name}</span>
+              <span className="flex justify-between text-[10px] text-fg-muted">
+                <span>{new Date(e.modified_unix_ms).toLocaleString()}</span>
+                <span>{fmtSize(e.size)}</span>
+              </span>
+            </button>
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/modules/logs/LogsView.tsx
+++ b/src/modules/logs/LogsView.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { FolderOpen, RefreshCw } from "lucide-react";
+import { useSettingsStore } from "@/stores/settingsStore";
+import {
+  enforceLogRetention,
+  listSessionLogs,
+  openSessionLogsDir,
+  readSessionLog,
+  saveTextAs,
+  type LogEntry,
+} from "./lib/sessionLog";
+import { renderLogToText } from "./lib/renderLog";
+
+function fmtSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function LogsView() {
+  const { t } = useTranslation();
+  const retentionDays = useSettingsStore((s) => s.logRetentionDays);
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [bytes, setBytes] = useState<Uint8Array | null>(null);
+  const [content, setContent] = useState("");
+  const [showRaw, setShowRaw] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    try {
+      setEntries(await listSessionLogs());
+    } catch (e: unknown) {
+      setError(`list: ${String(e)}`);
+    }
+  }
+
+  // Enforce retention once when the panel mounts, then list what remains.
+  useEffect(() => {
+    void enforceLogRetention(retentionDays).finally(() => void refresh());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function decode(raw: Uint8Array, raw_mode: boolean) {
+    if (raw_mode) {
+      setContent(new TextDecoder("utf-8", { fatal: false }).decode(raw));
+    } else {
+      setContent(await renderLogToText(raw));
+    }
+  }
+
+  async function select(name: string) {
+    setSelected(name);
+    setLoading(true);
+    setError(null);
+    setContent("");
+    setBytes(null);
+    try {
+      const raw = await readSessionLog(name);
+      setBytes(raw);
+      await decode(raw, showRaw);
+    } catch (e: unknown) {
+      setError(`read: ${String(e)}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function toggleRaw() {
+    const next = !showRaw;
+    setShowRaw(next);
+    if (!bytes) return;
+    setLoading(true);
+    try {
+      await decode(bytes, next);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function saveAs() {
+    if (!selected) return;
+    const suggested = selected.replace(/\.log$/, showRaw ? ".raw.log" : ".txt");
+    await saveTextAs(suggested, content);
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden">
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border px-3 text-sm font-medium text-fg">
+        {t("logs.title")}
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            aria-label={t("logs.refresh")}
+            onClick={() => void refresh()}
+            className="rounded p-1 text-fg-subtle hover:bg-bg-elevated hover:text-fg"
+          >
+            <RefreshCw size={14} />
+          </button>
+          <button
+            type="button"
+            aria-label={t("logs.openFolder")}
+            onClick={() => void openSessionLogsDir()}
+            className="rounded p-1 text-fg-subtle hover:bg-bg-elevated hover:text-fg"
+          >
+            <FolderOpen size={14} />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        <div className="w-56 shrink-0 overflow-auto border-r border-border p-1">
+          {entries.length === 0 ? (
+            <div className="p-4 text-center text-xs text-fg-muted">{t("logs.empty")}</div>
+          ) : (
+            entries.map((e) => (
+              <button
+                key={e.name}
+                type="button"
+                onClick={() => void select(e.name)}
+                className={`flex w-full flex-col gap-0.5 rounded px-2 py-1.5 text-left ${
+                  selected === e.name ? "bg-accent/15 text-accent" : "text-fg hover:bg-bg-elevated"
+                }`}
+                title={e.name}
+              >
+                <span className="truncate text-xs">{e.name}</span>
+                <span className="flex justify-between text-[10px] text-fg-muted">
+                  <span>{new Date(e.modified_unix_ms).toLocaleString()}</span>
+                  <span>{fmtSize(e.size)}</span>
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex h-8 shrink-0 items-center gap-2 border-b border-border px-3 text-xs text-fg-muted">
+            {selected ? (
+              <>
+                <span className="truncate">{selected}</span>
+                <label className="ml-auto flex cursor-pointer items-center gap-1">
+                  <input
+                    type="checkbox"
+                    checked={showRaw}
+                    onChange={() => void toggleRaw()}
+                    disabled={loading || !bytes}
+                    className="accent-accent"
+                  />
+                  {t("logs.raw")}
+                </label>
+                <button
+                  type="button"
+                  onClick={() => void navigator.clipboard.writeText(content)}
+                  disabled={!content}
+                  className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-50"
+                >
+                  {t("logs.copy")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void saveAs()}
+                  disabled={!content}
+                  className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-50"
+                >
+                  {t("logs.saveAs")}
+                </button>
+              </>
+            ) : (
+              <span>{t("logs.selectHint")}</span>
+            )}
+          </div>
+          {error && <div className="px-3 py-2 text-xs text-danger">{error}</div>}
+          {loading && <div className="px-3 py-2 text-xs text-fg-muted">{t("logs.loading")}</div>}
+          <pre className="m-0 flex-1 overflow-auto whitespace-pre p-3 font-mono text-xs text-fg">
+            {content}
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/logs/LogsView.tsx
+++ b/src/modules/logs/LogsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FolderOpen, RefreshCw } from "lucide-react";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -28,6 +28,9 @@ export function LogsView() {
   const [showRaw, setShowRaw] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Tracks the most recently requested log name so that a slow renderLogToText
+  // for an older selection cannot overwrite content after the user has moved on.
+  const requestedRef = useRef<string | null>(null);
 
   async function refresh() {
     try {
@@ -52,6 +55,9 @@ export function LogsView() {
   }
 
   async function select(name: string) {
+    // Record this as the latest request before any await so the stale-check
+    // below can detect if the user selected a different file while we waited.
+    requestedRef.current = name;
     setSelected(name);
     setLoading(true);
     setError(null);
@@ -59,12 +65,21 @@ export function LogsView() {
     setBytes(null);
     try {
       const raw = await readSessionLog(name);
+      // Bail if the user selected a different file while we were fetching.
+      if (requestedRef.current !== name) return;
+      const text = showRaw
+        ? new TextDecoder("utf-8", { fatal: false }).decode(raw)
+        : await renderLogToText(raw);
+      // Bail again after the potentially slow renderLogToText.
+      if (requestedRef.current !== name) return;
       setBytes(raw);
-      await decode(raw, showRaw);
+      setContent(text);
     } catch (e: unknown) {
+      if (requestedRef.current !== name) return;
       setError(`read: ${String(e)}`);
     } finally {
-      setLoading(false);
+      // Only clear the loading spinner when this is still the current request.
+      if (requestedRef.current === name) setLoading(false);
     }
   }
 
@@ -102,7 +117,7 @@ export function LogsView() {
           <button
             type="button"
             aria-label={t("logs.openFolder")}
-            onClick={() => void openSessionLogsDir()}
+            onClick={() => void openSessionLogsDir().catch(() => {})}
             className="rounded p-1 text-fg-subtle hover:bg-bg-elevated hover:text-fg"
           >
             <FolderOpen size={14} />

--- a/src/modules/logs/LogsView.tsx
+++ b/src/modules/logs/LogsView.tsx
@@ -39,7 +39,7 @@ export function LogsView() {
 
   // Enforce retention once when the panel mounts, then list what remains.
   useEffect(() => {
-    void enforceLogRetention(retentionDays).finally(() => void refresh());
+    void enforceLogRetention(retentionDays).catch(() => {}).finally(() => void refresh());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/modules/logs/lib/renderLog.test.ts
+++ b/src/modules/logs/lib/renderLog.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { collapseBlankRuns } from "./renderLog";
+
+describe("collapseBlankRuns", () => {
+  it("trims leading/trailing blanks and caps interior blank runs at 2", () => {
+    const input = ["", "", "a", "", "", "", "b", "", ""];
+    expect(collapseBlankRuns(input)).toEqual(["a", "", "", "b"]);
+  });
+
+  it("returns an empty array for all-blank input", () => {
+    expect(collapseBlankRuns(["", "", ""])).toEqual([]);
+  });
+});

--- a/src/modules/logs/lib/renderLog.ts
+++ b/src/modules/logs/lib/renderLog.ts
@@ -1,0 +1,62 @@
+import { Terminal } from "@xterm/xterm";
+import { getTheme } from "@/themes/themes";
+import { selectTerminalFontFamily, useFontStore } from "@/stores/fontStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+/** Trim leading/trailing blank lines and cap any interior run of blanks at 2. */
+export function collapseBlankRuns(lines: string[]): string[] {
+  const trimmed = [...lines];
+  while (trimmed.length && trimmed[0] === "") trimmed.shift();
+  while (trimmed.length && trimmed[trimmed.length - 1] === "") trimmed.pop();
+  const out: string[] = [];
+  let blankRun = 0;
+  for (const line of trimmed) {
+    if (line === "") {
+      blankRun += 1;
+      if (blankRun <= 2) out.push(line);
+    } else {
+      blankRun = 0;
+      out.push(line);
+    }
+  }
+  return out;
+}
+
+/**
+ * Render raw PTY bytes (with ANSI control sequences) into the plain text a real
+ * terminal would show, by feeding them through an off-DOM xterm and walking its
+ * buffer once parsing settles. Sized wide so reflow doesn't truncate long
+ * Claude/Codex transcripts.
+ */
+export async function renderLogToText(bytes: Uint8Array): Promise<string> {
+  const host = document.createElement("div");
+  host.style.cssText =
+    "position:fixed;left:-99999px;top:-99999px;width:1600px;height:400px;visibility:hidden";
+  document.body.appendChild(host);
+
+  const font = useFontStore.getState();
+  const term = new Terminal({
+    cols: 200,
+    rows: 50,
+    scrollback: 100000,
+    allowProposedApi: true,
+    fontFamily: selectTerminalFontFamily(font),
+    fontSize: font.fontSize,
+    theme: getTheme(useSettingsStore.getState().themeId).terminal,
+  });
+  term.open(host);
+
+  try {
+    await new Promise<void>((resolve) => term.write(bytes, () => resolve()));
+    const buf = term.buffer.active;
+    const lines: string[] = [];
+    for (let y = 0; y < buf.length; y++) {
+      const line = buf.getLine(y);
+      lines.push(line ? line.translateToString(true) : "");
+    }
+    return collapseBlankRuns(lines).join("\n");
+  } finally {
+    term.dispose();
+    host.remove();
+  }
+}

--- a/src/modules/logs/lib/renderLog.ts
+++ b/src/modules/logs/lib/renderLog.ts
@@ -38,6 +38,8 @@ export async function renderLogToText(bytes: Uint8Array): Promise<string> {
   const term = new Terminal({
     cols: 200,
     rows: 50,
+    // Clean-mode rendering caps at 100k scrollback lines; very large logs are
+    // truncated at the top in this view. Raw mode shows everything via TextDecoder.
     scrollback: 100000,
     allowProposedApi: true,
     fontFamily: selectTerminalFontFamily(font),

--- a/src/modules/logs/lib/sessionLog.ts
+++ b/src/modules/logs/lib/sessionLog.ts
@@ -11,8 +11,11 @@ export function listSessionLogs(): Promise<LogEntry[]> {
   return invoke<LogEntry[]>("session_logs_list");
 }
 
-export function readSessionLog(name: string): Promise<Uint8Array> {
-  return invoke<number[]>("session_log_read", { name }).then((arr) => new Uint8Array(arr));
+export async function readSessionLog(name: string): Promise<Uint8Array> {
+  // tauri::ipc::Response delivers raw binary as an ArrayBuffer on the frontend
+  // (not Uint8Array), so we wrap it explicitly.
+  const buf = await invoke<ArrayBuffer>("session_log_read", { name });
+  return new Uint8Array(buf);
 }
 
 export function openSessionLogsDir(): Promise<void> {

--- a/src/modules/logs/lib/sessionLog.ts
+++ b/src/modules/logs/lib/sessionLog.ts
@@ -1,0 +1,33 @@
+import { invoke } from "@tauri-apps/api/core";
+import { save } from "@tauri-apps/plugin-dialog";
+
+export interface LogEntry {
+  name: string;
+  size: number;
+  modified_unix_ms: number;
+}
+
+export function listSessionLogs(): Promise<LogEntry[]> {
+  return invoke<LogEntry[]>("session_logs_list");
+}
+
+export function readSessionLog(name: string): Promise<Uint8Array> {
+  return invoke<number[]>("session_log_read", { name }).then((arr) => new Uint8Array(arr));
+}
+
+export function openSessionLogsDir(): Promise<void> {
+  return invoke<void>("session_logs_open_dir");
+}
+
+export function enforceLogRetention(retentionDays: number | null): Promise<void> {
+  return invoke<void>("session_logs_enforce_retention", { retentionDays });
+}
+
+/** Native Save As dialog defaulting to a suggested name; writes `content` to
+ *  the chosen path. No-op if the user cancels. Returns the saved path or null. */
+export async function saveTextAs(suggestedName: string, content: string): Promise<string | null> {
+  const path = await save({ defaultPath: suggestedName });
+  if (!path) return null;
+  await invoke<void>("fs_write_file", { path, contents: content });
+  return path;
+}

--- a/src/modules/settings/LogsSettingsSection.tsx
+++ b/src/modules/settings/LogsSettingsSection.tsx
@@ -16,8 +16,10 @@ export function LogsSettingsSection() {
   const labelFor = (value: number | null): string => {
     if (value === null) return t("logsSettings.retentionForever");
     if (value === 7) return t("logsSettings.retention7");
-    if (value === 30) return t("logsSettings.retention30");
-    return t("logsSettings.retention90");
+    if (value === 90) return t("logsSettings.retention90");
+    // 30 is the default; any unexpected value falls back to it rather than
+    // silently masquerading as a different option.
+    return t("logsSettings.retention30");
   };
   const options = RETENTION_VALUES.map(labelFor);
 

--- a/src/modules/settings/LogsSettingsSection.tsx
+++ b/src/modules/settings/LogsSettingsSection.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from "react-i18next";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { Combobox } from "@/components/Combobox";
+import { openSessionLogsDir } from "@/modules/logs/lib/sessionLog";
+
+/** Retention dropdown option values; null means keep forever. */
+const RETENTION_VALUES: (number | null)[] = [null, 7, 30, 90];
+
+export function LogsSettingsSection() {
+  const { t } = useTranslation("settings");
+  const loggingEnabled = useSettingsStore((s) => s.loggingEnabled);
+  const setLoggingEnabled = useSettingsStore((s) => s.setLoggingEnabled);
+  const logRetentionDays = useSettingsStore((s) => s.logRetentionDays);
+  const setLogRetentionDays = useSettingsStore((s) => s.setLogRetentionDays);
+
+  const labelFor = (value: number | null): string => {
+    if (value === null) return t("logsSettings.retentionForever");
+    if (value === 7) return t("logsSettings.retention7");
+    if (value === 30) return t("logsSettings.retention30");
+    return t("logsSettings.retention90");
+  };
+  const options = RETENTION_VALUES.map(labelFor);
+
+  return (
+    <section>
+      <h2 className="mb-1 text-sm font-semibold uppercase tracking-wide text-fg-subtle">
+        {t("sections.logs")}
+      </h2>
+      <p className="mb-6 text-xs text-fg-muted">{t("logsSettings.description")}</p>
+
+      <div className="mb-6">
+        <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg">
+          <input
+            type="checkbox"
+            checked={loggingEnabled}
+            onChange={(e) => setLoggingEnabled(e.target.checked)}
+            className="accent-accent"
+          />
+          {t("logsSettings.enable")}
+        </label>
+        <p className="mt-1 text-xs text-fg-muted">{t("logsSettings.enableHint")}</p>
+      </div>
+
+      <div className="mb-6">
+        <label className="mb-2 block text-sm font-medium text-fg">{t("logsSettings.retention")}</label>
+        <Combobox
+          value={labelFor(logRetentionDays)}
+          options={options}
+          ariaLabel={t("logsSettings.retention")}
+          onChange={(label) => {
+            const picked = RETENTION_VALUES.find((v) => labelFor(v) === label) ?? null;
+            setLogRetentionDays(picked);
+          }}
+        />
+      </div>
+
+      <button
+        type="button"
+        onClick={() => void openSessionLogsDir()}
+        className="rounded-md border border-border px-3 py-1.5 text-xs text-fg-muted transition-colors hover:bg-bg-elevated hover:text-fg"
+      >
+        {t("logsSettings.openFolder")}
+      </button>
+    </section>
+  );
+}

--- a/src/modules/settings/LogsSettingsSection.tsx
+++ b/src/modules/settings/LogsSettingsSection.tsx
@@ -58,7 +58,7 @@ export function LogsSettingsSection() {
 
       <button
         type="button"
-        onClick={() => void openSessionLogsDir()}
+        onClick={() => void openSessionLogsDir().catch(() => {})}
         className="rounded-md border border-border px-3 py-1.5 text-xs text-fg-muted transition-colors hover:bg-bg-elevated hover:text-fg"
       >
         {t("logsSettings.openFolder")}

--- a/src/modules/settings/SettingsView.tsx
+++ b/src/modules/settings/SettingsView.tsx
@@ -12,7 +12,7 @@ import { LogsSettingsSection } from "./LogsSettingsSection";
 import { ShortcutsSettingsSection } from "./ShortcutsSettingsSection";
 import { AboutSettingsSection } from "./AboutSettingsSection";
 
-const SECTIONS = ["appearance", "terminal", "ai", "workspace", "logs", "shortcuts", "about"] as const;
+const SECTIONS = ["appearance", "terminal", "logs", "ai", "workspace", "shortcuts", "about"] as const;
 type SectionId = typeof SECTIONS[number];
 
 /**

--- a/src/modules/settings/SettingsView.tsx
+++ b/src/modules/settings/SettingsView.tsx
@@ -8,10 +8,11 @@ import { FontsSettingsSection } from "./FontsSettingsSection";
 import { TerminalSettingsSection } from "./TerminalSettingsSection";
 import { AiSettingsSection } from "./AiSettingsSection";
 import { WorkspaceSettingsSection } from "./WorkspaceSettingsSection";
+import { LogsSettingsSection } from "./LogsSettingsSection";
 import { ShortcutsSettingsSection } from "./ShortcutsSettingsSection";
 import { AboutSettingsSection } from "./AboutSettingsSection";
 
-const SECTIONS = ["appearance", "terminal", "ai", "workspace", "shortcuts", "about"] as const;
+const SECTIONS = ["appearance", "terminal", "ai", "workspace", "logs", "shortcuts", "about"] as const;
 type SectionId = typeof SECTIONS[number];
 
 /**
@@ -198,6 +199,7 @@ export function SettingsView() {
           {section === "terminal" && <TerminalSettingsSection />}
           {section === "ai" && <AiSettingsSection />}
           {section === "workspace" && <WorkspaceSettingsSection />}
+          {section === "logs" && <LogsSettingsSection />}
           {section === "shortcuts" && <ShortcutsSettingsSection />}
           {section === "about" && <AboutSettingsSection />}
         </div>

--- a/src/modules/ssh/lib/ssh-bridge.test.ts
+++ b/src/modules/ssh/lib/ssh-bridge.test.ts
@@ -7,6 +7,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 import { openSsh, startForward, stopForward } from "./ssh-bridge";
+import { useSettingsStore } from "@/stores/settingsStore";
 
 describe("openSsh", () => {
   it("invokes ssh_open and exposes write/resize/close on the returned id", async () => {
@@ -24,6 +25,7 @@ describe("openSsh", () => {
 
   it("passes the correct req shape to ssh_open", async () => {
     invoke.mockClear();
+    useSettingsStore.setState({ loggingEnabled: true });
     await openSsh({
       connectionId: "conn-42", host: "example.com", port: 2222, user: "alice",
       authMethod: "keyFile", keyPath: "~/.ssh/id_ed25519", cols: 120, rows: 40,
@@ -42,9 +44,23 @@ describe("openSsh", () => {
           cols: 120,
           rows: 40,
           forwards: [],
+          logEnabled: true,
         },
       }),
     );
+  });
+
+  it("forwards loggingEnabled=false from settings store to ssh_open", async () => {
+    invoke.mockClear();
+    useSettingsStore.setState({ loggingEnabled: false });
+    await openSsh({
+      connectionId: "conn-log", host: "example.com", port: 22, user: "alice",
+      authMethod: "password", cols: 80, rows: 24,
+      onData: () => {}, onExit: () => {},
+    });
+    const call = invoke.mock.calls.find(([cmd]) => cmd === "ssh_open");
+    expect((call?.[1] as { req: { logEnabled: boolean } }).req.logEnabled).toBe(false);
+    useSettingsStore.setState({ loggingEnabled: true });
   });
 
   it("includes forwards in the req when provided", async () => {

--- a/src/modules/ssh/lib/ssh-bridge.ts
+++ b/src/modules/ssh/lib/ssh-bridge.ts
@@ -1,6 +1,7 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { toBytes } from "@/modules/terminal/lib/channelBytes";
 import type { SshAuthMethod } from "./parseSshCommand";
+import { useSettingsStore } from "@/stores/settingsStore";
 
 export interface SshSession {
   id: number;
@@ -48,6 +49,7 @@ export async function openSsh(opts: OpenSshOptions): Promise<SshSession> {
       cols: opts.cols,
       rows: opts.rows,
       forwards: opts.forwards ?? [],
+      logEnabled: useSettingsStore.getState().loggingEnabled,
     },
     onData,
     onExit,

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -28,6 +28,9 @@ const GitGraphTabContent = lazy(() =>
     default: m.GitGraphTabContent,
   })),
 );
+const LogTabContent = lazy(() =>
+  import("@/modules/logs/LogTabContent").then((m) => ({ default: m.LogTabContent })),
+);
 import { LauncherPanel } from "@/components/LauncherPanel";
 import { dropOverlayClassName } from "@/components/EntryDropOverlay";
 import {
@@ -135,6 +138,9 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
         if (!entry.isDir) {
           setPaneContent(tab.id, leafId, { kind: "editor", path: entry.path });
         }
+        break;
+      case "log":
+        // Log panes are read-only; drops are ignored.
         break;
     }
   }
@@ -255,6 +261,8 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                   <PreviewTabContent url={pane.content.url} />
                 ) : pane.content.kind === "git-graph" ? (
                   <GitGraphTabContent />
+                ) : pane.content.kind === "log" ? (
+                  <LogTabContent logName={pane.content.logName} />
                 ) : pane.content.kind === "launcher" ? (
                   <LauncherPanel
                     target={{ mode: "replacePane", tabId: tab.id, leafId: pane.id }}

--- a/src/modules/terminal/lib/pty-bridge.test.ts
+++ b/src/modules/terminal/lib/pty-bridge.test.ts
@@ -9,6 +9,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 import { closeLocalSessions, openPty } from "./pty-bridge";
+import { useSettingsStore } from "@/stores/settingsStore";
 
 const opts = { cols: 80, rows: 24, suggestions: false, onData: () => {}, onExit: () => {} };
 
@@ -23,6 +24,16 @@ describe("pty-bridge session registry", () => {
 
     const open = invoke.mock.calls.find(([cmd]) => cmd === "pty_open");
     expect((open?.[1] as { suggestions: boolean }).suggestions).toBe(true);
+  });
+
+  it("forwards loggingEnabled=false from settings store to pty_open", async () => {
+    invoke.mockResolvedValueOnce(1);
+    useSettingsStore.setState({ loggingEnabled: false });
+    await openPty(opts);
+
+    const open = invoke.mock.calls.find(([cmd]) => cmd === "pty_open");
+    expect((open?.[1] as { logEnabled: boolean }).logEnabled).toBe(false);
+    useSettingsStore.setState({ loggingEnabled: true });
   });
 
   it("forwards the shell override to pty_open so the backend can spawn it", async () => {

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -1,5 +1,6 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { toBytes } from "@/modules/terminal/lib/channelBytes";
+import { useSettingsStore } from "@/stores/settingsStore";
 
 export interface PtySession {
   id: number;
@@ -52,6 +53,7 @@ export async function openPty(opts: OpenPtyOptions): Promise<PtySession> {
     cwd: opts.cwd,
     suggestions: opts.suggestions,
     shellOverride: opts.shellOverride,
+    logEnabled: useSettingsStore.getState().loggingEnabled,
     onData,
     onExit,
   });

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -17,7 +17,8 @@ export type PaneContent =
   | { kind: "note"; noteId: string }
   | { kind: "preview"; url: string }
   | { kind: "git-graph" }
-  | { kind: "launcher" };
+  | { kind: "launcher" }
+  | { kind: "log"; logName: string };
 
 export const TERMINAL_PANE: PaneContent = { kind: "terminal" };
 

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -12,6 +12,7 @@ import {
   LayoutGrid,
   Pencil,
   Plus,
+  ScrollText,
   SquareTerminal,
   Trash2,
   type LucideIcon,
@@ -49,6 +50,8 @@ function tabIcon(kind: TabKind): LucideIcon {
       return GitBranch;
     case "launcher":
       return LayoutGrid;
+    case "log":
+      return ScrollText;
   }
 }
 

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -131,4 +131,19 @@ describe("settingsStore", () => {
     useSettingsStore.getState().setCustomShellPath("/opt/homebrew/bin/pwsh");
     expect(useSettingsStore.getState().customShellPath).toBe("/opt/homebrew/bin/pwsh");
   });
+
+  it("defaults logging on with 30-day retention and updates via setters", () => {
+    const s = useSettingsStore.getState();
+    expect(s.loggingEnabled).toBe(true);
+    expect(s.logRetentionDays).toBe(30);
+
+    s.setLoggingEnabled(false);
+    expect(useSettingsStore.getState().loggingEnabled).toBe(false);
+
+    s.setLogRetentionDays(null);
+    expect(useSettingsStore.getState().logRetentionDays).toBeNull();
+
+    s.setLogRetentionDays(7);
+    expect(useSettingsStore.getState().logRetentionDays).toBe(7);
+  });
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -71,6 +71,12 @@ interface SettingsState {
   actionLinksEnabled: boolean;
   /** Webview zoom factor for the whole UI (1 = 100%); driven by ⌘+ / ⌘-. */
   uiZoom: number;
+  /** Tee each terminal session's output to a per-session log file. */
+  loggingEnabled: boolean;
+  /** Delete logs older than this many days. `null` keeps them forever. */
+  logRetentionDays: number | null;
+  setLoggingEnabled: (value: boolean) => void;
+  setLogRetentionDays: (value: number | null) => void;
   setLanguage: (language: SupportedLanguage) => void;
   setThemeId: (themeId: string) => void;
   setTerminalPadding: (padding: number) => void;
@@ -134,6 +140,8 @@ export const useSettingsStore = create<SettingsState>()(
       customShellPath: "",
       actionLinksEnabled: true,
       uiZoom: DEFAULT_UI_ZOOM,
+      loggingEnabled: true,
+      logRetentionDays: 30,
       setLanguage: (language) => set({ language }),
       setThemeId: (themeId) => set({ themeId }),
       setTerminalPadding: (padding) => set({ terminalPadding: clampPadding(padding) }),
@@ -155,6 +163,8 @@ export const useSettingsStore = create<SettingsState>()(
       zoomIn: () => set((s) => ({ uiZoom: clampZoom(s.uiZoom + UI_ZOOM_STEP) })),
       zoomOut: () => set((s) => ({ uiZoom: clampZoom(s.uiZoom - UI_ZOOM_STEP) })),
       resetZoom: () => set({ uiZoom: DEFAULT_UI_ZOOM }),
+      setLoggingEnabled: (value) => set({ loggingEnabled: value }),
+      setLogRetentionDays: (value) => set({ logRetentionDays: value }),
     }),
     {
       name: SETTINGS_STORAGE_KEY,

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -440,6 +440,32 @@ describe("openSshTab", () => {
   });
 });
 
+describe("openLogTab", () => {
+  beforeEach(reset);
+
+  it("creates a log tab with kind='log', correct title, and pane content on first call", () => {
+    const id = useTabsStore.getState().openLogTab("20260507_143343_zsh.log");
+    expect(useTabsStore.getState().activeId).toBe(id);
+    const tab = activeTab();
+    expect(tab.kind).toBe("log");
+    expect(tab.title).toBe("20260507_143343_zsh.log");
+    expect(firstLeafContent(tab)).toEqual({ kind: "log", logName: "20260507_143343_zsh.log" });
+    expect(leafIds(tab.paneTree)).toHaveLength(1);
+  });
+
+  it("reuses the same tab id and replaces content when called with a different log name", () => {
+    const id = useTabsStore.getState().openLogTab("first.log");
+    useTabsStore.getState().newTerminalTab();
+    const id2 = useTabsStore.getState().openLogTab("second.log");
+    expect(id2).toBe(id);
+    expect(useTabsStore.getState().activeId).toBe(id);
+    expect(useTabsStore.getState().tabs.filter((t) => t.kind === "log")).toHaveLength(1);
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === id)!;
+    expect(tab.title).toBe("second.log");
+    expect(firstLeafContent(tab)).toEqual({ kind: "log", logName: "second.log" });
+  });
+});
+
 describe("migratePersistedTabs", () => {
   it("migrates v0 simple tabs into single-leaf pane tabs", () => {
     const v0 = {

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -464,6 +464,32 @@ describe("openLogTab", () => {
     expect(tab.title).toBe("second.log");
     expect(firstLeafContent(tab)).toEqual({ kind: "log", logName: "second.log" });
   });
+
+  it("preserves split layout when replacing log content in a split log tab", () => {
+    // Open a log tab, then split it so the paneTree is no longer a single leaf.
+    const id = useTabsStore.getState().openLogTab("first.log");
+    const tab0 = useTabsStore.getState().tabs.find((t) => t.id === id)!;
+    const originalLeafId = tab0.activeLeafId;
+    // Split the active pane (adds a second pane).
+    useTabsStore.getState().splitActivePane("row");
+    const splitTab = useTabsStore.getState().tabs.find((t) => t.id === id)!;
+    expect(leafIds(splitTab.paneTree)).toHaveLength(2);
+
+    // Focus the original (log) leaf so openLogTab replaces it.
+    useTabsStore.getState().setActiveLeaf(id, originalLeafId);
+
+    // Calling openLogTab again should reuse the tab AND keep the split intact.
+    const id2 = useTabsStore.getState().openLogTab("second.log");
+    expect(id2).toBe(id);
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === id)!;
+    // Split must still have 2 leaves — not collapsed to 1.
+    expect(leafIds(updated.paneTree)).toHaveLength(2);
+    // The active leaf (the log pane) should show the new log name.
+    const panes = computeLayout(updated.paneTree);
+    const logPane = panes.find((p) => p.id === updated.activeLeafId);
+    expect(logPane?.content).toEqual({ kind: "log", logName: "second.log" });
+    expect(updated.title).toBe("second.log");
+  });
 });
 
 describe("migratePersistedTabs", () => {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -490,21 +490,14 @@ export const useTabsStore = create<TabsState>()(
     const spaceId = get().ensureSpace();
     const existing = get().tabs.find((t) => t.kind === "log" && t.spaceId === spaceId);
     if (existing) {
-      // Replace the single leaf's content with the new log, update title, and focus.
-      // Fall back to a fresh leaf if the tree has been split (should not happen in
-      // normal use since we always create it as a single leaf, but guard anyway).
-      const freshPaneId = nextPaneId();
-      const newPaneTree =
-        existing.paneTree.kind === "leaf"
-          ? setLeafPane(existing.paneTree, existing.activeLeafId, { kind: "log", logName })
-          : leaf(freshPaneId, { kind: "log", logName });
-      const newActiveLeafId =
-        existing.paneTree.kind === "leaf" ? existing.activeLeafId : freshPaneId;
+      // Replace the active leaf's content with the new log, update title, and focus.
+      // setLeafPane works for both single-leaf and split trees — it replaces in-place
+      // anywhere in the tree, so a split layout is preserved (not discarded).
+      const newPaneTree = setLeafPane(existing.paneTree, existing.activeLeafId, { kind: "log", logName });
+      // activeLeafId stays the same — the active leaf is what we replaced.
       set((state) => ({
         tabs: state.tabs.map((t) =>
-          t.id === existing.id
-            ? { ...t, title: logName, paneTree: newPaneTree, activeLeafId: newActiveLeafId }
-            : t,
+          t.id === existing.id ? { ...t, title: logName, paneTree: newPaneTree } : t,
         ),
         activeId: existing.id,
       }));

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -31,7 +31,7 @@ export interface Space {
   name: string;
 }
 
-export type TabKind = "terminal" | "editor" | "note" | "preview" | "git-graph" | "launcher";
+export type TabKind = "terminal" | "editor" | "note" | "preview" | "git-graph" | "launcher" | "log";
 
 /**
  * A single tab. `kind` is only the tab's creation type, used for the tab-bar
@@ -70,6 +70,11 @@ interface TabsState {
   openNoteTab: (noteId: string, title: string) => string;
   openPreviewTab: (url: string) => string;
   openGitGraphTab: () => string;
+  /**
+   * Open the single reusable log tab for this space. If one already exists,
+   * replace its pane content + title in place (no new tab) and focus it.
+   */
+  openLogTab: (logName: string) => string;
   setTabTitle: (id: string, title: string) => void;
   /** Update a terminal tab's title to follow its cwd, unless the user renamed it. */
   syncTabTitleToCwd: (id: string, cwd: string) => void;
@@ -475,6 +480,39 @@ export const useTabsStore = create<TabsState>()(
       kind: "git-graph",
       title: "Git Graph",
       paneTree: leaf(paneId, { kind: "git-graph" }),
+      activeLeafId: paneId,
+    };
+    set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
+    return id;
+  },
+
+  openLogTab: (logName) => {
+    const spaceId = get().ensureSpace();
+    const existing = get().tabs.find((t) => t.kind === "log" && t.spaceId === spaceId);
+    if (existing) {
+      // Replace the single leaf's content with the new log, update title, and focus.
+      // Fall back to a fresh leaf if the tree has been split (should not happen in
+      // normal use since we always create it as a single leaf, but guard anyway).
+      const newPaneTree =
+        existing.paneTree.kind === "leaf"
+          ? setLeafPane(existing.paneTree, existing.activeLeafId, { kind: "log", logName })
+          : leaf(nextPaneId(), { kind: "log", logName });
+      set((state) => ({
+        tabs: state.tabs.map((t) =>
+          t.id === existing.id ? { ...t, title: logName, paneTree: newPaneTree } : t,
+        ),
+        activeId: existing.id,
+      }));
+      return existing.id;
+    }
+    const id = nextTabId();
+    const paneId = nextPaneId();
+    const tab: Tab = {
+      id,
+      spaceId,
+      kind: "log",
+      title: logName,
+      paneTree: leaf(paneId, { kind: "log", logName }),
       activeLeafId: paneId,
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -493,13 +493,18 @@ export const useTabsStore = create<TabsState>()(
       // Replace the single leaf's content with the new log, update title, and focus.
       // Fall back to a fresh leaf if the tree has been split (should not happen in
       // normal use since we always create it as a single leaf, but guard anyway).
+      const freshPaneId = nextPaneId();
       const newPaneTree =
         existing.paneTree.kind === "leaf"
           ? setLeafPane(existing.paneTree, existing.activeLeafId, { kind: "log", logName })
-          : leaf(nextPaneId(), { kind: "log", logName });
+          : leaf(freshPaneId, { kind: "log", logName });
+      const newActiveLeafId =
+        existing.paneTree.kind === "leaf" ? existing.activeLeafId : freshPaneId;
       set((state) => ({
         tabs: state.tabs.map((t) =>
-          t.id === existing.id ? { ...t, title: logName, paneTree: newPaneTree } : t,
+          t.id === existing.id
+            ? { ...t, title: logName, paneTree: newPaneTree, activeLeafId: newActiveLeafId }
+            : t,
         ),
         activeId: existing.id,
       }));

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-export type SidebarView = "workspaces" | "explorer" | "sourceControl" | "ai" | "notes" | "connections";
+export type SidebarView = "workspaces" | "explorer" | "sourceControl" | "ai" | "notes" | "connections" | "logs";
 
 interface UiState {
   sidebarView: SidebarView;


### PR DESCRIPTION
## Summary

Adds a session logging subsystem and a Logs panel. Every local PTY and SSH terminal session tees its raw output (ANSI included, so terminal-resident AI agents like Claude Code / Codex are captured) into a per-session `.log` file under the app data dir. A new left-sidebar **Logs** panel lists those files; clicking one opens its content as a reusable tab in the main area.

## What's included

- **Backend `session_log` module** — a synchronous per-session log writer (dedicated thread + bounded channel; not tokio, because `pty_open` is a sync command) plus commands to list, read, reveal, and prune logs. Filenames are `<YYYYMMDD_HHMMSS>_<seq>_<label>.log` (label = shell name or `user@host`); a per-process sequence prevents same-second collisions.
- **Output tee** — PTY (`on_bytes`) and SSH (`run_session` data/extended-data) each tee a copy of every chunk via non-blocking `try_send`. Best-effort: a full channel drops the chunk rather than ever stalling or breaking the terminal. Gated on a setting, passed from the frontend at session open.
- **Logs panel** — sidebar list (newest first) + a reusable main-area tab (`LogTabContent`) showing clean text (rendered through an off-DOM xterm) with a Raw (ANSI) toggle, Copy, and Save As. Clicking a different log replaces the same tab's content per space.
- **Settings** — enable toggle (default on) and retention policy (Forever / 7 / 30 / 90 days, default 30), enforced on startup and on panel open.
- **Security** — on Unix the logs dir is created `0o700` and each log file `0o600` at creation time, since logs can contain secrets from terminal output.

## Test plan

- [x] `cargo test --lib` — 183 passing (session_log: writer + sanitize/filename/retention/path-traversal/owner-only-perms pure-fn tests)
- [x] `pnpm test` — 810 passing (renderLog post-processing, LogTabContent, LogsView, settings store, pty/ssh bridge `logEnabled` forwarding)
- [x] `pnpm typecheck` clean; `cargo build` clean, zero warnings; no unhandled promise rejections in test output
- [ ] **Manual (not yet done):** run the built app — open a terminal, confirm a `.log` is written; open the Logs panel, click a log (opens in a main-area tab), click another (replaces the same tab), toggle Raw, Copy, Save As, Open folder; verify retention prunes old logs; SSH path needs a live host

## Notes

- Spec and implementation plan live under `docs/superpowers/` (gitignored, not in this PR).
- SSH session capture mirrors the verified PTY path but its runtime check needs a live host, so it's deferred to manual verification.
