### PR TITLE
fix(pr): 修正 Windows 上偵測不到 gh CLI (#87)

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -4,8 +4,12 @@
 
 ### fix
 
+- 修正 Windows 上即使 `gh` 已安裝且在 PATH 仍顯示「PATH 上找不到 gh CLI」的問題：偵測時會解析 `gh.exe` 並涵蓋 Windows 常見安裝路徑。
+
 ## English
 
 ### feat
 
 ### fix
+
+- Fix "gh CLI not found on PATH" on Windows even when `gh` is installed and on PATH: detection now resolves `gh.exe` and covers the common Windows install locations.

--- a/src-tauri/src/modules/pr/mod.rs
+++ b/src-tauri/src/modules/pr/mod.rs
@@ -102,32 +102,75 @@ fn remote_origin_url(cwd: &str) -> Option<String> {
     remote.url().map(str::to_string)
 }
 
-/// Directories to search for a CLI binary. A GUI launch (Finder/Dock) hands the
-/// app a minimal PATH that omits Homebrew and other user install dirs, so we
-/// append the usual locations. Pure so it can be tested without the real env.
-fn cli_search_dirs(path_env: Option<&str>, home: Option<&str>) -> Vec<PathBuf> {
+/// Directories to search for a CLI binary, on top of `PATH`. A GUI launch hands
+/// the app a reduced environment that can omit user install dirs — Homebrew on
+/// macOS, winget/scoop/choco shims on Windows — so we append the usual
+/// per-platform locations. `windows` selects the platform layout; pure so it can
+/// be tested on any host without the real env.
+fn cli_search_dirs(path_env: Option<&str>, home: Option<&str>, windows: bool) -> Vec<PathBuf> {
     let mut dirs: Vec<PathBuf> = match path_env {
         Some(path) => std::env::split_paths(path).collect(),
         None => Vec::new(),
     };
-    for extra in ["/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin"] {
-        dirs.push(PathBuf::from(extra));
-    }
-    if let Some(home) = home {
-        dirs.push(PathBuf::from(home).join(".local").join("bin"));
+    if windows {
+        // winget/MSI land in Program Files; chocolatey shims its own bin.
+        for extra in [
+            r"C:\Program Files\GitHub CLI",
+            r"C:\Program Files (x86)\GitHub CLI",
+            r"C:\ProgramData\chocolatey\bin",
+        ] {
+            dirs.push(PathBuf::from(extra));
+        }
+        if let Some(home) = home {
+            // scoop puts shims under the user profile.
+            dirs.push(PathBuf::from(home).join("scoop").join("shims"));
+        }
+    } else {
+        for extra in ["/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin"] {
+            dirs.push(PathBuf::from(extra));
+        }
+        if let Some(home) = home {
+            dirs.push(PathBuf::from(home).join(".local").join("bin"));
+        }
     }
     dirs
 }
 
+/// Candidate file names for an executable. Windows binaries carry an extension
+/// (`gh.exe`), so a bare `gh` never matches on disk — try the common executable
+/// extensions there; elsewhere the stem itself is the only candidate. Pure for
+/// testing.
+fn exe_names(stem: &str, windows: bool) -> Vec<String> {
+    if windows {
+        [".exe", ".cmd", ".bat"]
+            .iter()
+            .map(|ext| format!("{stem}{ext}"))
+            .collect()
+    } else {
+        vec![stem.to_string()]
+    }
+}
+
 /// Absolute path to the `gh` binary, searching PATH plus the common install
-/// dirs a GUI launch drops, or None when it isn't installed.
+/// dirs a GUI launch drops, or None when it isn't installed. On Windows this
+/// resolves `gh.exe` (a bare `gh` file never exists there) and honours
+/// `USERPROFILE` as the home dir, since `HOME` is usually unset.
 fn find_gh() -> Option<PathBuf> {
     let path_env = std::env::var("PATH").ok();
-    let home = std::env::var("HOME").ok();
-    cli_search_dirs(path_env.as_deref(), home.as_deref())
-        .into_iter()
-        .map(|dir| dir.join("gh"))
-        .find(|candidate| candidate.is_file())
+    let home = std::env::var("HOME")
+        .ok()
+        .or_else(|| std::env::var("USERPROFILE").ok());
+    let windows = cfg!(windows);
+    let names = exe_names("gh", windows);
+    for dir in cli_search_dirs(path_env.as_deref(), home.as_deref(), windows) {
+        for name in &names {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
 }
 
 /// Whether the `gh` CLI is available.
@@ -289,8 +332,10 @@ mod tests {
     fn cli_search_dirs_adds_common_install_locations_to_a_minimal_path() {
         // A GUI launch (Finder/Dock) hands the app a minimal PATH without
         // Homebrew, so gh "isn't found" even when installed. The search must
-        // still cover the usual install dirs.
-        let dirs = cli_search_dirs(Some("/usr/bin:/bin"), Some("/Users/me"));
+        // still cover the usual install dirs. Build PATH with join_paths so the
+        // host's separator is used and split_paths round-trips on any runner.
+        let path = std::env::join_paths(["/usr/bin", "/bin"]).unwrap();
+        let dirs = cli_search_dirs(path.to_str(), Some("/Users/me"), false);
         assert!(dirs.contains(&PathBuf::from("/usr/bin"))); // PATH entries kept
         assert!(dirs.contains(&PathBuf::from("/opt/homebrew/bin"))); // Apple Silicon brew
         assert!(dirs.contains(&PathBuf::from("/usr/local/bin"))); // Intel brew
@@ -299,8 +344,31 @@ mod tests {
 
     #[test]
     fn cli_search_dirs_works_without_a_path_or_home() {
-        let dirs = cli_search_dirs(None, None);
+        let dirs = cli_search_dirs(None, None, false);
         assert!(dirs.contains(&PathBuf::from("/opt/homebrew/bin")));
         assert!(!dirs.iter().any(|d| d.ends_with(".local/bin")));
+    }
+
+    #[test]
+    fn cli_search_dirs_windows_uses_windows_install_locations() {
+        // The Windows GUI launch can hand the app a PATH without the gh install
+        // dir, so the search must cover the standard Windows locations and not
+        // leak the macOS ones. Build expected dirs with join (not backslash
+        // literals) so component comparison holds on a non-Windows host too.
+        let home = PathBuf::from(r"C:\Users\me");
+        let dirs = cli_search_dirs(None, Some(r"C:\Users\me"), true);
+        assert!(dirs.contains(&PathBuf::from(r"C:\Program Files\GitHub CLI")));
+        assert!(dirs.contains(&home.join("scoop").join("shims"))); // scoop shims
+        assert!(!dirs.contains(&PathBuf::from("/opt/homebrew/bin"))); // no macOS leak
+    }
+
+    #[test]
+    fn exe_names_appends_windows_extensions_only_on_windows() {
+        // The heart of issue #87: on Windows the binary is gh.exe, so probing a
+        // bare "gh" never matches and gh is reported missing even when on PATH.
+        assert_eq!(exe_names("gh", false), vec!["gh".to_string()]);
+        let win = exe_names("gh", true);
+        assert!(win.contains(&"gh.exe".to_string()));
+        assert!(!win.contains(&"gh".to_string()));
     }
 }


### PR DESCRIPTION
Closes #87

## 問題

Windows 上即使 `gh` 已安裝且在 PATH，設定頁仍顯示「PATH 上找不到 gh CLI」。

## 根因

`find_gh()` 以 `dir.join("gh")` 在各搜尋目錄尋找**無副檔名**的檔案 `gh`。Windows 的 binary 是 `gh.exe`，磁碟上不存在名為 `gh` 的檔，`candidate.is_file()` 永不命中 → `gh_available` 回傳 `false`。次要問題：搜尋目錄只補 macOS/Linux 路徑（`/opt/homebrew/bin` 等），且 home 取 `HOME`（Windows 通常未設）。

## 修正（`src-tauri/src/modules/pr/mod.rs`）

- 新增 `exe_names()`：Windows 補上 `.exe` / `.cmd` / `.bat` 副檔名後再探測；其他平台維持裸名 `gh`。
- `cli_search_dirs()` 依平台分流：Windows 改用常見安裝路徑（`Program Files\GitHub CLI`、chocolatey、scoop shims），不再附加 macOS 專屬路徑。
- home 以 `USERPROFILE` 後援。
- 平台邏輯參數化（傳入 `windows: bool`），讓兩條路徑在任一 host 都能單元測試。

macOS / Linux 行為不變（`windows = false` 分支等同原邏輯）。

## 測試

`cargo test pr::` 全數通過（於 Windows host 編譯，`cfg!(windows) = true`，實際走 Windows 修復路徑）：

```
running 12 tests
... test result: ok. 12 passed; 0 failed
```

新增測試：
- `cli_search_dirs_windows_uses_windows_install_locations` — Windows 安裝路徑涵蓋、不洩漏 macOS 路徑
- `exe_names_appends_windows_extensions_only_on_windows` — issue 核心：Windows 補 `.exe`、裸 `gh` 不在候選

> 註：手邊只有 Windows 環境，未在 macOS 上實機驗證打包；但 `windows = false` 分支邏輯與原本完全一致，且既有 macOS 測試（homebrew 路徑等）仍綠燈。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iocZ5BdXJQjKFCU3PGJFH