### PR TITLE
fix(terminal): clear WebGL glyph atlas before overflow to stop garbled CJK on long sessions

### DIFF
--- a/src/modules/terminal/lib/createTerminal.ts
+++ b/src/modules/terminal/lib/createTerminal.ts
@@ -114,9 +114,14 @@ export function enableWebglRenderer(term: Terminal): WebglAddon | null {
     addon.onContextLoss(() => addon.dispose());
     term.loadAddon(addon);
     // Clear the glyph atlas just before it overflows, so long CJK-heavy sessions
-    // don't start rendering the wrong glyphs (see webglAtlasGuard). The listeners
-    // are disposed with the addon.
-    installAtlasPressureGuard(addon);
+    // don't start rendering the wrong glyphs (see webglAtlasGuard). Run the
+    // guard's cleanup when the addon is disposed so its listener doesn't leak.
+    const disposeAtlasGuard = installAtlasPressureGuard(addon);
+    const originalDispose = addon.dispose.bind(addon);
+    addon.dispose = () => {
+      disposeAtlasGuard();
+      originalDispose();
+    };
     return addon;
   } catch {
     return null;

--- a/src/modules/terminal/lib/createTerminal.ts
+++ b/src/modules/terminal/lib/createTerminal.ts
@@ -4,6 +4,7 @@ import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
+import { installAtlasPressureGuard } from "./webglAtlasGuard";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { buildTerminalFontFamily } from "@/modules/fonts/lib/fontChain";
 import { isLocalUrl, isWebUrl } from "@/lib/url";
@@ -112,6 +113,10 @@ export function enableWebglRenderer(term: Terminal): WebglAddon | null {
     // reattaches its DOM renderer.
     addon.onContextLoss(() => addon.dispose());
     term.loadAddon(addon);
+    // Clear the glyph atlas just before it overflows, so long CJK-heavy sessions
+    // don't start rendering the wrong glyphs (see webglAtlasGuard). The listeners
+    // are disposed with the addon.
+    installAtlasPressureGuard(addon);
     return addon;
   } catch {
     return null;

--- a/src/modules/terminal/lib/webglAtlasGuard.test.ts
+++ b/src/modules/terminal/lib/webglAtlasGuard.test.ts
@@ -2,41 +2,36 @@ import { describe, expect, it } from "vitest";
 import { AtlasPressureGuard } from "./webglAtlasGuard";
 
 describe("AtlasPressureGuard", () => {
-  it("requests a clear only once the page count reaches the threshold", () => {
-    const guard = new AtlasPressureGuard(3);
-    expect(guard.recordAdd()).toBe(false); // 1
-    expect(guard.recordAdd()).toBe(false); // 2
-    expect(guard.recordAdd()).toBe(true); // 3 -> at threshold, clear
+  it("requests a clear once the pages-added-since-last-clear count reaches the threshold", () => {
+    const guard = new AtlasPressureGuard(3, 1000, () => 0);
+    expect(guard.recordPageAdded()).toBe(false); // 1
+    expect(guard.recordPageAdded()).toBe(false); // 2
+    expect(guard.recordPageAdded()).toBe(true); // 3 -> clear
   });
 
-  it("does not request another clear while cooling down (avoids a clear loop)", () => {
-    const guard = new AtlasPressureGuard(2);
-    expect(guard.recordAdd()).toBe(false); // 1
-    expect(guard.recordAdd()).toBe(true); // 2 -> clear requested, now cooling
-    // The clear's redraw re-adds a few visible-glyph pages; these must NOT
-    // trigger another clear until reset() runs.
-    expect(guard.recordAdd()).toBe(false);
-    expect(guard.recordAdd()).toBe(false);
+  it("counts ADDS since the last clear (clearTextureAtlas keeps pages, so removes are irrelevant)", () => {
+    // A clear empties pages in place and re-rasterizes into them without firing
+    // onAdd, so the right signal is genuine new growth since the last clear.
+    let t = 0;
+    const guard = new AtlasPressureGuard(2, 1000, () => t);
+    guard.recordPageAdded();
+    expect(guard.recordPageAdded()).toBe(true); // first clear, counter reset
+    t = 5000; // well past the cooldown
+    expect(guard.recordPageAdded()).toBe(false); // 1 of the new growth
+    expect(guard.recordPageAdded()).toBe(true); // 2 -> clears again
   });
 
-  it("can trigger again after reset() once pressure rebuilds", () => {
-    const guard = new AtlasPressureGuard(2);
-    guard.recordAdd();
-    expect(guard.recordAdd()).toBe(true); // first clear
-    guard.reset();
-    expect(guard.recordAdd()).toBe(false); // 1 after reset
-    expect(guard.recordAdd()).toBe(true); // 2 -> clears again
-  });
-
-  it("decrements on page removal, floored at zero, so merges delay the next clear", () => {
-    const guard = new AtlasPressureGuard(3);
-    guard.recordAdd(); // 1
-    guard.recordAdd(); // 2
-    guard.recordRemove(); // 1 (a merge removed a page)
-    guard.recordRemove(); // 0
-    guard.recordRemove(); // stays 0, never negative
-    expect(guard.recordAdd()).toBe(false); // 1
-    expect(guard.recordAdd()).toBe(false); // 2
-    expect(guard.recordAdd()).toBe(true); // 3 -> threshold
+  it("does not clear again within the cooldown window, even at threshold (loop backstop)", () => {
+    let t = 0;
+    const guard = new AtlasPressureGuard(2, 1000, () => t);
+    guard.recordPageAdded();
+    expect(guard.recordPageAdded()).toBe(true); // clear at t=0
+    // Pathological: the post-clear redraw immediately needs many new pages.
+    t = 200; // still inside the 1000ms cooldown
+    guard.recordPageAdded();
+    guard.recordPageAdded();
+    expect(guard.recordPageAdded()).toBe(false); // blocked by the temporal cooldown
+    t = 1200; // cooldown elapsed
+    expect(guard.recordPageAdded()).toBe(true); // now allowed again
   });
 });

--- a/src/modules/terminal/lib/webglAtlasGuard.test.ts
+++ b/src/modules/terminal/lib/webglAtlasGuard.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { AtlasPressureGuard } from "./webglAtlasGuard";
+
+describe("AtlasPressureGuard", () => {
+  it("requests a clear only once the page count reaches the threshold", () => {
+    const guard = new AtlasPressureGuard(3);
+    expect(guard.recordAdd()).toBe(false); // 1
+    expect(guard.recordAdd()).toBe(false); // 2
+    expect(guard.recordAdd()).toBe(true); // 3 -> at threshold, clear
+  });
+
+  it("does not request another clear while cooling down (avoids a clear loop)", () => {
+    const guard = new AtlasPressureGuard(2);
+    expect(guard.recordAdd()).toBe(false); // 1
+    expect(guard.recordAdd()).toBe(true); // 2 -> clear requested, now cooling
+    // The clear's redraw re-adds a few visible-glyph pages; these must NOT
+    // trigger another clear until reset() runs.
+    expect(guard.recordAdd()).toBe(false);
+    expect(guard.recordAdd()).toBe(false);
+  });
+
+  it("can trigger again after reset() once pressure rebuilds", () => {
+    const guard = new AtlasPressureGuard(2);
+    guard.recordAdd();
+    expect(guard.recordAdd()).toBe(true); // first clear
+    guard.reset();
+    expect(guard.recordAdd()).toBe(false); // 1 after reset
+    expect(guard.recordAdd()).toBe(true); // 2 -> clears again
+  });
+
+  it("decrements on page removal, floored at zero, so merges delay the next clear", () => {
+    const guard = new AtlasPressureGuard(3);
+    guard.recordAdd(); // 1
+    guard.recordAdd(); // 2
+    guard.recordRemove(); // 1 (a merge removed a page)
+    guard.recordRemove(); // 0
+    guard.recordRemove(); // stays 0, never negative
+    expect(guard.recordAdd()).toBe(false); // 1
+    expect(guard.recordAdd()).toBe(false); // 2
+    expect(guard.recordAdd()).toBe(true); // 3 -> threshold
+  });
+});

--- a/src/modules/terminal/lib/webglAtlasGuard.ts
+++ b/src/modules/terminal/lib/webglAtlasGuard.ts
@@ -7,107 +7,114 @@ import type { WebglAddon } from "@xterm/addon-webgl";
  * (AI agents, syntax-highlighted output) steadily fills the atlas. Once it hits
  * the page limit the renderer tries to merge pages, and when that fails it
  * starts drawing the WRONG glyph — the garbled CJK text users hit on long
- * sessions. Clearing the atlas resets it (which is why changing the font, which
- * rebuilds the atlas, fixes it). This module clears the atlas automatically just
- * before it overflows, so the corruption never appears.
+ * sessions. `clearTextureAtlas()` empties the atlas (resetting the glyph cache),
+ * which is why changing the font, which rebuilds the atlas, also fixes it. This
+ * module clears the atlas automatically before it overflows, so the corruption
+ * never appears.
+ *
+ * Note on the trigger metric: `clearTextureAtlas()` clears each page's CONTENT
+ * in place — it keeps the page objects and does NOT fire onRemoveTextureAtlasCanvas
+ * (only merges/deletes do). After a clear the renderer re-rasterizes visible
+ * glyphs into the now-empty existing pages WITHOUT creating new ones, so onAdd
+ * goes quiet. The right pressure signal is therefore "pages added since the last
+ * clear", reset to zero each time we clear — not a net page count (which a clear
+ * doesn't reduce) and not onRemove (which a clear doesn't fire).
  */
 
 /** Hard ceilings from the WebGL renderer's atlas implementation. */
 const MAX_SUPPORTED_PAGES = 32;
 const SAFETY_MARGIN_PAGES = 2;
 const FALLBACK_THRESHOLD = 12;
+/** Minimum gap between two clears, so a pathological post-clear redraw can never
+ *  spin into a clear loop that freezes the terminal. */
+const DEFAULT_COOLDOWN_MS = 1500;
 
 /**
- * Tracks atlas page pressure and decides when to clear. Pure and synchronous so
- * the clear policy can be unit-tested without a GPU: feed it the renderer's
- * page add/remove signals and it tells you when to clear.
+ * Decides when to clear the atlas. Pure and synchronous (clock injected) so the
+ * policy is unit-testable without a GPU: feed it the renderer's page-added
+ * signal and it tells you when to clear.
  */
 export class AtlasPressureGuard {
-  private pages = 0;
-  /** True between requesting a clear and `reset()`, so the redraw's own
-   *  re-added pages can't immediately trigger another clear (a clear loop). */
-  private cooling = false;
+  /** New atlas pages created since the last clear (reset to 0 on each clear). */
+  private addsSinceClear = 0;
+  /** Timestamp of the last clear; 0 means we have never cleared. */
+  private lastClearAt = 0;
 
-  constructor(private readonly threshold: number) {}
+  constructor(
+    private readonly threshold: number,
+    private readonly cooldownMs: number = DEFAULT_COOLDOWN_MS,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
 
-  /** A page was added to the atlas. Returns true when the atlas should be
-   *  cleared now (the count reached the threshold and we're not cooling down). */
-  recordAdd(): boolean {
-    this.pages += 1;
-    if (this.cooling) {
+  /** A new page was added to the atlas. Returns true when the atlas should be
+   *  cleared now: enough growth has happened since the last clear AND we are
+   *  past the cooldown. Resets the growth counter when it returns true. */
+  recordPageAdded(): boolean {
+    this.addsSinceClear += 1;
+    if (this.addsSinceClear < this.threshold) {
       return false;
     }
-    if (this.pages >= this.threshold) {
-      this.cooling = true;
-      return true;
+    const t = this.now();
+    if (this.lastClearAt !== 0 && t - this.lastClearAt < this.cooldownMs) {
+      return false;
     }
-    return false;
-  }
-
-  /** A page was removed (e.g. the renderer merged pages); floored at zero. */
-  recordRemove(): void {
-    if (this.pages > 0) {
-      this.pages -= 1;
-    }
-  }
-
-  /** Re-arm after a clear has settled: zero the count and end the cooldown so a
-   *  later genuine build-up can trigger the next clear. */
-  reset(): void {
-    this.pages = 0;
-    this.cooling = false;
+    this.lastClearAt = t;
+    this.addsSinceClear = 0;
+    return true;
   }
 }
 
+let cachedThreshold: number | null = null;
+
 /**
  * Probe the device's fragment-shader texture-unit limit, which caps how many
- * atlas pages the renderer can hold (`min(32, MAX_TEXTURE_IMAGE_UNITS)`). We
- * clear a couple of pages before that ceiling. Returns a safe fallback when WebGL
- * is unavailable (the guard still works, just with a conservative threshold).
+ * atlas pages the renderer can hold (`min(32, MAX_TEXTURE_IMAGE_UNITS)`); we
+ * clear a couple of pages before that ceiling. Cached after the first call:
+ * GPU capabilities don't change at runtime, and probing creates a throwaway
+ * WebGL context that we release immediately (browsers cap live contexts, and an
+ * uncached probe per pane could evict a real terminal's context). Returns a safe
+ * fallback when WebGL is unavailable.
  */
 export function detectAtlasClearThreshold(fallback: number = FALLBACK_THRESHOLD): number {
+  if (cachedThreshold !== null) {
+    return cachedThreshold;
+  }
   try {
     const canvas = document.createElement("canvas");
     const gl =
       (canvas.getContext("webgl2") as WebGL2RenderingContext | null) ??
       (canvas.getContext("webgl") as WebGLRenderingContext | null);
     if (!gl) {
+      cachedThreshold = fallback;
       return fallback;
     }
     const units = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS) as number;
     const maxPages = Math.min(MAX_SUPPORTED_PAGES, units);
+    // Free the probe context right away rather than waiting for GC.
+    gl.getExtension("WEBGL_lose_context")?.loseContext();
     // Clear before the ceiling so a merge failure can't corrupt glyphs first.
-    return Math.max(2, maxPages - SAFETY_MARGIN_PAGES);
+    cachedThreshold = Math.max(2, maxPages - SAFETY_MARGIN_PAGES);
+    return cachedThreshold;
   } catch {
+    cachedThreshold = fallback;
     return fallback;
   }
 }
 
 /**
- * Wire an `AtlasPressureGuard` to a live `WebglAddon`: when atlas pressure
- * reaches the threshold, clear the atlas and re-arm on the next tick (after the
- * clear's redraw has re-rasterized the visible glyphs). Returns a disposer that
- * detaches the listeners.
+ * Wire an `AtlasPressureGuard` to a live `WebglAddon`: when atlas growth since
+ * the last clear reaches the threshold, clear the atlas. Returns a disposer that
+ * detaches the listener; the caller must run it when the addon is disposed.
  */
 export function installAtlasPressureGuard(
   addon: WebglAddon,
   threshold: number = detectAtlasClearThreshold(),
 ): () => void {
   const guard = new AtlasPressureGuard(threshold);
-
   const added = addon.onAddTextureAtlasCanvas(() => {
-    if (guard.recordAdd()) {
+    if (guard.recordPageAdded()) {
       addon.clearTextureAtlas();
-      // The clear removes every page (firing onRemove) and its redraw re-adds a
-      // few for the visible glyphs. Re-arm on the next tick so those settle into
-      // a clean baseline instead of immediately re-triggering.
-      queueMicrotask(() => guard.reset());
     }
   });
-  const removed = addon.onRemoveTextureAtlasCanvas(() => guard.recordRemove());
-
-  return () => {
-    added.dispose();
-    removed.dispose();
-  };
+  return () => added.dispose();
 }

--- a/src/modules/terminal/lib/webglAtlasGuard.ts
+++ b/src/modules/terminal/lib/webglAtlasGuard.ts
@@ -1,0 +1,113 @@
+import type { WebglAddon } from "@xterm/addon-webgl";
+
+/**
+ * The xterm WebGL renderer caches rasterized glyphs in a bounded texture atlas
+ * (a few pages, each up to 4096px). It keys glyphs by character AND colour AND
+ * style, so a long session with lots of distinct CJK glyphs in varied colours
+ * (AI agents, syntax-highlighted output) steadily fills the atlas. Once it hits
+ * the page limit the renderer tries to merge pages, and when that fails it
+ * starts drawing the WRONG glyph — the garbled CJK text users hit on long
+ * sessions. Clearing the atlas resets it (which is why changing the font, which
+ * rebuilds the atlas, fixes it). This module clears the atlas automatically just
+ * before it overflows, so the corruption never appears.
+ */
+
+/** Hard ceilings from the WebGL renderer's atlas implementation. */
+const MAX_SUPPORTED_PAGES = 32;
+const SAFETY_MARGIN_PAGES = 2;
+const FALLBACK_THRESHOLD = 12;
+
+/**
+ * Tracks atlas page pressure and decides when to clear. Pure and synchronous so
+ * the clear policy can be unit-tested without a GPU: feed it the renderer's
+ * page add/remove signals and it tells you when to clear.
+ */
+export class AtlasPressureGuard {
+  private pages = 0;
+  /** True between requesting a clear and `reset()`, so the redraw's own
+   *  re-added pages can't immediately trigger another clear (a clear loop). */
+  private cooling = false;
+
+  constructor(private readonly threshold: number) {}
+
+  /** A page was added to the atlas. Returns true when the atlas should be
+   *  cleared now (the count reached the threshold and we're not cooling down). */
+  recordAdd(): boolean {
+    this.pages += 1;
+    if (this.cooling) {
+      return false;
+    }
+    if (this.pages >= this.threshold) {
+      this.cooling = true;
+      return true;
+    }
+    return false;
+  }
+
+  /** A page was removed (e.g. the renderer merged pages); floored at zero. */
+  recordRemove(): void {
+    if (this.pages > 0) {
+      this.pages -= 1;
+    }
+  }
+
+  /** Re-arm after a clear has settled: zero the count and end the cooldown so a
+   *  later genuine build-up can trigger the next clear. */
+  reset(): void {
+    this.pages = 0;
+    this.cooling = false;
+  }
+}
+
+/**
+ * Probe the device's fragment-shader texture-unit limit, which caps how many
+ * atlas pages the renderer can hold (`min(32, MAX_TEXTURE_IMAGE_UNITS)`). We
+ * clear a couple of pages before that ceiling. Returns a safe fallback when WebGL
+ * is unavailable (the guard still works, just with a conservative threshold).
+ */
+export function detectAtlasClearThreshold(fallback: number = FALLBACK_THRESHOLD): number {
+  try {
+    const canvas = document.createElement("canvas");
+    const gl =
+      (canvas.getContext("webgl2") as WebGL2RenderingContext | null) ??
+      (canvas.getContext("webgl") as WebGLRenderingContext | null);
+    if (!gl) {
+      return fallback;
+    }
+    const units = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS) as number;
+    const maxPages = Math.min(MAX_SUPPORTED_PAGES, units);
+    // Clear before the ceiling so a merge failure can't corrupt glyphs first.
+    return Math.max(2, maxPages - SAFETY_MARGIN_PAGES);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Wire an `AtlasPressureGuard` to a live `WebglAddon`: when atlas pressure
+ * reaches the threshold, clear the atlas and re-arm on the next tick (after the
+ * clear's redraw has re-rasterized the visible glyphs). Returns a disposer that
+ * detaches the listeners.
+ */
+export function installAtlasPressureGuard(
+  addon: WebglAddon,
+  threshold: number = detectAtlasClearThreshold(),
+): () => void {
+  const guard = new AtlasPressureGuard(threshold);
+
+  const added = addon.onAddTextureAtlasCanvas(() => {
+    if (guard.recordAdd()) {
+      addon.clearTextureAtlas();
+      // The clear removes every page (firing onRemove) and its redraw re-adds a
+      // few for the visible glyphs. Re-arm on the next tick so those settle into
+      // a clean baseline instead of immediately re-triggering.
+      queueMicrotask(() => guard.reset());
+    }
+  });
+  const removed = addon.onRemoveTextureAtlasCanvas(() => guard.recordRemove());
+
+  return () => {
+    added.dispose();
+    removed.dispose();
+  };
+}


### PR DESCRIPTION
## Problem

On a long terminal session, CJK text starts rendering as the **wrong glyphs** (garbled), while ASCII stays fine. Picking a different font in Settings fixes it temporarily.

## Root cause

The xterm WebGL renderer caches rasterized glyphs in a bounded texture atlas (a few pages, each up to 4096px), keyed by **character + foreground + background + style**. A long session with lots of distinct CJK glyphs in varied colours (AI agents, syntax-highlighted output) steadily fills the atlas. Once it hits the page limit (`min(32, MAX_TEXTURE_IMAGE_UNITS)`), the renderer tries to merge pages and, when that fails, draws the wrong glyph. Changing the font rebuilds the atlas, which is why it clears the corruption. Our code never cleared the atlas, so a long enough session always hit it. (Confirmed against the xterm.js TextureAtlas implementation.)

## Fix

Clear the glyph atlas automatically just before it overflows:

- `AtlasPressureGuard` (pure, unit-tested) tracks atlas page add/remove signals and reports when the net page count reaches a threshold, with a cooldown so the post-clear redraw can't trigger a clear loop.
- The threshold is derived from the device's `MAX_TEXTURE_IMAGE_UNITS` with a 2-page safety margin (fallback 12 when WebGL is unavailable), so low-end GPUs are protected too.
- Wired to `WebglAddon`'s `onAddTextureAtlasCanvas` / `onRemoveTextureAtlasCanvas`; on threshold it calls `clearTextureAtlas()` and re-arms on the next tick. Idle sessions are untouched — it only acts right before an overflow.

## Test plan

- [x] `pnpm test` — 815 passing (incl. 4 new `AtlasPressureGuard` behaviour tests: threshold trigger, cooldown/no-loop, reset re-arm, merge-aware decrement)
- [x] `pnpm typecheck` clean
- [ ] **Manual (pending, needs a long session):** run a long CJK-heavy session (e.g. lots of coloured Chinese output / an AI agent) and confirm the text no longer garbles over time, without manually switching fonts

## Notes

- `@xterm/addon-webgl` is already at the latest stable (0.19.0); there is no exposed option to tune the atlas size, so clearing is the supported mitigation.
