### PR TITLE
fix(ui): replace UA white focus ring with accent ring

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -144,7 +144,6 @@ button:disabled {
 :focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 1px;
-  border-radius: 2px;
 }
 
 .xterm:focus-visible,

--- a/src/index.css
+++ b/src/index.css
@@ -131,6 +131,30 @@ button:disabled {
   cursor: not-allowed;
 }
 
+/*
+ * Focus ring policy. WKWebView (and Chromium/Firefox) paints a white UA focus
+ * ring on `:focus-visible`. After a mouse click the ring stays suppressed, but
+ * pressing a non-typing key like F1–F12 re-promotes the element to "keyboard
+ * focused" and the white box flashes in. Replace the UA ring with a calm
+ * accent ring on real keyboard navigation, and drop it entirely on the xterm
+ * terminal surface (xterm shows its own focus state via the cursor) and on
+ * inputs/textareas (they already paint their own focused border via Tailwind
+ * `focus:border-accent`).
+ */
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+  border-radius: 2px;
+}
+
+.xterm:focus-visible,
+.xterm *:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+[contenteditable]:focus-visible {
+  outline: none;
+}
+
 /* Rendered note (markdown) typography */
 .note-md {
   color: var(--color-fg);


### PR DESCRIPTION
## Summary

Fixes #88. Pressing F1–F12 while focus was on a button or the terminal surface promoted the focused element back to `:focus-visible` and flashed the WKWebView default white outline. The ring itself is correct a11y behavior — the UA-default white box just looks broken against the dark Vitesse palette.

- Style `:focus-visible` globally with a calm accent outline so keyboard navigation still has a visible indicator.
- Suppress the ring on `.xterm` (xterm shows focus via its cursor) and on inputs/textareas/contenteditable (they already paint a focused border via Tailwind `focus:border-accent`).

## Test plan

- [ ] Click a button, press F2 / F3 / F5 — no white outline appears
- [ ] Click the terminal surface, press any F-key — no outline on the terminal
- [ ] Tab to a button with the keyboard — accent-colored focus ring is visible (a11y preserved)
- [ ] Focus an input in Settings — only the existing accent border, no double ring
- [ ] Verified on Windows (reporter follow-up)