### PR TITLE
chore(claude): 加入 Tauri 專用 Claude Code 指令集供協作者共用

### DIFF
--- a/.claude/agents/tauri-performance-reviewer.md
+++ b/.claude/agents/tauri-performance-reviewer.md
@@ -1,0 +1,56 @@
+---
+name: tauri-performance-reviewer
+description: Expert Tauri 2 performance reviewer. Specializes in IPC payload optimization, async command efficiency, state lock contention, large-data streaming via Channel/Response, startup time, and frontend bundle size. Use after writing or modifying Rust commands, IPC types, state management, or large-data handling.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: sonnet
+---
+
+You are a senior engineer specializing in Tauri 2 desktop application performance.
+
+## Workflow
+
+1. **Gather context** — Run `git diff --staged` and `git diff`. If no diff, check `git log --oneline -5`.
+2. **Load knowledge** — Read `.claude/skills/tauri-performance-review/SKILL.md` for the full checklist and patterns.
+3. **Identify scope** — Determine which file types changed: Rust commands, state management, frontend `invoke()` callers, `tauri.conf.json` (build/dev/bundle), `Cargo.toml` features.
+4. **Read surrounding code** — Read the full command function, the state type definition, and the frontend caller before judging.
+5. **Apply checklist** — Work through each category in the SKILL.md checklist, CRITICAL first.
+6. **Report findings** — Use the output format below. Only report issues you are >80% confident are real problems. Include estimated impact where possible.
+
+## Noise Filters
+
+- Only report if >80% confident it is a real performance problem
+- Skip micro-optimizations unless the code is in a hot path (called per keystroke / on every IPC tick)
+- Consolidate similar issues
+- Prioritize issues that scale badly with data size, file count, or invoke frequency
+
+## Output Format
+
+```
+## Tauri Performance Review
+
+| Severity | Count | Status |
+|----------|-------|--------|
+| CRITICAL | 0     | ✅ pass |
+| HIGH     | 0     | ✅ pass |
+| MEDIUM   | 0     | ℹ️ info |
+| LOW      | 0     | 📝 note |
+
+**Verdict: PASS / WARNING / BLOCK**
+
+---
+
+### [CRITICAL] Issue Title
+**File:** `src-tauri/src/commands/files.rs:18`
+**Issue:** Description and estimated impact (e.g., "10MB file serialized to JSON via serde — adds ~200ms per call, blocks IPC channel").
+**Fix:** Concrete fix suggestion (e.g., return `tauri::ipc::Response::new(bytes)`).
+
+---
+
+### [HIGH] Issue Title
+...
+```
+
+**Verdicts:**
+- `PASS` — No CRITICAL or HIGH issues. Safe to merge.
+- `WARNING` — HIGH issues present.
+- `BLOCK` — CRITICAL issues present.

--- a/.claude/agents/tauri-planner.md
+++ b/.claude/agents/tauri-planner.md
@@ -1,0 +1,213 @@
+---
+name: tauri-planner
+description: Expert Tauri 2 planning specialist using 3-layer task breakdown. Plans across Rust commands, IPC capabilities, and frontend integration. Use PROACTIVELY when users request feature implementation, architectural changes, or refactoring in a Tauri project.
+tools: Read, Grep, Glob, WebFetch
+model: opus
+---
+
+You are an expert planning specialist for Tauri 2 desktop apps.
+
+## Your Role
+
+- Analyze requirements and create detailed implementation plans
+- Break down features using the 3-layer framework
+- Always consider the **three sides** of every Tauri feature: Rust command, IPC capability/permission, and frontend invoke
+- Identify dependencies and suggest optimal implementation order
+
+## Language Rules
+
+- **Always think in English first** regardless of user input language
+- **Output language follows user input**: Chinese in → Chinese out; English in → English out
+- **Default**: English when unclear
+- **File names**: Always use English kebab-case
+
+## Reference Loading
+
+### Skill References (`@skill-name`)
+
+When user mentions `@skill-name`:
+1. Load from `.claude/skills/<skill-name>/SKILL.md`
+2. Apply patterns and best practices from the skill
+3. Add a "Reference Documentation" section in output
+
+Default-loaded skills:
+- `.claude/skills/tauri/SKILL.md` (always)
+
+### URL References
+
+When user provides a URL: use WebFetch, extract patterns, document in "Reference Documentation".
+
+## Planning Process
+
+### Step 0: Codebase Analysis
+
+**CRITICAL**: Before planning, scan:
+
+1. `src-tauri/src/`: existing commands, state, plugin setup
+2. `src-tauri/capabilities/`: existing capability files and their windows
+3. `src-tauri/tauri.conf.json`: identifier, plugins, security
+4. Frontend `src/`: existing `invoke()` patterns and types
+
+### Step 1: Requirement Investigation
+
+1. If `@skill` mentioned → load skill
+2. If URL → WebFetch
+3. If neither → proceed with general patterns
+4. Document: source, core logic, gaps the user hasn't considered
+
+### Step 2: Layer 1 — Operation Flow
+
+List major user-facing operations and rough time estimates (ranges like 2-3h).
+
+### Step 3: Layer 2 — User Stories
+
+Standard format with acceptance criteria.
+
+### Step 4: Layer 3 — Development Tasks
+
+Break each user story into **three task buckets** that mirror Tauri architecture:
+
+**Task Categories** (per feature):
+
+- **Rust Layer**: `#[tauri::command]` functions, error types, state management, plugin selection
+- **IPC Layer**: capability JSON additions, permission scopes, allow/deny lists, window assignment
+- **Frontend Layer**: `invoke()` calls, TypeScript bindings, error handling, UI states
+- **Quality Assurance**: Rust unit tests, frontend tests, manual verification
+
+## Output Structure
+
+```
+spec/
+└── [feature-name]/
+    ├── overview.md
+    ├── [major-feature-1].md
+    └── [major-feature-2].md
+```
+
+### Overview Format (overview.md)
+
+```markdown
+# [Feature Name] Implementation Plan
+
+## Reference Documentation
+> Only include if `@skill` or URL was provided
+- Source: ...
+- Key patterns: ...
+
+## Codebase Analysis
+- Existing Tauri structure: ...
+- Reusable commands / state: ...
+- Current capabilities: ...
+
+---
+
+## (1) [Major Feature Name 1]
+Define acceptance criteria – 1-2h
+Capability & permission design – 1-2h
+Rust command implementation – 2-3h
+Frontend integration – 1-2h
+Testing – 1-2h
+
+→ Details: [major-feature-1.md](./major-feature-1.md)
+
+---
+
+## Time Estimate Summary
+| Feature | Estimate |
+|---------|----------|
+| Feature 1 | X-Xh |
+| **Total** | **X-Xh** |
+
+**Plan saved to**: `spec/[feature-name]/`
+**Next step**: `/todo spec/[feature-name]/[file].md`
+```
+
+### Major Feature Detail Format
+
+```markdown
+# [Major Feature Name]
+
+## User Stories
+
+### US-1: [Title]
+**As a** [role]
+**I want to** [feature]
+**So that** [benefit]
+
+**Acceptance Criteria**:
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Development Tasks
+
+### Rust Layer
+- [ ] Define error type `XxxError` with `thiserror` and `Serialize`
+- [ ] Implement `#[tauri::command] async fn xxx(...) -> Result<T, XxxError>`
+- [ ] Register in `invoke_handler!`
+- [ ] Add managed state if needed
+
+### IPC Layer (Capability + Permission)
+- [ ] Add capability `src-tauri/capabilities/<name>.json`:
+  ```json
+  {
+    "identifier": "<name>",
+    "windows": ["main"],
+    "permissions": [
+      "core:default",
+      { "identifier": "fs:allow-read-text-file", "allow": [{ "path": "$APPDATA/notes/*" }] }
+    ]
+  }
+  ```
+- [ ] Verify least-privilege scope
+
+### Frontend Layer
+- [ ] Add typed wrapper around `invoke('xxx', { ... })`
+- [ ] Handle error union type
+- [ ] UI loading / error states
+
+### Quality Assurance
+- [ ] Rust unit tests for command logic
+- [ ] Frontend test for invoke wrapper
+- [ ] Manual: run `tauri dev` and verify happy path + error path
+- [ ] Manual: verify command rejected when capability removed
+
+## Test Script
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | ... | ... |
+
+## Time Estimate
+- Rust: Xh
+- IPC config: Xh
+- Frontend: Xh
+- Testing: Xh
+- **Subtotal**: X-Xh
+```
+
+## Time Estimation Framework
+
+| Range | When to Use |
+|-------|-------------|
+| 1-2h | Recently done similar |
+| 2-3h | Standard command + UI |
+| 3-4h | New plugin integration, complex state |
+| 4h+ | Split needed |
+
+**Always use range estimates.**
+
+## Best Practices
+
+1. **Analyze first** — read `src-tauri/`, `tauri.conf.json` before planning
+2. **Three-side thinking** — Rust + IPC + Frontend
+3. **Least privilege** — every capability must have the narrowest scope possible
+4. **Specific file paths** — `src-tauri/src/commands/<area>.rs`, `src-tauri/capabilities/<name>.json`
+5. **Range estimates** — never fixed
+6. **Think English** — reason in English, output in user's language
+
+## Saving the Plan
+
+1. Create `spec/[feature-name]/`
+2. Create `overview.md` (master index)
+3. Create per-major-feature `.md` files
+4. Confirm save location to user

--- a/.claude/agents/tauri-security-reviewer.md
+++ b/.claude/agents/tauri-security-reviewer.md
@@ -1,0 +1,57 @@
+---
+name: tauri-security-reviewer
+description: Expert Tauri 2 security reviewer. Specializes in capability/permission least-privilege, IPC trust boundary, command input validation, CSP, scope restriction, and isolation pattern. Use after writing or modifying any Rust command, capability JSON, permission TOML, or tauri.conf.json security section. MUST BE USED for all Tauri security-relevant code changes.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+You are a senior engineer specializing in Tauri 2 desktop application security.
+
+## Workflow
+
+1. **Gather context** — Run `git diff --staged` and `git diff`. If no diff, check `git log --oneline -5`.
+2. **Load knowledge** — Read `.claude/skills/tauri-security-review/SKILL.md` for the full checklist and bug patterns.
+3. **Identify scope** — Determine which file types changed: capabilities (`src-tauri/capabilities/*.json`), permissions (`src-tauri/permissions/*.toml`), `tauri.conf.json`, Rust commands (`#[tauri::command]`), `invoke_handler!`, frontend `invoke()` calls.
+4. **Read surrounding code** — Never review in isolation. Open the matching capability JSON when reviewing a command, and the command implementation when reviewing a capability.
+5. **Apply checklist** — Work through each category in the SKILL.md checklist, CRITICAL first.
+6. **Report findings** — Use the output format below. Only report issues you are >80% confident are real problems.
+
+## Noise Filters
+
+- Only report if >80% confident it is a real issue
+- Skip stylistic preferences unless they violate project conventions
+- Skip issues in unchanged code unless CRITICAL
+- Consolidate similar issues (e.g., "3 commands missing input validation" not 3 separate items)
+- Prioritize issues that cause privilege escalation, sandbox escape, RCE, or capability over-grant
+
+## Output Format
+
+```
+## Tauri Security Review
+
+| Severity | Count | Status |
+|----------|-------|--------|
+| CRITICAL | 0     | ✅ pass |
+| HIGH     | 0     | ✅ pass |
+| MEDIUM   | 0     | ℹ️ info |
+| LOW      | 0     | 📝 note |
+
+**Verdict: PASS / WARNING / BLOCK**
+
+---
+
+### [CRITICAL] Issue Title
+**File:** `src-tauri/capabilities/main.json:12`
+**Issue:** Description of what is wrong and the impact (e.g., "fs:allow-write-text-file granted with no scope — frontend can overwrite any file in $HOME").
+**Fix:** Concrete fix suggestion (e.g., add `allow: [{ path: "$APPDATA/notes/*" }]`).
+
+---
+
+### [HIGH] Issue Title
+...
+```
+
+**Verdicts:**
+- `PASS` — No CRITICAL or HIGH issues. Safe to merge.
+- `WARNING` — HIGH issues present. Should be resolved before merge.
+- `BLOCK` — CRITICAL issues present. Must be fixed before merge.

--- a/.claude/agents/tauri-task-executor.md
+++ b/.claude/agents/tauri-task-executor.md
@@ -1,0 +1,297 @@
+---
+name: tauri-task-executor
+description: Executes Tauri 2 development tasks from spec files. Implements Rust commands, capability JSON, and frontend invoke calls. Updates task status as tasks complete.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: opus
+---
+
+You are a task execution specialist for Tauri 2 desktop app development.
+
+## Execution Process
+
+### Step 1: Parse Command Arguments
+
+Parse the `/todo` command to extract:
+- **Spec file path**: the markdown file containing tasks
+- **Skills**: any `@skill-name` references
+- **TDD mode**: `--tdd`, `--tdd=rust`, `--tdd=unit`, `--tdd=e2e`
+
+### Step 2: Load Skills
+
+**Always load** (required for this project):
+- `.claude/skills/tauri/SKILL.md`
+
+**Load if specified**:
+| Reference | Path |
+|-----------|------|
+| `@tauri-security-review` | `.claude/skills/tauri-security-review/SKILL.md` |
+| `@tauri-performance-review` | `.claude/skills/tauri-performance-review/SKILL.md` |
+
+### Step 3: Analyze Codebase
+
+Before implementing, scan:
+- `src-tauri/src/`: command modules, state, lib.rs builder
+- `src-tauri/capabilities/`: existing capability files
+- `src-tauri/tauri.conf.json`: plugins, security, bundle config
+- Frontend `src/`: existing `invoke()` patterns
+
+### Step 4: Execute Tasks
+
+For each unchecked `- [ ]` task in the spec:
+
+1. **Announce** the task
+2. **Implement** following codebase conventions and loaded skills
+3. **Verify** the implementation compiles / runs
+4. **Update** spec: change `- [ ]` to `- [x]`
+
+### Step 5: Verify Build
+
+After all tasks complete:
+
+```bash
+# Rust compile check
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | head -100
+
+# Clippy (catch lints)
+cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings 2>&1 | head -100
+
+# Frontend build
+pnpm build 2>&1 | head -50
+```
+
+If any fails on files you created/modified:
+1. **Rust errors / clippy warnings** → fix immediately
+2. **TypeScript errors** → fix immediately
+3. Re-run until clean for your files
+
+### Step 6: Run Tests
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml    # Rust tests
+pnpm test:unit                                     # Frontend unit
+pnpm test:e2e                                      # E2E (if applicable)
+```
+
+---
+
+## Pre-Implementation Checklist
+
+Before writing code, verify:
+
+### 1. Tauri Command Definition
+
+When adding a `#[tauri::command]`:
+
+- [ ] **Define a typed error** (do not use `String`):
+  ```rust
+  #[derive(Debug, thiserror::Error)]
+  pub enum FileError {
+      #[error("not found")]
+      NotFound,
+      #[error("io: {0}")]
+      Io(#[from] std::io::Error),
+  }
+  impl serde::Serialize for FileError {
+      fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+          s.serialize_str(&self.to_string())
+      }
+  }
+  ```
+
+- [ ] **Async by default** for I/O work; sync only for pure compute
+- [ ] **Validate all inputs** — never pass user paths/strings to fs / shell unchanged
+- [ ] **Return `Result<T, E>`** with serializable types
+- [ ] **Register** in `tauri::generate_handler![...]` (single call only)
+- [ ] **Document arguments and return** with `///` doc comments
+
+### 2. Capability + Permission Wiring
+
+When a new command is added, the frontend cannot call it until a capability grants permission:
+
+- [ ] **Decide which window** uses this command (`main`, settings, etc.)
+- [ ] **Find or create the capability JSON** in `src-tauri/capabilities/`
+- [ ] **Add the permission** with the most restrictive scope:
+  ```json
+  { "identifier": "fs:allow-write-text-file", "allow": [{ "path": "$APPDATA/notes/*" }] }
+  ```
+- [ ] **Never use `**`** in path scopes — always narrow to a real subdirectory
+- [ ] **Use Tauri path vars** (`$APPDATA`, `$APPCONFIG`, etc.) instead of absolute paths — portable across users/platforms
+
+### 3. Frontend invoke()
+
+- [ ] **Type the response and the args**:
+  ```ts
+  import { invoke } from '@tauri-apps/api/core'
+  type SaveArgs = { path: string; contents: string }
+  await invoke<void>('save_note', { path, contents } satisfies SaveArgs)
+  ```
+- [ ] **Handle errors** — invoke rejects with the serialized error string
+- [ ] **No `any`** — define types for both args and return
+
+### 4. State Management
+
+- [ ] **Choose the right Mutex**:
+  - `std::sync::Mutex` if not held across `.await`
+  - `tokio::sync::Mutex` if held across `.await`
+- [ ] **Do NOT wrap `State<T>` with `Arc<Mutex<T>>` yourself** — Tauri handles sharing; just register `Mutex<T>` and ask for `State<'_, Mutex<T>>`
+- [ ] **Type alias** for state to avoid `State<MyState>` vs `State<Mutex<MyState>>` runtime panic
+
+### 5. CSP
+
+- [ ] If adding remote resources, update `tauri.conf.json > app.security.csp`
+- [ ] Never use `unsafe-inline` / `unsafe-eval` (except `wasm-unsafe-eval` if WASM is used)
+- [ ] Restrict `connect-src` to specific HTTPS domains
+
+### 6. Rust Code Quality
+
+- [ ] **No `unwrap()` or `expect()`** in command bodies — return `Result`
+- [ ] **No `.clone()`** on large data when a reference works
+- [ ] **Pass `&str` not `String`** for inputs unless ownership is required
+- [ ] **Use `tauri::ipc::Response::new(bytes)`** for binary returns >100KB
+- [ ] **Use `tauri::ipc::Channel<T>`** for streaming/progress
+- [ ] **Derive paths via `app.path()` API** (e.g., `app_data_dir()`) — never hardcode `~/Documents`
+
+### 7. TypeScript Strict Typing (No `any`)
+
+- [ ] Type `invoke()` generics explicitly
+- [ ] Type catch clauses as `unknown`:
+  ```ts
+  try { await invoke('x') } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+  }
+  ```
+
+### 8. No Unused Variables / Imports
+
+- [ ] Remove unused imports
+- [ ] Prefix intentionally unused with `_` (Rust and TS both)
+
+### 9. Tauri 2 Migration Gotchas
+
+- [ ] Use `@tauri-apps/api/core` (not `@tauri-apps/api/tauri` — that's v1)
+- [ ] Plugin imports: `@tauri-apps/plugin-fs`, `@tauri-apps/plugin-shell` (not `@tauri-apps/api/fs`)
+- [ ] `tauri::Builder::default().plugin(tauri_plugin_xxx::init())` for plugin registration
+
+---
+
+## TDD Mode
+
+When `--tdd` is specified, follow Red-Green-Refactor.
+
+### TDD Flow
+
+```
+🔴 Red    → Write failing test first
+🟢 Green  → Write minimum code to pass
+🔵 Blue   → Refactor with test protection
+```
+
+### Test Type Selection
+
+| Option | Test Type | Tool | File Pattern |
+|--------|-----------|------|--------------|
+| `--tdd=rust` | Rust unit | cargo test | inline `#[cfg(test)] mod tests` in module |
+| `--tdd=unit` | Frontend unit | Vitest | `tests/unit/**/*.unit.spec.ts(x)` |
+| `--tdd=e2e` | E2E | Playwright + tauri-driver | `tests/e2e/**/*.e2e.spec.ts` |
+
+### Auto-Detection Guide
+
+| Task Type | Test Type |
+|-----------|-----------|
+| `#[tauri::command]` logic | Rust unit |
+| Pure Rust function | Rust unit |
+| Frontend hook / component | Frontend unit |
+| invoke wrapper | Frontend unit |
+| User flow across windows | E2E |
+
+### TDD Output Format
+
+```
+### Task: [Task Name]
+
+#### 🔴 Red Phase
+- Test file: src-tauri/src/commands/files.rs (mod tests)
+- Test: should_reject_path_outside_container
+- Result: FAILED ✓
+
+#### 🟢 Green Phase
+- Implementation: src-tauri/src/commands/files.rs
+- Result: PASSED ✓
+
+#### 🔵 Refactor Phase
+- Changes: extracted path-validation helper
+- Result: PASSED ✓
+```
+
+---
+
+## Output Format
+
+After execution, provide this summary:
+
+```
+## Execution Summary
+
+### Completed Tasks
+- [x] Task 1
+- [x] Task 2
+
+### Pending Tasks
+- [ ] Task 3 (blocked: reason)
+
+### Files Modified
+- src-tauri/src/commands/files.rs (created)
+- src-tauri/capabilities/main.json (modified — added fs scope)
+- src/lib/notes.ts (created)
+
+### Tests Written (TDD mode only)
+- src-tauri/src/commands/files.rs#tests (4 tests)
+
+### Test Results ✅
+Rust: 12 passed
+Frontend Unit: 8 passed
+Total: 20 passed
+
+### Build Verification ✅
+cargo check: clean
+cargo clippy: clean
+pnpm build: clean
+
+### Skills Applied
+- @tauri (auto-loaded)
+
+### Next Steps
+- Run `/tauri-check` before commit
+```
+
+**IMPORTANT**: `### Test Results` and `### Build Verification` are mandatory.
+
+---
+
+## Rules
+
+1. **One task at a time** — complete and verify before proceeding
+2. **Follow existing patterns** — match codebase conventions
+3. **Update immediately** — mark complete right after finishing
+4. **Skip completed** — don't re-implement `- [x]` items
+5. **Document blockers** — add `> ⚠️ Blocked: [reason]` if stuck
+6. **Build before tests** — run `cargo check` + `pnpm build` and fix all errors first
+7. **Run tests at end** — always execute test suite before reporting completion
+8. **Fix failures** — do not report success with failing tests
+9. **Check before code** — complete Pre-Implementation Checklist for relevant items
+10. **Zero `any` / `unwrap()`** — never use `any` in TS or `unwrap()` in command bodies
+11. **Zero unused code** — prefix intentionally unused with `_`
+12. **Least-privilege capabilities** — never broaden a capability scope without justification
+
+---
+
+## Error Handling
+
+If a task cannot be completed:
+
+```markdown
+- [ ] Task description
+  > ⚠️ Blocked: [reason]
+```
+
+Continue with independent tasks; stop if dependent tasks are blocked.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,40 @@
+---
+description: Create Tauri implementation plan using 3-layer task breakdown. Covers Rust backend, IPC capabilities, and frontend integration. WAIT for user CONFIRM before touching any code.
+invokes_agent: tauri-planner
+---
+
+# Plan Command
+
+Create a comprehensive Tauri 2 implementation plan before writing any code. Output considers Rust commands, IPC capabilities, and frontend integration.
+
+## When to Use
+
+- Starting a new Tauri feature (new window, new command, new plugin)
+- Adding a system integration (filesystem, shell, notifications, etc.)
+- Architectural changes that touch IPC or capabilities
+
+## Syntax
+
+```bash
+/plan Build a markdown notes editor with autosave
+/plan @tauri Build a folder watcher feature
+/plan @tauri-security-review Add a file export feature
+```
+
+## What the planner will check
+
+1. **Rust side** — which `#[tauri::command]` to add, state, error types, async vs sync.
+2. **IPC surface** — required permissions and which capability file (`src-tauri/capabilities/*.json`) the window needs.
+3. **Frontend side** — `invoke()` calls, types, error handling.
+4. **Plugin choice** — official plugin (`tauri-plugin-fs`, `tauri-plugin-shell`, etc.) vs custom command.
+
+## Output
+
+Plan saved to `spec/[feature-name]/`:
+- `overview.md` — master index
+- `[major-feature].md` — per-feature breakdown including Rust tasks, capability JSON snippets, and frontend tasks.
+
+## Related
+
+- Agent: `.claude/agents/tauri-planner.md`
+- Skills: `.claude/skills/tauri/`

--- a/.claude/commands/tauri-audit.md
+++ b/.claude/commands/tauri-audit.md
@@ -1,0 +1,65 @@
+Run a comprehensive full-codebase audit for a Tauri 2 app.
+
+Scans the entire codebase (not just git diff) across two dimensions simultaneously:
+- **Security** — capabilities, permissions, command input validation, CSP, isolation
+- **Performance** — IPC payload, async commands, state contention, startup time
+
+## Execution
+
+Launch **two agents in parallel**, each scanning the full codebase:
+
+1. **`tauri-security-reviewer`** — Read `.claude/skills/tauri-security-review/SKILL.md`, then scan: `src-tauri/capabilities/**/*.json`, `src-tauri/permissions/**/*.toml`, `src-tauri/tauri.conf.json`, all files containing `#[tauri::command]`, `invoke_handler!`, `tauri::Builder`, frontend files using `@tauri-apps/api/core`'s `invoke()`.
+
+2. **`tauri-performance-reviewer`** — Read `.claude/skills/tauri-performance-review/SKILL.md`, then scan all Rust commands for: `serde_json::to_string` on large data, missing `Channel` for streaming, `std::sync::Mutex` held across `.await`, blocking I/O in async commands, frontend bundle size in `tauri.conf.json`, dev URL config.
+
+Each agent should use the **Grep tool** (not bash grep/rg) and the **Read tool** for deep inspection.
+
+## Consolidation
+
+After both agents complete, merge findings into a single report sorted by severity:
+
+```
+# Tauri Full Audit Report
+Date: {today}
+Scope: Full codebase
+
+## Summary
+
+| Severity | Security | Performance | Total |
+|----------|----------|-------------|-------|
+| CRITICAL | 0        | 0           | 0     |
+| HIGH     | 0        | 0           | 0     |
+| MEDIUM   | 0        | 0           | 0     |
+| LOW      | 0        | 0           | 0     |
+| **Total**| 0        | 0           | **0** |
+
+**Overall verdict: PASS / WARNING / BLOCK**
+
+---
+
+## Issues (sorted by severity)
+
+### #1 [CRITICAL / Security] Issue Title
+**File:** `src-tauri/src/commands/files.rs:18`
+**Category:** Security — Input Validation
+**Issue:** Description.
+**Fix:** Concrete fix.
+
+---
+
+## Recommended Fix Order
+
+1. All Security CRITICAL — privilege escalation / data leak
+2. Security HIGH — fix before merge
+3. Performance CRITICAL / HIGH — user-visible jank, fix before merge
+4. MEDIUM — follow-up tickets
+5. LOW — backlog
+```
+
+## Usage
+
+```
+/tauri-audit
+```
+
+Best for: quarterly health checks, major version bumps, onboarding to existing Tauri codebases.

--- a/.claude/commands/tauri-check.md
+++ b/.claude/commands/tauri-check.md
@@ -1,0 +1,44 @@
+Run targeted Tauri reviews based on what files have changed.
+
+自動偵測修改檔案（staged + unstaged），只啟動相關的 review agents，避免不必要的 review 與 token 浪費。
+
+## Steps
+
+1. **Detect changes** — Run `git diff --name-only` and `git diff --staged --name-only`.
+
+2. **Determine which reviews to run** based on changed file paths:
+
+   | File pattern | Agent to launch |
+   |---|---|
+   | `src-tauri/capabilities/*.json`, `src-tauri/permissions/*.toml`, `src-tauri/tauri.conf.json` (security 區塊), `#[tauri::command]` 函數，`invoke_handler!` 註冊變動 | `tauri-security-reviewer` |
+   | Rust 命令邏輯（資料量大、async/await、Mutex、Channel、Response），前端 `invoke()` 高頻呼叫，`tauri.conf.json` 的 bundle/dev 設定 | `tauri-performance-reviewer` |
+
+3. **Launch only matched agents in parallel.** 沒符合的 pattern 就回報 "No Tauri-related changes detected — no review needed."
+
+4. **Consolidate results** — 多個 agent 跑完後，依嚴重度合併：
+
+```
+## Tauri Check Results
+
+Reviews triggered: Security ✅ | Performance ✅
+
+| Severity | Count | Status |
+|----------|-------|--------|
+| CRITICAL | 0     | ✅ pass |
+| HIGH     | 0     | ✅ pass |
+| MEDIUM   | 0     | ℹ️ info |
+| LOW      | 0     | 📝 note |
+
+**Verdict: PASS / WARNING / BLOCK**
+
+---
+(依嚴重度列出 issues)
+```
+
+## Usage
+
+```
+/tauri-check
+```
+
+完成程式碼變更後、`git commit` 之前執行。有問題就修，再跑一次直到 PASS。

--- a/.claude/commands/tauri-perf.md
+++ b/.claude/commands/tauri-perf.md
@@ -1,0 +1,7 @@
+Run a Tauri 2 performance review on the current git diff.
+
+Launch the `tauri-performance-reviewer` agent to execute the review.
+
+Focus areas: IPC payload size (`tauri::ipc::Response` for binary, `Channel` for streaming), async command usage, state lock contention (sync `Mutex` vs Tokio `Mutex` across `.await`), unnecessary serde JSON for large data, excessive `invoke()` round-trips, frontend bundle size, startup time.
+
+When to use: after each commit push, especially when modifying Rust commands, IPC types, state management, or large-data handling.

--- a/.claude/commands/tauri-review.md
+++ b/.claude/commands/tauri-review.md
@@ -1,0 +1,7 @@
+Run a Tauri 2 security review on the current git diff.
+
+Launch the `tauri-security-reviewer` agent to execute the review.
+
+Focus areas: capability scope (`src-tauri/capabilities/*.json`), permission least-privilege, custom command input validation, fs/shell/http scope restriction, CSP in `tauri.conf.json`, isolation pattern, IPC trust boundary, plugin allowlist.
+
+When to use: after each commit push, especially when modifying `src-tauri/`, capabilities, permissions, `tauri.conf.json`, or any `#[tauri::command]` function.

--- a/.claude/commands/todo.md
+++ b/.claude/commands/todo.md
@@ -1,0 +1,87 @@
+---
+description: Execute Tauri development tasks from a spec file. Handles Rust commands, capabilities, and frontend invoke calls. Optional skills and TDD mode.
+invokes_agent: tauri-task-executor
+---
+
+# Todo Command
+
+Execute development tasks defined in a spec file with Tauri-aware conventions.
+
+## Syntax
+
+```bash
+/todo <spec-file> [@skill...] [--tdd[=type]]
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<spec-file>` | Yes | Path to spec (e.g., `spec/notes-editor/autosave.md`) |
+| `@skill` | No | Additional skill (`@tauri`, `@tauri-security-review`, etc.) |
+| `--tdd` | No | Test-driven development mode |
+
+## TDD Mode Options
+
+| Option | Description |
+|--------|-------------|
+| `--tdd` | Auto-detect (Rust unit / Vitest / Playwright) |
+| `--tdd=rust` | Rust `#[cfg(test)]` unit tests via `cargo test` |
+| `--tdd=unit` | Frontend unit tests (Vitest) |
+| `--tdd=e2e` | E2E with WebDriver (`tauri-driver`) or Playwright |
+
+## TDD 工作流程（紅-綠-重構）
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  1. RED — 撰寫失敗的測試                                     │
+│     ├── Rust: #[cfg(test)] mod tests { #[test] fn ... }     │
+│     ├── 前端: Vitest 或 Playwright                            │
+│     └── 執行測試確認失敗（紅燈）                              │
+├─────────────────────────────────────────────────────────────┤
+│  2. GREEN — 撰寫最小可行程式碼                                │
+│     └── 執行測試確認通過（綠燈）                              │
+├─────────────────────────────────────────────────────────────┤
+│  3. REFACTOR — 重構（可選）                                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 測試類型選擇指南
+
+| 測試類型 | 適用場景 | 工具 | 檔案位置 |
+|---------|---------|------|---------|
+| **Rust unit** | command 邏輯、純函數、error 轉換 | `cargo test` | `src-tauri/src/**/mod.rs` 內 `#[cfg(test)]` |
+| **Frontend unit** | UI hooks、純函數、`invoke()` wrapper | Vitest | `tests/unit/*.unit.spec.ts` |
+| **E2E** | 完整 IPC 流程、視窗互動 | Playwright + tauri-driver | `tests/e2e/*.e2e.spec.ts` |
+
+## Available Skills
+
+| Skill | Use Case |
+|-------|----------|
+| `@tauri` | Tauri 2 commands、capabilities、permissions、state |
+| `@tauri-security-review` | IPC、CSP、scope、input validation |
+| `@tauri-performance-review` | IPC payload、async commands、state contention |
+
+> **Note**: `@tauri` 會自動載入。
+
+## Examples
+
+```bash
+/todo spec/notes-editor/autosave.md
+/todo spec/file-watcher/core.md @tauri --tdd=rust
+/todo spec/export/pdf.md @tauri @tauri-security-review --tdd
+```
+
+## Test Commands
+
+| Command | Description |
+|---------|-------------|
+| `cargo test --manifest-path src-tauri/Cargo.toml` | Rust 單元測試 |
+| `pnpm test:unit` | 前端單元測試 (Vitest) |
+| `pnpm test:e2e` | E2E 測試 |
+| `pnpm tauri build --debug` | 確認可編譯 |
+
+## Related
+
+- `/plan` — 建立 spec
+- `/tauri-check` — diff-based 自動審查
+- Agent: `.claude/agents/tauri-task-executor.md`
+- Skills: `.claude/skills/tauri/`

--- a/.claude/skills/tauri-performance-review/SKILL.md
+++ b/.claude/skills/tauri-performance-review/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: tauri-performance-review
+description: Expert workflow for reviewing Tauri 2 desktop app performance. Covers IPC payload optimization, async command efficiency, state lock contention, large-data streaming via Channel/Response, frontend bundle size, and startup time.
+---
+
+# Tauri 2 Performance Review Skill
+
+Expert workflow for reviewing Tauri 2 code with a focus on IPC throughput, async correctness, and binary/large-payload handling.
+
+## When to Use
+
+Invoke this skill (or the `tauri-performance-reviewer` agent) when changes touch:
+- Any `#[tauri::command]` returning or accepting non-trivial data
+- Frontend `invoke()` callers (especially in hot paths)
+- State management — `Mutex`, `RwLock`, `Arc`
+- `tauri.conf.json` build / dev / bundle settings
+- `Cargo.toml` features and profiles
+
+## Core Principle: IPC Has Cost
+
+Every `invoke()` round-trip serializes args to JSON, crosses a process boundary, and deserializes the response. **Optimize per call**, then **minimize call count**, then **stream when total bytes are large**.
+
+---
+
+## Checklist by Area
+
+### Rust Commands
+
+```
+□ Async fn for I/O work (file, net, db) — never block the runtime
+□ Sync fn for pure compute / very fast operations
+□ Returns < 100KB use normal serde JSON
+□ Returns ≥ 100KB binary use tauri::ipc::Response::new(bytes)
+□ Streaming/progress uses tauri::ipc::Channel<T>
+□ Inputs aren't Vec<u8> when an ArrayBuffer Request body would work
+□ No std::sync::Mutex held across .await (use tokio::sync::Mutex)
+□ No .clone() of large Vec/String when a reference works
+□ &str arguments instead of String when ownership not needed
+□ No JSON parse/stringify inside hot loops
+□ Database/HTTP connection pooled (managed state, not per-call)
+```
+
+### State Management
+
+```
+□ Mutex chosen for the access pattern (sync vs tokio)
+□ Read-heavy state uses RwLock, not Mutex
+□ Lock scope is minimal — release before slow work
+□ No Arc<Mutex<T>> wrapping (Tauri does the Arc internally)
+□ No deep clones of state on every read — return references via map_or borrow
+```
+
+### Frontend invoke()
+
+```
+□ No invoke() in render loops without memoization
+□ Multiple sequential invokes that fetch related data → combine into one command
+□ Large blob downloads use Channel for progress + Response for bytes
+□ Listen for Tauri events instead of polling via invoke
+□ No invoke() inside React useEffect without dependency array
+```
+
+### tauri.conf.json
+
+```
+□ build.frontendDist points to a built (minified) frontend, not dev source
+□ bundle.resources only includes what's needed (not entire src/)
+□ bundle.macOS.minimumSystemVersion set (avoids fat universal slices for old macOS)
+□ app.windows[].visible: false at start if you want to wait for "ready" event (avoids white flash)
+□ app.windows[].decorations / transparent set conservatively (each costs paint perf)
+□ No huge bundled binaries in externalBin if avoidable
+```
+
+### Cargo.toml
+
+```
+□ [profile.release] uses opt-level = 3 (default) and lto = "thin" or "fat"
+□ codegen-units = 1 in release for max optimization (slower compile, faster binary)
+□ strip = true in release (smaller binary)
+□ panic = "abort" in release (smaller binary, faster)
+□ No unnecessary default features on heavy crates (use default-features = false)
+```
+
+### Startup Time
+
+```
+□ tauri::Builder::default() doesn't do heavy work in setup (defer to first command)
+□ Plugins initialized lazily where the plugin supports it
+□ Frontend doesn't fetch all data on mount — paginate
+□ Splash window or hidden-then-show pattern for slow initialization
+```
+
+---
+
+## Common Tauri 2 Performance Bug Patterns
+
+### Pattern 1: Large Binary Returned As serde JSON
+
+```rust
+// ❌ WRONG — 10MB image becomes ~14MB base64 JSON, ~200ms encode + parse
+#[tauri::command]
+fn read_image(path: String) -> Result<Vec<u8>, Error> {
+    Ok(std::fs::read(path)?)
+}
+
+// ✅ CORRECT — raw ArrayBuffer, ~10ms
+#[tauri::command]
+fn read_image(path: String) -> Result<tauri::ipc::Response, Error> {
+    Ok(tauri::ipc::Response::new(std::fs::read(path)?))
+}
+```
+
+Frontend:
+```ts
+const buf = await invoke<ArrayBuffer>('read_image', { path })
+```
+
+### Pattern 2: `std::sync::Mutex` Across `.await` (Panic + Slow)
+
+```rust
+// ❌ WRONG — panics in some Tokio configs; serializes async tasks
+#[tauri::command]
+async fn save(state: State<'_, std::sync::Mutex<AppState>>) -> Result<(), Error> {
+    let mut s = state.lock().unwrap();    // sync lock
+    tokio::fs::write("...", &s.buf).await?;  // held across .await
+    Ok(())
+}
+
+// ✅ CORRECT — use tokio's async mutex
+#[tauri::command]
+async fn save(state: State<'_, tokio::sync::Mutex<AppState>>) -> Result<(), Error> {
+    let mut s = state.lock().await;
+    tokio::fs::write("...", &s.buf).await?;
+    Ok(())
+}
+```
+
+### Pattern 3: Polling Instead of Events
+
+```ts
+// ❌ WRONG — invoke every 500ms, wakes the UI thread + Rust constantly
+setInterval(async () => {
+    setStatus(await invoke<Status>('get_status'))
+}, 500)
+
+// ✅ CORRECT — emit from Rust, listen from frontend
+import { listen } from '@tauri-apps/api/event'
+const un = await listen<Status>('status:changed', (e) => setStatus(e.payload))
+```
+
+```rust
+app.emit("status:changed", status)?;
+```
+
+### Pattern 4: Streaming Without Channel
+
+```rust
+// ❌ WRONG — caller waits 30s for download; no progress UI possible
+#[tauri::command]
+async fn download(url: String) -> Result<Vec<u8>, Error> {
+    Ok(reqwest::get(&url).await?.bytes().await?.to_vec())
+}
+
+// ✅ CORRECT — Channel sends progress + chunks
+#[derive(Clone, Serialize)]
+#[serde(tag = "event", content = "data")]
+enum DownloadEvent {
+    Progress { downloaded: u64, total: u64 },
+    Chunk(Vec<u8>),
+    Done,
+}
+
+#[tauri::command]
+async fn download(url: String, on_event: Channel<DownloadEvent>) -> Result<(), Error> {
+    let resp = reqwest::get(&url).await?;
+    let total = resp.content_length().unwrap_or(0);
+    let mut downloaded = 0;
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        downloaded += chunk.len() as u64;
+        on_event.send(DownloadEvent::Progress { downloaded, total })?;
+        on_event.send(DownloadEvent::Chunk(chunk.to_vec()))?;
+    }
+    on_event.send(DownloadEvent::Done)?;
+    Ok(())
+}
+```
+
+### Pattern 5: N+1 Invoke Calls
+
+```ts
+// ❌ WRONG — 50 round-trips for 50 notes
+const notes: Note[] = []
+for (const id of ids) {
+    notes.push(await invoke<Note>('get_note', { id }))
+}
+
+// ✅ CORRECT — one round-trip
+const notes = await invoke<Note[]>('get_notes', { ids })
+```
+
+### Pattern 6: Mutex Held While Doing Work
+
+```rust
+// ❌ WRONG — lock held while writing 100MB to disk; blocks all readers
+let mut s = state.lock().await;
+tokio::fs::write(&path, &s.huge_buffer).await?;  // 2 seconds
+s.last_saved = Some(now());
+drop(s);
+
+// ✅ CORRECT — clone what's needed, release lock immediately
+let buffer = {
+    let s = state.lock().await;
+    s.huge_buffer.clone()
+};
+tokio::fs::write(&path, &buffer).await?;
+state.lock().await.last_saved = Some(now());
+```
+
+### Pattern 7: Heavy Work in `.setup()` Blocks Window Show
+
+```rust
+// ❌ WRONG — DB load on startup adds 3s to first paint
+.setup(|app| {
+    let db = load_database_sync()?;   // blocks
+    app.manage(db);
+    Ok(())
+})
+
+// ✅ CORRECT — initialize lazily, show window first
+.setup(|app| {
+    let handle = app.handle().clone();
+    tauri::async_runtime::spawn(async move {
+        let db = load_database().await.unwrap();
+        handle.manage(db);
+        handle.emit("db:ready", ()).ok();
+    });
+    Ok(())
+})
+```
+
+### Pattern 8: Cargo Release Profile Not Tuned
+
+```toml
+# ❌ Default — 80MB binary
+[profile.release]
+opt-level = 3
+
+# ✅ Tuned for ship-quality binary — typically 25-40MB
+[profile.release]
+opt-level = "z"      # or "s" for size
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true
+```
+
+### Pattern 9: Frontend Bundles Dev Dependencies
+
+```json
+// ❌ WRONG — frontendDist points at unminified source
+"build": { "frontendDist": "../src" }
+
+// ✅ CORRECT — point at production build output
+"build": {
+  "beforeBuildCommand": "pnpm build",
+  "frontendDist": "../dist"
+}
+```
+
+### Pattern 10: `.clone()` On Large `State` Read
+
+```rust
+// ❌ WRONG — clones a 10MB Vec on every read
+#[tauri::command]
+fn get_buffer(state: State<'_, Mutex<AppState>>) -> Vec<u8> {
+    state.lock().unwrap().buffer.clone()
+}
+
+// ✅ CORRECT — return Response (raw bytes), no JSON, single copy
+#[tauri::command]
+fn get_buffer(state: State<'_, Mutex<AppState>>) -> tauri::ipc::Response {
+    tauri::ipc::Response::new(state.lock().unwrap().buffer.clone())
+}
+// Or even better: use Bytes/Arc<[u8]> in state to avoid the clone entirely
+```
+
+---
+
+## Severity Guide
+
+| Severity | Examples | Action |
+|----------|----------|--------|
+| CRITICAL | std::sync::Mutex across .await (panic risk), 100MB+ JSON returns, polling at <1s interval, blocking I/O in async command | Block merge |
+| HIGH | Channel not used for streaming, N+1 invoke pattern, large clone() in hot path, lock held across slow work | Fix before merge |
+| MEDIUM | Missing release profile tuning, missing minimumSystemVersion, suboptimal Mutex choice for read-heavy state | Follow-up |
+| LOW | Stylistic, micro-opts in cold paths | Backlog |
+
+---
+
+## Official Documentation References
+
+| Check | Source |
+|-------|--------|
+| Calling Rust (commands, Channel, Response) | https://v2.tauri.app/develop/calling-rust/ |
+| State management | https://v2.tauri.app/develop/state-management/ |
+| Bundle / config | https://v2.tauri.app/reference/config/ |
+
+---
+
+## Related
+
+- Agent: `tauri-performance-reviewer`
+- Commands: `/tauri-perf`, `/tauri-check`, `/tauri-audit`

--- a/.claude/skills/tauri-security-review/SKILL.md
+++ b/.claude/skills/tauri-security-review/SKILL.md
@@ -252,10 +252,13 @@ impl serde::Serialize for DbError { /* serialize as string */ }
 ### Pattern 9: Open URL With User-Controlled String
 
 ```rust
+// tauri-plugin-shell's `open` is deprecated in Tauri v2; use tauri-plugin-opener.
+use tauri_plugin_opener::OpenerExt;
+
 // ❌ WRONG — "javascript:..." or arbitrary scheme
 #[tauri::command]
 fn open_link(url: String, app: AppHandle) {
-    app.shell().open(&url, None).ok();
+    app.opener().open_url(&url, None::<&str>).ok();
 }
 
 // ✅ CORRECT — validate scheme + domain
@@ -265,7 +268,7 @@ fn open_link(url: String, app: AppHandle) -> Result<(), Error> {
     if !matches!(parsed.scheme(), "https" | "http") { return Err(Error::InvalidScheme); }
     let host = parsed.host_str().ok_or(Error::InvalidUrl)?;
     if !["docs.example.com", "github.com"].contains(&host) { return Err(Error::DomainNotAllowed); }
-    app.shell().open(parsed.as_str(), None).map_err(|_| Error::OpenFailed)?;
+    app.opener().open_url(parsed.as_str(), None::<&str>).map_err(|_| Error::OpenFailed)?;
     Ok(())
 }
 ```

--- a/.claude/skills/tauri-security-review/SKILL.md
+++ b/.claude/skills/tauri-security-review/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: tauri-security-review
+description: Expert workflow for reviewing Tauri 2 desktop app security. Covers capabilities/permissions least-privilege, IPC trust boundary, command input validation, CSP, scope restriction, isolation pattern, and frontend-side hygiene.
+---
+
+# Tauri 2 Security Review Skill
+
+Expert workflow for reviewing Tauri 2 code with a focus on the IPC trust boundary, capability least-privilege, and command-level input validation.
+
+## When to Use
+
+Invoke this skill (or the `tauri-security-reviewer` agent) when changes touch:
+- `src-tauri/capabilities/*.json`
+- `src-tauri/permissions/*.toml`
+- `src-tauri/tauri.conf.json` (security / app / bundle sections)
+- Any `#[tauri::command]` function
+- `tauri::generate_handler!` registration
+- `tauri::Builder` plugin registration
+- Frontend `invoke()` callers (especially passing user input)
+
+## Core Principle: Frontend Is Untrusted
+
+The webview is part of the **untrusted** side of the trust boundary. **Every command must validate every input as if it came from a remote attacker.** A capability grants the *ability* to call a command — it does not validate the *contents* of the call.
+
+---
+
+## Checklist by File Type
+
+### Capability Files (`src-tauri/capabilities/*.json`)
+
+```
+□ identifier is unique and descriptive
+□ windows / webviews are explicitly listed (no broad globs unless justified)
+□ permissions list is minimal — every entry has a justified use case
+□ fs/shell/http permissions use scoped objects with allow path lists
+□ allow paths use Tauri path vars ($APPDATA, etc.), not absolute paths
+□ allow paths do NOT use ** wildcards
+□ deny rules added for sensitive subpaths (secrets, .env)
+□ platforms[] excludes platforms that don't need this capability
+□ remote.urls (if present) is a specific allowlist, not "https://*"
+□ local: false used when capability is for remote-only contexts
+```
+
+### Custom Permission Files (`src-tauri/permissions/*.toml`)
+
+```
+□ identifier prefixed with intended namespace
+□ commands.allow is the smallest set possible
+□ scope.allow paths are specific
+□ scope.deny added for any obvious dangerous subpath
+□ description explains the security impact, not just the feature
+```
+
+### `tauri.conf.json`
+
+```
+□ app.security.csp present and restrictive
+   - default-src 'self'
+   - no 'unsafe-inline' for script-src
+   - no 'unsafe-eval' (except 'wasm-unsafe-eval' if WASM is used)
+   - connect-src is a specific allowlist
+□ app.security.devCsp present (or same as csp) — dev mode shouldn't relax everything
+□ app.security.dangerousDisableAssetCspModification is NOT true
+□ app.security.assetProtocol.scope is restrictive (not "**")
+□ app.windows[].url is local (path) or trusted https — not http or untrusted host
+□ build.devUrl is localhost only
+□ identifier is reverse-DNS and matches the App Store record
+□ plugins.shell.open is restrictive or absent
+□ plugins.http.scope (if used) lists exact allowed origins
+```
+
+### Rust Commands (`#[tauri::command]`)
+
+```
+□ All path inputs validated:
+   - canonicalize() to resolve symlinks
+   - check that resolved path is inside an expected base dir
+   - reject paths containing ".." segments or null bytes
+□ Shell-bound inputs never concatenated — use std::process::Command with args[], not args.join(" ")
+□ SQL inputs parameterized (never format!())
+□ HTTP URLs validated to be in expected origin set
+□ Input length bounded — no infinite-size strings/bytes accepted
+□ Errors don't leak sensitive paths or stack traces (use a typed error enum that rewrites messages)
+□ No unwrap()/expect() — they panic and crash the app
+□ Async commands don't hold std::sync::Mutex across .await
+□ No use of std::env::set_var (security side effects across threads)
+```
+
+### `invoke_handler!` Registration
+
+```
+□ Single tauri::generate_handler![...] call (multiple calls silently overwrite)
+□ All commands listed actually exist as #[tauri::command]
+□ No leftover/dead command registrations exposing unused attack surface
+```
+
+### Frontend Callers (`invoke('cmd', { ... })`)
+
+```
+□ User input never used as an `invoke` command name (must be a hardcoded string literal)
+□ Argument types match the Rust signature exactly
+□ Error from invoke is caught and shown safely (not innerHTML'd into DOM — XSS)
+```
+
+---
+
+## Common Tauri 2 Security Bug Patterns
+
+### Pattern 1: Over-Broad Capability Scope
+
+```json
+// ❌ WRONG — frontend can read/write anywhere in $HOME
+{
+  "identifier": "main",
+  "windows": ["main"],
+  "permissions": [
+    { "identifier": "fs:allow-write-text-file", "allow": [{ "path": "$HOME/**" }] }
+  ]
+}
+
+// ✅ CORRECT — narrowly scoped to app data
+{
+  "identifier": "main",
+  "windows": ["main"],
+  "permissions": [
+    { "identifier": "fs:allow-write-text-file", "allow": [{ "path": "$APPDATA/notes/*" }] }
+  ]
+}
+```
+
+### Pattern 2: Path Traversal in Command
+
+```rust
+// ❌ WRONG — frontend can escape with "../../../etc/passwd"
+#[tauri::command]
+async fn read_note(name: String, app: AppHandle) -> Result<String, NoteError> {
+    let dir = app.path().app_data_dir()?;
+    let path = dir.join(&name);
+    Ok(tokio::fs::read_to_string(&path).await?)
+}
+
+// ✅ CORRECT — canonicalize and verify containment
+#[tauri::command]
+async fn read_note(name: String, app: AppHandle) -> Result<String, NoteError> {
+    let dir = app.path().app_data_dir()?.canonicalize()?;
+    let path = dir.join(&name).canonicalize()?;
+    if !path.starts_with(&dir) {
+        return Err(NoteError::InvalidPath);
+    }
+    Ok(tokio::fs::read_to_string(&path).await?)
+}
+```
+
+### Pattern 3: Shell Injection via String Concat
+
+```rust
+// ❌ WRONG — RCE if `query` contains "; rm -rf ~"
+#[tauri::command]
+fn search(query: String) -> Result<String, Error> {
+    let out = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!("grep {} ~/notes", query))
+        .output()?;
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+// ✅ CORRECT — pass args directly, no shell
+#[tauri::command]
+fn search(query: String) -> Result<String, Error> {
+    if query.len() > 200 { return Err(Error::TooLong); }
+    let out = std::process::Command::new("grep")
+        .arg("--")            // end of options
+        .arg(&query)          // safe: passed as argv, no shell parsing
+        .arg(notes_dir())
+        .output()?;
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+```
+
+### Pattern 4: Missing Capability — Implicit Trust on a New Window
+
+```rust
+// ❌ WRONG — created new window, didn't add capability — but ALSO didn't restrict commands
+// New "settings" window can call EVERY command listed in invoke_handler if a wildcard capability exists
+let _settings = WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App("settings".into()))
+    .build()?;
+
+// ✅ CORRECT — explicit capability with minimum permissions for settings window
+// src-tauri/capabilities/settings.json
+{
+  "identifier": "settings",
+  "windows": ["settings"],
+  "permissions": ["core:default", "settings:allow-read", "settings:allow-write"],
+  "platforms": ["macOS"]
+}
+```
+
+### Pattern 5: CSP Allows Inline Script (XSS Amplifier)
+
+```json
+// ❌ WRONG — any reflected XSS becomes RCE via invoke()
+"csp": "default-src 'self'; script-src 'self' 'unsafe-inline'"
+
+// ✅ CORRECT — Tauri injects nonces for bundled scripts; no inline needed
+"csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.example.com"
+```
+
+### Pattern 6: `dangerousDisableAssetCspModification: true`
+
+```json
+// ❌ WRONG — disables Tauri's automatic nonce/hash injection
+"app": { "security": { "dangerousDisableAssetCspModification": true } }
+
+// ✅ CORRECT — leave default (false). Only enable if you have a strong CSP without it.
+```
+
+### Pattern 7: Untyped Error Leaks Internals
+
+```rust
+// ❌ WRONG — full path leaks to frontend (and into logs / crash reports)
+#[tauri::command]
+fn open_db() -> Result<(), String> {
+    std::fs::File::open("/Users/alice/secrets.db").map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+// ✅ CORRECT — typed error rewrites messages
+#[derive(thiserror::Error, Debug)]
+enum DbError {
+    #[error("database unavailable")]
+    Unavailable,
+}
+impl serde::Serialize for DbError { /* serialize as string */ }
+```
+
+### Pattern 8: Remote URL in Window Without Capability Audit
+
+```json
+// ❌ WRONG — loading a third-party URL into a window with all permissions
+{ "label": "embed", "url": "https://untrusted.example.com/widget" }
+// + capability with broad permissions for "embed" window
+
+// ✅ CORRECT — remote content gets a separate capability with NO commands granted
+{
+  "identifier": "embed-readonly",
+  "windows": ["embed"],
+  "permissions": ["core:event:default"],  // events only, no fs/shell/etc
+  "remote": { "urls": ["https://untrusted.example.com/*"] }
+}
+```
+
+### Pattern 9: Open URL With User-Controlled String
+
+```rust
+// ❌ WRONG — "javascript:..." or arbitrary scheme
+#[tauri::command]
+fn open_link(url: String, app: AppHandle) {
+    app.shell().open(&url, None).ok();
+}
+
+// ✅ CORRECT — validate scheme + domain
+#[tauri::command]
+fn open_link(url: String, app: AppHandle) -> Result<(), Error> {
+    let parsed = url::Url::parse(&url).map_err(|_| Error::InvalidUrl)?;
+    if !matches!(parsed.scheme(), "https" | "http") { return Err(Error::InvalidScheme); }
+    let host = parsed.host_str().ok_or(Error::InvalidUrl)?;
+    if !["docs.example.com", "github.com"].contains(&host) { return Err(Error::DomainNotAllowed); }
+    app.shell().open(parsed.as_str(), None).map_err(|_| Error::OpenFailed)?;
+    Ok(())
+}
+```
+
+### Pattern 10: Isolation Pattern Not Used For High-Risk IPC
+
+When the app handles secrets (tokens, keys) **and** loads any remote/3rd-party content, enable Tauri's [Isolation Pattern](https://v2.tauri.app/concept/inter-process-communication/isolation/) — it routes all IPC through a sandboxed inner iframe so a compromised main webview cannot forge invoke calls.
+
+---
+
+## Severity Guide
+
+| Severity | Examples | Action |
+|----------|----------|--------|
+| CRITICAL | Path traversal in command, shell injection, capability with `$HOME/**` write, CSP `unsafe-eval`, command exposed without capability check, secret leaked in error | Block merge |
+| HIGH | Over-broad permission scope, missing input validation, `unwrap()` in command, `unsafe-inline` script, http (not https) connect-src | Fix before merge |
+| MEDIUM | Missing platforms[] narrowing, missing description, weak error type, asset scope too broad | Fix in follow-up |
+| LOW | Identifier naming, missing comments, unused permission entries | Backlog |
+
+---
+
+## Official Documentation References
+
+| Check | Source |
+|-------|--------|
+| Capability schema | https://v2.tauri.app/reference/acl/capability/ |
+| Permission scopes | https://v2.tauri.app/security/permissions/ |
+| Security overview | https://v2.tauri.app/security/ |
+| CSP | https://v2.tauri.app/security/csp/ |
+| Isolation pattern | https://v2.tauri.app/concept/inter-process-communication/isolation/ |
+| Calling Rust safely | https://v2.tauri.app/develop/calling-rust/ |
+
+---
+
+## Related
+
+- Agent: `tauri-security-reviewer`
+- Commands: `/tauri-review`, `/tauri-check`, `/tauri-audit`

--- a/.claude/skills/tauri/SKILL.md
+++ b/.claude/skills/tauri/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: tauri
+description: Use when working with Tauri 2 projects (tauri.conf.json, src-tauri/, capabilities, permissions, #[tauri::command], invoke). Covers commands, IPC, state, plugins, and CSP.
+---
+
+# Tauri 2 Application Development
+
+Tauri 2 is a Rust-based framework for building lightweight, secure cross-platform desktop apps with web frontends. This skill covers Tauri 2 specifically (not v1 — APIs differ).
+
+## Quick Reference
+
+| Task | Solution | Notes |
+|------|----------|-------|
+| Define backend command | `#[tauri::command] async fn name(...)` | Register in `generate_handler!` |
+| Call from frontend | `invoke<T>('name', { args })` | Import from `@tauri-apps/api/core` |
+| Grant frontend access | Add to `src-tauri/capabilities/*.json` | Permission = `"plugin:command"` |
+| Restrict file access | Permission with `allow: [{ path: "$APPDATA/x/*" }]` | Use Tauri path vars, not absolute |
+| Manage shared state | `app.manage(Mutex::new(state))` + `State<'_, Mutex<T>>` | Tauri wraps in Arc internally |
+| Stream large data | `tauri::ipc::Channel<T>` | Avoids JSON overhead |
+| Return binary efficiently | `tauri::ipc::Response::new(bytes)` | Skip serde JSON encoding |
+| Custom error type | `thiserror::Error` + manual `Serialize` | Don't return `Result<T, String>` |
+| Lock across `.await` | `tokio::sync::Mutex` | `std::sync::Mutex` panics if held across await |
+| Add a plugin | `.plugin(tauri_plugin_xxx::init())` in builder | Plus `pnpm add @tauri-apps/plugin-xxx` |
+| Strict CSP | `tauri.conf.json > app.security.csp` | Tauri auto-injects nonces for bundled assets |
+
+## Project Structure
+
+```
+my-tauri-app/
+├── src/                          # Frontend (React/Vue/Svelte/...)
+├── src-tauri/
+│   ├── Cargo.toml
+│   ├── tauri.conf.json           # Main config
+│   ├── capabilities/
+│   │   └── default.json          # IPC permissions per window
+│   ├── permissions/              # Custom permission definitions
+│   ├── icons/
+│   └── src/
+│       ├── main.rs               # Just calls into lib
+│       ├── lib.rs                # tauri::Builder setup, generate_handler!
+│       └── commands/             # Command modules
+└── package.json
+```
+
+## Minimal Setup
+
+### `src-tauri/src/lib.rs`
+
+```rust
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_fs::init())
+        .manage(AppState::default())
+        .invoke_handler(tauri::generate_handler![
+            commands::greet,
+            commands::save_note,
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+```
+
+### A Command (best practice)
+
+```rust
+// src-tauri/src/commands/notes.rs
+use serde::Serialize;
+use tauri::State;
+use tokio::sync::Mutex;
+
+#[derive(Debug, thiserror::Error)]
+pub enum NoteError {
+    #[error("invalid path")]
+    InvalidPath,
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl Serialize for NoteError {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_string())
+    }
+}
+
+#[derive(Default)]
+pub struct AppState {
+    pub last_saved: Option<String>,
+}
+
+#[tauri::command]
+pub async fn save_note(
+    contents: String,
+    state: State<'_, Mutex<AppState>>,
+    app: tauri::AppHandle,
+) -> Result<(), NoteError> {
+    let dir = app.path().app_data_dir().map_err(|_| NoteError::InvalidPath)?;
+    let path = dir.join("note.md");
+    tokio::fs::create_dir_all(&dir).await?;
+    tokio::fs::write(&path, contents).await?;
+    state.lock().await.last_saved = Some(path.to_string_lossy().into_owned());
+    Ok(())
+}
+```
+
+### Frontend Call
+
+```ts
+// src/lib/notes.ts
+import { invoke } from '@tauri-apps/api/core'
+
+export async function saveNote(contents: string): Promise<void> {
+    return invoke<void>('save_note', { contents })
+}
+```
+
+### Capability JSON
+
+```json
+// src-tauri/capabilities/main.json
+{
+  "identifier": "main",
+  "description": "Permissions granted to the main window",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "core:event:default",
+    {
+      "identifier": "fs:allow-write-text-file",
+      "allow": [{ "path": "$APPDATA/notes/*" }]
+    }
+  ],
+  "platforms": ["macOS", "windows", "linux"]
+}
+```
+
+## Capability Schema (Official)
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `identifier` | string | ✓ | Unique name |
+| `permissions` | array | ✓ | `"plugin:command"` strings or scoped objects |
+| `description` | string | — | Human-readable purpose |
+| `windows` | string[] | — | Window labels; supports glob |
+| `webviews` | string[] | — | Webview labels; supports glob |
+| `platforms` | string[] | — | `macOS` / `windows` / `linux` / `iOS` / `android` |
+| `local` | boolean | — | Default true; for local app URLs |
+| `remote.urls` | string[] | — | Allowed remote URL patterns (URLPattern syntax) |
+
+**Security rule**: A window with **no matching capability** has **zero IPC access**. Use this — make new windows opt-in.
+
+## Permission Format
+
+Three forms inside `permissions: []`:
+
+```json
+"core:default"                              // simple string
+"fs:allow-read-text-file"                   // plugin:command
+
+{                                            // scoped object
+  "identifier": "fs:allow-write-text-file",
+  "allow": [{ "path": "$APPDATA/notes/*" }],
+  "deny": [{ "path": "$APPDATA/notes/secret" }]
+}
+```
+
+### Tauri Path Variables (use these, not absolute paths)
+
+| Var | Maps to (macOS sandboxed) |
+|-----|---------------------------|
+| `$APPDATA` | `~/Library/Application Support/<bundle-id>` |
+| `$APPCONFIG` | `~/Library/Application Support/<bundle-id>` |
+| `$APPCACHE` | `~/Library/Caches/<bundle-id>` |
+| `$APPLOG` | `~/Library/Logs/<bundle-id>` |
+| `$DOCUMENT` | `~/Documents` (requires user-selected-files entitlement under sandbox) |
+| `$HOME` | sandbox container home |
+| `$RESOURCE` | bundled resources |
+
+## Custom Permissions
+
+Define reusable permission sets in `src-tauri/permissions/<name>.toml`:
+
+```toml
+[[permission]]
+identifier = "read-notes"
+description = "Read user notes from app data"
+commands.allow = ["read_text_file", "read_dir"]
+
+[[scope.allow]]
+path = "$APPDATA/notes/*"
+```
+
+Then reference in capability: `"permissions": ["fs:read-notes"]`.
+
+## State Management
+
+```rust
+// Register
+.manage(Mutex::new(AppState::default()))
+
+// Use in command (sync mutex — fine if NOT held across .await)
+#[tauri::command]
+fn get_count(state: State<'_, std::sync::Mutex<AppState>>) -> u32 {
+    state.lock().unwrap().count
+}
+
+// Use in async command — MUST be tokio::sync::Mutex if held across .await
+#[tauri::command]
+async fn save(state: State<'_, tokio::sync::Mutex<AppState>>) -> Result<(), Error> {
+    let mut s = state.lock().await;
+    do_async_work().await?;
+    s.last_saved = Some(now());
+    Ok(())
+}
+```
+
+**Pitfall**: type mismatch between `manage(T)` and `State<'_, U>` causes a runtime panic. Use a type alias.
+
+## Async Commands — Key Rules
+
+- Async runs on Tokio; preferred for I/O
+- Cannot use `&str` or `State<'_, T>` directly with naked async — wrap return in `Result<T, E>` (this satisfies the lifetime requirement)
+- Use `tokio::fs`, `tokio::sync::*`, never block the runtime
+
+## Streaming with Channel
+
+```rust
+use tauri::ipc::Channel;
+
+#[derive(Clone, Serialize)]
+#[serde(tag = "event", content = "data")]
+enum DownloadEvent {
+    Progress { downloaded: u64, total: u64 },
+    Done,
+}
+
+#[tauri::command]
+async fn download(url: String, on_event: Channel<DownloadEvent>) -> Result<(), Error> {
+    // ... fetch
+    on_event.send(DownloadEvent::Progress { downloaded: 1024, total: 10240 })?;
+    on_event.send(DownloadEvent::Done)?;
+    Ok(())
+}
+```
+
+Frontend:
+
+```ts
+import { Channel, invoke } from '@tauri-apps/api/core'
+const channel = new Channel<DownloadEvent>()
+channel.onmessage = (e) => console.log(e)
+await invoke('download', { url: '...', onEvent: channel })
+```
+
+## Binary Response (avoid JSON)
+
+```rust
+#[tauri::command]
+fn read_image(path: String) -> Result<tauri::ipc::Response, Error> {
+    let bytes = std::fs::read(path)?;
+    Ok(tauri::ipc::Response::new(bytes))
+}
+```
+
+Frontend gets an `ArrayBuffer` directly — no JSON parse cost.
+
+## CSP — Production-Grade Example
+
+`tauri.conf.json`:
+
+```json
+{
+  "app": {
+    "security": {
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: data:; connect-src 'self' https://api.example.com; font-src 'self' data:"
+    }
+  }
+}
+```
+
+Tauri auto-adds nonces for bundled assets. Avoid `unsafe-eval`. If using WASM, add `'wasm-unsafe-eval'` to `script-src`.
+
+## Plugins — Tauri 2 Naming
+
+| v1 | v2 |
+|----|-----|
+| `@tauri-apps/api/fs` | `@tauri-apps/plugin-fs` |
+| `@tauri-apps/api/shell` | `@tauri-apps/plugin-shell` |
+| `@tauri-apps/api/dialog` | `@tauri-apps/plugin-dialog` |
+| `@tauri-apps/api/tauri` (`invoke`) | `@tauri-apps/api/core` |
+| `@tauri-apps/api/notification` | `@tauri-apps/plugin-notification` |
+| `@tauri-apps/api/clipboard` | `@tauri-apps/plugin-clipboard-manager` |
+
+## Common Pitfalls (Tauri 2)
+
+1. **Forgot to register command** in `generate_handler!` — frontend gets "command not found"
+2. **Multiple `invoke_handler!` calls** — only the last one wins; use a single call
+3. **Missing capability** — frontend invoke rejected with permission error
+4. **Path var typo** — `$APP_DATA` is wrong; correct is `$APPDATA`
+5. **`std::sync::Mutex` across `.await`** — panic at runtime
+6. **`unwrap()` in command** — panics propagate to JS as an opaque error
+7. **`Result<T, String>`** — works but loses type safety; use `thiserror` enum
+8. **Return `Vec<u8>` via JSON** — encodes as base64, slow; use `Response::new(bytes)`
+9. **Frontend imports v1 path** — `@tauri-apps/api/tauri` doesn't exist in v2
+
+## Official Documentation Links
+
+| Topic | URL |
+|-------|-----|
+| Capabilities | https://v2.tauri.app/reference/acl/capability/ |
+| Permissions | https://v2.tauri.app/security/permissions/ |
+| CSP | https://v2.tauri.app/security/csp/ |
+| Calling Rust | https://v2.tauri.app/develop/calling-rust/ |
+| State management | https://v2.tauri.app/develop/state-management/ |

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ docs/
 *.key
 updater-key*.json
 
-# Claude Code local state (settings, worktrees, transcripts, etc.)
-.claude/
+# Claude Code: ignore local state (settings.local.json, worktrees, transcripts,
+# etc.) by default, but share the project's Tauri skills / commands / agents so
+# collaborators get the same tooling.
+.claude/*
+!.claude/agents
+!.claude/commands
+!.claude/skills
 CLAUDE.md


### PR DESCRIPTION
## 這個 PR 做什麼

把專案 `.claude/` 內的 **Tauri 開發輔助工具**納入版控,讓其他協作者 clone 之後就能直接使用同一組指令,不必各自重建。

### 納入追蹤的內容
- **commands**:`/tauri-review`、`/tauri-audit`、`/tauri-perf`、`/tauri-check`、`/plan`、`/todo`
- **skills**:`tauri`、`tauri-security-review`、`tauri-performance-review`
- **agents**:`tauri-planner`、`tauri-security-reviewer`、`tauri-performance-reviewer`、`tauri-task-executor`

### `.gitignore` 調整
原本 `.claude/` 整個被忽略,改成 **allowlist**:
```
.claude/*
!.claude/agents
!.claude/commands
!.claude/skills
```
只共用工具目錄,個人本機狀態(`settings.local.json`、worktrees、transcripts)仍保持忽略,不會外洩個人權限設定。

### 備註
- 已掃描要提交的檔案,確認無密鑰或個資(skills 內出現的 "secret" 皆為文件範例)。
- 純設定/文件變更,不影響應用程式程式碼與建置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)