### PR TITLE
fix(preview): track address-bar navigation and add scheme to bare hosts

### DIFF
--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isLocalUrl, isWebUrl } from "./url";
+import { isLocalUrl, isWebUrl, normalizeAddressInput } from "./url";
 
 describe("isWebUrl", () => {
   it("treats an https URL as a web URL", () => {
@@ -37,5 +37,38 @@ describe("isLocalUrl", () => {
   it("returns false for non-URLs", () => {
     expect(isLocalUrl("not a url")).toBe(false);
     expect(isLocalUrl("")).toBe(false);
+  });
+});
+
+describe("normalizeAddressInput", () => {
+  it("adds https:// to a bare public host", () => {
+    expect(normalizeAddressInput("google.com.tw")).toBe("https://google.com.tw");
+  });
+
+  it("keeps the path and query when adding the scheme", () => {
+    expect(normalizeAddressInput("google.com.tw/search?q=a")).toBe(
+      "https://google.com.tw/search?q=a",
+    );
+  });
+
+  it("adds http:// to localhost, loopback and IPv4 hosts (dev servers)", () => {
+    expect(normalizeAddressInput("localhost:3000")).toBe("http://localhost:3000");
+    expect(normalizeAddressInput("127.0.0.1:8080/admin")).toBe("http://127.0.0.1:8080/admin");
+    expect(normalizeAddressInput("192.168.1.5")).toBe("http://192.168.1.5");
+  });
+
+  it("leaves an input that already has a scheme untouched", () => {
+    expect(normalizeAddressInput("https://muki.tw/wp-admin")).toBe("https://muki.tw/wp-admin");
+    expect(normalizeAddressInput("http://localhost:3000")).toBe("http://localhost:3000");
+    expect(normalizeAddressInput("file:///x/index.html")).toBe("file:///x/index.html");
+  });
+
+  it("leaves an absolute file path for the asset resolver to handle", () => {
+    expect(normalizeAddressInput("/Users/me/page.html")).toBe("/Users/me/page.html");
+  });
+
+  it("trims and returns empty for blank input", () => {
+    expect(normalizeAddressInput("  https://muki.tw  ")).toBe("https://muki.tw");
+    expect(normalizeAddressInput("   ")).toBe("");
   });
 });

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -71,4 +71,18 @@ describe("normalizeAddressInput", () => {
     expect(normalizeAddressInput("  https://muki.tw  ")).toBe("https://muki.tw");
     expect(normalizeAddressInput("   ")).toBe("");
   });
+
+  it("isolates the host from query and userinfo before choosing the scheme", () => {
+    expect(normalizeAddressInput("localhost?x=foo:bar")).toBe("http://localhost?x=foo:bar");
+    expect(normalizeAddressInput("user:pass@localhost:3000")).toBe(
+      "http://user:pass@localhost:3000",
+    );
+  });
+
+  it("leaves Windows absolute paths untouched", () => {
+    expect(normalizeAddressInput("C:\\Users\\me\\page.html")).toBe("C:\\Users\\me\\page.html");
+    expect(normalizeAddressInput("\\\\server\\share\\page.html")).toBe(
+      "\\\\server\\share\\page.html",
+    );
+  });
 });

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -6,6 +6,16 @@ export function isWebUrl(href: string): boolean {
   return /^(https?|mailto):/i.test(href.trim());
 }
 
+/** True for a hostname on the local machine (localhost, loopback, or IPv4). */
+function isLocalHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "0.0.0.0" ||
+    hostname === "::1" ||
+    /^(?:\d{1,3}\.){3}\d{1,3}$/.test(hostname)
+  );
+}
+
 /**
  * True when `href` is an http(s) URL pointing at the local machine (localhost,
  * loopback, or any IPv4 host). These are the URLs worth opening in the in-app
@@ -13,14 +23,25 @@ export function isWebUrl(href: string): boolean {
  */
 export function isLocalUrl(href: string): boolean {
   try {
-    const { hostname } = new URL(href.trim());
-    return (
-      hostname === "localhost" ||
-      hostname === "0.0.0.0" ||
-      hostname === "::1" ||
-      /^(?:\d{1,3}\.){3}\d{1,3}$/.test(hostname)
-    );
+    return isLocalHostname(new URL(href.trim()).hostname);
   } catch {
     return false;
   }
+}
+
+/**
+ * Normalize an address-bar entry into a url the preview can load. A bare host
+ * like "google.com.tw" or "localhost:3000" has no scheme, so the webview treats
+ * it as a relative path and shows a blank page; add the scheme the host implies
+ * (http for localhost/loopback/IPv4 dev servers, https otherwise). Inputs that
+ * already carry a scheme (http://, https://, file://) or are absolute file
+ * paths ("/Users/...") pass through untouched.
+ */
+export function normalizeAddressInput(input: string): string {
+  const value = input.trim();
+  if (value === "" || value.startsWith("/") || /^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
+    return value;
+  }
+  const host = value.split("/")[0].split(":")[0];
+  return `${isLocalHostname(host) ? "http" : "https"}://${value}`;
 }

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -35,13 +35,22 @@ export function isLocalUrl(href: string): boolean {
  * it as a relative path and shows a blank page; add the scheme the host implies
  * (http for localhost/loopback/IPv4 dev servers, https otherwise). Inputs that
  * already carry a scheme (http://, https://, file://) or are absolute file
- * paths ("/Users/...") pass through untouched.
+ * paths (Unix "/Users/...", Windows "C:\..." or "\\unc") pass through untouched.
  */
 export function normalizeAddressInput(input: string): string {
   const value = input.trim();
-  if (value === "" || value.startsWith("/") || /^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
+  if (
+    value === "" ||
+    value.startsWith("/") ||
+    value.startsWith("\\") ||
+    /^[a-z]:[\\/]/i.test(value) ||
+    /^[a-z][a-z0-9+.-]*:\/\//i.test(value)
+  ) {
     return value;
   }
-  const host = value.split("/")[0].split(":")[0];
+  // Isolate the authority (drop any path/query/fragment, then userinfo) before
+  // reading the hostname, so a "?"/"@" in a query can't be mistaken for the host.
+  const authority = value.split(/[/?#]/)[0];
+  const host = (authority.split("@").pop() ?? authority).split(":")[0];
   return `${isLocalHostname(host) ? "http" : "https"}://${value}`;
 }

--- a/src/modules/preview/PreviewTabContent.test.tsx
+++ b/src/modules/preview/PreviewTabContent.test.tsx
@@ -3,7 +3,7 @@
 // useNativePreviewWebview (which touches Tauri APIs unavailable under jsdom), so
 // it is stubbed here and its reload() is captured to assert the file watcher
 // triggers a reload on a matching change and stays put on a non-matching one.
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { act } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@/i18n";
@@ -52,5 +52,40 @@ describe("PreviewTabContent auto-reload", () => {
       changeHandler?.("/proj/other.html");
     });
     expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe("PreviewTabContent navigation", () => {
+  it("notifies onNavigate with the trimmed url when the address is submitted", () => {
+    const onNavigate = vi.fn();
+    const { getByRole } = render(
+      <PreviewTabContent
+        url="http://localhost:3000"
+        leafId="pane-1"
+        visible
+        onNavigate={onNavigate}
+      />,
+    );
+    const input = getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "  https://muki.tw/wp-admin  " } });
+    fireEvent.submit(input.closest("form")!);
+    expect(onNavigate).toHaveBeenCalledWith("https://muki.tw/wp-admin");
+  });
+
+  it("adds a scheme to a bare host before navigating and reflects it in the bar", () => {
+    const onNavigate = vi.fn();
+    const { getByRole } = render(
+      <PreviewTabContent
+        url="http://localhost:3000"
+        leafId="pane-1"
+        visible
+        onNavigate={onNavigate}
+      />,
+    );
+    const input = getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "google.com.tw" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(onNavigate).toHaveBeenCalledWith("https://google.com.tw");
+    expect(input.value).toBe("https://google.com.tw");
   });
 });

--- a/src/modules/preview/PreviewTabContent.tsx
+++ b/src/modules/preview/PreviewTabContent.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { RotateCw } from "lucide-react";
 import { onEditorFileChanged } from "@/modules/editor/lib/editorWatch";
+import { normalizeAddressInput } from "@/lib/url";
 import { previewLocalPath } from "./lib/htmlPreviewTarget";
 import { useNativePreviewWebview } from "./hooks/useNativePreviewWebview";
 
@@ -15,9 +16,14 @@ interface PreviewTabContentProps {
    * (inactive tab/space, split drag, or an open overlay).
    */
   visible: boolean;
+  /**
+   * Called when the user navigates via the address bar, so the owning pane can
+   * persist the new url and retitle the tab. Local-file previews don't supply it.
+   */
+  onNavigate?: (url: string) => void;
 }
 
-export function PreviewTabContent({ url, leafId, visible }: PreviewTabContentProps) {
+export function PreviewTabContent({ url, leafId, visible, onNavigate }: PreviewTabContentProps) {
   const { t } = useTranslation("preview");
   const [current, setCurrent] = useState(url);
   const [input, setInput] = useState(url);
@@ -65,7 +71,10 @@ export function PreviewTabContent({ url, leafId, visible }: PreviewTabContentPro
         className="flex h-9 shrink-0 items-center gap-2 border-b border-border px-2"
         onSubmit={(e) => {
           e.preventDefault();
-          setCurrent(input.trim());
+          const next = normalizeAddressInput(input);
+          setCurrent(next);
+          setInput(next);
+          onNavigate?.(next);
         }}
       >
         <input

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -58,6 +58,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   const resizePane = useTabsStore((s) => s.resizePane);
   const splitPaneWith = useTabsStore((s) => s.splitPaneWith);
   const setPaneContent = useTabsStore((s) => s.setPaneContent);
+  const navigatePreview = useTabsStore((s) => s.navigatePreview);
   const setTerminalCwd = useTabsStore((s) => s.setTerminalCwd);
   const closePane = useTabsStore((s) => s.closePane);
   const openHtmlPreview = useTabsStore((s) => s.openHtmlPreview);
@@ -274,6 +275,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                       dragging: draggingSplitterId !== null,
                       anyOverlay,
                     })}
+                    onNavigate={(url) => navigatePreview(tab.id, pane.id, url)}
                   />
                 ) : pane.content.kind === "git-graph" ? (
                   <GitGraphTabContent />

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -60,6 +60,69 @@ describe("openEditorPaths", () => {
   });
 });
 
+describe("navigatePreview", () => {
+  beforeEach(reset);
+
+  it("updates a single-pane preview tab's url and title to the new host", () => {
+    const id = useTabsStore.getState().openPreviewTab("http://localhost:3000");
+    const leafId = activeTab().activeLeafId;
+    expect(activeTab().title).toBe("localhost:3000");
+
+    useTabsStore.getState().navigatePreview(id, leafId, "https://muki.tw/wp-admin");
+
+    const tab = activeTab();
+    expect(firstLeafContent(tab)).toEqual({
+      kind: "preview",
+      url: "https://muki.tw/wp-admin",
+    });
+    expect(tab.title).toBe("muki.tw");
+  });
+
+  it("updates only the url, not the tab title, when the preview is one pane of several", () => {
+    const tabId = useTabsStore.getState().openEditorTab("/a/b.ts");
+    const editorLeafId = activeTab().activeLeafId;
+    useTabsStore
+      .getState()
+      .splitPaneWith(tabId, editorLeafId, { kind: "preview", url: "http://localhost:3000" }, "row");
+    const previewLeafId = activeTab().activeLeafId;
+
+    useTabsStore.getState().navigatePreview(tabId, previewLeafId, "https://muki.tw/wp-admin");
+
+    const tab = activeTab();
+    expect(findPaneContent(tab.paneTree, previewLeafId)).toEqual({
+      kind: "preview",
+      url: "https://muki.tw/wp-admin",
+    });
+    expect(tab.title).toBe("b.ts");
+  });
+
+  it("keeps a user-renamed preview tab's title when navigating", () => {
+    const id = useTabsStore.getState().openPreviewTab("http://localhost:3000");
+    const leafId = activeTab().activeLeafId;
+    useTabsStore.getState().setTabTitle(id, "My Site");
+
+    useTabsStore.getState().navigatePreview(id, leafId, "https://muki.tw/wp-admin");
+
+    const tab = activeTab();
+    expect(firstLeafContent(tab)).toEqual({
+      kind: "preview",
+      url: "https://muki.tw/wp-admin",
+    });
+    expect(tab.title).toBe("My Site");
+  });
+
+  it("is a no-op when the leaf is not a preview pane", () => {
+    const id = useTabsStore.getState().newTerminalTab("/a/proj");
+    const leafId = activeTab().activeLeafId;
+
+    useTabsStore.getState().navigatePreview(id, leafId, "https://muki.tw");
+
+    const tab = activeTab();
+    expect(tab.title).toBe("proj");
+    expect(firstLeafContent(tab).kind).toBe("terminal");
+  });
+});
+
 describe("tabsStore", () => {
   beforeEach(reset);
 

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -102,6 +102,12 @@ interface TabsState {
     content: PaneContent,
     direction: SplitDirection,
   ) => void;
+  /**
+   * Follow an in-preview navigation: update the pane's previewed url, and when
+   * the preview is the tab's whole content (single pane, not user-renamed),
+   * retitle the tab to the new host.
+   */
+  navigatePreview: (tabId: string, leafId: string, url: string) => void;
   /** Replace a pane's content in place (used when dropping a file onto it). */
   setPaneContent: (tabId: string, leafId: string, content: PaneContent) => void;
   /** Remember a terminal pane's current working directory for session restore. */
@@ -188,6 +194,18 @@ export function localPreviewFilePaths(tabs: Tab[]): string[] {
     }
   }
   return paths;
+}
+
+/**
+ * Title for a web preview tab: the URL's host (with port), falling back to the
+ * raw string when it can't be parsed (e.g. a `file://` local preview).
+ */
+function previewTitle(url: string): string {
+  try {
+    return new URL(url).host || url;
+  } catch {
+    return url;
+  }
 }
 
 /** True when a tab is a single, unsplit leaf showing exactly `content`. */
@@ -462,17 +480,11 @@ export const useTabsStore = create<TabsState>()(
     const spaceId = get().ensureSpace();
     const id = nextTabId();
     const paneId = nextPaneId();
-    let host = url;
-    try {
-      host = new URL(url).host || url;
-    } catch {
-      host = url;
-    }
     const tab: Tab = {
       id,
       spaceId,
       kind: "preview",
-      title: host,
+      title: previewTitle(url),
       paneTree: leaf(paneId, { kind: "preview", url }),
       activeLeafId: paneId,
     };
@@ -733,6 +745,36 @@ export const useTabsStore = create<TabsState>()(
           : tab,
       ),
     })),
+
+  navigatePreview: (tabId, leafId, url) =>
+    set((state) => {
+      const tab = state.tabs.find((t) => t.id === tabId);
+      if (!tab) {
+        return state;
+      }
+      const current = findPaneContent(tab.paneTree, leafId);
+      // Only preview panes navigate; skip a no-op write so persistence is not
+      // churned when the url hasn't actually changed.
+      if (!current || current.kind !== "preview" || current.url === url) {
+        return state;
+      }
+      // The tab title follows the previewed site only when the preview fills the
+      // whole tab and the user hasn't given it a name of their own. In a split,
+      // the title belongs to the tab as a whole, not to one preview pane.
+      const isWholeTab = leafIds(tab.paneTree).length === 1;
+      const retitle = isWholeTab && !tab.renamed;
+      return {
+        tabs: state.tabs.map((t) =>
+          t.id === tabId
+            ? {
+                ...t,
+                title: retitle ? previewTitle(url) : t.title,
+                paneTree: setLeafPane(t.paneTree, leafId, { kind: "preview", url }),
+              }
+            : t,
+        ),
+      };
+    }),
 
   setTerminalCwd: (tabId, leafId, cwd) =>
     set((state) => {


### PR DESCRIPTION
## Summary

The web preview's address bar only updated the component's local state when you navigated, so the new url never flowed back to the store. Two user-visible bugs came from that single root cause:

1. **Tab title stuck on the initial host.** Navigating to a new site (e.g. typing `https://muki.tw/wp-admin` in a tab opened at `localhost:3000`) left the tab labelled `localhost:3000` forever.
2. **Bare hosts wouldn't load.** Typing `google.com.tw` without a scheme handed the raw string to the webview, which treated it as a relative path and rendered a blank page.

### Changes

- Add a `navigatePreview` store action that persists the previewed url and, when the preview is the tab's whole content (single pane, not user-renamed), retitles the tab to the new host. Persisting the url also fixes a latent bug where switching tabs and back discarded the navigation (it only lived in component state).
- Add an `onNavigate` callback to `PreviewTabContent`, wired by `PaneTabContent` to the new action.
- Add `normalizeAddressInput` in `lib/url`: `https://` for public hosts, `http://` for localhost/loopback/IPv4 dev servers; inputs that already carry a scheme (`http://`, `https://`, `file://`) and absolute file paths pass through untouched. The normalized url is reflected back into the address bar.
- Title is derived from the url host (`muki.tw`, `localhost:3000`); reading the real page `<title>` would require building the child webview on the Rust side to inject a script, which the current front-end webview API can't do — tracked separately if we want true site names later.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 870 passing (added: 4 `navigatePreview` store cases, 6 `normalizeAddressInput` cases, 2 `PreviewTabContent` navigation cases)
- [ ] Manual: open a web preview, navigate to a new site → tab title follows the new host
- [ ] Manual: type a bare host like `google.com.tw` → loads over https; type `localhost:3000` → loads over http