### PR TITLE
fix(tabs): unify sidebar context menu with main TabBar

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -7,7 +7,6 @@ import {
   Globe,
   LayoutGrid,
   PanelLeft,
-  Pencil,
   Plus,
   ScrollText,
   SquareTerminal,
@@ -36,6 +35,7 @@ import { IS_MAC } from "@/lib/platform";
 import { SpaceDropdown } from "./SpaceDropdown";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { ContextMenu } from "./ContextMenu";
+import { tabContextMenuItems } from "./tabContextMenuItems";
 
 // Module-level so the reference stays stable across renders. Passing an inline
 // options object would make useSensor/useSensors return a new sensors array on
@@ -199,23 +199,10 @@ function TabItem({ id }: { id: string }) {
           x={menu.x}
           y={menu.y}
           onClose={() => setMenu(null)}
-          items={[
-            {
-              id: "rename",
-              label: t("actions.renameTab"),
-              icon: Pencil,
-              group: 0,
-              onSelect: startRename,
-            },
-            {
-              id: "close",
-              label: t("actions.closeTab"),
-              icon: X,
-              group: 1,
-              danger: true,
-              onSelect: requestClose,
-            },
-          ]}
+          items={tabContextMenuItems(t, {
+            onRename: startRename,
+            onClose: requestClose,
+          })}
         />
       )}
     </div>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -28,12 +28,11 @@ import {
   horizontalListSortingStrategy,
   useSortable,
 } from "@dnd-kit/sortable";
-import { useTabsStore, tabHasDirtyEditor, type Tab } from "@/stores/tabsStore";
-import { useEditorStore } from "@/modules/editor/store/editorStore";
+import { useTabsStore, type Tab } from "@/stores/tabsStore";
+import { useTabCloseRequest } from "./useTabCloseRequest";
 import { useUiStore } from "@/stores/uiStore";
 import { IS_MAC } from "@/lib/platform";
 import { SpaceDropdown } from "./SpaceDropdown";
-import { ConfirmDialog } from "./ConfirmDialog";
 import { ContextMenu } from "./ContextMenu";
 import { tabContextMenuItems } from "./tabContextMenuItems";
 
@@ -67,18 +66,12 @@ function TabItem({ id }: { id: string }) {
   const tab = useTabsStore((s) => s.tabs.find((x) => x.id === id));
   const activeId = useTabsStore((s) => s.activeId);
   const setActive = useTabsStore((s) => s.setActive);
-  const closeTab = useTabsStore((s) => s.closeTab);
   const setTabTitle = useTabsStore((s) => s.setTabTitle);
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id });
-  // A tab is dirty when any of its editor panes has unsaved changes.
-  const dirty = useEditorStore((s) => {
-    if (!tab) return false;
-    return tabHasDirtyEditor(tab, s.buffers);
-  });
+  const { dirty, requestClose, confirmCloseDialog } = useTabCloseRequest(tab);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
-  const [confirmClose, setConfirmClose] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   if (!tab) {
     return null;
@@ -102,17 +95,6 @@ function TabItem({ id }: { id: string }) {
       setTabTitle(tab.id, draft.trim());
     }
     setEditing(false);
-  }
-
-  function requestClose() {
-    if (!tab) {
-      return;
-    }
-    if (dirty) {
-      setConfirmClose(true);
-    } else {
-      closeTab(tab.id);
-    }
   }
 
   return (
@@ -181,19 +163,7 @@ function TabItem({ id }: { id: string }) {
           <X size={13} />
         )}
       </button>
-      {confirmClose && (
-        <ConfirmDialog
-          title={t("editor:closeUnsavedTitle")}
-          message={t("editor:closeUnsavedMessage")}
-          confirmLabel={t("editor:discardClose")}
-          cancelLabel={t("actions.cancel")}
-          onConfirm={() => {
-            setConfirmClose(false);
-            closeTab(tab.id);
-          }}
-          onCancel={() => setConfirmClose(false)}
-        />
-      )}
+      {confirmCloseDialog}
       {menu && (
         <ContextMenu
           x={menu.x}

--- a/src/components/tabContextMenuItems.ts
+++ b/src/components/tabContextMenuItems.ts
@@ -1,0 +1,35 @@
+import { Pencil, X } from "lucide-react";
+import type { TFunction } from "i18next";
+import type { ContextMenuItem } from "./ContextMenu";
+
+interface TabContextMenuActions {
+  onRename: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Shared item list for a tab's right-click menu. Used by both the main TabBar
+ * and the sidebar workspace TabCard so the two surfaces stay in lockstep.
+ */
+export function tabContextMenuItems(
+  t: TFunction,
+  { onRename, onClose }: TabContextMenuActions,
+): ContextMenuItem[] {
+  return [
+    {
+      id: "rename",
+      label: t("actions.renameTab"),
+      icon: Pencil,
+      group: 0,
+      onSelect: onRename,
+    },
+    {
+      id: "close",
+      label: t("actions.closeTab"),
+      icon: X,
+      group: 1,
+      danger: true,
+      onSelect: onClose,
+    },
+  ];
+}

--- a/src/components/useTabCloseRequest.tsx
+++ b/src/components/useTabCloseRequest.tsx
@@ -1,0 +1,63 @@
+import { useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { useEditorStore } from "@/modules/editor/store/editorStore";
+import { useTabsStore, tabHasDirtyEditor, type Tab } from "@/stores/tabsStore";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+interface TabCloseRequest {
+  dirty: boolean;
+  /** Trigger a close; pops the unsaved-changes dialog when the tab is dirty. */
+  requestClose: () => void;
+  /** Render this inside the consumer's tree so the confirm dialog can mount. */
+  confirmCloseDialog: ReactNode;
+}
+
+/**
+ * Shared close-request logic for tab surfaces (main TabBar and sidebar TabCard)
+ * so they both honor the editor's unsaved-changes confirmation instead of one
+ * silently dropping unsaved work.
+ *
+ * Accepts `Tab | undefined` so the caller can use the hook before its
+ * `if (!tab) return null` guard without violating the rules of hooks.
+ */
+export function useTabCloseRequest(tab: Tab | undefined): TabCloseRequest {
+  const { t } = useTranslation();
+  const closeTab = useTabsStore((s) => s.closeTab);
+  const dirty = useEditorStore((s) =>
+    tab ? tabHasDirtyEditor(tab, s.buffers) : false,
+  );
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const requestClose = () => {
+    if (!tab) return;
+    if (dirty) {
+      setConfirmOpen(true);
+    } else {
+      closeTab(tab.id);
+    }
+  };
+
+  // Portal the dialog so consumers can place {confirmCloseDialog} inside any
+  // wrapper (e.g. the sidebar TabCard is a <button>) without producing invalid
+  // <button>-inside-<button> markup.
+  const confirmCloseDialog =
+    confirmOpen && tab
+      ? createPortal(
+          <ConfirmDialog
+            title={t("editor:closeUnsavedTitle")}
+            message={t("editor:closeUnsavedMessage")}
+            confirmLabel={t("editor:discardClose")}
+            cancelLabel={t("actions.cancel")}
+            onConfirm={() => {
+              setConfirmOpen(false);
+              closeTab(tab.id);
+            }}
+            onCancel={() => setConfirmOpen(false)}
+          />,
+          document.body,
+        )
+      : null;
+
+  return { dirty, requestClose, confirmCloseDialog };
+}

--- a/src/modules/workspace/WorkspacePanel.test.tsx
+++ b/src/modules/workspace/WorkspacePanel.test.tsx
@@ -10,8 +10,10 @@ import { useWorktreeStore } from "./lib/worktreeStore";
 import { useTitlesStore } from "./lib/titlesStore";
 import { usePrStore } from "./lib/prStore";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useEditorStore } from "@/modules/editor/store/editorStore";
 
 beforeEach(() => {
+  useEditorStore.setState({ buffers: {} });
   useSessionStatusStore.setState({ statuses: {}, agents: {} });
   useWorktreeStore.setState({ infos: {} });
   useTitlesStore.setState({ titles: {} });
@@ -304,6 +306,35 @@ describe("WorkspacePanel", () => {
     fireEvent.contextMenu(beta);
     fireEvent.click(screen.getByRole("menuitem", { name: /Close Tab/i }));
     expect(useTabsStore.getState().tabs.find((tab) => tab.id === "t2")).toBeUndefined();
+  });
+
+  it("keeps a dirty tab open and confirms before closing via the sidebar menu", () => {
+    // Replace beta with an editor tab pointing at /file.ts so we can mark it dirty.
+    useTabsStore.setState({
+      ...useTabsStore.getState(),
+      tabs: [
+        useTabsStore.getState().tabs[0],
+        {
+          id: "t2",
+          spaceId: "s1",
+          title: "beta",
+          kind: "editor",
+          paneTree: leaf("p2", { kind: "editor", path: "/file.ts" }),
+          activeLeafId: "p2",
+        },
+      ],
+    });
+    useEditorStore.setState({
+      buffers: { "/file.ts": { content: "edited", baseline: "" } },
+    });
+    render(<WorkspacePanel />);
+    const beta = screen.getByRole("button", { name: /beta/ });
+    fireEvent.contextMenu(beta);
+    fireEvent.click(screen.getByRole("menuitem", { name: /Close Tab/i }));
+    // Tab must NOT close immediately — confirm dialog should appear and t2 stays.
+    expect(useTabsStore.getState().tabs.find((tab) => tab.id === "t2")).toBeDefined();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
   });
 
   it("renames a tab from the sidebar context menu", () => {

--- a/src/modules/workspace/WorkspacePanel.test.tsx
+++ b/src/modules/workspace/WorkspacePanel.test.tsx
@@ -288,4 +288,32 @@ describe("WorkspacePanel", () => {
     expect(within(beta).getByText("2")).toBeInTheDocument();
     expect(screen.queryByText("alpha")).toBeNull();
   });
+
+  it("opens a tab context menu on right-click with rename and close items", () => {
+    render(<WorkspacePanel />);
+    const alpha = screen.getByRole("button", { name: /alpha/ });
+    fireEvent.contextMenu(alpha);
+    // The menu items match those in the main TabBar (Rename Tab / Close Tab).
+    expect(screen.getByRole("menuitem", { name: /Rename Tab/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Close Tab/i })).toBeInTheDocument();
+  });
+
+  it("closes a tab from the sidebar context menu", () => {
+    render(<WorkspacePanel />);
+    const beta = screen.getByRole("button", { name: /beta/ });
+    fireEvent.contextMenu(beta);
+    fireEvent.click(screen.getByRole("menuitem", { name: /Close Tab/i }));
+    expect(useTabsStore.getState().tabs.find((tab) => tab.id === "t2")).toBeUndefined();
+  });
+
+  it("renames a tab from the sidebar context menu", () => {
+    render(<WorkspacePanel />);
+    const alpha = screen.getByRole("button", { name: /alpha/ });
+    fireEvent.contextMenu(alpha);
+    fireEvent.click(screen.getByRole("menuitem", { name: /Rename Tab/i }));
+    const input = screen.getByDisplayValue("alpha");
+    fireEvent.change(input, { target: { value: "renamed" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(useTabsStore.getState().tabs.find((tab) => tab.id === "t1")?.title).toBe("renamed");
+  });
 });

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ChevronDown,
@@ -18,6 +18,8 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useTabsStore, type Tab, type TabKind } from "@/stores/tabsStore";
+import { ContextMenu } from "@/components/ContextMenu";
+import { tabContextMenuItems } from "@/components/tabContextMenuItems";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
 import type { SessionStatus } from "@/modules/claude-progress/lib/sessionStatus";
@@ -218,14 +220,21 @@ function SessionRow({
 }
 
 function TabCard({ tab, index }: { tab: Tab; index: number }) {
+  const { t } = useTranslation();
   const activeId = useTabsStore((s) => s.activeId);
   const setActive = useTabsStore((s) => s.setActive);
+  const setTabTitle = useTabsStore((s) => s.setTabTitle);
+  const closeTab = useTabsStore((s) => s.closeTab);
   const statuses = useSessionStatusStore((s) => s.statuses);
   const leafAgents = useSessionStatusStore((s) => s.agents);
   const infos = useWorktreeStore((s) => s.infos);
   const titles = useTitlesStore((s) => s.titles);
   const prs = usePrStore((s) => s.prs);
   const card = useSettingsStore((s) => s.workspaceCard);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const active = tab.id === activeId;
   const cwd = deriveTabCwd(tab);
   // Each pane running an agent is its own session. With two or more, the header
@@ -244,10 +253,36 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
   const Icon = tabIcon(tab.kind);
   const label = agentLabel(primary?.agent);
 
+  function startRename() {
+    setDraft(title);
+    setEditing(true);
+  }
+
+  function commitRename() {
+    const next = draft.trim();
+    if (next) {
+      setTabTitle(tab.id, next);
+    }
+    setEditing(false);
+  }
+
+  // Focus + select the inline rename input once it mounts so the user can type
+  // a new name immediately, matching the main TabBar's rename UX.
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
   return (
     <button
       type="button"
       onClick={() => setActive(tab.id)}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenu({ x: event.clientX, y: event.clientY });
+      }}
       className={`flex w-full items-stretch gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors ${
         active
           ? "border-accent bg-accent/10 text-fg"
@@ -260,7 +295,24 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
       </span>
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-1.5">
-          <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">{title}</span>
+          {editing ? (
+            <input
+              ref={inputRef}
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onBlur={commitRename}
+              onClick={(event) => event.stopPropagation()}
+              onPointerDown={(event) => event.stopPropagation()}
+              onContextMenu={(event) => event.stopPropagation()}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") commitRename();
+                if (event.key === "Escape") setEditing(false);
+              }}
+              className="min-w-0 flex-1 rounded border border-accent bg-bg px-1 text-xs text-fg outline-none"
+            />
+          ) : (
+            <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">{title}</span>
+          )}
           {!multi && card.status && status && <StatusBadge status={status} />}
           {!multi && card.status && status && label && (
             <span className="shrink-0 text-[11px] text-fg-subtle">{label}</span>
@@ -285,6 +337,17 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
           </span>
         )}
       </span>
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          onClose={() => setMenu(null)}
+          items={tabContextMenuItems(t, {
+            onRename: startRename,
+            onClose: () => closeTab(tab.id),
+          })}
+        />
+      )}
     </button>
   );
 }

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -20,6 +20,7 @@ import {
 import { useTabsStore, type Tab, type TabKind } from "@/stores/tabsStore";
 import { ContextMenu } from "@/components/ContextMenu";
 import { tabContextMenuItems } from "@/components/tabContextMenuItems";
+import { useTabCloseRequest } from "@/components/useTabCloseRequest";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
 import type { SessionStatus } from "@/modules/claude-progress/lib/sessionStatus";
@@ -224,7 +225,7 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
   const activeId = useTabsStore((s) => s.activeId);
   const setActive = useTabsStore((s) => s.setActive);
   const setTabTitle = useTabsStore((s) => s.setTabTitle);
-  const closeTab = useTabsStore((s) => s.closeTab);
+  const { requestClose, confirmCloseDialog } = useTabCloseRequest(tab);
   const statuses = useSessionStatusStore((s) => s.statuses);
   const leafAgents = useSessionStatusStore((s) => s.agents);
   const infos = useWorktreeStore((s) => s.infos);
@@ -344,10 +345,11 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
           onClose={() => setMenu(null)}
           items={tabContextMenuItems(t, {
             onRename: startRename,
-            onClose: () => closeTab(tab.id),
+            onClose: requestClose,
           })}
         />
       )}
+      {confirmCloseDialog}
     </button>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #86. The sidebar workspace TabCard had no `onContextMenu` handler, so right-clicking fell through to the WebView's native menu (Back / Reload / Print). The main TabBar already showed a custom Rename Tab / Close Tab menu via `ContextMenu`. Both surfaces now share the same menu and the same dirty-tab close confirmation.

- Extract `tabContextMenuItems` so both surfaces stay in lockstep.
- Add `onContextMenu`, inline rename, and the shared menu to sidebar `TabCard`.
- Extract `useTabCloseRequest` hook that owns the dirty check + confirm dialog so closing a dirty tab from the sidebar no longer silently drops unsaved work. Dialog is portaled so consumers can drop the returned node inside any wrapper (including `<button>`).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 850/850 (added 1 lock-in test for sidebar dirty-close path)
- [ ] Main TabBar right-click → Rename Tab / Close Tab menu, same as before
- [ ] Sidebar TabCard right-click → identical menu (no native WebView menu)
- [ ] Sidebar Rename → inline input, Enter commits, Esc cancels
- [ ] Sidebar Close on a clean tab → tab closes immediately
- [ ] Sidebar Close on a dirty editor tab → Unsaved changes dialog appears, tab does not close until confirmed