### PR TITLE
feat(preview): 網頁預覽分頁標題、前後導覽與網址列快捷鍵

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -2,10 +2,14 @@
 
 ### feat
 
+- 網頁預覽分頁標題改為跟隨網頁實際的 Title；新增「上一頁／下一頁」按鈕，並可用 ⌘[ 與 ⌘] 切換；新增 ⌘L 快速跳到網址列。
+
 ### fix
 
 ## English
 
 ### feat
+
+- Web preview tab titles now follow the page's real `<title>`; added Back/Forward buttons (⌘[ and ⌘]) and ⌘L to jump to the address bar.
 
 ### fix

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,10 @@ use modules::git::{
     git_unstage, git_worktree_info,
 };
 use modules::pr::{gh_available, pr_via_api, pr_via_gh};
+use modules::preview::{
+    preview_close, preview_create, preview_history_back, preview_history_forward, preview_navigate,
+    preview_reload,
+};
 use modules::secrets::{
     secrets_delete_key, secrets_has_key, secrets_set_key, ssh_secret_delete, ssh_secret_set,
 };
@@ -193,6 +197,12 @@ pub fn run() {
             gh_available,
             pr_via_gh,
             pr_via_api,
+            preview_create,
+            preview_navigate,
+            preview_reload,
+            preview_history_back,
+            preview_history_forward,
+            preview_close,
             ai_chat,
             terminal_history_save,
             terminal_history_load,

--- a/src-tauri/src/modules/menu.rs
+++ b/src-tauri/src/modules/menu.rs
@@ -1,12 +1,25 @@
 use tauri::menu::{Menu, MenuItem, MenuItemKind, PredefinedMenuItem};
 use tauri::window::Color;
-use tauri::{App, AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{App, AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
 const NEW_WINDOW_ID: &str = "new-window";
+const CLOSE_TAB_ID: &str = "close-tab";
 const CLOSE_WINDOW_ID: &str = "close-window";
+const OPEN_LOCATION_ID: &str = "preview-open-location";
+/// Emitted to the focused window when ⌘/Ctrl+L is pressed, so the frontend can
+/// focus the address bar of the active preview pane. A menu accelerator is used
+/// because the native preview webview swallows key events before the app webview
+/// can see them.
+const OPEN_LOCATION_EVENT: &str = "menu:preview-open-location";
+const CYCLE_PANE_ID: &str = "cycle-pane";
+/// Emitted to the focused window when ⌘/Ctrl+` is pressed, so the frontend can
+/// move focus to the next pane of the active tab. A menu accelerator is used for
+/// the same reason as Open Location: a focused native preview webview would
+/// otherwise swallow the key before the app webview's handler sees it.
+const CYCLE_PANE_EVENT: &str = "menu:focus-next-pane";
 
-/// Build the menu (Tauri's default plus a New Window item injected into File),
-/// set it as the app menu, and wire the menu-event handler.
+/// Build the menu (Tauri's default plus custom items and a Cmd+W rebind), set it
+/// as the app menu, and wire the menu-event handler.
 pub fn init(app: &mut App) -> tauri::Result<()> {
     // Owned handle so the menu-building borrows do not tangle with the later
     // app.set_menu / app.on_menu_event calls.
@@ -19,28 +32,26 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
         true,
         Some("CmdOrCtrl+N"),
     )?;
-    // Tauri's default menu bundles TWO separate native "Close Window" items
-    // bound to Cmd+W (the OS's standard accelerator) — the last item in
-    // "File" (its only item) and the last item in "Window" (after
-    // Minimize/Maximize/separator). Either one closes the actual window
-    // directly at the Tauri-runtime level, bypassing the frontend's own
-    // close-pane-or-tab keydown handler (src/App.tsx's `key === "w"`
-    // branch) entirely — and since this app is usually a single window,
-    // closing it quits the whole app. Both must be removed (removing only
-    // one still leaves Cmd+W captured by the other) so Cmd+W reaches the
-    // frontend handler. Closing the actual window moves to Shift+Cmd+W
-    // instead, wired below as a custom item since
-    // PredefinedMenuItem::close_window has no accelerator override.
+    // Cmd+W must peel the active tab, not destroy the window. Tauri's default
+    // menu bundles a native "Close Window" (bound to the OS's standard Cmd+W) as
+    // the LAST item of BOTH the File and Window submenus; either one closes the
+    // real window at the runtime level before the frontend can react, and since
+    // this app is usually a single window that quits the whole app. Both are
+    // removed so Cmd+W is free for our custom "Close Tab"; closing the actual
+    // window moves to Shift+Cmd+W.
     //
-    // Removal matches by POSITION, not by the item's text — predefined
-    // items are localized by the OS (e.g. "Fermer la fenêtre" in French),
-    // so a text match would silently fail on non-English systems, and their
-    // `MenuId` is a random per-instance counter (confirmed by reading
-    // muda's source), not a stable value tied to which predefined action
-    // they represent, so an id match doesn't work either. The exact
-    // position was confirmed empirically for this tauri/muda version via a
-    // temporary runtime diagnostic dump of the actual default menu
-    // structure, not just from documentation.
+    // Removal matches by POSITION, not text or id: predefined items are
+    // OS-localized (e.g. "Fermer la fenêtre") so a text match fails on non-English
+    // systems, and their MenuId is a random per-instance counter (per muda's
+    // source), so an id match fails too. The last-item position was confirmed
+    // empirically for this tauri/muda version.
+    //
+    // Cmd+W / Cmd+` / Cmd+L are driven by menu accelerators (not webview keydown)
+    // so they still fire when a native preview webview holds keyboard focus and
+    // would otherwise swallow the key. Each emits an event to the focused window;
+    // the frontend listens scoped to its own label.
+    let close_tab =
+        MenuItem::with_id(&handle, CLOSE_TAB_ID, "Close Tab", true, Some("CmdOrCtrl+W"))?;
     let close_window = MenuItem::with_id(
         &handle,
         CLOSE_WINDOW_ID,
@@ -48,35 +59,74 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
         true,
         Some("Shift+CmdOrCtrl+W"),
     )?;
-    let mut inserted_close_window = false;
+    let open_location = MenuItem::with_id(
+        &handle,
+        OPEN_LOCATION_ID,
+        "Open Location",
+        true,
+        Some("CmdOrCtrl+L"),
+    )?;
+    let cycle_pane =
+        MenuItem::with_id(&handle, CYCLE_PANE_ID, "Cycle Pane", true, Some("CmdOrCtrl+`"))?;
+    let mut inserted = false;
     for item in menu.items()? {
-        if let MenuItemKind::Submenu(submenu) = item {
-            let text = submenu.text()?;
-            if text == "File" || text == "Window" {
-                let items = submenu.items()?;
-                if matches!(items.last(), Some(MenuItemKind::Predefined(_))) {
-                    submenu.remove_at(items.len() - 1)?;
-                }
+        let MenuItemKind::Submenu(submenu) = item else {
+            continue;
+        };
+        let text = submenu.text()?;
+        // Strip the trailing native "Close Window" from File and Window.
+        if text == "File" || text == "Window" {
+            let items = submenu.items()?;
+            if matches!(items.last(), Some(MenuItemKind::Predefined(_))) {
+                submenu.remove_at(items.len() - 1)?;
             }
-            if text == "File" {
+        }
+        match text.as_str() {
+            "File" => {
                 submenu.insert(&new_window, 0)?;
                 submenu.insert(&PredefinedMenuItem::separator(&handle)?, 1)?;
-                submenu.append(&close_window)?;
-                inserted_close_window = true;
+                submenu.append(&open_location)?;
+                submenu.append(&PredefinedMenuItem::separator(&handle)?)?;
+                submenu.append(&close_tab)?;
+                inserted = true;
             }
+            "Window" => {
+                submenu.append(&cycle_pane)?;
+                submenu.append(&close_window)?;
+            }
+            _ => {}
         }
     }
     debug_assert!(
-        inserted_close_window,
-        "menu default no longer has a File submenu to attach Close Window to"
+        inserted,
+        "menu default no longer has a File submenu to attach custom items to"
     );
     app.set_menu(menu)?;
     app.on_menu_event(|app, event| {
         if event.id() == NEW_WINDOW_ID {
             let _ = create_new_window(app);
+        } else if event.id() == CLOSE_TAB_ID {
+            // Target the focused window's label so only its frontend closes a
+            // tab. The webview listens scoped to its own label; a bare emit()
+            // would broadcast and close a tab in every open window.
+            if let Some(win) = app.get_focused_window() {
+                let _ = win.emit_to(win.label(), "menu:close-tab", ());
+            }
         } else if event.id() == CLOSE_WINDOW_ID {
-            if let Some(window) = app.get_focused_window() {
-                let _ = window.close();
+            if let Some(win) = app.get_focused_window() {
+                let _ = win.close();
+            }
+        } else if event.id() == OPEN_LOCATION_ID {
+            // Target the focused window's label so only its frontend focuses the
+            // preview address bar; a bare emit() would broadcast to every window.
+            if let Some(win) = app.get_focused_window() {
+                let _ = win.emit_to(win.label(), OPEN_LOCATION_EVENT, ());
+            }
+        } else if event.id() == CYCLE_PANE_ID {
+            // Target the focused window's label so only its frontend advances the
+            // active pane; a bare emit() would cycle panes in every window.
+            if let Some(win) = app.get_focused_window() {
+                let _ = win.emit_to(win.label(), CYCLE_PANE_EVENT, ());
             }
         }
     });

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -14,6 +14,7 @@ pub mod menu;
 pub mod notes;
 pub mod ports;
 pub mod pr;
+pub mod preview;
 pub mod pty;
 pub mod secrets;
 pub mod session_log;

--- a/src-tauri/src/modules/preview.rs
+++ b/src-tauri/src/modules/preview.rs
@@ -1,0 +1,196 @@
+// Native preview webview lifecycle, owned by Rust so we can attach builder-only
+// callbacks the JS `Webview` API lacks: `on_document_title_changed` (drives the
+// tab title from the real page `<title>`) and `on_navigation` (keeps the address
+// bar in sync with in-page link clicks). Positioning/show/hide stays on the JS
+// side (via `Webview.getByLabel`); only creation and history control live here.
+
+use serde::Serialize;
+use tauri::webview::WebviewBuilder;
+use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Url, WebviewUrl, Window};
+
+/// Prefix every preview webview label carries (see `previewWebviewLabel` in
+/// previewWebview.ts). Commands refuse any label without it, so they can never
+/// target the app's own window.
+const LABEL_PREFIX: &str = "preview-";
+
+/// Emitted whenever a preview page's title changes. The frontend filters by
+/// `label` and retitles the owning tab.
+const TITLE_EVENT: &str = "preview://title";
+/// Emitted on every top-level navigation (link click, redirect, or address-bar
+/// load). The frontend filters by `label` and follows the url in the address bar.
+const NAVIGATED_EVENT: &str = "preview://navigated";
+
+// Injected into every previewed page so ⌘/Ctrl + [ and ] drive the page's own
+// history even while the native webview — not the app — holds keyboard focus.
+// Uses capture so it beats a page's own key handlers.
+const HISTORY_KEY_SCRIPT: &str = r#"
+(function () {
+  document.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+      if (e.key === '[') { e.preventDefault(); window.history.back(); }
+      else if (e.key === ']') { e.preventDefault(); window.history.forward(); }
+    }
+  }, true);
+})();
+"#;
+
+#[derive(Clone, Serialize)]
+struct TitlePayload {
+    label: String,
+    title: String,
+}
+
+#[derive(Clone, Serialize)]
+struct NavigatedPayload {
+    label: String,
+    url: String,
+}
+
+/// Create the native child webview for a preview pane inside the calling window.
+/// The rect is in unzoomed window (logical) pixels; the JS side keeps it aligned
+/// to the pane afterwards.
+///
+/// `async` on purpose: a sync command runs on the macOS main thread, where
+/// `add_child` blocks it on WKWebView init (50–200 ms first time) and freezes the
+/// UI. An async command runs on a worker, so `add_child` waits off the main
+/// thread and the event loop stays responsive.
+#[tauri::command]
+pub async fn preview_create(
+    window: Window,
+    app: AppHandle,
+    label: String,
+    url: String,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+) -> Result<(), String> {
+    // The frontend supplies `label` and `url`; validate both so a compromised
+    // webview can't drive an arbitrary window (e.g. navigate/close "main") or
+    // load a privileged scheme (`file://` bypasses the assetProtocol deny-list).
+    ensure_preview_label(&label)?;
+    let parsed = parse_preview_url(&url)?;
+
+    // Idempotent: if a preview webview with this label already exists (e.g. a
+    // racing re-mount got here first), just point it at the url instead of
+    // failing to build a duplicate. The label guard above ensures we only ever
+    // touch a preview webview here, never the app's own window.
+    if let Some(existing) = app.get_webview(&label) {
+        return existing.navigate(parsed).map_err(|e| e.to_string());
+    }
+
+    // Scope the title/navigation events to the owning window so a secondary
+    // window never receives another window's browsing titles/urls.
+    let win_label = window.label().to_string();
+    let title_label = label.clone();
+    let title_app = app.clone();
+    let title_win = win_label.clone();
+    let nav_label = label.clone();
+    let nav_app = app.clone();
+    let nav_win = win_label;
+
+    let builder = WebviewBuilder::new(&label, WebviewUrl::External(parsed))
+        .initialization_script(HISTORY_KEY_SCRIPT)
+        .on_document_title_changed(move |_webview, title| {
+            let _ = title_app.emit_to(
+                &title_win,
+                TITLE_EVENT,
+                TitlePayload {
+                    label: title_label.clone(),
+                    title,
+                },
+            );
+        })
+        .on_navigation(move |url| {
+            let _ = nav_app.emit_to(
+                &nav_win,
+                NAVIGATED_EVENT,
+                NavigatedPayload {
+                    label: nav_label.clone(),
+                    url: url.to_string(),
+                },
+            );
+            // Always allow the navigation; we only observe it.
+            true
+        });
+
+    window
+        .add_child(
+            builder,
+            LogicalPosition::new(x, y),
+            LogicalSize::new(width, height),
+        )
+        .map_err(|e| format!("failed to create preview webview {label}: {e}"))?;
+    Ok(())
+}
+
+/// Navigate the existing preview webview to a new url without recreating it, so
+/// its back/forward history survives.
+#[tauri::command]
+pub fn preview_navigate(app: AppHandle, label: String, url: String) -> Result<(), String> {
+    let parsed = parse_preview_url(&url)?;
+    webview(&app, &label)?
+        .navigate(parsed)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn preview_reload(app: AppHandle, label: String) -> Result<(), String> {
+    webview(&app, &label)?.reload().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn preview_history_back(app: AppHandle, label: String) -> Result<(), String> {
+    eval_history(&app, &label, "back")
+}
+
+#[tauri::command]
+pub fn preview_history_forward(app: AppHandle, label: String) -> Result<(), String> {
+    eval_history(&app, &label, "forward")
+}
+
+/// Close and drop the preview webview. Safe to call when it is already gone.
+#[tauri::command]
+pub fn preview_close(app: AppHandle, label: String) -> Result<(), String> {
+    ensure_preview_label(&label)?;
+    if let Some(webview) = app.get_webview(&label) {
+        webview.close().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn eval_history(app: &AppHandle, label: &str, direction: &str) -> Result<(), String> {
+    webview(app, label)?
+        .eval(format!("window.history.{direction}()"))
+        .map_err(|e| e.to_string())
+}
+
+/// Resolve a preview webview by label, refusing any label that isn't namespaced
+/// as a preview so these commands can never target the app's own window.
+fn webview(app: &AppHandle, label: &str) -> Result<tauri::Webview, String> {
+    ensure_preview_label(label)?;
+    app.get_webview(label)
+        .ok_or_else(|| format!("preview webview {label} not found"))
+}
+
+/// Reject any label the frontend didn't namespace with the preview prefix (see
+/// `previewWebviewLabel` in previewWebview.ts) — the trust boundary that keeps a
+/// compromised frontend from driving or closing the main app window.
+fn ensure_preview_label(label: &str) -> Result<(), String> {
+    if label.starts_with(LABEL_PREFIX) {
+        Ok(())
+    } else {
+        Err(format!("refusing to operate on non-preview webview {label}"))
+    }
+}
+
+/// Accept only the schemes previews actually use. Notably rejects `file://`,
+/// which WKWebView would load natively and thereby bypass the `asset://`
+/// secrets deny-list in tauri.conf.json.
+fn parse_preview_url(url: &str) -> Result<Url, String> {
+    let parsed = Url::parse(url).map_err(|e| format!("invalid preview url {url}: {e}"))?;
+    match parsed.scheme() {
+        "http" | "https" | "asset" => Ok(parsed),
+        other => Err(format!("refusing to load unsupported scheme '{other}' in preview")),
+    }
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,11 +1,27 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
 import "./i18n";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useUiStore } from "@/stores/uiStore";
 import { useTabsStore } from "@/stores/tabsStore";
-import { leaf, splitLeaf } from "@/modules/terminal/lib/terminalLayout";
+import { leaf, splitLeaf, type LayoutNode } from "@/modules/terminal/lib/terminalLayout";
+
+// ⌘W is driven by the "Close Tab" menu accelerator, which the backend delivers
+// as a `menu:close-tab` event to this webview's scoped listener. Capture that
+// handler so tests can fire ⌘W the way the real app does.
+const menuBridge = vi.hoisted(() => ({ closeTab: null as null | (() => void) }));
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    setZoom: () => Promise.resolve(),
+    listen: (event: string, handler: () => void) => {
+      if (event === "menu:close-tab") {
+        menuBridge.closeTab = handler;
+      }
+      return Promise.resolve(() => {});
+    },
+  }),
+}));
 
 describe("App shell", () => {
   beforeEach(() => {
@@ -87,10 +103,49 @@ describe("App shell", () => {
     });
     render(<App />);
 
-    fireEvent.keyDown(window, { code: "KeyW", key: "w", metaKey: true });
+    // Fire ⌘W via the menu bridge (the only path — see App.tsx), exactly once.
+    act(() => menuBridge.closeTab?.());
 
     const tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
     expect(tab?.paneTree).toEqual(leaf("right-leaf", { kind: "launcher" }));
+  });
+
+  it("closes only one pane per Cmd+W press (no double-close)", () => {
+    // Three stacked launcher panes; ⌘W must peel exactly one, not cascade.
+    const twoPanes = splitLeaf(leaf("p1", { kind: "launcher" }), "p1", "row", "p2", {
+      kind: "launcher",
+    });
+    const paneTree = splitLeaf(twoPanes, "p2", "row", "p3", { kind: "launcher" });
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space 1" }],
+      activeSpaceId: "s1",
+      tabs: [
+        {
+          id: "a",
+          spaceId: "s1",
+          title: "a",
+          kind: "launcher" as const,
+          paneTree,
+          activeLeafId: "p1",
+        },
+      ],
+      activeId: "a",
+    });
+    render(<App />);
+
+    const paneCount = (tree: LayoutNode): number =>
+      tree.kind === "split" ? paneCount(tree.children[0]) + paneCount(tree.children[1]) : 1;
+
+    // A single keydown of ⌘W must not close a pane at all: ⌘W lives on the menu
+    // accelerator, so a stray keydown handler responding too would double-close.
+    fireEvent.keyDown(window, { code: "KeyW", key: "w", metaKey: true });
+    let tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
+    expect(paneCount(tab!.paneTree)).toBe(3);
+
+    // One menu-driven ⌘W closes exactly one pane, leaving two.
+    act(() => menuBridge.closeTab?.());
+    tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
+    expect(paneCount(tab!.paneTree)).toBe(2);
   });
 
   it("selects the Nth sidebar panel with Option+digit", () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -127,6 +127,7 @@ describe("App shell", () => {
           kind: "launcher" as const,
           paneTree,
           activeLeafId: "p1",
+          paneOrder: ["p1", "p2", "p3"],
         },
       ],
       activeId: "a",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TabBar } from "@/components/TabBar";
 import { TitleBar } from "@/components/TitleBar";
@@ -19,7 +19,8 @@ import { installEditorWatchSync } from "@/modules/editor/lib/editorWatch";
 import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { pruneTerminalHistory } from "@/modules/terminal/lib/terminalHistory";
-import { leafIds } from "@/modules/terminal/lib/terminalLayout";
+import { findPaneContent, leafIds } from "@/modules/terminal/lib/terminalLayout";
+import { getPreviewControls } from "@/modules/preview/lib/previewControls";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { applyTheme, getTheme } from "@/themes/themes";
 import { listen } from "@tauri-apps/api/event";
@@ -72,6 +73,46 @@ function isEditableTarget(target: EventTarget | null): boolean {
   return tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable;
 }
 
+/**
+ * Controls for the preview pane the user is currently on (active tab's focused
+ * leaf), or undefined when that pane isn't a live preview. Lets the ⌘L menu
+ * accelerator and ⌘[ / ⌘] shortcuts target the right preview without stealing
+ * those keys from editors/terminals.
+ */
+function activePreviewControls() {
+  const state = useTabsStore.getState();
+  const tab = state.tabs.find((tt) => tt.id === state.activeId);
+  if (!tab) {
+    return undefined;
+  }
+  const content = findPaneContent(tab.paneTree, tab.activeLeafId);
+  if (!content || content.kind !== "preview") {
+    return undefined;
+  }
+  return getPreviewControls(tab.activeLeafId);
+}
+
+/**
+ * Subscribe to a backend event scoped to this window's webview, returning a
+ * cleanup for useEffect. Race-safe under React StrictMode: listen() is async, so
+ * the cleanup awaits its promise before unsubscribing — a mount→unmount→mount
+ * cycle can never leak a duplicate listener. A leaked duplicate is what made one
+ * ⌘W close two tabs at once. No-op when there is no Tauri webview (unit tests).
+ */
+function listenWebview(event: string, handler: () => void): () => void {
+  let promise: Promise<(() => void) | undefined> | null = null;
+  try {
+    promise = getCurrentWebview()
+      .listen(event, handler)
+      .catch(() => undefined);
+  } catch {
+    // No Tauri webview available (unit tests / web preview).
+  }
+  return () => {
+    void promise?.then((off) => off?.());
+  };
+}
+
 function App() {
   const { t } = useTranslation();
   const themeId = useSettingsStore((s) => s.themeId);
@@ -80,6 +121,43 @@ function App() {
   const settingsOpen = useUiStore((s) => s.settingsOpen);
   const [sidebarWidth, setSidebarWidth] = useState(260);
   const [pendingCloseAction, setPendingCloseAction] = useState<(() => void) | null>(null);
+
+  // Close the focused pane, or the whole tab when it holds a single pane. Shared
+  // by the ⌘W key handler and the "Close Tab" menu item (both must behave the
+  // same, and a dirty editor routes through the unsaved-changes confirmation).
+  const closeActiveTabOrPane = useCallback(() => {
+    const tabsState = useTabsStore.getState();
+    const tab = tabsState.tabs.find((t) => t.id === tabsState.activeId);
+    if (!tab) {
+      return;
+    }
+    const panes = computeLayout(tab.paneTree);
+    const buffers = useEditorStore.getState().buffers;
+    if (panes.length <= 1) {
+      if (tabHasDirtyEditor(tab, buffers)) {
+        setPendingCloseAction(() => () => tabsState.closeTab(tab.id));
+      } else {
+        tabsState.closePaneOrTab();
+      }
+    } else {
+      // Close the currently focused pane; fall back to the bottom-right
+      // pane if the active leaf is somehow stale.
+      const target =
+        panes.find((p) => p.id === tab.activeLeafId) ??
+        panes.reduce((a, b) => {
+          if (b.rect.top !== a.rect.top) return b.rect.top > a.rect.top ? b : a;
+          return b.rect.left > a.rect.left ? b : a;
+        });
+      const targetBuf =
+        target.content.kind === "editor" ? buffers[target.content.path] : undefined;
+      const targetDirty = targetBuf ? targetBuf.content !== targetBuf.baseline : false;
+      if (targetDirty) {
+        setPendingCloseAction(() => () => tabsState.closePane(tab.id, target.id));
+      } else {
+        tabsState.closePane(tab.id, target.id);
+      }
+    }
+  }, []);
 
   useWatchSessions();
   useWatchNotes();
@@ -234,13 +312,10 @@ function App() {
         return;
       }
 
-      // ⌘` cycles focus through the panes of the active tab (⌘~ works too, since
-      // both sit on the Backquote key). No-op with one pane.
-      if (e.code === "Backquote" && !e.altKey && !editable) {
-        e.preventDefault();
-        useTabsStore.getState().focusNextPane();
-        return;
-      }
+      // ⌘` (cycle panes) is intentionally NOT handled here — it is driven by the
+      // "Cycle Pane" menu accelerator (see the listener below), which fires even
+      // when a native preview webview holds focus and would swallow the keydown.
+      // Handling it here too would advance the pane twice per press.
 
       // Zoom the whole UI. `code` is used so it works regardless of layout/Shift:
       // the "=" key (⌘= or ⌘+) zooms in, "-" zooms out, "0" resets to 100%.
@@ -262,6 +337,23 @@ function App() {
         }
       }
 
+      // ⌘[ / ⌘] step the active preview's history back/forward. Only acts on a
+      // preview pane, so editors/terminals keep these keys. (When the native
+      // preview webview holds focus, an injected script handles them instead —
+      // this covers the case where the app webview has focus.)
+      if ((e.code === "BracketLeft" || e.code === "BracketRight") && !e.altKey && !e.shiftKey) {
+        const controls = activePreviewControls();
+        if (controls) {
+          e.preventDefault();
+          if (e.code === "BracketLeft") {
+            controls.back();
+          } else {
+            controls.forward();
+          }
+          return;
+        }
+      }
+
       const key = e.key.toLowerCase();
       if (key === "t") {
         e.preventDefault();
@@ -272,39 +364,6 @@ function App() {
             .newTerminalTab(useWorkspaceStore.getState().rootPath ?? undefined);
         } else {
           useTabsStore.getState().openLauncherTab();
-        }
-      } else if (key === "w") {
-        e.preventDefault();
-        const tabsState = useTabsStore.getState();
-        const tab = tabsState.tabs.find((t) => t.id === tabsState.activeId);
-        if (!tab) {
-          return;
-        }
-        const panes = computeLayout(tab.paneTree);
-        const buffers = useEditorStore.getState().buffers;
-        if (panes.length <= 1) {
-          if (tabHasDirtyEditor(tab, buffers)) {
-            setPendingCloseAction(() => () => tabsState.closeTab(tab.id));
-          } else {
-            tabsState.closePaneOrTab();
-          }
-        } else {
-          // Close the currently focused pane; fall back to the bottom-right
-          // pane if the active leaf is somehow stale.
-          const target =
-            panes.find((p) => p.id === tab.activeLeafId) ??
-            panes.reduce((a, b) => {
-              if (b.rect.top !== a.rect.top) return b.rect.top > a.rect.top ? b : a;
-              return b.rect.left > a.rect.left ? b : a;
-            });
-          const targetBuf =
-            target.content.kind === "editor" ? buffers[target.content.path] : undefined;
-          const targetDirty = targetBuf ? targetBuf.content !== targetBuf.baseline : false;
-          if (targetDirty) {
-            setPendingCloseAction(() => () => tabsState.closePane(tab.id, target.id));
-          } else {
-            tabsState.closePane(tab.id, target.id);
-          }
         }
       } else if (key === "p") {
         e.preventDefault();
@@ -324,6 +383,31 @@ function App() {
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, []);
+
+  // ⌘W closes the active tab/pane. It is driven solely by the "Close Tab" menu
+  // accelerator, NOT a keydown branch: the native menu fires even when a preview
+  // webview holds focus, and having both a keydown handler and the menu
+  // accelerator respond to one ⌘W press would close two tabs at once. The
+  // backend emits scoped to this window's label, so a ⌘W in one window never
+  // closes a tab in another.
+  useEffect(
+    () => listenWebview("menu:close-tab", () => closeActiveTabOrPane()),
+    [closeActiveTabOrPane],
+  );
+
+  // ⌘L focuses the active preview pane's address bar. Driven by a menu
+  // accelerator so it works even while the native preview webview holds focus.
+  useEffect(
+    () => listenWebview("menu:preview-open-location", () => activePreviewControls()?.focusAddressBar()),
+    [],
+  );
+
+  // ⌘` cycles focus through the active tab's panes. Menu-accelerator driven for
+  // the same reason as ⌘W / ⌘L above.
+  useEffect(
+    () => listenWebview("menu:focus-next-pane", () => useTabsStore.getState().focusNextPane()),
+    [],
+  );
 
   return (
     <div className="flex h-screen w-screen flex-col overflow-hidden bg-bg text-fg">

--- a/src/i18n/locales/en/preview.json
+++ b/src/i18n/locales/en/preview.json
@@ -1,5 +1,7 @@
 {
   "title": "Web Preview",
   "urlPlaceholder": "http://localhost:3000",
-  "reload": "Reload"
+  "reload": "Reload",
+  "back": "Back",
+  "forward": "Forward"
 }

--- a/src/i18n/locales/zh-Hant/preview.json
+++ b/src/i18n/locales/zh-Hant/preview.json
@@ -1,5 +1,7 @@
 {
   "title": "網頁預覽",
   "urlPlaceholder": "http://localhost:3000",
-  "reload": "重新載入"
+  "reload": "重新載入",
+  "back": "上一頁",
+  "forward": "下一頁"
 }

--- a/src/modules/preview/PreviewTabContent.test.tsx
+++ b/src/modules/preview/PreviewTabContent.test.tsx
@@ -19,16 +19,22 @@ vi.mock("@/modules/editor/lib/editorWatch", () => ({
   },
 }));
 
-// Stub the native webview hook and expose its reload() for assertions.
+// Stub the native webview hook and expose its reload() for assertions. back and
+// forward are stable module-level fns so the controls-registration effect does
+// not re-run every render.
 const reload = vi.fn();
+const back = vi.fn();
+const forward = vi.fn();
 vi.mock("./hooks/useNativePreviewWebview", () => ({
-  useNativePreviewWebview: () => ({ hostRef: { current: null }, reload }),
+  useNativePreviewWebview: () => ({ hostRef: { current: null }, reload, back, forward }),
 }));
 
 import { PreviewTabContent } from "./PreviewTabContent";
 
 afterEach(() => {
   reload.mockClear();
+  back.mockClear();
+  forward.mockClear();
   changeHandler = null;
 });
 

--- a/src/modules/preview/PreviewTabContent.tsx
+++ b/src/modules/preview/PreviewTabContent.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { RotateCw } from "lucide-react";
+import { ArrowLeft, ArrowRight, RotateCw } from "lucide-react";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { onEditorFileChanged } from "@/modules/editor/lib/editorWatch";
 import { normalizeAddressInput } from "@/lib/url";
 import { previewLocalPath } from "./lib/htmlPreviewTarget";
+import { registerPreviewControls } from "./lib/previewControls";
 import { useNativePreviewWebview } from "./hooks/useNativePreviewWebview";
 
 interface PreviewTabContentProps {
@@ -17,30 +19,63 @@ interface PreviewTabContentProps {
    */
   visible: boolean;
   /**
-   * Called when the user navigates via the address bar, so the owning pane can
-   * persist the new url and retitle the tab. Local-file previews don't supply it.
+   * Called when the page navigates (address bar, link click, or redirect), so
+   * the owning pane can persist the new url and retitle the tab. Local-file
+   * previews don't supply it.
    */
   onNavigate?: (url: string) => void;
+  /** Called when the page's `<title>` changes, so the owning tab can retitle. */
+  onTitle?: (title: string) => void;
 }
 
-export function PreviewTabContent({ url, leafId, visible, onNavigate }: PreviewTabContentProps) {
+export function PreviewTabContent({
+  url,
+  leafId,
+  visible,
+  onNavigate,
+  onTitle,
+}: PreviewTabContentProps) {
   const { t } = useTranslation("preview");
-  const [current, setCurrent] = useState(url);
   const [input, setInput] = useState(url);
-  const { hostRef, reload } = useNativePreviewWebview({ url: current, leafId, visible });
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { hostRef, reload, back, forward } = useNativePreviewWebview({
+    url,
+    leafId,
+    visible,
+    onNavigate,
+    onTitle,
+  });
 
-  // Follow the url prop when it changes (e.g. a file dropped onto this pane).
+  // Follow the url prop when it changes (a file dropped onto this pane, or a
+  // navigation persisted from within the page).
   useEffect(() => {
-    setCurrent(url);
     setInput(url);
   }, [url]);
+
+  const focusAddressBar = useCallback(() => {
+    // The native preview webview holds key focus; pull it back to the app webview
+    // before selecting the input so the user can type immediately.
+    void getCurrentWebview().setFocus().catch(() => {});
+    const el = inputRef.current;
+    if (el) {
+      el.focus();
+      el.select();
+    }
+  }, []);
+
+  // Expose this preview's controls so the ⌘L menu accelerator and ⌘[ / ⌘]
+  // shortcuts can reach whichever preview pane is active.
+  useEffect(
+    () => registerPreviewControls(leafId, { focusAddressBar, back, forward, reload }),
+    [leafId, focusAddressBar, back, forward, reload],
+  );
 
   // Local-file previews auto-reload when the file changes on disk (e.g. you save
   // it in the editor). Web urls are not watched. The watched SET is maintained
   // by installEditorWatchSync (it includes local preview paths); here we only
   // listen and reload the native webview when our own file is the one changed.
   useEffect(() => {
-    const localPath = previewLocalPath(current);
+    const localPath = previewLocalPath(url);
     if (!localPath) {
       return;
     }
@@ -63,21 +98,39 @@ export function PreviewTabContent({ url, leafId, visible, onNavigate }: PreviewT
       disposed = true;
       unlisten?.();
     };
-  }, [current, reload]);
+  }, [url, reload]);
 
   return (
     <div className="flex h-full flex-col bg-bg">
       <form
-        className="flex h-9 shrink-0 items-center gap-2 border-b border-border px-2"
+        className="flex h-9 shrink-0 items-center gap-1 border-b border-border px-2"
         onSubmit={(e) => {
           e.preventDefault();
           const next = normalizeAddressInput(input);
-          setCurrent(next);
           setInput(next);
           onNavigate?.(next);
         }}
       >
+        <button
+          type="button"
+          aria-label={t("back")}
+          title={t("back")}
+          onClick={back}
+          className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+        >
+          <ArrowLeft size={14} />
+        </button>
+        <button
+          type="button"
+          aria-label={t("forward")}
+          title={t("forward")}
+          onClick={forward}
+          className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+        >
+          <ArrowRight size={14} />
+        </button>
         <input
+          ref={inputRef}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder={t("urlPlaceholder")}

--- a/src/modules/preview/hooks/useNativePreviewWebview.ts
+++ b/src/modules/preview/hooks/useNativePreviewWebview.ts
@@ -123,6 +123,11 @@ export function useNativePreviewWebview({ url, leafId, visible, onNavigate, onTi
   // The last src we asked the webview to load, so a url-prop change only
   // navigates when it is genuinely different (and never re-loads the initial).
   const loadedSrcRef = useRef<string | null>(null);
+  // The latest url prop, readable inside the creation effect's async closure
+  // (which otherwise captures a stale url). Lets us catch up if the url changes
+  // while the webview is still being built — see the creation effect below.
+  const latestUrlRef = useRef(url);
+  latestUrlRef.current = url;
   const uiZoom = useSettingsStore((s) => s.uiZoom);
   const zoomRef = useRef(uiZoom);
   const onNavigateRef = useRef(onNavigate);
@@ -212,6 +217,15 @@ export function useNativePreviewWebview({ url, leafId, visible, onNavigate, onTi
       shownRef.current = false;
       lastRectRef.current = null;
       sync();
+
+      // If the url prop changed while the webview was being built, the navigate
+      // effect ran too early (webviewRef was still null) and bailed. Reconcile
+      // now so that in-flight change isn't lost.
+      const latestSrc = resolvePreviewSrc(latestUrlRef.current);
+      if (latestSrc !== loadedSrcRef.current) {
+        loadedSrcRef.current = latestSrc;
+        void invoke("preview_navigate", { label, url: latestSrc }).catch(() => {});
+      }
     })();
 
     return () => {

--- a/src/modules/preview/hooks/useNativePreviewWebview.ts
+++ b/src/modules/preview/hooks/useNativePreviewWebview.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { Webview } from "@tauri-apps/api/webview";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { LogicalPosition, LogicalSize } from "@tauri-apps/api/dpi";
@@ -15,7 +17,7 @@ interface Rect {
 }
 
 interface Options {
-  /** URL or local path to preview. Changing it recreates the webview. */
+  /** URL or local path to preview. A change navigates the existing webview. */
   url: string;
   /** The owning pane's leaf id; part of the unique webview label. */
   leafId: string;
@@ -25,6 +27,54 @@ interface Options {
    * screen (inactive tab/space, split drag, or an open overlay).
    */
   visible: boolean;
+  /**
+   * Called when the page navigates (link click, redirect, or address-bar load)
+   * so the owning pane can follow the url in the address bar and persist it.
+   * Local-file (asset://) targets are not reported.
+   */
+  onNavigate?: (url: string) => void;
+  /** Called when the page's `<title>` changes so the owning tab can retitle. */
+  onTitle?: (title: string) => void;
+}
+
+interface TitleEvent {
+  label: string;
+  title: string;
+}
+
+interface NavigatedEvent {
+  label: string;
+  url: string;
+}
+
+// React StrictMode double-invokes effects (mount → unmount → mount) in dev, and
+// creation/teardown of the native webview is async — so a naive "create on
+// mount, close on cleanup" races itself into a closed or duplicated webview.
+// Two module-level, label-keyed guards make the lifecycle idempotent:
+//  - `creatingWebviews`: coalesces concurrent create requests so a double-mount
+//    never builds two webviews with the same label.
+//  - `pendingCloses`: defers the close so a fast remount can cancel it and adopt
+//    the still-alive webview instead of tearing it down and rebuilding.
+const creatingWebviews = new Map<string, Promise<void>>();
+const pendingCloses = new Map<string, ReturnType<typeof setTimeout>>();
+const CLOSE_DELAY_MS = 100;
+
+/** Create the webview once per label; concurrent callers share one request. */
+function ensurePreviewWebview(label: string, url: string, rect: Rect): Promise<void> {
+  const existing = creatingWebviews.get(label);
+  if (existing) {
+    return existing;
+  }
+  const inflight = invoke<void>("preview_create", { label, url, ...rect })
+    .catch((e) => {
+      // eslint-disable-next-line no-console
+      console.error(`[preview] failed to create webview "${label}":`, e);
+    })
+    .finally(() => {
+      creatingWebviews.delete(label);
+    });
+  creatingWebviews.set(label, inflight);
+  return inflight;
 }
 
 function rectOf(el: HTMLElement | null): Rect | null {
@@ -47,8 +97,14 @@ function sameRect(a: Rect | null, b: Rect | null): boolean {
  * Unlike an `<iframe>`, the child webview is a native layer composited over the
  * window — so it ignores `X-Frame-Options`/`frame-ancestors` (it can show
  * wp-admin etc.), but it is NOT part of the DOM: it must be positioned, shown,
- * and hidden manually to track the pane. `@tauri-apps/api@2.11` has no
- * `navigate`/`reload`, so a URL change or reload recreates the webview.
+ * and hidden manually to track the pane.
+ *
+ * The webview is CREATED in Rust (`preview_create`) so it can attach the
+ * builder-only callbacks the JS API lacks: page-title changes and navigation
+ * tracking, both surfaced here as events. Once created, its JS handle (via
+ * `Webview.getByLabel`) is used for positioning/show/hide, and the `preview_*`
+ * commands drive navigate/reload/back/forward without recreating it — which is
+ * what keeps the back/forward history intact.
  *
  * A child webview's position is relative to the window in logical pixels and is
  * NOT affected by the main webview's zoom. The app zooms the main webview via
@@ -56,20 +112,28 @@ function sameRect(a: Rect | null, b: Rect | null): boolean {
  * pixels whose on-screen size is `value * uiZoom` window-logical pixels. We
  * therefore multiply the host rect by `uiZoom` before positioning the child.
  *
- * Returns the host ref to attach where the webview should sit, and a `reload`.
+ * Returns the host ref plus navigate/reload/back/forward controls.
  */
-export function useNativePreviewWebview({ url, leafId, visible }: Options) {
+export function useNativePreviewWebview({ url, leafId, visible, onNavigate, onTitle }: Options) {
   const hostRef = useRef<HTMLDivElement>(null);
   const webviewRef = useRef<Webview | null>(null);
   const visibleRef = useRef(visible);
   const shownRef = useRef(false);
   const lastRectRef = useRef<Rect | null>(null);
-  const [reloadNonce, setReloadNonce] = useState(0);
+  // The last src we asked the webview to load, so a url-prop change only
+  // navigates when it is genuinely different (and never re-loads the initial).
+  const loadedSrcRef = useRef<string | null>(null);
   const uiZoom = useSettingsStore((s) => s.uiZoom);
   const zoomRef = useRef(uiZoom);
+  const onNavigateRef = useRef(onNavigate);
+  const onTitleRef = useRef(onTitle);
 
   visibleRef.current = visible;
   zoomRef.current = uiZoom;
+  onNavigateRef.current = onNavigate;
+  onTitleRef.current = onTitle;
+
+  const label = previewWebviewLabel(getCurrentWindow().label, leafId);
 
   // Push the webview to match the host's current rect and visibility. Cheap to
   // call often: it no-ops unless something actually changed.
@@ -80,7 +144,7 @@ export function useNativePreviewWebview({ url, leafId, visible }: Options) {
     if (!visibleRef.current) {
       if (shownRef.current) {
         shownRef.current = false;
-        void webview.hide();
+        void webview.hide().catch(() => {});
       }
       return;
     }
@@ -93,12 +157,12 @@ export function useNativePreviewWebview({ url, leafId, visible }: Options) {
       // The host rect is in zoomed page pixels; the child webview lives in
       // unzoomed window pixels, so scale by the UI zoom factor.
       const z = zoomRef.current;
-      void webview.setPosition(new LogicalPosition(rect.x * z, rect.y * z));
-      void webview.setSize(new LogicalSize(rect.width * z, rect.height * z));
+      void webview.setPosition(new LogicalPosition(rect.x * z, rect.y * z)).catch(() => {});
+      void webview.setSize(new LogicalSize(rect.width * z, rect.height * z)).catch(() => {});
     }
     if (!shownRef.current) {
       shownRef.current = true;
-      void webview.show();
+      void webview.show().catch(() => {});
     }
   }, []);
 
@@ -109,50 +173,113 @@ export function useNativePreviewWebview({ url, leafId, visible }: Options) {
     sync();
   }, [uiZoom, sync]);
 
-  // Create the webview, and recreate it whenever the URL changes or reload is
-  // requested. A fresh label per instance avoids colliding with the previous
-  // webview while it is still closing.
+  // Create the webview once per pane. A url change navigates it (below) rather
+  // than recreating, so its history survives. StrictMode-safe via the module
+  // guards above.
   useEffect(() => {
     let cancelled = false;
+    // A pending close from a just-unmounted instance (StrictMode remount) would
+    // tear this webview down; cancel it so we adopt the live one.
+    const pending = pendingCloses.get(label);
+    if (pending) {
+      clearTimeout(pending);
+      pendingCloses.delete(label);
+    }
+
     const z = zoomRef.current;
     const initial = rectOf(hostRef.current);
-    const label = `${previewWebviewLabel(getCurrentWindow().label, leafId)}-${reloadNonce}`;
-    const webview = new Webview(getCurrentWindow(), label, {
-      url: resolvePreviewSrc(url),
-      // Always pass a rect (in unzoomed window pixels); omitting it makes the
-      // webview fill the whole window. Start at 1×1 when the host is not
-      // measurable so nothing flashes before the first sync positions and shows it.
+    const src = resolvePreviewSrc(url);
+    // Always pass a rect (in unzoomed window pixels); start at 1×1 when the host
+    // is not measurable so nothing flashes before the first sync shows it.
+    const rect: Rect = {
       x: initial ? initial.x * z : 0,
       y: initial ? initial.y * z : 0,
       width: initial ? initial.width * z : 1,
       height: initial ? initial.height * z : 1,
-    });
+    };
 
-    webview.once("tauri://created", () => {
-      if (cancelled) {
-        void webview.close();
-        return;
+    void (async () => {
+      let webview = await Webview.getByLabel(label).catch(() => null);
+      if (!webview) {
+        loadedSrcRef.current = src;
+        await ensurePreviewWebview(label, src, rect);
+        if (cancelled) return;
+        webview = await Webview.getByLabel(label).catch(() => null);
       }
+      if (cancelled || !webview) return;
+      loadedSrcRef.current ??= src;
       webviewRef.current = webview;
       shownRef.current = false;
       lastRectRef.current = null;
       sync();
-    });
-    webview.once("tauri://error", (e) => {
-      // eslint-disable-next-line no-console
-      console.error(`[preview] failed to create webview "${label}":`, e.payload);
-    });
+    })();
 
     return () => {
       cancelled = true;
-      if (webviewRef.current === webview) {
-        webviewRef.current = null;
-      }
+      webviewRef.current = null;
       shownRef.current = false;
       lastRectRef.current = null;
-      void webview.close();
+      // Defer the close so a StrictMode remount (or fast re-mount) can cancel it
+      // and re-adopt the webview instead of destroying and rebuilding it.
+      const existing = pendingCloses.get(label);
+      if (existing) clearTimeout(existing);
+      pendingCloses.set(
+        label,
+        setTimeout(() => {
+          pendingCloses.delete(label);
+          loadedSrcRef.current = null;
+          void invoke("preview_close", { label }).catch(() => {});
+        }, CLOSE_DELAY_MS),
+      );
     };
-  }, [url, leafId, reloadNonce, sync]);
+    // Only leafId (via label) recreates the webview; url is handled separately.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [label, sync]);
+
+  // Navigate the existing webview when the url prop changes (e.g. a file dropped
+  // onto this pane). Skips the initial load and any no-op change.
+  useEffect(() => {
+    if (!webviewRef.current) return;
+    const src = resolvePreviewSrc(url);
+    if (src === loadedSrcRef.current) return;
+    loadedSrcRef.current = src;
+    void invoke("preview_navigate", { label, url: src }).catch(() => {});
+  }, [url, label]);
+
+  // Subscribe to the Rust-side title/navigation events for this webview.
+  useEffect(() => {
+    let disposed = false;
+    const unlisteners: Array<() => void> = [];
+    const track = (p: Promise<() => void>) => {
+      void p.then((un) => {
+        if (disposed) un();
+        else unlisteners.push(un);
+      });
+    };
+    track(
+      listen<TitleEvent>("preview://title", (e) => {
+        if (e.payload.label === label) {
+          onTitleRef.current?.(e.payload.title);
+        }
+      }),
+    );
+    track(
+      listen<NavigatedEvent>("preview://navigated", (e) => {
+        if (e.payload.label !== label) return;
+        const next = e.payload.url;
+        loadedSrcRef.current = next;
+        // Local-file previews load through asset://; keep the typed file path in
+        // the address bar rather than replacing it with the asset url.
+        if (!next.startsWith("asset:")) {
+          onNavigateRef.current?.(next);
+        }
+      }),
+    );
+    return () => {
+      disposed = true;
+      unlisteners.forEach((un) => un());
+    };
+  }, [label]);
 
   // Re-sync after every render: a split can move the pane without resizing it,
   // which a ResizeObserver would miss. sync() no-ops when nothing changed.
@@ -179,7 +306,15 @@ export function useNativePreviewWebview({ url, leafId, visible }: Options) {
     };
   }, [sync]);
 
-  const reload = useCallback(() => setReloadNonce((n) => n + 1), []);
+  const reload = useCallback(() => {
+    void invoke("preview_reload", { label }).catch(() => {});
+  }, [label]);
+  const back = useCallback(() => {
+    void invoke("preview_history_back", { label }).catch(() => {});
+  }, [label]);
+  const forward = useCallback(() => {
+    void invoke("preview_history_forward", { label }).catch(() => {});
+  }, [label]);
 
-  return { hostRef, reload };
+  return { hostRef, reload, back, forward };
 }

--- a/src/modules/preview/lib/previewControls.ts
+++ b/src/modules/preview/lib/previewControls.ts
@@ -1,0 +1,31 @@
+// A tiny registry that lets app-level shortcuts and the native menu reach the
+// preview pane the user is looking at. The preview toolbar lives in the DOM but
+// its actions (focus the address bar, go back/forward) must be callable from
+// outside the component — the ⌘L menu accelerator fires in Rust, and ⌘[ / ⌘]
+// may arrive while another element holds focus. Each mounted preview registers
+// its controls under its pane's leaf id; callers look them up by leaf id.
+
+export interface PreviewControls {
+  /** Focus and select the address-bar input. */
+  focusAddressBar: () => void;
+  back: () => void;
+  forward: () => void;
+  reload: () => void;
+}
+
+const registry = new Map<string, PreviewControls>();
+
+/** Register a preview pane's controls; returns an unregister fn for cleanup. */
+export function registerPreviewControls(leafId: string, controls: PreviewControls): () => void {
+  registry.set(leafId, controls);
+  return () => {
+    if (registry.get(leafId) === controls) {
+      registry.delete(leafId);
+    }
+  };
+}
+
+/** Look up a preview pane's controls, or undefined when it isn't a live preview. */
+export function getPreviewControls(leafId: string): PreviewControls | undefined {
+  return registry.get(leafId);
+}

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -65,6 +65,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   const wrapPaneWith = useTabsStore((s) => s.wrapPaneWith);
   const setPaneContent = useTabsStore((s) => s.setPaneContent);
   const navigatePreview = useTabsStore((s) => s.navigatePreview);
+  const setPreviewTabTitle = useTabsStore((s) => s.setPreviewTabTitle);
   const setTerminalCwd = useTabsStore((s) => s.setTerminalCwd);
   const closePane = useTabsStore((s) => s.closePane);
   const openHtmlPreview = useTabsStore((s) => s.openHtmlPreview);
@@ -443,6 +444,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                       anyOverlay,
                     })}
                     onNavigate={(url) => navigatePreview(tab.id, pane.id, url)}
+                    onTitle={(title) => setPreviewTabTitle(tab.id, pane.id, title)}
                   />
                 ) : pane.content.kind === "git-graph" ? (
                   <GitGraphTabContent />

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -125,6 +125,51 @@ describe("navigatePreview", () => {
   });
 });
 
+describe("setPreviewTabTitle", () => {
+  beforeEach(reset);
+
+  it("retitles a single-pane preview tab from the page title", () => {
+    const id = useTabsStore.getState().openPreviewTab("http://localhost:3000");
+    const leafId = activeTab().activeLeafId;
+
+    useTabsStore.getState().setPreviewTabTitle(id, leafId, "  My Cool Page  ");
+
+    expect(activeTab().title).toBe("My Cool Page");
+  });
+
+  it("ignores an empty title", () => {
+    const id = useTabsStore.getState().openPreviewTab("http://localhost:3000");
+    const leafId = activeTab().activeLeafId;
+
+    useTabsStore.getState().setPreviewTabTitle(id, leafId, "   ");
+
+    expect(activeTab().title).toBe("localhost:3000");
+  });
+
+  it("does not retitle when the preview is one pane of several", () => {
+    const tabId = useTabsStore.getState().openEditorTab("/a/b.ts");
+    const editorLeafId = activeTab().activeLeafId;
+    useTabsStore
+      .getState()
+      .splitPaneWith(tabId, editorLeafId, { kind: "preview", url: "http://localhost:3000" }, "row");
+    const previewLeafId = activeTab().activeLeafId;
+
+    useTabsStore.getState().setPreviewTabTitle(tabId, previewLeafId, "My Cool Page");
+
+    expect(activeTab().title).toBe("b.ts");
+  });
+
+  it("keeps a user-renamed tab's title", () => {
+    const id = useTabsStore.getState().openPreviewTab("http://localhost:3000");
+    const leafId = activeTab().activeLeafId;
+    useTabsStore.getState().setTabTitle(id, "My Site");
+
+    useTabsStore.getState().setPreviewTabTitle(id, leafId, "Page Title");
+
+    expect(activeTab().title).toBe("My Site");
+  });
+});
+
 describe("tabsStore", () => {
   beforeEach(reset);
 
@@ -295,6 +340,24 @@ describe("tabsStore", () => {
     useTabsStore.getState().closePane(id, activeTab().activeLeafId);
     const tab = activeTab();
     expect(leafIds(tab.paneTree)).toEqual([firstLeaf]);
+  });
+
+  it("focuses the last remaining pane after closing the active pane", () => {
+    const id = useTabsStore.getState().newTerminalTab();
+    useTabsStore.getState().splitActivePane("row");
+    useTabsStore.getState().splitActivePane("row");
+    const ids = leafIds(activeTab().paneTree);
+    expect(ids).toHaveLength(3);
+    // Focus and close the middle pane; focus must land on the last remaining
+    // pane, not the first.
+    useTabsStore.setState({
+      tabs: useTabsStore.getState().tabs.map((t) =>
+        t.id === id ? { ...t, activeLeafId: ids[1] } : t,
+      ),
+    });
+    useTabsStore.getState().closePane(id, ids[1]);
+    expect(leafIds(activeTab().paneTree)).toEqual([ids[0], ids[2]]);
+    expect(activeTab().activeLeafId).toBe(ids[2]);
   });
 
   it("activates a neighbour when the active tab closes", () => {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -8,7 +8,6 @@ import { fileUrl } from "@/modules/explorer/lib/dragEntry";
 import {
   computeLayout,
   findPaneContent,
-  firstLeafId,
   gridLayout,
   leaf,
   leafIds,
@@ -155,6 +154,12 @@ interface TabsState {
    * retitle the tab to the new host.
    */
   navigatePreview: (tabId: string, leafId: string, url: string) => void;
+  /**
+   * Retitle a tab from a preview page's real `<title>`. Applies only when the
+   * preview is the tab's whole content (single pane, not user-renamed), and
+   * ignores empty titles.
+   */
+  setPreviewTabTitle: (tabId: string, leafId: string, title: string) => void;
   /** Replace a pane's content in place (used when dropping a file onto it). */
   setPaneContent: (tabId: string, leafId: string, content: PaneContent) => void;
   /** Remember a terminal pane's current working directory for session restore. */
@@ -937,6 +942,28 @@ export const useTabsStore = create<TabsState>()(
     return newId;
   },
 
+  setPreviewTabTitle: (tabId, leafId, title) =>
+    set((state) => {
+      const trimmed = title.trim();
+      const tab = state.tabs.find((t) => t.id === tabId);
+      if (!tab || trimmed === "" || tab.title === trimmed) {
+        return state;
+      }
+      const current = findPaneContent(tab.paneTree, leafId);
+      if (!current || current.kind !== "preview") {
+        return state;
+      }
+      // The tab title follows the previewed page only when the preview fills the
+      // whole tab and the user hasn't given it a name of their own.
+      const isWholeTab = leafIds(tab.paneTree).length === 1;
+      if (!isWholeTab || tab.renamed) {
+        return state;
+      }
+      return {
+        tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, title: trimmed } : t)),
+      };
+    }),
+
   setPaneContent: (tabId, leafId, content) =>
     set((state) => ({
       tabs: state.tabs.map((tab) =>
@@ -1022,8 +1049,14 @@ export const useTabsStore = create<TabsState>()(
         }
         return { tabs, activeId };
       }
+      // When the focused pane is the one closing, move focus to the LAST
+      // remaining pane (reading order) rather than the first, so closing a pane
+      // keeps focus near where it was instead of jumping to the leftmost pane.
+      const remaining = leafIds(paneTree);
       const activeLeafId =
-        tab.activeLeafId === leafId ? (firstLeafId(paneTree) ?? tab.activeLeafId) : tab.activeLeafId;
+        tab.activeLeafId === leafId
+          ? (remaining[remaining.length - 1] ?? tab.activeLeafId)
+          : tab.activeLeafId;
       return {
         tabs: state.tabs.map((t) =>
           t.id === tabId


### PR DESCRIPTION
## Summary

為網頁預覽分頁補上「像瀏覽器」的三個核心操作，並順帶納入以相同原生選單快捷鍵機制實作的 Close Tab / Cycle Pane。

### 網頁預覽分頁
- **分頁標題跟隨網頁 `<title>`** — 透過 Rust `on_document_title_changed`，經 `preview://title` 事件回傳，落到新的 `setPreviewTabTitle`（僅在單一 pane、未被使用者改名時套用）。
- **上一頁／下一頁** — 網址列新增 `←` `→` 按鈕，快捷鍵 `⌘[` / `⌘]`。webview 有焦點時由注入的 `initialization_script` 直接呼叫 `history.back/forward`；app 有焦點時由 App 層 DOM handler 處理，兩種焦點情況都涵蓋。
- **`⌘L` 跳到網址列** — 因為原生預覽 webview 有焦點時會吃掉鍵盤事件，改用原生選單快捷鍵（File → Open Location）→ `emit_to` 聚焦視窗 → 前端 focus 網址列。

### 架構
- 預覽 webview 改由 **Rust** 建立（`preview_create` 等 6 個命令），才能掛上 JS API 沒有的 `on_document_title_changed` / `on_navigation` callback；定位／顯示／隱藏仍由前端透過 `Webview.getByLabel` 操作。
- 以 `navigate` 取代「重建 webview」，**保留前後歷史**（這是前後導覽能運作的前提）。

### 穩定性 / 安全性 / 效能（review 後修正）
- 修正 React StrictMode 下 webview 建立/關閉的競態：延遲關閉（remount 會取消並沿用）、同 label 建立去重、所有 fire-and-forget 呼叫加 `.catch()`。
- 安全：每個命令驗證 `label` 前綴（不得操作 app 自身視窗）、URL scheme 白名單 `http`/`https`/`asset`（擋 `file://` 繞過 assetProtocol secrets deny-list）。
- 效能：`preview_create` 改 `async`，避免 WKWebView 初始化阻塞主執行緒；title/navigation 事件改 `emit_to` 限定所屬視窗。

### 同時納入
以相同「原生選單快捷鍵 → `emit_to` 聚焦視窗 → 前端 listener」機制實作的 **Close Tab（⌘W）** 與 **Cycle Pane（⌘\`）**。

## Test plan
- ✅ `pnpm typecheck`
- ✅ 前端 878 測試全過（含新增的 `setPreviewTabTitle` 測試）
- ✅ `cargo build` + 193 Rust 測試全過
- ⏳ 需在 `pnpm tauri dev` 手動 smoke test：本地 HTML 預覽仍正常、標題跟隨、⌘L / ⌘[ / ⌘] / 前後按鈕

🤖 Generated with [Claude Code](https://claude.com/claude-code)