### PR TITLE
perf(git-graph): virtualize diff & file lists, fix Windows release diff-open lag

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -12,6 +12,7 @@
 - 終端機長時間使用後中文字會渲染成亂碼的問題已修：原因是 WebGL 字形快取塞滿後畫到錯的字，現在會在快滿之前自動清一次快取，不用再手動切換字體
 - 側邊欄切換到工作區面板時短暫卡頓、像當機的問題已修：原因是面板每次顯示都重複做大量計算，現在改成只算必要的部分，切換變順
 - Git 線圖點開 commit 看 diff 時的卡頓已修：之前不論 diff 多長都一次把每一行畫成節點，大檔會塞進上千個 DOM；現在只渲染可視範圍內的行，超長 diff 也順
+- Git 線圖在正式版（Windows）點 commit／檔案時明顯延遲、視窗閃一下的問題已修：正式版沒有主控台，每次跑 git 都被 Windows 配一個新主控台視窗、每次多花上百毫秒；現在用 CREATE_NO_WINDOW 抑制，點開 diff 立即反應（開發版有主控台所以一直都正常）
 
 ## English
 
@@ -27,3 +28,4 @@
 - Fixed CJK text rendering as garbled glyphs after a long terminal session: the WebGL glyph cache overflowed and drew the wrong glyphs, so the cache is now cleared automatically before it fills up, with no need to switch fonts by hand
 - Fixed a brief freeze when switching the sidebar to the Workspaces panel: the panel repeated heavy work every time it showed, and now computes only what it needs so the switch stays responsive
 - Fixed jank when opening a commit's diff in the git graph: every diff line was rendered as a DOM node regardless of length, so large files mounted thousands at once; only the rows in the viewport are now rendered, keeping even very long diffs smooth
+- Fixed a noticeable delay (and window flash) when opening a commit or file diff in the git graph on Windows release builds: a release build has no console, so Windows allocated a fresh console for every git subprocess, costing ~100ms per call; spawning with CREATE_NO_WINDOW removes it so diffs open instantly (dev builds own a console, which is why they were never affected)

--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -13,6 +13,7 @@
 - 側邊欄切換到工作區面板時短暫卡頓、像當機的問題已修：原因是面板每次顯示都重複做大量計算，現在改成只算必要的部分，切換變順
 - Git 線圖點開 commit 看 diff 時的卡頓已修：之前不論 diff 多長都一次把每一行畫成節點，大檔會塞進上千個 DOM；現在只渲染可視範圍內的行，超長 diff 也順
 - Git 線圖在正式版（Windows）點 commit／檔案時明顯延遲、視窗閃一下的問題已修：正式版沒有主控台，每次跑 git 都被 Windows 配一個新主控台視窗、每次多花上百毫秒；現在用 CREATE_NO_WINDOW 抑制，點開 diff 立即反應（開發版有主控台所以一直都正常）
+- Git 線圖 commit 詳情的變更檔案清單也改成虛擬化：改動上千個檔案的 commit 不再一次掛上幾千個項目；左欄改成 metadata／訊息固定在上、檔案清單自己捲動
 
 ## English
 
@@ -29,3 +30,4 @@
 - Fixed a brief freeze when switching the sidebar to the Workspaces panel: the panel repeated heavy work every time it showed, and now computes only what it needs so the switch stays responsive
 - Fixed jank when opening a commit's diff in the git graph: every diff line was rendered as a DOM node regardless of length, so large files mounted thousands at once; only the rows in the viewport are now rendered, keeping even very long diffs smooth
 - Fixed a noticeable delay (and window flash) when opening a commit or file diff in the git graph on Windows release builds: a release build has no console, so Windows allocated a fresh console for every git subprocess, costing ~100ms per call; spawning with CREATE_NO_WINDOW removes it so diffs open instantly (dev builds own a console, which is why they were never affected)
+- The changed-files list in a commit's details is now virtualized too: a commit touching thousands of files no longer mounts thousands of list items at once. The left column now keeps the metadata/message pinned at the top while the file list scrolls on its own

--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -13,7 +13,7 @@
 - 側邊欄切換到工作區面板時短暫卡頓、像當機的問題已修：原因是面板每次顯示都重複做大量計算，現在改成只算必要的部分，切換變順
 - Git 線圖點開 commit 看 diff 時的卡頓已修：之前不論 diff 多長都一次把每一行畫成節點，大檔會塞進上千個 DOM；現在只渲染可視範圍內的行，超長 diff 也順
 - Git 線圖在正式版（Windows）點 commit／檔案時明顯延遲、視窗閃一下的問題已修：正式版沒有主控台，每次跑 git 都被 Windows 配一個新主控台視窗、每次多花上百毫秒；現在用 CREATE_NO_WINDOW 抑制，點開 diff 立即反應（開發版有主控台所以一直都正常）
-- Git 線圖 commit 詳情的變更檔案清單也改成虛擬化：改動上千個檔案的 commit 不再一次掛上幾千個項目；左欄改成 metadata／訊息固定在上、檔案清單自己捲動
+- Git 線圖 commit 詳情的變更檔案清單也改成虛擬化：改動上千個檔案的 commit 不再一次掛上幾千個項目；左欄維持整欄單一卷軸，metadata／訊息和檔案清單一起捲動
 
 ## English
 
@@ -30,4 +30,4 @@
 - Fixed a brief freeze when switching the sidebar to the Workspaces panel: the panel repeated heavy work every time it showed, and now computes only what it needs so the switch stays responsive
 - Fixed jank when opening a commit's diff in the git graph: every diff line was rendered as a DOM node regardless of length, so large files mounted thousands at once; only the rows in the viewport are now rendered, keeping even very long diffs smooth
 - Fixed a noticeable delay (and window flash) when opening a commit or file diff in the git graph on Windows release builds: a release build has no console, so Windows allocated a fresh console for every git subprocess, costing ~100ms per call; spawning with CREATE_NO_WINDOW removes it so diffs open instantly (dev builds own a console, which is why they were never affected)
-- The changed-files list in a commit's details is now virtualized too: a commit touching thousands of files no longer mounts thousands of list items at once. The left column now keeps the metadata/message pinned at the top while the file list scrolls on its own
+- The changed-files list in a commit's details is now virtualized too: a commit touching thousands of files no longer mounts thousands of list items at once. The left column still scrolls as a single unit, with the metadata, message, and file list all under one scrollbar

--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -11,6 +11,7 @@
 - Windows 上的 Claude 狀態 hook 現在會正常觸發：之前 hook 的路徑用反斜線，被 bash 當成逃脫字元吃掉導致整個失效，改用正斜線（Git Bash 也吃得下）後就正常了
 - 終端機長時間使用後中文字會渲染成亂碼的問題已修：原因是 WebGL 字形快取塞滿後畫到錯的字，現在會在快滿之前自動清一次快取，不用再手動切換字體
 - 側邊欄切換到工作區面板時短暫卡頓、像當機的問題已修：原因是面板每次顯示都重複做大量計算，現在改成只算必要的部分，切換變順
+- Git 線圖點開 commit 看 diff 時的卡頓已修：之前不論 diff 多長都一次把每一行畫成節點，大檔會塞進上千個 DOM；現在只渲染可視範圍內的行，超長 diff 也順
 
 ## English
 
@@ -25,3 +26,4 @@
 - The Claude status hook now fires on Windows: its script path used backslashes that bash treated as escapes and dropped, so the hook is now stored with forward slashes that Git Bash accepts
 - Fixed CJK text rendering as garbled glyphs after a long terminal session: the WebGL glyph cache overflowed and drew the wrong glyphs, so the cache is now cleared automatically before it fills up, with no need to switch fonts by hand
 - Fixed a brief freeze when switching the sidebar to the Workspaces panel: the panel repeated heavy work every time it showed, and now computes only what it needs so the switch stays responsive
+- Fixed jank when opening a commit's diff in the git graph: every diff line was rendered as a DOM node regardless of length, so large files mounted thousands at once; only the rows in the viewport are now rendered, keeping even very long diffs smooth

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -404,12 +404,21 @@ pub fn git_commit(repo_path: String, message: String) -> Result<String, String> 
 /// Run a git subcommand against `repo_path` using the system git binary. This
 /// reuses the user's configured credentials/helpers, which matters for push.
 fn run_git(repo_path: &str, args: &[&str]) -> Result<String, String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(repo_path)
-        .args(args)
-        .output()
-        .map_err(|e| e.to_string())?;
+    let mut command = std::process::Command::new("git");
+    command.arg("-C").arg(repo_path).args(args);
+    // A release build runs without a console (windows_subsystem = "windows" in
+    // main.rs), so without this flag Windows allocates a fresh console for every
+    // spawned git process — each one flashes a window and adds ~100ms. That is
+    // felt as lag every time a commit or file diff is opened (one spawn per
+    // click). CREATE_NO_WINDOW suppresses the console; a no-op on a debug build
+    // that already owns one, which is why `tauri dev` never shows the slowdown.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = command.output().map_err(|e| e.to_string())?;
     if output.status.success() {
         Ok(String::from_utf8_lossy(&output.stdout).into_owned())
     } else {

--- a/src/modules/git-graph/CommitDetailsPanel.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.tsx
@@ -5,6 +5,7 @@ import { Resizer } from "@/components/Resizer";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 import { gitCommitDetails, gitCommitFileDiff } from "./lib/gitGraphBridge";
 import { parseDiffLines } from "./lib/parseDiff";
+import { useVirtualRows } from "./lib/useVirtualRows";
 import { DiffView } from "./DiffView";
 import { DiffExplain } from "./DiffExplain";
 import type { CommitDetails, CommitNode, DiffLine } from "./types";
@@ -41,6 +42,12 @@ const STATUS_COLORS: Record<string, string> = {
   C: "text-accent",
   T: "text-fg-muted",
 };
+
+// Fixed row height for the changed-files list, so it can be windowed the same
+// way as the diff. A commit touching thousands of files would otherwise mount
+// thousands of buttons at once.
+const FILE_ROW_HEIGHT = 22;
+const FILE_OVERSCAN = 20;
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -131,6 +138,21 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
     };
   }, [repo, commit.hash, selectedFile]);
 
+  // Window the changed-files list inside the left column's single scroll
+  // container: the metadata/message header scrolls with it, so the list is
+  // measured relative to its own offset (fileListRef) rather than the container
+  // top. Keeps one scrollbar over the whole column.
+  const files = details?.files ?? [];
+  const fileListRef = useRef<HTMLDivElement>(null);
+  const filesWindow = useVirtualRows(
+    files.length,
+    FILE_ROW_HEIGHT,
+    FILE_OVERSCAN,
+    commit.hash,
+    { listRef: fileListRef },
+  );
+  const visibleFiles = files.slice(filesWindow.start, filesWindow.end);
+
   return (
     <div className="flex h-full flex-col overflow-hidden bg-bg">
       <div className="flex items-center justify-between border-b border-border bg-bg-inset px-3 py-1.5">
@@ -150,10 +172,12 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
       {error && <div className="px-3 py-1.5 text-xs text-danger" role="alert">{error}</div>}
 
       <div className="flex min-h-0 flex-1">
-        {/* 左欄：metadata + 訊息 + 變更檔案 */}
+        {/* 左欄：metadata + 訊息 + 變更檔案，整欄共用單一卷軸；檔案清單虛擬化 */}
         <div
+          ref={filesWindow.scrollRef}
+          onScroll={filesWindow.onScroll}
           style={{ width: `${leftWidth}px` }}
-          className="shrink-0 overflow-auto px-3 py-2"
+          className="relative shrink-0 overflow-auto px-3 py-2"
         >
           <div className="flex flex-wrap gap-x-4 gap-y-0.5 font-mono text-[11px] text-fg-subtle">
             <span>
@@ -168,37 +192,41 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
               {details.message}
             </pre>
           )}
-          <div className="mt-2">
-            <div className="mb-1 text-[11px] font-medium text-fg-subtle">
-              {labels.changedFiles} ({details?.files.length ?? 0})
-            </div>
-            {details && details.files.length === 0 ? (
-              <div className="text-[11px] text-fg-subtle">{labels.noChanges}</div>
-            ) : (
-              <ul className="space-y-0.5">
-                {details?.files.map((f) => (
-                  <li key={f.path}>
-                    <button
-                      type="button"
-                      onClick={() => setSelectedFile(f.path)}
-                      className={`flex w-full items-center gap-2 rounded px-2 py-0.5 text-left font-mono text-[11px] ${
-                        selectedFile === f.path
-                          ? "bg-bg-elevated text-fg"
-                          : "text-fg-muted hover:bg-bg-elevated/50"
-                      }`}
-                    >
-                      <span
-                        className={`w-3 shrink-0 font-semibold ${STATUS_COLORS[f.status] ?? "text-fg-muted"}`}
-                      >
-                        {f.status}
-                      </span>
-                      <span className="truncate">{f.path}</span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
+          <div className="mt-2 text-[11px] font-medium text-fg-subtle">
+            {labels.changedFiles} ({details?.files.length ?? 0})
           </div>
+          {details && files.length === 0 ? (
+            <div className="mt-1 text-[11px] text-fg-subtle">{labels.noChanges}</div>
+          ) : (
+            <div
+              ref={fileListRef}
+              style={{ height: `${filesWindow.totalHeight}px` }}
+              className="relative mt-0.5"
+            >
+              <div style={{ transform: `translateY(${filesWindow.offsetTop}px)` }}>
+                {visibleFiles.map((f) => (
+                  <button
+                    key={f.path}
+                    type="button"
+                    onClick={() => setSelectedFile(f.path)}
+                    style={{ height: `${FILE_ROW_HEIGHT}px` }}
+                    className={`flex w-full items-center gap-2 rounded px-2 text-left font-mono text-[11px] ${
+                      selectedFile === f.path
+                        ? "bg-bg-elevated text-fg"
+                        : "text-fg-muted hover:bg-bg-elevated/50"
+                    }`}
+                  >
+                    <span
+                      className={`w-3 shrink-0 font-semibold ${STATUS_COLORS[f.status] ?? "text-fg-muted"}`}
+                    >
+                      {f.status}
+                    </span>
+                    <span className="truncate">{f.path}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
 
         <Resizer

--- a/src/modules/git-graph/DiffView.test.tsx
+++ b/src/modules/git-graph/DiffView.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DiffView } from "./DiffView";
+import type { DiffLine } from "./types";
+
+function makeLines(n: number): DiffLine[] {
+  return Array.from({ length: n }, (_, i) => ({
+    kind: "context" as const,
+    text: `line-${i}`,
+  }));
+}
+
+describe("DiffView", () => {
+  it("shows the empty label when there are no lines", () => {
+    render(<DiffView lines={[]} emptyLabel="nothing here" />);
+    expect(screen.getByText("nothing here")).toBeInTheDocument();
+  });
+
+  it("renders only a window of rows for a large diff", () => {
+    render(<DiffView lines={makeLines(500)} emptyLabel="empty" />);
+
+    // The top of the diff is mounted...
+    expect(screen.getByText("line-0")).toBeInTheDocument();
+    // ...but rows far below the viewport are virtualized away.
+    expect(screen.queryByText("line-499")).not.toBeInTheDocument();
+    expect(screen.queryByText("line-300")).not.toBeInTheDocument();
+  });
+
+  it("reserves full scroll height so the scrollbar reflects the whole diff", () => {
+    const { container } = render(
+      <DiffView lines={makeLines(100)} emptyLabel="empty" />,
+    );
+    // 100 rows * 20px per row.
+    const spacer = container.querySelector<HTMLElement>("div[style*='height']");
+    expect(spacer?.style.height).toBe("2000px");
+  });
+});

--- a/src/modules/git-graph/DiffView.tsx
+++ b/src/modules/git-graph/DiffView.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import type { DiffLine } from "./types";
 
 const LINE_STYLES: Record<DiffLine["kind"], string> = {
@@ -9,13 +10,52 @@ const LINE_STYLES: Record<DiffLine["kind"], string> = {
   context: "text-fg-muted",
 };
 
+// Each diff row is a fixed height so the visible window can be derived from
+// scrollTop alone (matches the windowing approach in GitGraph). The line-height
+// utility on the rows must equal this value.
+const ROW_HEIGHT = 20;
+// Extra rows rendered above/below the viewport so fast scrolling never reveals
+// blank space before the next render lands.
+const OVERSCAN = 20;
+
 interface DiffViewProps {
   lines: DiffLine[];
   emptyLabel: string;
 }
 
-/** Renders parsed unified-diff lines with per-kind semantic colours. */
+/**
+ * Renders parsed unified-diff lines with per-kind semantic colours. Only the
+ * rows inside the scroll viewport (plus an overscan margin) are mounted, so a
+ * multi-thousand-line diff no longer pushes thousands of DOM nodes at once.
+ */
 export function DiffView({ lines, emptyLabel }: DiffViewProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [viewport, setViewport] = useState({ scrollTop: 0, height: 360 });
+
+  // Track the real container height so the window covers the full visible area
+  // even before the first scroll.
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) {
+      return;
+    }
+    const sync = () =>
+      setViewport((prev) => ({ ...prev, height: element.clientHeight }));
+    sync();
+    const observer = new ResizeObserver(sync);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  // A new file/commit replaces `lines`; jump back to the top so the viewport is
+  // not left scrolled past the (possibly shorter) new content.
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
+    setViewport((prev) => ({ ...prev, scrollTop: 0 }));
+  }, [lines]);
+
   if (lines.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-xs text-fg-subtle">
@@ -23,13 +63,39 @@ export function DiffView({ lines, emptyLabel }: DiffViewProps) {
       </div>
     );
   }
+
+  const visibleStart = Math.max(
+    0,
+    Math.floor(viewport.scrollTop / ROW_HEIGHT) - OVERSCAN,
+  );
+  const visibleEnd = Math.min(
+    lines.length,
+    Math.ceil((viewport.scrollTop + viewport.height) / ROW_HEIGHT) + OVERSCAN,
+  );
+  const visibleLines = lines.slice(visibleStart, visibleEnd);
+
   return (
-    <div className="h-full overflow-auto font-mono text-[12px] leading-relaxed">
-      {lines.map((line, i) => (
-        <div key={i} className={`whitespace-pre px-3 ${LINE_STYLES[line.kind]}`}>
-          {line.text === "" ? " " : line.text}
+    <div
+      ref={scrollRef}
+      className="h-full overflow-auto font-mono text-[12px]"
+      onScroll={(event) => {
+        const target = event.currentTarget;
+        setViewport({ scrollTop: target.scrollTop, height: target.clientHeight });
+      }}
+    >
+      <div style={{ height: `${lines.length * ROW_HEIGHT}px` }} className="relative">
+        <div style={{ transform: `translateY(${visibleStart * ROW_HEIGHT}px)` }}>
+          {visibleLines.map((line, i) => (
+            <div
+              key={visibleStart + i}
+              style={{ height: `${ROW_HEIGHT}px` }}
+              className={`whitespace-pre px-3 leading-5 ${LINE_STYLES[line.kind]}`}
+            >
+              {line.text === "" ? " " : line.text}
+            </div>
+          ))}
         </div>
-      ))}
+      </div>
     </div>
   );
 }

--- a/src/modules/git-graph/DiffView.tsx
+++ b/src/modules/git-graph/DiffView.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
 import type { DiffLine } from "./types";
+import { useVirtualRows } from "./lib/useVirtualRows";
 
 const LINE_STYLES: Record<DiffLine["kind"], string> = {
   add: "bg-success/10 text-success",
@@ -11,8 +11,7 @@ const LINE_STYLES: Record<DiffLine["kind"], string> = {
 };
 
 // Each diff row is a fixed height so the visible window can be derived from
-// scrollTop alone (matches the windowing approach in GitGraph). The line-height
-// utility on the rows must equal this value.
+// scrollTop alone. The line-height utility on the rows must equal this value.
 const ROW_HEIGHT = 20;
 // Extra rows rendered above/below the viewport so fast scrolling never reveals
 // blank space before the next render lands.
@@ -29,32 +28,8 @@ interface DiffViewProps {
  * multi-thousand-line diff no longer pushes thousands of DOM nodes at once.
  */
 export function DiffView({ lines, emptyLabel }: DiffViewProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [viewport, setViewport] = useState({ scrollTop: 0, height: 360 });
-
-  // Track the real container height so the window covers the full visible area
-  // even before the first scroll.
-  useEffect(() => {
-    const element = scrollRef.current;
-    if (!element) {
-      return;
-    }
-    const sync = () =>
-      setViewport((prev) => ({ ...prev, height: element.clientHeight }));
-    sync();
-    const observer = new ResizeObserver(sync);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, []);
-
-  // A new file/commit replaces `lines`; jump back to the top so the viewport is
-  // not left scrolled past the (possibly shorter) new content.
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = 0;
-    }
-    setViewport((prev) => ({ ...prev, scrollTop: 0 }));
-  }, [lines]);
+  const { scrollRef, onScroll, start, end, offsetTop, totalHeight } =
+    useVirtualRows(lines.length, ROW_HEIGHT, OVERSCAN, lines);
 
   if (lines.length === 0) {
     return (
@@ -64,30 +39,19 @@ export function DiffView({ lines, emptyLabel }: DiffViewProps) {
     );
   }
 
-  const visibleStart = Math.max(
-    0,
-    Math.floor(viewport.scrollTop / ROW_HEIGHT) - OVERSCAN,
-  );
-  const visibleEnd = Math.min(
-    lines.length,
-    Math.ceil((viewport.scrollTop + viewport.height) / ROW_HEIGHT) + OVERSCAN,
-  );
-  const visibleLines = lines.slice(visibleStart, visibleEnd);
+  const visibleLines = lines.slice(start, end);
 
   return (
     <div
       ref={scrollRef}
+      onScroll={onScroll}
       className="h-full overflow-auto font-mono text-[12px]"
-      onScroll={(event) => {
-        const target = event.currentTarget;
-        setViewport({ scrollTop: target.scrollTop, height: target.clientHeight });
-      }}
     >
-      <div style={{ height: `${lines.length * ROW_HEIGHT}px` }} className="relative">
-        <div style={{ transform: `translateY(${visibleStart * ROW_HEIGHT}px)` }}>
+      <div style={{ height: `${totalHeight}px` }} className="relative">
+        <div style={{ transform: `translateY(${offsetTop}px)` }}>
           {visibleLines.map((line, i) => (
             <div
-              key={visibleStart + i}
+              key={start + i}
               style={{ height: `${ROW_HEIGHT}px` }}
               className={`whitespace-pre px-3 leading-5 ${LINE_STYLES[line.kind]}`}
             >

--- a/src/modules/git-graph/lib/useVirtualRows.ts
+++ b/src/modules/git-graph/lib/useVirtualRows.ts
@@ -1,0 +1,105 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+export interface VirtualRows {
+  /** Attach to the scroll container. */
+  scrollRef: React.RefObject<HTMLDivElement | null>;
+  /** Wire to the scroll container's onScroll. */
+  onScroll: (event: React.UIEvent<HTMLDivElement>) => void;
+  /** First row index to render (inclusive). */
+  start: number;
+  /** Last row index to render (exclusive). */
+  end: number;
+  /** Pixel offset of the first rendered row, for a translateY spacer. */
+  offsetTop: number;
+  /** Full scroll height the rows occupy, for the spacer that reserves space. */
+  totalHeight: number;
+}
+
+interface Options {
+  /**
+   * When the rows do not start at the top of the scroll container (e.g. a list
+   * below a header that scrolls with it), point this at the rows' wrapper so the
+   * visible window is measured relative to its position. Omit when the rows fill
+   * the container, keeping a single scrollbar over header + rows.
+   */
+  listRef?: React.RefObject<HTMLElement | null>;
+}
+
+/**
+ * Fixed-height row windowing: render only the rows inside the scroll viewport
+ * (plus an overscan margin) so a list of thousands of equal-height rows costs a
+ * constant number of DOM nodes. Shared by the diff viewer and the changed-files
+ * list. Pass `resetKey` (e.g. the commit hash or diff identity) to scroll back
+ * to the top when the underlying data is replaced.
+ */
+export function useVirtualRows(
+  count: number,
+  rowHeight: number,
+  overscan: number,
+  resetKey: unknown,
+  options: Options = {},
+): VirtualRows {
+  const { listRef } = options;
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [viewport, setViewport] = useState({ scrollTop: 0, height: 360 });
+  // Offset of the rows within the scroll content. Stays 0 when no listRef is
+  // given (rows fill the container).
+  const [listTop, setListTop] = useState(0);
+
+  // Track the real container height (and the rows' offset) so the window covers
+  // the full visible area even before the first scroll, and recompute on resize
+  // — including width changes from the panel resizer, which can re-wrap a header
+  // and shift the rows down.
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) {
+      return;
+    }
+    const sync = () => {
+      setViewport((prev) => ({ ...prev, height: element.clientHeight }));
+      if (listRef?.current) {
+        setListTop(listRef.current.offsetTop);
+      }
+    };
+    sync();
+    const observer = new ResizeObserver(sync);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [listRef]);
+
+  // Re-measure the rows' offset once new content has laid out (a longer commit
+  // message pushes the file list further down).
+  useLayoutEffect(() => {
+    if (listRef?.current) {
+      setListTop(listRef.current.offsetTop);
+    }
+  }, [listRef, resetKey, count]);
+
+  // New data replaces the rows; jump back to the top so the viewport is not left
+  // scrolled past the (possibly shorter) new content.
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
+    setViewport((prev) => ({ ...prev, scrollTop: 0 }));
+  }, [resetKey]);
+
+  const scrolledIntoRows = viewport.scrollTop - listTop;
+  const start = Math.max(0, Math.floor(scrolledIntoRows / rowHeight) - overscan);
+  const end = Math.min(
+    count,
+    Math.ceil((scrolledIntoRows + viewport.height) / rowHeight) + overscan,
+  );
+
+  return {
+    scrollRef,
+    onScroll: (event) => {
+      const target = event.currentTarget;
+      setViewport({ scrollTop: target.scrollTop, height: target.clientHeight });
+    },
+    start,
+    end,
+    offsetTop: start * rowHeight,
+    totalHeight: count * rowHeight,
+  };
+}

--- a/src/modules/git-graph/lib/useVirtualRows.ts
+++ b/src/modules/git-graph/lib/useVirtualRows.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 export interface VirtualRows {
   /** Attach to the scroll container. */
@@ -91,12 +91,16 @@ export function useVirtualRows(
     Math.ceil((scrolledIntoRows + viewport.height) / rowHeight) + overscan,
   );
 
+  // Stable identity so consumers passing this to onScroll don't re-bind it each
+  // render. setViewport from useState is stable, so no deps are needed.
+  const onScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
+    const target = event.currentTarget;
+    setViewport({ scrollTop: target.scrollTop, height: target.clientHeight });
+  }, []);
+
   return {
     scrollRef,
-    onScroll: (event) => {
-      const target = event.currentTarget;
-      setViewport({ scrollTop: target.scrollTop, height: target.clientHeight });
-    },
+    onScroll,
     start,
     end,
     offsetTop: start * rowHeight,


### PR DESCRIPTION
Three related fixes for the responsiveness of the git graph commit-details viewer, found while chasing "opening a commit diff feels laggy" on Windows.

## Problem

- On a **Windows release build**, clicking a commit — and each file within it — lagged noticeably and briefly flashed a window, even for tiny diffs. `tauri dev` never showed it.
- Opening a commit with a **large file diff** janked the main thread.
- Opening a commit that **changed many files** janked as well.

## Root cause

- **Per-spawn console (the big one):** `run_git` spawned `git` without `CREATE_NO_WINDOW`. A release build sets `windows_subsystem = "windows"` and owns no console, so Windows allocates a fresh console for every git subprocess — a window flash plus ~100ms per call. Opening a commit and clicking each file each fire a spawn, so every interaction paid it. Debug builds own a console, which is why `tauri dev` never reproduced it.
- **Un-windowed rendering:** `DiffView` rendered every diff line as a DOM node, and the commit details panel rendered every changed file as a button — so a large file or a many-file commit mounted thousands of nodes at once.

## Changes

- `fix(git)`: spawn git with `CREATE_NO_WINDOW` on Windows. No flash, no per-call console cost; diffs open instantly.
- `perf(git-graph)`: add a `useVirtualRows` hook (fixed-height row windowing with overscan) and render only the diff rows inside the viewport.
- `perf(git-graph)`: window the changed-files list with the same hook. The hook takes an optional `listRef` so the list is measured relative to its offset inside the left column's **single** scroll container — the metadata/message header still scrolls together with the list under one scrollbar, so there is no UX change.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 835 passing, incl. a new `DiffView.test.tsx` covering the windowing
- [x] **Manual (Windows release build):** clicking commits/files is instant with no window flash; a large diff and a many-file commit both scroll smoothly; the left column keeps a single scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)