### PR TITLE
feat(editor): web-preview button for HTML files

### DIFF
--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -15,6 +15,7 @@
   "useDiskVersion": "Use disk version",
   "keepMine": "Keep mine",
   "wrap": "Word wrap",
+  "webPreview": "Web preview",
   "mode": {
     "edit": "Edit",
     "split": "Split",

--- a/src/i18n/locales/zh-Hant/editor.json
+++ b/src/i18n/locales/zh-Hant/editor.json
@@ -15,6 +15,7 @@
   "useDiskVersion": "使用磁碟版本",
   "keepMine": "保留我的",
   "wrap": "自動換行",
+  "webPreview": "網頁預覽",
   "mode": {
     "edit": "編輯",
     "split": "並排",

--- a/src/modules/editor/EditorTabContent.test.tsx
+++ b/src/modules/editor/EditorTabContent.test.tsx
@@ -1,0 +1,47 @@
+// Tests the extracted EditorToolbar component (see EditorToolbar.tsx).
+// We test the toolbar in isolation to avoid mounting CodeMirror and its
+// heavy Tauri/codemirror dependencies in jsdom. The behavior under test —
+// "HTML file shows a Globe button; non-HTML hides it; click fires callback" —
+// lives entirely inside the toolbar and is fully covered here.
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@/i18n";
+import { EditorToolbar } from "./EditorToolbar";
+
+const base = {
+  wordWrap: false,
+  onToggleWordWrap: vi.fn(),
+  onRefresh: vi.fn(),
+  mode: "edit" as const,
+  onSetMode: vi.fn(),
+};
+
+describe("EditorToolbar web preview button", () => {
+  it("shows the web-preview button for an HTML file and calls the callback", () => {
+    const onOpenWebPreview = vi.fn();
+    render(
+      <EditorToolbar {...base} path="/proj/index.html" onOpenWebPreview={onOpenWebPreview} />,
+    );
+    const btn = screen.getByRole("button", { name: "Web preview" });
+    fireEvent.click(btn);
+    expect(onOpenWebPreview).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the web-preview button for an .htm file", () => {
+    const onOpenWebPreview = vi.fn();
+    render(
+      <EditorToolbar {...base} path="/proj/page.htm" onOpenWebPreview={onOpenWebPreview} />,
+    );
+    expect(screen.getByRole("button", { name: "Web preview" })).toBeInTheDocument();
+  });
+
+  it("does not show the button for a non-HTML file", () => {
+    render(<EditorToolbar {...base} path="/proj/notes.txt" onOpenWebPreview={() => {}} />);
+    expect(screen.queryByRole("button", { name: "Web preview" })).toBeNull();
+  });
+
+  it("does not show the button when onOpenWebPreview is not provided", () => {
+    render(<EditorToolbar {...base} path="/proj/index.html" />);
+    expect(screen.queryByRole("button", { name: "Web preview" })).toBeNull();
+  });
+});

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Columns2, Eye, RefreshCw, SquarePen, WrapText, type LucideIcon } from "lucide-react";
 import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { EditorView as CMView } from "@codemirror/view";
 import { Compartment } from "@codemirror/state";
@@ -15,24 +14,11 @@ import { buildCompletionMessages, cleanCompletion } from "@/modules/ai/lib/compl
 import { externalChangeAction, manualReloadAction, shouldReloadFromDisk } from "./lib/reload";
 import { onEditorFileChanged } from "./lib/editorWatch";
 import { fsReadFile, fsWriteFile } from "@/modules/explorer/lib/fsBridge";
-import { basename } from "@/modules/explorer/lib/paths";
 import { MarkdownView } from "@/components/MarkdownView";
-import { Tooltip } from "@/components/Tooltip";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { EditorToolbar, type EditorMode } from "./EditorToolbar";
 import { selectTerminalFontFamily, useFontStore } from "@/stores/fontStore";
 import { useSettingsStore } from "@/stores/settingsStore";
-
-type EditorMode = "edit" | "split" | "preview";
-
-const MODES: { key: EditorMode; icon: LucideIcon }[] = [
-  { key: "edit", icon: SquarePen },
-  { key: "split", icon: Columns2 },
-  { key: "preview", icon: Eye },
-];
-
-function isMarkdownPath(path: string): boolean {
-  return /\.(md|markdown|mdx)$/i.test(path);
-}
 
 // After we save, the watcher reports our own write back as a change. Ignore
 // those echoes for a short window so a save never bounces back as a reload.
@@ -57,7 +43,13 @@ async function requestCompletion(
 }
 
 /** One open file. Each editor tab renders a single file with its own buffer. */
-export function EditorTabContent({ path }: { path: string }) {
+export function EditorTabContent({
+  path,
+  onOpenWebPreview,
+}: {
+  path: string;
+  onOpenWebPreview?: () => void;
+}) {
   const { t } = useTranslation("editor");
   const setBaseline = useEditorStore((s) => s.setBaseline);
   const setContent = useEditorStore((s) => s.setContent);
@@ -71,7 +63,7 @@ export function EditorTabContent({ path }: { path: string }) {
   const toggleWordWrap = useSettingsStore((s) => s.toggleWordWrap);
   const aiInlineCompletionEnabled = useSettingsStore((s) => s.aiInlineCompletion);
 
-  const isMarkdown = isMarkdownPath(path);
+  const isMarkdown = /\.(md|markdown|mdx)$/i.test(path);
   const [mode, setMode] = useState<EditorMode>("edit");
   const [confirmReload, setConfirmReload] = useState(false);
   const [externalChanged, setExternalChanged] = useState(false);
@@ -242,57 +234,15 @@ export function EditorTabContent({ path }: { path: string }) {
         }
       }}
     >
-      {/* pr-8 leaves room for the pane's close button (absolute, top-right). */}
-      <div className="flex h-7 shrink-0 items-center justify-between gap-2 border-b border-border pl-2 pr-8">
-        <span className="min-w-0 truncate text-xs text-fg-muted" title={path}>
-          {basename(path)}
-        </span>
-        <div className="flex shrink-0 items-center gap-0.5">
-        <Tooltip label={t("refresh")}>
-          <button
-            type="button"
-            aria-label={t("refresh")}
-            onClick={handleRefresh}
-            className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
-          >
-            <RefreshCw size={14} />
-          </button>
-        </Tooltip>
-        <Tooltip label={t("wrap")}>
-          <button
-            type="button"
-            aria-label={t("wrap")}
-            aria-pressed={wordWrap}
-            onClick={toggleWordWrap}
-            className={`rounded p-1 ${
-              wordWrap ? "bg-bg-elevated text-fg" : "text-fg-muted hover:bg-bg-elevated hover:text-fg"
-            }`}
-          >
-            <WrapText size={14} />
-          </button>
-        </Tooltip>
-        {isMarkdown &&
-          MODES.map((m) => {
-            const Icon = m.icon;
-            const active = mode === m.key;
-            return (
-              <Tooltip key={m.key} label={t(`mode.${m.key}`)}>
-                <button
-                  type="button"
-                  aria-label={t(`mode.${m.key}`)}
-                  aria-pressed={active}
-                  onClick={() => setMode(m.key)}
-                  className={`rounded p-1 ${
-                    active ? "bg-bg-elevated text-fg" : "text-fg-muted hover:bg-bg-elevated hover:text-fg"
-                  }`}
-                >
-                  <Icon size={14} />
-                </button>
-              </Tooltip>
-            );
-          })}
-        </div>
-      </div>
+      <EditorToolbar
+        path={path}
+        wordWrap={wordWrap}
+        onToggleWordWrap={toggleWordWrap}
+        onRefresh={handleRefresh}
+        onOpenWebPreview={onOpenWebPreview}
+        mode={mode}
+        onSetMode={setMode}
+      />
 
       {externalChanged && (
         <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-warning/10 px-3 py-1.5 text-xs text-fg">

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -4,7 +4,7 @@ import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { EditorView as CMView } from "@codemirror/view";
 import { Compartment } from "@codemirror/state";
 import { editorSyntaxTheme } from "@/themes/editorTheme";
-import { languageLabel, loadLanguageExtension } from "./lib/language";
+import { isMarkdownPath, languageLabel, loadLanguageExtension } from "./lib/language";
 import { inlineCompletion, type CompletionRequest } from "./lib/inlineCompletion";
 import { useEditorStore } from "./store/editorStore";
 import { aiChat } from "@/modules/ai/lib/aiBridge";
@@ -63,7 +63,7 @@ export function EditorTabContent({
   const toggleWordWrap = useSettingsStore((s) => s.toggleWordWrap);
   const aiInlineCompletionEnabled = useSettingsStore((s) => s.aiInlineCompletion);
 
-  const isMarkdown = /\.(md|markdown|mdx)$/i.test(path);
+  const isMarkdown = isMarkdownPath(path);
   const [mode, setMode] = useState<EditorMode>("edit");
   const [confirmReload, setConfirmReload] = useState(false);
   const [externalChanged, setExternalChanged] = useState(false);

--- a/src/modules/editor/EditorToolbar.tsx
+++ b/src/modules/editor/EditorToolbar.tsx
@@ -1,0 +1,115 @@
+import { useTranslation } from "react-i18next";
+import {
+  Columns2,
+  Eye,
+  Globe,
+  RefreshCw,
+  SquarePen,
+  WrapText,
+  type LucideIcon,
+} from "lucide-react";
+import { Tooltip } from "@/components/Tooltip";
+import { basename } from "@/modules/explorer/lib/paths";
+
+export type EditorMode = "edit" | "split" | "preview";
+
+const MODES: { key: EditorMode; icon: LucideIcon }[] = [
+  { key: "edit", icon: SquarePen },
+  { key: "split", icon: Columns2 },
+  { key: "preview", icon: Eye },
+];
+
+interface EditorToolbarProps {
+  path: string;
+  wordWrap: boolean;
+  onToggleWordWrap: () => void;
+  onRefresh: () => void;
+  onOpenWebPreview?: () => void;
+  mode: EditorMode;
+  onSetMode: (mode: EditorMode) => void;
+}
+
+/** Toolbar row shown at the top of every editor pane. Fully presentational. */
+export function EditorToolbar({
+  path,
+  wordWrap,
+  onToggleWordWrap,
+  onRefresh,
+  onOpenWebPreview,
+  mode,
+  onSetMode,
+}: EditorToolbarProps) {
+  const { t } = useTranslation("editor");
+  const isMarkdown = /\.(md|markdown|mdx)$/i.test(path);
+  const isHtml = /\.(html|htm)$/i.test(path);
+
+  return (
+    /* pr-8 leaves room for the pane's close button (absolute, top-right). */
+    <div className="flex h-7 shrink-0 items-center justify-between gap-2 border-b border-border pl-2 pr-8">
+      <span className="min-w-0 truncate text-xs text-fg-muted" title={path}>
+        {basename(path)}
+      </span>
+      <div className="flex shrink-0 items-center gap-0.5">
+        <Tooltip label={t("refresh")}>
+          <button
+            type="button"
+            aria-label={t("refresh")}
+            onClick={onRefresh}
+            className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+          >
+            <RefreshCw size={14} />
+          </button>
+        </Tooltip>
+        <Tooltip label={t("wrap")}>
+          <button
+            type="button"
+            aria-label={t("wrap")}
+            aria-pressed={wordWrap}
+            onClick={onToggleWordWrap}
+            className={`rounded p-1 ${
+              wordWrap
+                ? "bg-bg-elevated text-fg"
+                : "text-fg-muted hover:bg-bg-elevated hover:text-fg"
+            }`}
+          >
+            <WrapText size={14} />
+          </button>
+        </Tooltip>
+        {isHtml && onOpenWebPreview && (
+          <Tooltip label={t("webPreview")}>
+            <button
+              type="button"
+              aria-label={t("webPreview")}
+              onClick={onOpenWebPreview}
+              className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+            >
+              <Globe size={14} />
+            </button>
+          </Tooltip>
+        )}
+        {isMarkdown &&
+          MODES.map((m) => {
+            const Icon = m.icon;
+            const active = mode === m.key;
+            return (
+              <Tooltip key={m.key} label={t(`mode.${m.key}`)}>
+                <button
+                  type="button"
+                  aria-label={t(`mode.${m.key}`)}
+                  aria-pressed={active}
+                  onClick={() => onSetMode(m.key)}
+                  className={`rounded p-1 ${
+                    active
+                      ? "bg-bg-elevated text-fg"
+                      : "text-fg-muted hover:bg-bg-elevated hover:text-fg"
+                  }`}
+                >
+                  <Icon size={14} />
+                </button>
+              </Tooltip>
+            );
+          })}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/editor/EditorToolbar.tsx
+++ b/src/modules/editor/EditorToolbar.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
 import { basename } from "@/modules/explorer/lib/paths";
+import { isHtmlPath, isMarkdownPath } from "./lib/language";
 
 export type EditorMode = "edit" | "split" | "preview";
 
@@ -40,8 +41,8 @@ export function EditorToolbar({
   onSetMode,
 }: EditorToolbarProps) {
   const { t } = useTranslation("editor");
-  const isMarkdown = /\.(md|markdown|mdx)$/i.test(path);
-  const isHtml = /\.(html|htm)$/i.test(path);
+  const isMarkdown = isMarkdownPath(path);
+  const isHtml = isHtmlPath(path);
 
   return (
     /* pr-8 leaves room for the pane's close button (absolute, top-right). */

--- a/src/modules/editor/lib/editorWatch.ts
+++ b/src/modules/editor/lib/editorWatch.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { openEditorPaths, useTabsStore } from "@/stores/tabsStore";
+import { localPreviewFilePaths, openEditorPaths, useTabsStore } from "@/stores/tabsStore";
 
 /**
  * Frontend wrappers around the Rust editor file watcher. The backend watches the
@@ -29,7 +29,8 @@ export function installEditorWatchSync(): () => void {
   // resizer doesn't tear down and rebuild the OS watcher dozens of times a second.
   let lastPathsKey = "";
   const sync = () => {
-    const paths = openEditorPaths(useTabsStore.getState().tabs).sort();
+    const tabs = useTabsStore.getState().tabs;
+    const paths = Array.from(new Set([...openEditorPaths(tabs), ...localPreviewFilePaths(tabs)])).sort();
     const pathsKey = paths.join("\n");
     if (pathsKey === lastPathsKey) {
       return;

--- a/src/modules/editor/lib/language.ts
+++ b/src/modules/editor/lib/language.ts
@@ -32,6 +32,16 @@ export function languageDescriptionForPath(path: string): LanguageDescription | 
   return LanguageDescription.matchFilename(languages, name);
 }
 
+/** True for markdown file paths (.md / .markdown / .mdx). */
+export function isMarkdownPath(path: string): boolean {
+  return /\.(md|markdown|mdx)$/i.test(path);
+}
+
+/** True for HTML file paths (.html / .htm). */
+export function isHtmlPath(path: string): boolean {
+  return /\.(html|htm)$/i.test(path);
+}
+
 /**
  * Load the CodeMirror language support extension for a path. Returns an empty
  * list for unknown files (or when the grammar fails to load), so the editor

--- a/src/modules/preview/PreviewTabContent.test.tsx
+++ b/src/modules/preview/PreviewTabContent.test.tsx
@@ -1,0 +1,50 @@
+// Tests that PreviewTabContent reloads its iframe when the previewed local
+// file changes on disk. The `reloadKey` state is internal, so we expose it
+// observably via a `data-reload` attribute on the iframe and assert that it
+// increments on a matching file-change event and stays put on a non-matching one.
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { describe, expect, it, vi } from "vitest";
+import "@/i18n";
+
+// Capture the change handler so the test can fire a file-change event.
+let changeHandler: ((path: string) => void) | null = null;
+vi.mock("@/modules/editor/lib/editorWatch", () => ({
+  onEditorFileChanged: (h: (p: string) => void) => {
+    changeHandler = h;
+    return Promise.resolve(() => {
+      changeHandler = null;
+    });
+  },
+}));
+
+import { PreviewTabContent } from "./PreviewTabContent";
+
+describe("PreviewTabContent auto-reload", () => {
+  it("reloads the iframe when the previewed local file changes", async () => {
+    render(<PreviewTabContent url="file:///proj/index.html" />);
+    const getIframe = () => screen.getByTitle(/preview/i) as HTMLIFrameElement;
+    const initialReloadKey = Number(getIframe().dataset.reload);
+    // wait a microtask so the mocked listen promise resolves and sets the handler
+    await act(async () => {});
+    await act(async () => {
+      changeHandler?.("/proj/index.html");
+    });
+    // The iframe is remounted via key bump; assert the reload counter incremented.
+    expect(Number(getIframe().dataset.reload)).toBe(initialReloadKey + 1);
+    // The subscription is still alive after the reload (effect deps didn't change).
+    expect(changeHandler).not.toBeNull();
+  });
+
+  it("ignores changes to a different file", async () => {
+    render(<PreviewTabContent url="file:///proj/index.html" />);
+    const getIframe = () => screen.getByTitle(/preview/i) as HTMLIFrameElement;
+    const initialReloadKey = Number(getIframe().dataset.reload);
+    await act(async () => {});
+    await act(async () => {
+      changeHandler?.("/proj/other.html");
+    });
+    // A different file must not trigger a reload.
+    expect(Number(getIframe().dataset.reload)).toBe(initialReloadKey);
+  });
+});

--- a/src/modules/preview/PreviewTabContent.tsx
+++ b/src/modules/preview/PreviewTabContent.tsx
@@ -39,7 +39,7 @@ export function PreviewTabContent({ url }: { url: string }) {
       } else {
         unlisten = fn;
       }
-    });
+    }).catch(() => {});
     return () => {
       disposed = true;
       unlisten?.();

--- a/src/modules/preview/PreviewTabContent.tsx
+++ b/src/modules/preview/PreviewTabContent.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { RotateCw } from "lucide-react";
+import { onEditorFileChanged } from "@/modules/editor/lib/editorWatch";
 import { resolvePreviewSrc } from "./lib/resolvePreviewSrc";
+import { previewLocalPath } from "./lib/htmlPreviewTarget";
 
 export function PreviewTabContent({ url }: { url: string }) {
   const { t } = useTranslation("preview");
@@ -15,6 +17,34 @@ export function PreviewTabContent({ url }: { url: string }) {
     setCurrent(url);
     setInput(url);
   }, [url]);
+
+  // Local-file previews auto-reload when the file changes on disk (e.g. you save
+  // it in the editor). Web urls are not watched. The watched SET is maintained
+  // by installEditorWatchSync (it includes local preview paths); here we only
+  // listen and reload when our own file is the one that changed.
+  useEffect(() => {
+    const localPath = previewLocalPath(current);
+    if (!localPath) {
+      return;
+    }
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+    void onEditorFileChanged((changedPath) => {
+      if (changedPath === localPath) {
+        setReloadKey((k) => k + 1);
+      }
+    }).then((fn) => {
+      if (disposed) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [current]);
 
   return (
     <div className="flex h-full flex-col bg-bg">
@@ -46,6 +76,7 @@ export function PreviewTabContent({ url }: { url: string }) {
       <iframe
         ref={frameRef}
         key={reloadKey}
+        data-reload={reloadKey}
         src={resolvePreviewSrc(current)}
         title={t("title")}
         className="min-h-0 flex-1 w-full border-0 bg-white"

--- a/src/modules/preview/lib/htmlPreviewTarget.test.ts
+++ b/src/modules/preview/lib/htmlPreviewTarget.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { decideHtmlPreviewOpen, previewLocalPath } from "./htmlPreviewTarget";
+import { leaf, splitLeaf } from "@/modules/terminal/lib/terminalLayout";
+
+describe("decideHtmlPreviewOpen", () => {
+  it("replaces an existing preview pane in the same tab", () => {
+    // editor leaf split with a preview leaf beside it
+    const tree = splitLeaf(leaf("ed", { kind: "editor", path: "/a.html" }), "ed", "row", "pv", {
+      kind: "preview",
+      url: "file:///old.html",
+    });
+    expect(decideHtmlPreviewOpen(tree, "ed")).toEqual({ kind: "replace", leafId: "pv" });
+  });
+
+  it("splits beside a single-pane (unsplit) editor tab", () => {
+    const tree = leaf("ed", { kind: "editor", path: "/a.html" });
+    expect(decideHtmlPreviewOpen(tree, "ed")).toEqual({ kind: "split", fromLeafId: "ed" });
+  });
+
+  it("opens a preview tab when the tab is split but has no preview pane", () => {
+    const tree = splitLeaf(leaf("ed", { kind: "editor", path: "/a.html" }), "ed", "row", "term", {
+      kind: "terminal",
+    });
+    expect(decideHtmlPreviewOpen(tree, "ed")).toEqual({ kind: "previewTab" });
+  });
+});
+
+describe("previewLocalPath", () => {
+  it("returns the path for file:// and absolute urls, null for web urls", () => {
+    expect(previewLocalPath("file:///Users/me/a.html")).toBe("/Users/me/a.html");
+    expect(previewLocalPath("/Users/me/a.html")).toBe("/Users/me/a.html");
+    expect(previewLocalPath("http://localhost:3000")).toBeNull();
+    expect(previewLocalPath("https://example.com")).toBeNull();
+  });
+});

--- a/src/modules/preview/lib/htmlPreviewTarget.test.ts
+++ b/src/modules/preview/lib/htmlPreviewTarget.test.ts
@@ -32,4 +32,8 @@ describe("previewLocalPath", () => {
     expect(previewLocalPath("http://localhost:3000")).toBeNull();
     expect(previewLocalPath("https://example.com")).toBeNull();
   });
+
+  it("handles file:// urls with a host component", () => {
+    expect(previewLocalPath("file://localhost/Users/me/a.html")).toBe("/Users/me/a.html");
+  });
 });

--- a/src/modules/preview/lib/htmlPreviewTarget.ts
+++ b/src/modules/preview/lib/htmlPreviewTarget.ts
@@ -33,11 +33,15 @@ export function decideHtmlPreviewOpen(paneTree: LayoutNode, fromLeafId: string):
 export function previewLocalPath(url: string): string | null {
   const value = url.trim();
   if (value.startsWith("file://")) {
-    const withoutScheme = value.replace(/^file:\/\//i, "");
     try {
-      return decodeURIComponent(withoutScheme);
+      return decodeURIComponent(new URL(value).pathname);
     } catch {
-      return withoutScheme;
+      const withoutScheme = value.replace(/^file:\/\//i, "");
+      try {
+        return decodeURIComponent(withoutScheme);
+      } catch {
+        return withoutScheme;
+      }
     }
   }
   if (value.startsWith("/")) {

--- a/src/modules/preview/lib/htmlPreviewTarget.ts
+++ b/src/modules/preview/lib/htmlPreviewTarget.ts
@@ -1,0 +1,47 @@
+import { findPaneContent, leafIds, type LayoutNode } from "@/modules/terminal/lib/terminalLayout";
+
+/** Where an HTML web-preview should open, given the source tab's layout. */
+export type HtmlPreviewTarget =
+  | { kind: "replace"; leafId: string } // a preview pane already exists in this tab
+  | { kind: "split"; fromLeafId: string } // single-pane editor tab: split beside it
+  | { kind: "previewTab" }; // split tab without a preview pane: use a preview tab
+
+/**
+ * Smart open rule (first match wins):
+ * 1. the tab already shows a preview pane -> replace its content
+ * 2. the tab is a single (unsplit) pane -> split the preview beside the editor
+ * 3. otherwise (already split, no preview) -> open/reuse a dedicated preview tab
+ */
+export function decideHtmlPreviewOpen(paneTree: LayoutNode, fromLeafId: string): HtmlPreviewTarget {
+  const previewLeafId = leafIds(paneTree).find(
+    (id) => findPaneContent(paneTree, id)?.kind === "preview",
+  );
+  if (previewLeafId) {
+    return { kind: "replace", leafId: previewLeafId };
+  }
+  if (paneTree.kind === "leaf") {
+    return { kind: "split", fromLeafId };
+  }
+  return { kind: "previewTab" };
+}
+
+/**
+ * The local filesystem path a preview url points at, or null for a web url.
+ * Mirrors resolvePreviewSrc's input handling: `file://` (decoded) and absolute
+ * `/` paths are local; everything else (http(s)/asset) is not.
+ */
+export function previewLocalPath(url: string): string | null {
+  const value = url.trim();
+  if (value.startsWith("file://")) {
+    const withoutScheme = value.replace(/^file:\/\//i, "");
+    try {
+      return decodeURIComponent(withoutScheme);
+    } catch {
+      return withoutScheme;
+    }
+  }
+  if (value.startsWith("/")) {
+    return value;
+  }
+  return null;
+}

--- a/src/modules/preview/lib/resolvePreviewSrc.test.ts
+++ b/src/modules/preview/lib/resolvePreviewSrc.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { resolvePreviewSrc } from "./resolvePreviewSrc";
 
-// The asset URL keeps directory structure (slashes literal, segments encoded)
-// so the iframe's base resolves the page's relative CSS/JS/images.
+// The asset URL encodes the leading slash as %2F (Tauri's handler strips the
+// URL's structural leading "/" before resolving the file, so the path's own
+// leading slash must survive as %2F or an absolute path is read as relative and
+// 404s). Inner slashes stay literal so the iframe base resolves relative assets.
 function assetUrl(path: string): string {
-  return "asset://localhost" + path.split("/").map(encodeURIComponent).join("/");
+  const segments = path.split("/").filter((seg) => seg !== "").map(encodeURIComponent);
+  return "asset://localhost/%2F" + segments.join("/");
 }
 
 describe("resolvePreviewSrc", () => {
@@ -16,12 +19,20 @@ describe("resolvePreviewSrc", () => {
     expect(resolvePreviewSrc("/Users/me/page.html")).toBe(assetUrl("/Users/me/page.html"));
   });
 
-  it("keeps directory structure so relative assets resolve", () => {
+  it("encodes the leading slash as %2F so the asset handler finds the file", () => {
+    // Tauri's asset handler does `request.uri().path()[1..]` then percent-decode;
+    // a literal leading "/" gets stripped, turning /Users/... into the relative
+    // Users/... -> File::open -> 404. %2F survives the strip and decodes to "/".
     const src = resolvePreviewSrc("/Users/me/site/pages/index.html");
-    // Slashes stay literal — the base dir is preserved, not collapsed into one
-    // encoded segment.
-    expect(src).toBe("asset://localhost/Users/me/site/pages/index.html");
-    expect(src).not.toContain("%2F");
+    expect(src).toBe("asset://localhost/%2FUsers/me/site/pages/index.html");
+  });
+
+  it("keeps inner slashes literal so relative assets resolve to sibling files", () => {
+    const src = resolvePreviewSrc("/Users/me/site/pages/index.html");
+    // Exactly one %2F (the leading slash); directory separators stay literal so
+    // the base dir is preserved, not collapsed into one encoded segment.
+    expect(src.match(/%2F/g)?.length).toBe(1);
+    expect(src).toContain("/site/pages/");
   });
 
   it("leaves real web URLs untouched", () => {

--- a/src/modules/preview/lib/resolvePreviewSrc.ts
+++ b/src/modules/preview/lib/resolvePreviewSrc.ts
@@ -13,16 +13,24 @@ function fileUrlToPath(url: string): string {
 }
 
 /**
- * Build an asset-protocol URL that keeps the file's directory structure: each
- * path segment is encoded but the slashes stay literal. This matters because
- * the iframe uses this URL as its base, so a previewed page's relative CSS, JS,
- * and images resolve to their sibling files. (Tauri's `convertFileSrc`
- * percent-encodes the whole path into a single segment, which collapses the
- * base directory and breaks every relative reference.)
+ * Build an asset-protocol URL for an absolute file path.
+ *
+ * Tauri's asset handler resolves the file from `request.uri().path()[1..]` (it
+ * strips exactly the URL's structural leading "/") and then percent-decodes it.
+ * So the path's OWN leading slash must be sent as `%2F` — a literal leading
+ * slash gets stripped, turning `/Users/x` into the relative `Users/x`, which
+ * `File::open` then fails to find (the 404 we hit). The `%2F` survives the strip
+ * and decodes back to `/`, yielding the correct absolute path.
+ *
+ * Inner separators stay literal (segments encoded, slashes kept) so the iframe
+ * uses this URL as a real base and a previewed page's relative CSS/JS/images
+ * resolve to their sibling files. (Tauri's `convertFileSrc` percent-encodes the
+ * whole path into one segment, which collapses the base dir and breaks every
+ * relative reference.)
  */
 function toAssetUrl(path: string): string {
-  const encoded = path.split("/").map(encodeURIComponent).join("/");
-  return `${ASSET_ORIGIN}${encoded.startsWith("/") ? "" : "/"}${encoded}`;
+  const segments = path.split("/").filter((seg) => seg !== "").map(encodeURIComponent);
+  return `${ASSET_ORIGIN}/%2F${segments.join("/")}`;
 }
 
 /**

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -251,16 +251,17 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                 }
               >
                 {pane.content.kind === "editor" ? (
-                  <EditorTabContent
-                    path={pane.content.path}
-                    onOpenWebPreview={() =>
-                      openHtmlPreview(
-                        tab.id,
-                        pane.id,
-                        (pane.content as { kind: "editor"; path: string }).path,
-                      )
-                    }
-                  />
+                  (() => {
+                    const editorPath = pane.content.path;
+                    return (
+                      <EditorTabContent
+                        path={editorPath}
+                        onOpenWebPreview={() =>
+                          openHtmlPreview(tab.id, pane.id, editorPath)
+                        }
+                      />
+                    );
+                  })()
                 ) : pane.content.kind === "note" ? (
                   <NoteTabContent
                     noteId={pane.content.noteId}

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -61,6 +61,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   const setPaneContent = useTabsStore((s) => s.setPaneContent);
   const setTerminalCwd = useTabsStore((s) => s.setTerminalCwd);
   const closePane = useTabsStore((s) => s.closePane);
+  const openHtmlPreview = useTabsStore((s) => s.openHtmlPreview);
   const isActiveTab = useTabsStore((s) => s.activeId === tab.id);
   const paneAreaRef = useRef<HTMLDivElement>(null);
   // Which splitter is currently being dragged, so its hairline keeps its
@@ -250,7 +251,16 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                 }
               >
                 {pane.content.kind === "editor" ? (
-                  <EditorTabContent path={pane.content.path} />
+                  <EditorTabContent
+                    path={pane.content.path}
+                    onOpenWebPreview={() =>
+                      openHtmlPreview(
+                        tab.id,
+                        pane.id,
+                        (pane.content as { kind: "editor"; path: string }).path,
+                      )
+                    }
+                  />
                 ) : pane.content.kind === "note" ? (
                   <NoteTabContent
                     noteId={pane.content.noteId}

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   activeEditorPath,
+  localPreviewFilePaths,
   openEditorPaths,
   tabHasDirtyEditor,
   useTabsStore,
@@ -655,6 +656,44 @@ describe("openHtmlPreview", () => {
     });
     // Active leaf points at the preview pane.
     expect(updated.activeLeafId).toBe(previewLeafId);
+  });
+});
+
+describe("localPreviewFilePaths", () => {
+  it("includes the decoded local path for a file:// preview pane", () => {
+    const tab: Tab = {
+      id: "t1",
+      spaceId: "s1",
+      title: "a.html",
+      kind: "preview",
+      paneTree: leaf("l1", { kind: "preview", url: "file:///proj/a.html" }),
+      activeLeafId: "l1",
+    };
+    expect(localPreviewFilePaths([tab])).toContain("/proj/a.html");
+  });
+
+  it("excludes web preview urls (http://)", () => {
+    const tab: Tab = {
+      id: "t2",
+      spaceId: "s1",
+      title: "localhost",
+      kind: "preview",
+      paneTree: leaf("l2", { kind: "preview", url: "http://localhost:3000" }),
+      activeLeafId: "l2",
+    };
+    expect(localPreviewFilePaths([tab])).toHaveLength(0);
+  });
+
+  it("contributes nothing for a tab with no preview pane", () => {
+    const tab: Tab = {
+      id: "t3",
+      spaceId: "s1",
+      title: "Term",
+      kind: "terminal",
+      paneTree: leaf("l3", { kind: "terminal" }),
+      activeLeafId: "l3",
+    };
+    expect(localPreviewFilePaths([tab])).toHaveLength(0);
   });
 });
 

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -626,6 +626,36 @@ describe("openHtmlPreview", () => {
     expect(useTabsStore.getState().tabs.filter((t) => t.kind === "preview").length).toBe(1);
     expect(useTabsStore.getState().tabs.find((t) => t.kind === "preview")!.title).toBe("c.html");
   });
+
+  it("replaces the preview pane content in place when the tab already has a preview pane", () => {
+    const tabId = useTabsStore.getState().openEditorTab("/proj/a.html");
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    const editorLeafId = tab.activeLeafId;
+    // Split the editor with a preview pane so the tab already has a preview.
+    useTabsStore
+      .getState()
+      .splitPaneWith(tabId, editorLeafId, { kind: "preview", url: "file:///proj/old.html" }, "row");
+    const withPreview = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    const beforeLeafCount = leafIds(withPreview.paneTree).length;
+    const beforeTabCount = useTabsStore.getState().tabs.length;
+    // After the split the active leaf is the new preview leaf.
+    const previewLeafId = withPreview.activeLeafId;
+
+    // Call openHtmlPreview — hits the replace branch.
+    useTabsStore.getState().openHtmlPreview(tabId, editorLeafId, "/proj/new.html");
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+
+    // No new leaves and no new tabs.
+    expect(leafIds(updated.paneTree)).toHaveLength(beforeLeafCount);
+    expect(useTabsStore.getState().tabs).toHaveLength(beforeTabCount);
+    // Preview pane now shows the new file url.
+    expect(findPaneContent(updated.paneTree, previewLeafId)).toEqual({
+      kind: "preview",
+      url: "file:///proj/new.html",
+    });
+    // Active leaf points at the preview pane.
+    expect(updated.activeLeafId).toBe(previewLeafId);
+  });
 });
 
 describe("activeEditorPath", () => {

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./tabsStore";
 import {
   computeLayout,
+  findPaneContent,
   leaf,
   leafIds,
   paneOf,
@@ -591,6 +592,39 @@ describe("tabHasDirtyEditor", () => {
       "/a/dirty.ts": { content: "changed", baseline: "original" },
     };
     expect(tabHasDirtyEditor(tab, buffers)).toBe(true);
+  });
+});
+
+describe("openHtmlPreview", () => {
+  beforeEach(reset);
+
+  it("splits beside a single-pane editor tab", () => {
+    const store = useTabsStore.getState();
+    const tabId = store.openEditorTab("/proj/a.html");
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    useTabsStore.getState().openHtmlPreview(tabId, tab.activeLeafId, "/proj/a.html");
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree.kind).toBe("split");
+    const kinds = leafIds(updated.paneTree).map((id) => findPaneContent(updated.paneTree, id)?.kind);
+    expect(kinds).toContain("editor");
+    expect(kinds).toContain("preview");
+  });
+
+  it("opens a reusable preview tab when the source tab is already split", () => {
+    const tabId = useTabsStore.getState().openEditorTab("/proj/b.html");
+    // split the editor tab so it has no preview pane but is multi-pane
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    useTabsStore.getState().splitPaneWith(tabId, tab.activeLeafId, { kind: "terminal" }, "row");
+    const before = useTabsStore.getState().tabs.length;
+    useTabsStore.getState().openHtmlPreview(tabId, tab.activeLeafId, "/proj/b.html");
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs.length).toBe(before + 1);
+    const previewTab = tabs.find((t) => t.kind === "preview")!;
+    expect(previewTab.title).toBe("b.html");
+    // a second preview of a different file reuses the same preview tab
+    useTabsStore.getState().openHtmlPreview(tabId, tab.activeLeafId, "/proj/c.html");
+    expect(useTabsStore.getState().tabs.filter((t) => t.kind === "preview").length).toBe(1);
+    expect(useTabsStore.getState().tabs.find((t) => t.kind === "preview")!.title).toBe("c.html");
   });
 });
 

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -3,6 +3,8 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import { uid } from "@/lib/id";
 import { perWindowStorage } from "@/lib/window";
 import { markFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
+import { decideHtmlPreviewOpen, previewLocalPath } from "@/modules/preview/lib/htmlPreviewTarget";
+import { fileUrl } from "@/modules/explorer/lib/dragEntry";
 import {
   computeLayout,
   findPaneContent,
@@ -75,6 +77,12 @@ interface TabsState {
    * replace its pane content + title in place (no new tab) and focus it.
    */
   openLogTab: (logName: string) => string;
+  /**
+   * Open the web preview of a local HTML file with a smart target: reuse an
+   * existing preview pane in this tab, else split beside a single-pane editor,
+   * else open/reuse a per-space preview tab.
+   */
+  openHtmlPreview: (tabId: string, fromLeafId: string, filePath: string) => void;
   setTabTitle: (id: string, title: string) => void;
   /** Update a terminal tab's title to follow its cwd, unless the user renamed it. */
   syncTabTitleToCwd: (id: string, cwd: string) => void;
@@ -168,6 +176,23 @@ export function openEditorPaths(tabs: Tab[]): string[] {
     }
   }
   return [...paths];
+}
+
+/** Absolute paths of local-file preview panes across all tabs, for file watching. */
+export function localPreviewFilePaths(tabs: Tab[]): string[] {
+  const paths: string[] = [];
+  for (const tab of tabs) {
+    for (const id of leafIds(tab.paneTree)) {
+      const content = findPaneContent(tab.paneTree, id);
+      if (content?.kind === "preview") {
+        const local = previewLocalPath(content.url);
+        if (local) {
+          paths.push(local);
+        }
+      }
+    }
+  }
+  return paths;
 }
 
 /** True when a tab is a single, unsplit leaf showing exactly `content`. */
@@ -515,6 +540,66 @@ export const useTabsStore = create<TabsState>()(
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return id;
+  },
+
+  openHtmlPreview: (tabId, fromLeafId, filePath) => {
+    const tab = get().tabs.find((t) => t.id === tabId);
+    if (!tab) {
+      return;
+    }
+    const url = fileUrl(filePath);
+    const title = filePath.split(/[\\/]/).pop() ?? "preview";
+    const target = decideHtmlPreviewOpen(tab.paneTree, fromLeafId);
+
+    if (target.kind === "replace") {
+      set((state) => ({
+        tabs: state.tabs.map((t) =>
+          t.id === tabId
+            ? {
+                ...t,
+                paneTree: setLeafPane(t.paneTree, target.leafId, { kind: "preview", url }),
+                activeLeafId: target.leafId,
+              }
+            : t,
+        ),
+      }));
+      return;
+    }
+
+    if (target.kind === "split") {
+      get().splitPaneWith(tabId, target.fromLeafId, { kind: "preview", url }, "row");
+      return;
+    }
+
+    // previewTab: open or reuse the single preview tab in this tab's space.
+    const spaceId = tab.spaceId;
+    const existing = get().tabs.find((t) => t.kind === "preview" && t.spaceId === spaceId);
+    if (existing) {
+      set((state) => ({
+        tabs: state.tabs.map((t) =>
+          t.id === existing.id
+            ? {
+                ...t,
+                title,
+                paneTree: setLeafPane(existing.paneTree, existing.activeLeafId, { kind: "preview", url }),
+              }
+            : t,
+        ),
+        activeId: existing.id,
+      }));
+      return;
+    }
+    const id = nextTabId();
+    const paneId = nextPaneId();
+    const newTab: Tab = {
+      id,
+      spaceId,
+      kind: "preview",
+      title,
+      paneTree: leaf(paneId, { kind: "preview", url }),
+      activeLeafId: paneId,
+    };
+    set((state) => ({ tabs: [...state.tabs, newTab], activeId: id }));
   },
 
   setTabTitle: (id, title) =>

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -548,7 +548,7 @@ export const useTabsStore = create<TabsState>()(
       return;
     }
     const url = fileUrl(filePath);
-    const title = filePath.split(/[\\/]/).pop() ?? "preview";
+    const title = basename(filePath) || "preview";
     const target = decideHtmlPreviewOpen(tab.paneTree, fromLeafId);
 
     if (target.kind === "replace") {


### PR DESCRIPTION
## Summary

Adds a web-preview button to the editor toolbar for HTML files. When the open file is `.html`/`.htm`, a Globe button appears next to word-wrap; clicking it opens the app's web preview of that local file with a smart target, and the preview auto-reloads when the file is saved.

## Behavior

- **Button**: shown only for `.html`/`.htm`, next to the word-wrap toggle.
- **Smart open** (first match wins):
  1. the tab already has a preview pane → replace its content;
  2. the tab is a single (unsplit) pane → split the preview beside the editor (code + preview side by side);
  3. otherwise (already split, no preview) → open/reuse a per-space preview tab (avoids pane clutter).
- **Auto-reload**: a local-file preview reloads automatically when the file changes on disk (e.g. you save it), so edit-while-preview just works. Reuses the existing editor file-watch bridge.
- Preview loads the saved file via Tauri's `asset://` protocol (relative CSS/JS/images resolve to sibling files).

## Notable fix included

Previewing a local `file://` HTML rendered **blank (404)**. Root cause: Tauri's asset handler resolves the file from `request.uri().path()[1..]` — it strips the URL's structural leading `/` — so our literal-leading-slash asset URL (`asset://localhost/Users/…`) became the *relative* path `Users/…` and `File::open` failed. Fixed by encoding the path's own leading slash as `%2F` (kept inner slashes literal so relative assets still resolve). Verified against `tauri-2.11.2/src/protocol/asset.rs` and confirmed in the running app.

## Scope (out)

- No split↔tab conversion (separate future features).
- Preview reflects the saved file, not the unsaved editor buffer (auto-reload covers the save path).

## Test plan

- [x] `pnpm test` — full suite green (incl. `decideHtmlPreviewOpen`/`previewLocalPath`, the three `openHtmlPreview` store branches, `localPreviewFilePaths`, the toolbar button show/hide/click, preview reload-on-match vs no-reload-on-mismatch, and the corrected `resolvePreviewSrc` asset-URL format)
- [x] `pnpm typecheck` clean; `cargo test --lib` green; no unhandled promise rejections
- [x] **Manual (done):** single-pane editor → split preview; already-split → preview tab that swaps on a different HTML; edit + save → preview auto-reloads; local `file://` HTML now renders (was blank); `.txt` shows no button

## Notes

- The editor toolbar was extracted into a presentational `EditorToolbar` to keep it testable.
- Spec/plan under `docs/superpowers/` (gitignored, not in this PR).
