### PR TITLE
fix(terminal): 切換分頁時自動對焦終端機輸入

### DIFF
--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -286,6 +286,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                 ) : (
                   <TerminalView
                     active={active}
+                    isActiveTab={isActiveTab}
                     cwdTracking={
                       active &&
                       isActiveTab &&

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -125,6 +125,8 @@ function formatSkipped(bytes: number): string {
 
 interface TerminalViewProps {
   active: boolean;
+  /** Whether the tab hosting this pane is the currently visible tab. */
+  isActiveTab?: boolean;
   /** When true, this pane drives the file explorer root from its shell CWD. */
   cwdTracking?: boolean;
   /** Directory the shell starts in. */
@@ -144,6 +146,7 @@ interface TerminalViewProps {
 
 export function TerminalView({
   active,
+  isActiveTab = true,
   cwdTracking = false,
   cwd,
   ssh,
@@ -925,9 +928,12 @@ export function TerminalView({
   }, []);
 
   // When a background tab becomes visible again its container regains size, so
-  // refit, push the new dimensions to the shell and grab focus.
+  // refit, push the new dimensions to the shell and grab focus. Keyed on
+  // isActiveTab too: switching tabs does not change this pane's `active` flag
+  // (it stays the tab's active leaf), so without it the effect would not re-run
+  // and keyboard focus would be lost until the user clicks the terminal.
   useEffect(() => {
-    if (!active) {
+    if (!active || !isActiveTab) {
       return;
     }
     const handle = handleRef.current;
@@ -947,7 +953,7 @@ export function TerminalView({
       handle.term.focus();
     });
     return () => cancelAnimationFrame(frame);
-  }, [active]);
+  }, [active, isActiveTab]);
 
   // Apply live font changes from the settings panel to an already-open terminal.
   useEffect(() => {


### PR DESCRIPTION
## 問題

切換到含終端機視窗的分頁時，鍵盤焦點不會落在終端機輸入上，必須額外點一下才能開始輸入。

## 根因

`TerminalView` 的對焦 effect 原本只依賴 `active`（= `pane.id === tab.activeLeafId`）。切換分頁時，被切到的分頁裡的作用中窗格 `active` 一直維持 `true`（它本來就是該分頁的 activeLeaf），值沒變，所以 effect 不會重新執行，`handle.term.focus()` 不會被呼叫。

## 修法

- `TerminalView.tsx`：新增 `isActiveTab` prop，對焦 effect 改為 `if (!active || !isActiveTab) return`，依賴陣列加入 `isActiveTab`。分頁由隱藏變為可見時（`isActiveTab: false → true`）即觸發 refit / resize / focus。
- `PaneTabContent.tsx`：將既有的 `isActiveTab`（`s.activeId === tab.id`）傳給 `<TerminalView>`。

## 驗證

- `pnpm typecheck` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)