### PR TITLE
feat: unify sidebar open/split behavior across click, right-click, and drag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ CLAUDE.md
 
 # Superpowers brainstorming companion scratch files
 .superpowers/
+
+# TypeScript project-reference build artifacts (tsc -b)
+*.tsbuildinfo
+/vite.config.js
+/vite.config.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ updater-key*.json
 # Claude Code local state (settings, worktrees, transcripts, etc.)
 .claude/
 CLAUDE.md
+
+# Superpowers brainstorming companion scratch files
+.superpowers/

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@tauri-apps/cli": "^2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@types/node": "^22.20.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,7 +182,7 @@ importers:
         version: 2.6.2
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.1(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.3.1(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0))
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.11.2
@@ -192,6 +192,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/node':
+        specifier: ^22.20.0
+        version: 22.20.0
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.17
@@ -203,7 +206,7 @@ importers:
         version: 15.5.13
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.7.0(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0))
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -215,10 +218,10 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^7.0.4
-        version: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.6(@types/debug@4.1.13)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)
 
 packages:
 
@@ -1354,6 +1357,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
+
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
 
@@ -2375,6 +2381,9 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -3376,12 +3385,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/vite@4.3.1(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.3.1(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@tauri-apps/api@2.11.0': {}
 
@@ -3742,6 +3751,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@22.20.0':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/prismjs@1.26.6': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
@@ -3829,7 +3842,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -3837,7 +3850,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3849,13 +3862,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -5074,6 +5087,8 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
+  undici-types@6.21.0: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -5132,13 +5147,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(jiti@2.7.0)(lightningcss@1.32.0):
+  vite-node@3.2.4(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5153,7 +5168,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0):
+  vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5162,15 +5177,16 @@ snapshots:
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 22.20.0
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
 
-  vitest@3.2.6(@types/debug@4.1.13)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0):
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -5188,11 +5204,12 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
-      vite-node: 3.2.4(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
+      '@types/node': 22.20.0
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -45,6 +45,7 @@ describe("App shell", () => {
       // Launcher panes render a lightweight panel — no terminal, so no Tauri.
       paneTree: leaf(`${id}-leaf`, { kind: "launcher" }),
       activeLeafId: `${id}-leaf`,
+      paneOrder: [`${id}-leaf`],
     }));
     useTabsStore.setState({
       spaces: [{ id: "s1", name: "Space 1" }],
@@ -79,6 +80,7 @@ describe("App shell", () => {
           kind: "launcher" as const,
           paneTree,
           activeLeafId: "left-leaf",
+          paneOrder: ["left-leaf", "right-leaf"],
         },
       ],
       activeId: "a",
@@ -109,6 +111,7 @@ describe("App shell", () => {
       kind: "launcher" as const,
       paneTree: leaf(`${id}-leaf`, { kind: "launcher" }),
       activeLeafId: `${id}-leaf`,
+      paneOrder: [`${id}-leaf`],
     }));
     useTabsStore.setState({
       spaces: [{ id: "s1", name: "Space 1" }],

--- a/src/components/EntryDropOverlay.test.tsx
+++ b/src/components/EntryDropOverlay.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { dropOverlayClassName, outerBandOverlayClassName } from "./EntryDropOverlay";
+
+describe("dropOverlayClassName", () => {
+  it("covers the whole pane for center", () => {
+    expect(dropOverlayClassName({ kind: "center" }, true)).toContain("inset-0");
+  });
+
+  it("covers the whole pane when zone is null (no zone resolved yet)", () => {
+    expect(dropOverlayClassName(null, true)).toContain("inset-0");
+  });
+
+  it("renders a top strip for an individual col/before zone", () => {
+    const cls = dropOverlayClassName(
+      { kind: "split", scope: "individual", direction: "col", anchor: "before" },
+      true,
+    );
+    expect(cls).toContain("top-0");
+    expect(cls).toContain("h-1/4");
+  });
+
+  it("renders a right strip for an individual row/after zone", () => {
+    const cls = dropOverlayClassName(
+      { kind: "split", scope: "individual", direction: "row", anchor: "after" },
+      true,
+    );
+    expect(cls).toContain("right-0");
+    expect(cls).toContain("w-1/4");
+  });
+
+  it("uses the danger color when ok is false", () => {
+    expect(dropOverlayClassName({ kind: "center" }, false)).toContain("border-danger");
+  });
+});
+
+describe("outerBandOverlayClassName", () => {
+  it("renders a left band for row/before", () => {
+    const cls = outerBandOverlayClassName("row", "before");
+    expect(cls).toContain("left-0");
+  });
+
+  it("renders a bottom band for col/after", () => {
+    const cls = outerBandOverlayClassName("col", "after");
+    expect(cls).toContain("bottom-0");
+  });
+});

--- a/src/components/EntryDropOverlay.tsx
+++ b/src/components/EntryDropOverlay.tsx
@@ -1,6 +1,47 @@
-/** The dashed drop-zone outline shown over a pane that can receive a drop. */
-export function dropOverlayClassName(ok: boolean): string {
-  return `absolute inset-0 z-30 border-2 border-dashed pointer-events-none ${
-    ok ? "border-accent/60 bg-accent/[0.07]" : "border-danger/40 bg-danger/[0.04]"
-  }`;
+import type { DropZone } from "@/modules/terminal/lib/terminalLayout";
+import type { SplitDirection } from "@/modules/terminal/lib/terminalLayout";
+
+const BASE = "absolute z-30 border-2 border-dashed pointer-events-none";
+
+function colorClass(ok: boolean): string {
+  return ok ? "border-accent/60 bg-accent/[0.07]" : "border-danger/40 bg-danger/[0.04]";
+}
+
+/**
+ * The drop-zone outline shown inside the hovered pane itself: a full block
+ * for center (or when no zone has resolved yet), or a narrow strip on the
+ * relevant edge for an individual split zone. Outer-scope zones are NOT
+ * rendered here — see `outerBandOverlayClassName`, rendered once across the
+ * whole pane area instead of inside any single pane's div.
+ */
+export function dropOverlayClassName(zone: DropZone | null, ok: boolean): string {
+  const color = colorClass(ok);
+  if (!zone || zone.kind === "center" || zone.scope === "outer") {
+    return `${BASE} inset-0 ${color}`;
+  }
+  if (zone.direction === "col") {
+    return zone.anchor === "before"
+      ? `${BASE} inset-x-0 top-0 h-1/4 ${color}`
+      : `${BASE} inset-x-0 bottom-0 h-1/4 ${color}`;
+  }
+  return zone.anchor === "before"
+    ? `${BASE} inset-y-0 left-0 w-1/4 ${color}`
+    : `${BASE} inset-y-0 right-0 w-1/4 ${color}`;
+}
+
+/**
+ * The drop-zone outline for an outer-scope zone: a band spanning the whole
+ * pane area along its near edge, always the "allowed" color since there is
+ * no source that can't be dropped there.
+ */
+export function outerBandOverlayClassName(direction: SplitDirection, anchor: "before" | "after"): string {
+  const color = colorClass(true);
+  if (direction === "row") {
+    return anchor === "before"
+      ? `${BASE} inset-y-0 left-0 w-[12%] ${color}`
+      : `${BASE} inset-y-0 right-0 w-[12%] ${color}`;
+  }
+  return anchor === "before"
+    ? `${BASE} inset-x-0 top-0 h-[12%] ${color}`
+    : `${BASE} inset-x-0 bottom-0 h-[12%] ${color}`;
 }

--- a/src/components/InfoDialog.test.tsx
+++ b/src/components/InfoDialog.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { InfoDialog } from "./InfoDialog";
+
+describe("InfoDialog", () => {
+  it("renders the title and message", () => {
+    render(
+      <InfoDialog title="Heads up" message="Something happened" confirmLabel="OK" onConfirm={() => {}} />,
+    );
+    expect(screen.getByText("Heads up")).toBeInTheDocument();
+    expect(screen.getByText("Something happened")).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when the confirm button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <InfoDialog title="Heads up" message="Something happened" confirmLabel="OK" onConfirm={onConfirm} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "OK" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onConfirm when Escape or Enter is pressed", () => {
+    const onConfirm = vi.fn();
+    render(
+      <InfoDialog title="Heads up" message="Something happened" confirmLabel="OK" onConfirm={onConfirm} />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/InfoDialog.tsx
+++ b/src/components/InfoDialog.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { useOverlayGuard } from "@/lib/overlayGuard";
+
+interface InfoDialogProps {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+}
+
+/**
+ * A single-button modal for messages that only need acknowledgement (no
+ * confirm/cancel choice) — styled like ConfirmDialog so it matches the rest
+ * of the app instead of a native window.alert.
+ */
+export function InfoDialog({ title, message, confirmLabel, onConfirm }: InfoDialogProps) {
+  // Mounted only while open, so guard unconditionally to hide the preview webview.
+  useOverlayGuard(true);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "Enter") {
+        onConfirm();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onConfirm]);
+
+  return (
+    <div onPointerDown={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+      <div className="fixed inset-0 z-[95] bg-black/60" onClick={onConfirm} />
+      <div className="fixed left-1/2 top-1/2 z-[100] w-[400px] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-bg-elevated shadow-2xl">
+        <div className="border-b border-border px-4 py-3">
+          <span className="text-sm font-semibold text-fg">{title}</span>
+        </div>
+        <div className="px-4 py-4 text-sm text-fg-muted">{message}</div>
+        <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-md bg-accent px-4 py-1.5 text-xs font-medium text-white"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -57,4 +57,9 @@ describe("TabBar tab context menu", () => {
     fireEvent.contextMenu(screen.getByRole("textbox"));
     expect(screen.queryByRole("menuitem")).toBeNull();
   });
+
+  it("marks the tab strip as a drop target for open-in-new-tab", () => {
+    render(<TabBar />);
+    expect(document.querySelector("[data-tab-bar]")).not.toBeNull();
+  });
 });

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -17,6 +17,7 @@ beforeEach(() => {
         kind: "terminal",
         paneTree: leaf("p1", { kind: "terminal" }),
         activeLeafId: "p1",
+        paneOrder: ["p1"],
       },
     ],
     activeId: "t1",

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "@/i18n";
 import { TabBar } from "./TabBar";
 import { useTabsStore } from "@/stores/tabsStore";
 import { leaf } from "@/modules/terminal/lib/terminalLayout";
+import { useEntryDragStore } from "@/modules/explorer/lib/dragEntry";
+import { useNoteDragStore } from "@/modules/notes/lib/noteDrag";
+import { useSshDragStore } from "@/modules/ssh/lib/sshDrag";
 
 beforeEach(() => {
   useTabsStore.setState({
@@ -22,6 +25,12 @@ beforeEach(() => {
     ],
     activeId: "t1",
   });
+});
+
+afterEach(() => {
+  useEntryDragStore.setState({ tabBarHover: null });
+  useNoteDragStore.setState({ tabBarHover: null });
+  useSshDragStore.setState({ tabBarHover: null });
 });
 
 describe("TabBar tab context menu", () => {
@@ -61,5 +70,70 @@ describe("TabBar tab context menu", () => {
   it("marks the tab strip as a drop target for open-in-new-tab", () => {
     render(<TabBar />);
     expect(document.querySelector("[data-tab-bar]")).not.toBeNull();
+  });
+});
+
+describe("TabBar insertion line", () => {
+  beforeEach(() => {
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "One" }],
+      activeSpaceId: "s1",
+      tabs: [
+        {
+          id: "t1",
+          spaceId: "s1",
+          title: "Terminal 1",
+          kind: "terminal",
+          paneTree: leaf("p1", { kind: "terminal" }),
+          activeLeafId: "p1",
+          paneOrder: ["p1"],
+        },
+        {
+          id: "t2",
+          spaceId: "s1",
+          title: "Terminal 2",
+          kind: "terminal",
+          paneTree: leaf("p2", { kind: "terminal" }),
+          activeLeafId: "p2",
+          paneOrder: ["p2"],
+        },
+      ],
+      activeId: "t1",
+    });
+  });
+
+  it("renders no insertion line when no drag store reports a tab-bar hover", () => {
+    render(<TabBar />);
+    expect(screen.queryByTestId("tab-insertion-line")).toBeNull();
+  });
+
+  it("renders the insertion line immediately before the tab named by insertBeforeId", () => {
+    useEntryDragStore.setState({ tabBarHover: { insertBeforeId: "t2" } });
+    render(<TabBar />);
+    const tabBar = document.querySelector("[data-tab-bar]");
+    expect(tabBar).not.toBeNull();
+    const children = Array.from(tabBar!.children);
+    const lineIndex = children.findIndex((el) => el.getAttribute("data-testid") === "tab-insertion-line");
+    const t2Index = children.findIndex((el) => el.getAttribute("data-tab-id") === "t2");
+    expect(lineIndex).toBeGreaterThanOrEqual(0);
+    expect(lineIndex).toBe(t2Index - 1);
+  });
+
+  it("renders the insertion line after the last tab and before the add-tab button when insertBeforeId is null", () => {
+    useNoteDragStore.setState({ tabBarHover: { insertBeforeId: null } });
+    render(<TabBar />);
+    const tabBar = document.querySelector("[data-tab-bar]");
+    expect(tabBar).not.toBeNull();
+    const children = Array.from(tabBar!.children);
+    const lineIndex = children.findIndex((el) => el.getAttribute("data-testid") === "tab-insertion-line");
+    const addButtonIndex = children.findIndex((el) => el.getAttribute("aria-label") === "Add tab");
+    expect(lineIndex).toBeGreaterThanOrEqual(0);
+    expect(lineIndex).toBe(addButtonIndex - 1);
+  });
+
+  it("falls back through the entry, note, and ssh drag stores in that order", () => {
+    useSshDragStore.setState({ tabBarHover: { insertBeforeId: "t1" } });
+    render(<TabBar />);
+    expect(screen.getByTestId("tab-insertion-line")).toBeInTheDocument();
   });
 });

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   FileCode,
@@ -34,6 +34,9 @@ import { IS_MAC } from "@/lib/platform";
 import { SpaceDropdown } from "./SpaceDropdown";
 import { ContextMenu } from "./ContextMenu";
 import { tabContextMenuItems } from "./tabContextMenuItems";
+import { useEntryDragStore } from "@/modules/explorer/lib/dragEntry";
+import { useNoteDragStore } from "@/modules/notes/lib/noteDrag";
+import { useSshDragStore } from "@/modules/ssh/lib/sshDrag";
 
 // Module-level so the reference stays stable across renders. Passing an inline
 // options object would make useSensor/useSensors return a new sensors array on
@@ -104,6 +107,7 @@ function TabItem({ id }: { id: string }) {
       {...attributes}
       {...listeners}
       role="tab"
+      data-tab-id={id}
       aria-selected={active}
       onClick={() => setActive(tab.id)}
       onDoubleClick={startRename}
@@ -176,6 +180,16 @@ function TabItem({ id }: { id: string }) {
   );
 }
 
+function TabInsertionLine() {
+  return (
+    <div
+      aria-hidden
+      data-testid="tab-insertion-line"
+      className="h-7 w-0.5 shrink-0 rounded-full bg-accent"
+    />
+  );
+}
+
 function TabOverlay({ tab }: { tab: Tab }) {
   const Icon = tabIcon(tab.kind);
   return (
@@ -195,6 +209,10 @@ export function TabBar() {
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
   const sidebarVisible = useUiStore((s) => s.sidebarVisible);
   const reorderTab = useTabsStore((s) => s.reorderTab);
+  const entryTabBarHover = useEntryDragStore((s) => s.tabBarHover);
+  const noteTabBarHover = useNoteDragStore((s) => s.tabBarHover);
+  const sshTabBarHover = useSshDragStore((s) => s.tabBarHover);
+  const tabBarHover = entryTabBarHover ?? noteTabBarHover ?? sshTabBarHover ?? null;
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const sensors = useSensors(useSensor(PointerSensor, POINTER_SENSOR_OPTIONS));
   const draggingTab = visibleTabs.find((tab) => tab.id === draggingId);
@@ -253,9 +271,13 @@ export function TabBar() {
             strategy={horizontalListSortingStrategy}
           >
             {visibleTabs.map((tab) => (
-              <TabItem key={tab.id} id={tab.id} />
+              <Fragment key={tab.id}>
+                {tabBarHover?.insertBeforeId === tab.id && <TabInsertionLine />}
+                <TabItem id={tab.id} />
+              </Fragment>
             ))}
           </SortableContext>
+          {tabBarHover !== null && tabBarHover.insertBeforeId === null && <TabInsertionLine />}
           <button
             type="button"
             aria-label={t("workspace.addTab")}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -244,6 +244,7 @@ export function TabBar() {
         onDragCancel={handleDragCancel}
       >
         <div
+          data-tab-bar
           data-tauri-drag-region
           className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
         >

--- a/src/components/TabsArea.test.tsx
+++ b/src/components/TabsArea.test.tsx
@@ -43,6 +43,7 @@ beforeEach(() => {
         kind: "terminal",
         paneTree: leaf("p1", { kind: "terminal" }),
         activeLeafId: "p1",
+        paneOrder: ["p1"],
       },
     ],
     activeId: "t1",

--- a/src/components/lib/tabBarDrop.test.ts
+++ b/src/components/lib/tabBarDrop.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { nearestTabInsertion, type TabBarSlot } from "./tabBarDrop";
+
+describe("nearestTabInsertion", () => {
+  const tabs: TabBarSlot[] = [
+    { id: "a", left: 0, width: 100 },
+    { id: "b", left: 100, width: 100 },
+    { id: "c", left: 200, width: 100 },
+  ];
+
+  it("returns the first tab's id when the pointer is left of its midpoint", () => {
+    expect(nearestTabInsertion(tabs, 10)).toBe("a");
+  });
+
+  it("returns the next tab's id when the pointer is past the first tab's midpoint but before the second's", () => {
+    expect(nearestTabInsertion(tabs, 120)).toBe("b");
+  });
+
+  it("returns null when the pointer is past every tab's midpoint (insert at the very end)", () => {
+    expect(nearestTabInsertion(tabs, 280)).toBeNull();
+  });
+
+  it("returns null when there are no tabs at all", () => {
+    expect(nearestTabInsertion([], 50)).toBeNull();
+  });
+
+  it("resolves a boundary exactly at a midpoint to the next tab (strict less-than, so the midpoint itself is already 'past')", () => {
+    expect(nearestTabInsertion(tabs, 50)).toBe("b");
+    expect(nearestTabInsertion(tabs, 150)).toBe("c");
+  });
+});

--- a/src/components/lib/tabBarDrop.ts
+++ b/src/components/lib/tabBarDrop.ts
@@ -1,0 +1,32 @@
+/** One tab's horizontal position in the tab bar, read live from the DOM. */
+export interface TabBarSlot {
+  id: string;
+  left: number;
+  width: number;
+}
+
+/** Every tab's current on-screen rect, in DOM order, or an empty array if the tab bar isn't mounted. */
+export function tabRectsInTabBar(): TabBarSlot[] {
+  const bar = document.querySelector("[data-tab-bar]");
+  if (!bar) {
+    return [];
+  }
+  return Array.from(bar.querySelectorAll<HTMLElement>('[role="tab"]')).map((el) => {
+    const rect = el.getBoundingClientRect();
+    return { id: el.dataset.tabId ?? "", left: rect.left, width: rect.width };
+  });
+}
+
+/**
+ * Which existing tab a drop at `pointerX` should land before, or null to
+ * land at the very end (after the last tab, or immediately when there are
+ * no tabs at all). Tabs must be in left-to-right DOM order.
+ */
+export function nearestTabInsertion(tabs: TabBarSlot[], pointerX: number): string | null {
+  for (const tab of tabs) {
+    if (pointerX < tab.left + tab.width / 2) {
+      return tab.id;
+    }
+  }
+  return null;
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -99,6 +99,7 @@
     "save": "Save",
     "confirm": "Confirm"
   },
+  "paneCapacityAlert": "This tab can hold at most 8 panes — close one and try again",
   "placeholder": {
     "comingSoon": "Coming soon",
     "terminalArea": "Terminal sessions will appear here",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -142,6 +142,7 @@
     "cancelDelete": "Cancel",
     "emptyTitle": "No saved connections",
     "emptyHint": "Save SSH connections here to connect with one click",
+    "alreadyOpenAlert": "{{name}} is already connected, so a second one can't be opened",
     "forwards": {
       "session": "Session {{id}}",
       "statusActive": "Active",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -144,6 +144,7 @@
     "emptyTitle": "No saved connections",
     "emptyHint": "Save SSH connections here to connect with one click",
     "alreadyOpenAlert": "{{name}} is already connected, so a second one can't be opened",
+    "openInNewTab": "Open in new tab",
     "forwards": {
       "session": "Session {{id}}",
       "statusActive": "Active",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -144,6 +144,7 @@
     "emptyTitle": "No saved connections",
     "emptyHint": "Save SSH connections here to connect with one click",
     "alreadyOpenAlert": "{{name}} is already connected, so a second one can't be opened",
+    "open": "Open in split pane",
     "openInNewTab": "Open in new tab",
     "forwards": {
       "session": "Session {{id}}",

--- a/src/i18n/locales/en/explorer.json
+++ b/src/i18n/locales/en/explorer.json
@@ -12,6 +12,7 @@
   "loading": "Loading…",
   "menu": {
     "open": "Open",
+    "openInNewTab": "Open in New Tab",
     "reveal": "Reveal in Finder",
     "openInTerminal": "Open in Terminal",
     "newFile": "New File",

--- a/src/i18n/locales/en/explorer.json
+++ b/src/i18n/locales/en/explorer.json
@@ -11,7 +11,7 @@
   "empty": "This folder is empty",
   "loading": "Loading…",
   "menu": {
-    "open": "Open",
+    "open": "Open in Split Pane",
     "openInNewTab": "Open in New Tab",
     "reveal": "Reveal in Finder",
     "openInTerminal": "Open in Terminal",

--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -3,6 +3,7 @@
   "newNote": "New note",
   "newFolder": "New folder",
   "deleteNote": "Delete note",
+  "open": "Open in split pane",
   "openInNewTab": "Open in new tab",
   "deleteFolder": "Delete folder",
   "renameFolderHint": "Double-click to rename",

--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -3,6 +3,7 @@
   "newNote": "New note",
   "newFolder": "New folder",
   "deleteNote": "Delete note",
+  "openInNewTab": "Open in new tab",
   "deleteFolder": "Delete folder",
   "renameFolderHint": "Double-click to rename",
   "empty": "Global notes that persist across projects — write anytime, saved anytime.",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -144,6 +144,7 @@
     "emptyTitle": "尚無已儲存的連線",
     "emptyHint": "在這裡儲存 SSH 連線，即可一鍵連線",
     "alreadyOpenAlert": "{{name}} 已在連線中，無法重複建立連線",
+    "open": "在分割面板開啟",
     "openInNewTab": "在新分頁開啟",
     "forwards": {
       "session": "工作階段 {{id}}",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -144,6 +144,7 @@
     "emptyTitle": "尚無已儲存的連線",
     "emptyHint": "在這裡儲存 SSH 連線，即可一鍵連線",
     "alreadyOpenAlert": "{{name}} 已在連線中，無法重複建立連線",
+    "openInNewTab": "在新分頁開啟",
     "forwards": {
       "session": "工作階段 {{id}}",
       "statusActive": "作用中",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -99,6 +99,7 @@
     "save": "儲存",
     "confirm": "確認"
   },
+  "paneCapacityAlert": "這個分頁最多只能開 8 個面板，請先關掉一個再試",
   "placeholder": {
     "comingSoon": "即將推出",
     "terminalArea": "終端機工作階段會顯示在這裡",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -142,6 +142,7 @@
     "cancelDelete": "取消",
     "emptyTitle": "尚無已儲存的連線",
     "emptyHint": "在這裡儲存 SSH 連線，即可一鍵連線",
+    "alreadyOpenAlert": "{{name}} 已經連線中，不能再開一個",
     "forwards": {
       "session": "工作階段 {{id}}",
       "statusActive": "作用中",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -142,7 +142,7 @@
     "cancelDelete": "取消",
     "emptyTitle": "尚無已儲存的連線",
     "emptyHint": "在這裡儲存 SSH 連線，即可一鍵連線",
-    "alreadyOpenAlert": "{{name}} 已經連線中，不能再開一個",
+    "alreadyOpenAlert": "{{name}} 已在連線中，無法重複建立連線",
     "forwards": {
       "session": "工作階段 {{id}}",
       "statusActive": "作用中",

--- a/src/i18n/locales/zh-Hant/explorer.json
+++ b/src/i18n/locales/zh-Hant/explorer.json
@@ -12,6 +12,7 @@
   "loading": "載入中⋯",
   "menu": {
     "open": "開啟",
+    "openInNewTab": "在新分頁開啟",
     "reveal": "在 Finder 中顯示",
     "openInTerminal": "從終端機開啟",
     "newFile": "新增檔案",

--- a/src/i18n/locales/zh-Hant/explorer.json
+++ b/src/i18n/locales/zh-Hant/explorer.json
@@ -11,7 +11,7 @@
   "empty": "這個資料夾是空的",
   "loading": "載入中⋯",
   "menu": {
-    "open": "開啟",
+    "open": "在分割面板開啟",
     "openInNewTab": "在新分頁開啟",
     "reveal": "在 Finder 中顯示",
     "openInTerminal": "從終端機開啟",

--- a/src/i18n/locales/zh-Hant/notes.json
+++ b/src/i18n/locales/zh-Hant/notes.json
@@ -3,6 +3,7 @@
   "newNote": "新增筆記",
   "newFolder": "新增資料夾",
   "deleteNote": "刪除筆記",
+  "openInNewTab": "在新分頁開啟",
   "deleteFolder": "刪除資料夾",
   "renameFolderHint": "雙擊可重新命名",
   "empty": "跨專案保存的全域筆記，隨時記錄，隨時保存",

--- a/src/i18n/locales/zh-Hant/notes.json
+++ b/src/i18n/locales/zh-Hant/notes.json
@@ -3,6 +3,7 @@
   "newNote": "新增筆記",
   "newFolder": "新增資料夾",
   "deleteNote": "刪除筆記",
+  "open": "在分割面板開啟",
   "openInNewTab": "在新分頁開啟",
   "deleteFolder": "刪除資料夾",
   "renameFolderHint": "雙擊可重新命名",

--- a/src/modules/claude-progress/lib/collectSessionCwds.test.ts
+++ b/src/modules/claude-progress/lib/collectSessionCwds.test.ts
@@ -11,6 +11,7 @@ function terminalTab(overrides: Partial<Tab> = {}): Tab {
     kind: "terminal",
     paneTree: leaf("a", { kind: "terminal" }),
     activeLeafId: "a",
+    paneOrder: ["a"],
     ...overrides,
   };
 }

--- a/src/modules/explorer/FileFinder.test.tsx
+++ b/src/modules/explorer/FileFinder.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { FileFinder } from "./FileFinder";
+import { useTabsStore } from "@/stores/tabsStore";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("./lib/fsBridge", () => ({
+  fsListFiles: vi.fn(() => Promise.resolve(["/p/main.ts", "/p/util.ts"])),
+}));
+
+describe("FileFinder opening a file", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("opens the selected file via openFromSidebar instead of openEditorTab", async () => {
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("main.ts"));
+
+    fireEvent.click(screen.getByText("main.ts"));
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    const pane = tabs[0].paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toMatchObject({
+      kind: "editor",
+      path: "/p/main.ts",
+    });
+  });
+
+  it("splits into the active tab when a file is already open, instead of opening a second tab", async () => {
+    useTabsStore.getState().openEditorTab("/p/main.ts");
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("util.ts"));
+
+    fireEvent.click(screen.getByText("util.ts"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    const tab = useTabsStore.getState().tabs[0];
+    expect(tab.paneTree.kind).toBe("split");
+  });
+});

--- a/src/modules/explorer/FileFinder.test.tsx
+++ b/src/modules/explorer/FileFinder.test.tsx
@@ -43,3 +43,22 @@ describe("FileFinder opening a file", () => {
     expect(tab.paneTree.kind).toBe("split");
   });
 });
+
+describe("FileFinder at pane capacity", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("shows an InfoDialog instead of opening a 9th pane", async () => {
+    useTabsStore.getState().openEditorTab("/0.ts");
+    for (let i = 1; i < 8; i++) {
+      useTabsStore.getState().openFromSidebar({ kind: "editor", path: `/${i}.ts` });
+    }
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("main.ts"));
+
+    fireEvent.click(screen.getByText("main.ts"));
+
+    expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
+  });
+});

--- a/src/modules/explorer/FileFinder.tsx
+++ b/src/modules/explorer/FileFinder.tsx
@@ -16,7 +16,7 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   const [query, setQuery] = useState("");
   const [files, setFiles] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
-  const openEditorTab = useTabsStore((s) => s.openEditorTab);
+  const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -36,7 +36,7 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   const results = useMemo(() => fuzzyRank(query, files).slice(0, 50), [query, files]);
 
   function open(path: string) {
-    openEditorTab(path);
+    openFromSidebar({ kind: "editor", path });
     onClose();
   }
 

--- a/src/modules/explorer/FileFinder.tsx
+++ b/src/modules/explorer/FileFinder.tsx
@@ -4,6 +4,7 @@ import { Search } from "lucide-react";
 import { fsListFiles } from "./lib/fsBridge";
 import { fuzzyRank } from "./lib/fuzzy";
 import { relativePath } from "./lib/paths";
+import { InfoDialog } from "@/components/InfoDialog";
 import { useTabsStore } from "@/stores/tabsStore";
 
 interface FileFinderProps {
@@ -13,8 +14,10 @@ interface FileFinderProps {
 
 export function FileFinder({ root, onClose }: FileFinderProps) {
   const { t } = useTranslation("explorer");
+  const { t: tCommon } = useTranslation("common");
   const [query, setQuery] = useState("");
   const [files, setFiles] = useState<string[]>([]);
+  const [atCapacity, setAtCapacity] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
 
@@ -36,7 +39,11 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   const results = useMemo(() => fuzzyRank(query, files).slice(0, 50), [query, files]);
 
   function open(path: string) {
-    openFromSidebar({ kind: "editor", path });
+    const result = openFromSidebar({ kind: "editor", path });
+    if (result.status === "at-capacity") {
+      setAtCapacity(true);
+      return;
+    }
     onClose();
   }
 
@@ -85,6 +92,15 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
         </ul>
       </div>
       <div className="absolute inset-0 -z-10" onClick={onClose} />
+
+      {atCapacity && (
+        <InfoDialog
+          title={t("findFiles")}
+          message={tCommon("paneCapacityAlert")}
+          confirmLabel={tCommon("actions.confirm")}
+          onConfirm={() => setAtCapacity(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { FileTree } from "./FileTree";
+import { useTabsStore } from "@/stores/tabsStore";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -25,5 +27,41 @@ describe("FileTree icons", () => {
     // The vendored TypeScript icon colours its stroke with var(--vscode-ctp-*),
     // which the lucide File glyph never contains.
     expect(container.innerHTML).toContain("vscode-ctp");
+  });
+});
+
+describe("FileTree opening a file", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("opens the clicked file via openFromSidebar instead of openEditorTab", () => {
+    const entries = [{ name: "main.ts", path: "/p/main.ts", is_dir: false, size: 0 }];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.click(screen.getByText("main.ts"));
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    const pane = tabs[0].paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toMatchObject({
+      kind: "editor",
+      path: "/p/main.ts",
+    });
+  });
+
+  it("splits a second click on a different file next to the first, instead of replacing it", () => {
+    const entries = [
+      { name: "main.ts", path: "/p/main.ts", is_dir: false, size: 0 },
+      { name: "util.ts", path: "/p/util.ts", is_dir: false, size: 0 },
+    ];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.click(screen.getByText("main.ts"));
+    fireEvent.click(screen.getByText("util.ts"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    const tab = useTabsStore.getState().tabs[0];
+    expect(tab.paneTree.kind).toBe("split");
   });
 });

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -85,3 +85,20 @@ describe("FileTree at pane capacity", () => {
     expect(useTabsStore.getState().tabs[0].paneOrder).toHaveLength(8);
   });
 });
+
+describe("FileTree context menu: open in new tab", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("always opens a new tab, even when the file is already open in the active tab", () => {
+    useTabsStore.getState().openEditorTab("/main.ts");
+    const entries = [{ name: "main.ts", path: "/main.ts", is_dir: false, size: 0 }];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.contextMenu(screen.getByText("main.ts"));
+    fireEvent.click(screen.getByText("menu.openInNewTab"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(2);
+  });
+});

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -65,3 +65,23 @@ describe("FileTree opening a file", () => {
     expect(tab.paneTree.kind).toBe("split");
   });
 });
+
+describe("FileTree at pane capacity", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("shows an InfoDialog instead of opening a 9th pane", () => {
+    useTabsStore.getState().openEditorTab("/0.ts");
+    for (let i = 1; i < 8; i++) {
+      useTabsStore.getState().openFromSidebar({ kind: "editor", path: `/${i}.ts` });
+    }
+    const entries = [{ name: "9.ts", path: "/9.ts", is_dir: false, size: 0 }];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.click(screen.getByText("9.ts"));
+
+    expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
+    expect(useTabsStore.getState().tabs[0].paneOrder).toHaveLength(8);
+  });
+});

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -10,6 +10,7 @@ import {
   FolderOpen,
   FolderPlus,
   MessageSquarePlus,
+  SquarePlus,
   TerminalSquare,
   Trash2,
 } from "lucide-react";
@@ -57,6 +58,7 @@ function TreeNode({ entry, depth, onReloadParent }: TreeNodeProps) {
   const [hovered, setHovered] = useState(false);
 
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
+  const openInNewTab = useTabsStore((s) => s.openInNewTab);
   const rootPath = useWorkspaceStore((s) => s.rootPath);
   const selectSidebar = useUiStore((s) => s.selectSidebar);
   const attachPath = useChatStore((s) => s.attachPath);
@@ -168,6 +170,17 @@ function TreeNode({ entry, depth, onReloadParent }: TreeNodeProps) {
       group: 0,
       onSelect: () => void toggle(),
     },
+    ...(!entry.is_dir
+      ? [
+          {
+            id: "openInNewTab",
+            label: t("menu.openInNewTab"),
+            icon: SquarePlus,
+            group: 0,
+            onSelect: () => openInNewTab({ kind: "editor", path: entry.path }),
+          } satisfies ContextMenuItem,
+        ]
+      : []),
     {
       id: "reveal",
       label: t("menu.reveal"),

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -53,7 +53,7 @@ function TreeNode({ entry, depth, onReloadParent }: TreeNodeProps) {
   // track hover manually to highlight just this row.
   const [hovered, setHovered] = useState(false);
 
-  const openEditorTab = useTabsStore((s) => s.openEditorTab);
+  const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const rootPath = useWorkspaceStore((s) => s.rootPath);
   const selectSidebar = useUiStore((s) => s.selectSidebar);
   const attachPath = useChatStore((s) => s.attachPath);
@@ -86,7 +86,7 @@ function TreeNode({ entry, depth, onReloadParent }: TreeNodeProps) {
 
   async function toggle() {
     if (!entry.is_dir) {
-      openEditorTab(entry.path);
+      openFromSidebar({ kind: "editor", path: entry.path });
       return;
     }
     if (expanded) {
@@ -129,7 +129,7 @@ function TreeNode({ entry, depth, onReloadParent }: TreeNodeProps) {
       onReloadParent();
     }
     if (creating.kind === "file") {
-      openEditorTab(path);
+      openFromSidebar({ kind: "editor", path });
     }
   }
 

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -25,6 +25,7 @@ import {
 import { dirname, joinPath, relativePath } from "./lib/paths";
 import { beginEntryDrag, consumeDragClick } from "./lib/dragEntry";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
+import { InfoDialog } from "@/components/InfoDialog";
 import { useTabsStore } from "@/stores/tabsStore";
 import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -45,10 +46,12 @@ interface TreeNodeProps {
 
 function TreeNode({ entry, depth, onReloadParent }: TreeNodeProps) {
   const { t } = useTranslation("explorer");
+  const { t: tCommon } = useTranslation("common");
   const [expanded, setExpanded] = useState(false);
   const [children, setChildren] = useState<DirEntry[] | null>(null);
   const [menu, setMenu] = useState<MenuPosition | null>(null);
   const [creating, setCreating] = useState<Creating>(null);
+  const [atCapacity, setAtCapacity] = useState(false);
   // JS hover: CSS :hover is suppressed inside a draggable subtree (WebKit), so
   // track hover manually to highlight just this row.
   const [hovered, setHovered] = useState(false);
@@ -86,7 +89,10 @@ function TreeNode({ entry, depth, onReloadParent }: TreeNodeProps) {
 
   async function toggle() {
     if (!entry.is_dir) {
-      openFromSidebar({ kind: "editor", path: entry.path });
+      const result = openFromSidebar({ kind: "editor", path: entry.path });
+      if (result.status === "at-capacity") {
+        setAtCapacity(true);
+      }
       return;
     }
     if (expanded) {
@@ -129,7 +135,10 @@ function TreeNode({ entry, depth, onReloadParent }: TreeNodeProps) {
       onReloadParent();
     }
     if (creating.kind === "file") {
-      openFromSidebar({ kind: "editor", path });
+      const result = openFromSidebar({ kind: "editor", path });
+      if (result.status === "at-capacity") {
+        setAtCapacity(true);
+      }
     }
   }
 
@@ -307,6 +316,15 @@ function TreeNode({ entry, depth, onReloadParent }: TreeNodeProps) {
           y={menu.y}
           items={menuItems}
           onClose={() => setMenu(null)}
+        />
+      )}
+
+      {atCapacity && (
+        <InfoDialog
+          title={t("menu.open")}
+          message={tCommon("paneCapacityAlert")}
+          confirmLabel={tCommon("actions.confirm")}
+          onConfirm={() => setAtCapacity(false)}
         />
       )}
     </li>

--- a/src/modules/explorer/lib/dragEntry.test.ts
+++ b/src/modules/explorer/lib/dragEntry.test.ts
@@ -4,6 +4,7 @@ import {
   fileUrl,
   getDraggedEntry,
   markdownLink,
+  pointerToPaneAreaPct,
   setDraggedEntry,
   shellQuotePath,
 } from "./dragEntry";
@@ -50,5 +51,17 @@ describe("getDraggedEntry / setDraggedEntry", () => {
 describe("consumeDragClick", () => {
   it("is false when no drag has just finished", () => {
     expect(consumeDragClick()).toBe(false);
+  });
+});
+
+describe("pointerToPaneAreaPct", () => {
+  it("converts a client point to a 0-100 percentage of the given container rect", () => {
+    const containerRect = { left: 100, top: 50, width: 400, height: 200 } as DOMRect;
+    expect(pointerToPaneAreaPct(containerRect, 300, 150)).toEqual({ xPct: 50, yPct: 50 });
+  });
+
+  it("clamps to 0-100 when the point is outside the container (fast pointer movement)", () => {
+    const containerRect = { left: 0, top: 0, width: 100, height: 100 } as DOMRect;
+    expect(pointerToPaneAreaPct(containerRect, -20, 250)).toEqual({ xPct: 0, yPct: 100 });
   });
 });

--- a/src/modules/explorer/lib/dragEntry.test.ts
+++ b/src/modules/explorer/lib/dragEntry.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// jsdom has no PointerEvent constructor; a MouseEvent dispatched under the
+// pointermove/pointerup type names reaches the same window listeners since
+// beginEntryDrag's handlers only read clientX/clientY off the event.
+function firePointer(type: "pointermove" | "pointerup", clientX: number, clientY: number): void {
+  window.dispatchEvent(new MouseEvent(type, { clientX, clientY }));
+}
 import {
+  beginEntryDrag,
   consumeDragClick,
   fileUrl,
   getDraggedEntry,
@@ -8,7 +15,9 @@ import {
   pointerToPaneAreaPct,
   setDraggedEntry,
   shellQuotePath,
+  useEntryDragStore,
 } from "./dragEntry";
+import { useTabsStore } from "@/stores/tabsStore";
 
 describe("shellQuotePath", () => {
   it("leaves simple paths unquoted", () => {
@@ -78,5 +87,81 @@ describe("tab-bar drop priority", () => {
 
   it("isOverTabBar resolves false otherwise", () => {
     expect(isOverTabBar(document.createElement("div"))).toBe(false);
+  });
+});
+
+describe("beginEntryDrag tab-bar drop with insertion", () => {
+  beforeEach(() => {
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "One" }],
+      activeSpaceId: "s1",
+      tabs: [],
+      activeId: null,
+    });
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // @ts-expect-error jsdom has no native elementFromPoint; tests assign one directly.
+    delete document.elementFromPoint;
+    document.body.innerHTML = "";
+    useEntryDragStore.setState({ entry: null, dragging: false, tabBarHover: null });
+  });
+
+  function setUpTabBarDom(tabIdA: string, tabIdB: string): { elA: Element; elB: Element; bar: Element } {
+    document.body.innerHTML = `
+      <div data-tab-bar>
+        <div role="tab" data-tab-id="${tabIdA}"></div>
+        <div role="tab" data-tab-id="${tabIdB}"></div>
+      </div>
+    `;
+    const bar = document.querySelector("[data-tab-bar]")!;
+    const [elA, elB] = Array.from(document.querySelectorAll('[role="tab"]'));
+    vi.spyOn(elA, "getBoundingClientRect").mockReturnValue({ left: 0, width: 100 } as DOMRect);
+    vi.spyOn(elB, "getBoundingClientRect").mockReturnValue({ left: 100, width: 100 } as DOMRect);
+    vi.spyOn(bar, "getBoundingClientRect").mockReturnValue({} as DOMRect);
+    return { elA, elB, bar };
+  }
+
+  it("reorders the newly-opened tab to land before the tab it was dropped nearest to", () => {
+    const tabIdA = useTabsStore.getState().newTerminalTab();
+    const tabIdB = useTabsStore.getState().newTerminalTab();
+    const { bar } = setUpTabBarDom(tabIdA, tabIdB);
+    document.elementFromPoint = vi.fn().mockReturnValue(bar);
+
+    const startEvent = { clientX: 500, clientY: 10, button: 0 } as unknown as React.PointerEvent;
+    beginEntryDrag({ path: "/new.ts", name: "new.ts", isDir: false }, startEvent);
+
+    firePointer("pointermove", 10, 10);
+    firePointer("pointerup", 10, 10);
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(3);
+    const newTab = tabs.find((t) => t.kind === "editor")!;
+    expect(newTab).toBeDefined();
+    const indexOfNew = tabs.findIndex((t) => t.id === newTab.id);
+    const indexOfA = tabs.findIndex((t) => t.id === tabIdA);
+    // The new tab lands immediately before tabIdA — it takes tabIdA's former
+    // slot and tabIdA shifts one place to the right.
+    expect(indexOfNew).toBe(indexOfA - 1);
+  });
+
+  it("leaves the new tab at the end (no reorder) when dropped past every tab's midpoint", () => {
+    const tabIdA = useTabsStore.getState().newTerminalTab();
+    const tabIdB = useTabsStore.getState().newTerminalTab();
+    const { bar } = setUpTabBarDom(tabIdA, tabIdB);
+    document.elementFromPoint = vi.fn().mockReturnValue(bar);
+
+    const startEvent = { clientX: 500, clientY: 10, button: 0 } as unknown as React.PointerEvent;
+    beginEntryDrag({ path: "/new.ts", name: "new.ts", isDir: false }, startEvent);
+
+    firePointer("pointermove", 280, 10);
+    firePointer("pointerup", 280, 10);
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(3);
+    const newTab = tabs.find((t) => t.kind === "editor")!;
+    expect(tabs[tabs.length - 1].id).toBe(newTab.id);
   });
 });

--- a/src/modules/explorer/lib/dragEntry.test.ts
+++ b/src/modules/explorer/lib/dragEntry.test.ts
@@ -3,6 +3,7 @@ import {
   consumeDragClick,
   fileUrl,
   getDraggedEntry,
+  isOverTabBar,
   markdownLink,
   pointerToPaneAreaPct,
   setDraggedEntry,
@@ -63,5 +64,19 @@ describe("pointerToPaneAreaPct", () => {
   it("clamps to 0-100 when the point is outside the container (fast pointer movement)", () => {
     const containerRect = { left: 0, top: 0, width: 100, height: 100 } as DOMRect;
     expect(pointerToPaneAreaPct(containerRect, -20, 250)).toEqual({ xPct: 0, yPct: 100 });
+  });
+});
+
+describe("tab-bar drop priority", () => {
+  it("isOverTabBar resolves true when the element is inside a data-tab-bar container", () => {
+    const outer = document.createElement("div");
+    outer.dataset.tabBar = "";
+    const inner = document.createElement("div");
+    outer.appendChild(inner);
+    expect(isOverTabBar(inner)).toBe(true);
+  });
+
+  it("isOverTabBar resolves false otherwise", () => {
+    expect(isOverTabBar(document.createElement("div"))).toBe(false);
   });
 });

--- a/src/modules/explorer/lib/dragEntry.ts
+++ b/src/modules/explorer/lib/dragEntry.ts
@@ -8,6 +8,7 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { create } from "zustand";
 import { useTabsStore } from "@/stores/tabsStore";
+import { nearestTabInsertion, tabRectsInTabBar } from "@/components/lib/tabBarDrop";
 
 export interface DraggedEntry {
   path: string;
@@ -34,6 +35,8 @@ interface EntryDragState {
   hoverPointerPct: { xPct: number; yPct: number } | null;
   /** A resolved drop waiting for its owning pane to consume it. */
   pendingDrop: PendingDrop | null;
+  /** Where a drop on the tab bar would insert a new tab, while dragging over it; null when not hovering the tab bar at all. */
+  tabBarHover: { insertBeforeId: string | null } | null;
   setHover: (leafId: string | null) => void;
   clearPendingDrop: () => void;
 }
@@ -44,6 +47,7 @@ export const useEntryDragStore = create<EntryDragState>((set) => ({
   hoverLeafId: null,
   hoverPointerPct: null,
   pendingDrop: null,
+  tabBarHover: null,
   setHover: (leafId) => set((s) => (s.hoverLeafId === leafId ? s : { hoverLeafId: leafId })),
   clearPendingDrop: () => set({ pendingDrop: null }),
 }));
@@ -165,6 +169,15 @@ export function beginEntryDrag(entry: DraggedEntry, event: ReactPointerEvent): v
       showGhost(entry.name, e.clientX, e.clientY);
     }
     moveGhost(e.clientX, e.clientY);
+    if (isOverTabBar(document.elementFromPoint(e.clientX, e.clientY))) {
+      useEntryDragStore.setState({
+        hoverLeafId: null,
+        hoverPointerPct: null,
+        tabBarHover: { insertBeforeId: nearestTabInsertion(tabRectsInTabBar(), e.clientX) },
+      });
+      return;
+    }
+    useEntryDragStore.setState({ tabBarHover: null });
     useEntryDragStore.getState().setHover(leafAt(e.clientX, e.clientY));
     const areaRect = paneAreaRectAt(e.clientX, e.clientY);
     useEntryDragStore.setState({
@@ -183,15 +196,23 @@ export function beginEntryDrag(entry: DraggedEntry, event: ReactPointerEvent): v
       suppressClick = false;
     }, 0);
     if (isOverTabBar(document.elementFromPoint(e.clientX, e.clientY))) {
+      const insertBeforeId = nearestTabInsertion(tabRectsInTabBar(), e.clientX);
       useEntryDragStore.setState({
         dragging: false,
         hoverLeafId: null,
         hoverPointerPct: null,
         entry: null,
         pendingDrop: null,
+        tabBarHover: null,
       });
       if (!entry.isDir) {
-        useTabsStore.getState().openInNewTab({ kind: "editor", path: entry.path });
+        const result = useTabsStore.getState().openInNewTab({ kind: "editor", path: entry.path });
+        if (result.status === "opened" && insertBeforeId !== null) {
+          const newTabId = useTabsStore.getState().activeId;
+          if (newTabId) {
+            useTabsStore.getState().reorderTab(newTabId, insertBeforeId);
+          }
+        }
       }
       return;
     }
@@ -211,7 +232,13 @@ export function beginEntryDrag(entry: DraggedEntry, event: ReactPointerEvent): v
 
   const onCancel = () => {
     stop();
-    useEntryDragStore.setState({ dragging: false, hoverLeafId: null, hoverPointerPct: null, entry: null });
+    useEntryDragStore.setState({
+      dragging: false,
+      hoverLeafId: null,
+      hoverPointerPct: null,
+      entry: null,
+      tabBarHover: null,
+    });
   };
 
   window.addEventListener("pointermove", onMove);

--- a/src/modules/explorer/lib/dragEntry.ts
+++ b/src/modules/explorer/lib/dragEntry.ts
@@ -17,6 +17,8 @@ export interface DraggedEntry {
 interface PendingDrop {
   leafId: string;
   entry: DraggedEntry;
+  xPct: number;
+  yPct: number;
 }
 
 interface EntryDragState {
@@ -26,6 +28,9 @@ interface EntryDragState {
   dragging: boolean;
   /** Leaf id of the pane under the cursor, for the drop highlight. */
   hoverLeafId: string | null;
+  /** The pointer's live position, as a percentage of the pane-area container
+   * under it, for resolving the live drop-zone highlight while dragging. */
+  hoverPointerPct: { xPct: number; yPct: number } | null;
   /** A resolved drop waiting for its owning pane to consume it. */
   pendingDrop: PendingDrop | null;
   setHover: (leafId: string | null) => void;
@@ -36,6 +41,7 @@ export const useEntryDragStore = create<EntryDragState>((set) => ({
   entry: null,
   dragging: false,
   hoverLeafId: null,
+  hoverPointerPct: null,
   pendingDrop: null,
   setHover: (leafId) => set((s) => (s.hoverLeafId === leafId ? s : { hoverLeafId: leafId })),
   clearPendingDrop: () => set({ pendingDrop: null }),
@@ -67,6 +73,28 @@ export function consumeDragClick(): boolean {
 function leafAt(x: number, y: number): string | null {
   return (
     document.elementFromPoint(x, y)?.closest<HTMLElement>("[data-pane-leaf]")?.dataset.paneLeaf ??
+    null
+  );
+}
+
+/** Convert a client point into a 0-100 percentage of `rect`, clamped at the edges. */
+export function pointerToPaneAreaPct(
+  rect: { left: number; top: number; width: number; height: number },
+  clientX: number,
+  clientY: number,
+): { xPct: number; yPct: number } {
+  const xPct = rect.width > 0 ? ((clientX - rect.left) / rect.width) * 100 : 0;
+  const yPct = rect.height > 0 ? ((clientY - rect.top) / rect.height) * 100 : 0;
+  return {
+    xPct: Math.min(100, Math.max(0, xPct)),
+    yPct: Math.min(100, Math.max(0, yPct)),
+  };
+}
+
+/** The pane-area container rect under a client point, or null. */
+function paneAreaRectAt(x: number, y: number): DOMRect | null {
+  return (
+    document.elementFromPoint(x, y)?.closest<HTMLElement>("[data-pane-area]")?.getBoundingClientRect() ??
     null
   );
 }
@@ -132,6 +160,10 @@ export function beginEntryDrag(entry: DraggedEntry, event: ReactPointerEvent): v
     }
     moveGhost(e.clientX, e.clientY);
     useEntryDragStore.getState().setHover(leafAt(e.clientX, e.clientY));
+    const areaRect = paneAreaRectAt(e.clientX, e.clientY);
+    useEntryDragStore.setState({
+      hoverPointerPct: areaRect ? pointerToPaneAreaPct(areaRect, e.clientX, e.clientY) : null,
+    });
   };
 
   const onUp = (e: PointerEvent) => {
@@ -145,17 +177,22 @@ export function beginEntryDrag(entry: DraggedEntry, event: ReactPointerEvent): v
       suppressClick = false;
     }, 0);
     const leafId = leafAt(e.clientX, e.clientY);
+    const areaRect = paneAreaRectAt(e.clientX, e.clientY);
+    const { xPct, yPct } = areaRect
+      ? pointerToPaneAreaPct(areaRect, e.clientX, e.clientY)
+      : { xPct: 0, yPct: 0 };
     useEntryDragStore.setState({
       dragging: false,
       hoverLeafId: null,
+      hoverPointerPct: null,
       entry: null,
-      pendingDrop: leafId ? { leafId, entry } : null,
+      pendingDrop: leafId ? { leafId, entry, xPct, yPct } : null,
     });
   };
 
   const onCancel = () => {
     stop();
-    useEntryDragStore.setState({ dragging: false, hoverLeafId: null, entry: null });
+    useEntryDragStore.setState({ dragging: false, hoverLeafId: null, hoverPointerPct: null, entry: null });
   };
 
   window.addEventListener("pointermove", onMove);

--- a/src/modules/explorer/lib/dragEntry.ts
+++ b/src/modules/explorer/lib/dragEntry.ts
@@ -7,6 +7,7 @@
  */
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { create } from "zustand";
+import { useTabsStore } from "@/stores/tabsStore";
 
 export interface DraggedEntry {
   path: string;
@@ -99,6 +100,11 @@ function paneAreaRectAt(x: number, y: number): DOMRect | null {
   );
 }
 
+/** True when `el` (or an ancestor) is the tab bar — takes priority over any pane target. */
+export function isOverTabBar(el: Element | null): boolean {
+  return el?.closest("[data-tab-bar]") != null;
+}
+
 let ghostEl: HTMLDivElement | null = null;
 
 function showGhost(label: string, x: number, y: number): void {
@@ -176,6 +182,19 @@ export function beginEntryDrag(entry: DraggedEntry, event: ReactPointerEvent): v
     setTimeout(() => {
       suppressClick = false;
     }, 0);
+    if (isOverTabBar(document.elementFromPoint(e.clientX, e.clientY))) {
+      useEntryDragStore.setState({
+        dragging: false,
+        hoverLeafId: null,
+        hoverPointerPct: null,
+        entry: null,
+        pendingDrop: null,
+      });
+      if (!entry.isDir) {
+        useTabsStore.getState().openInNewTab({ kind: "editor", path: entry.path });
+      }
+      return;
+    }
     const leafId = leafAt(e.clientX, e.clientY);
     const areaRect = paneAreaRectAt(e.clientX, e.clientY);
     const { xPct, yPct } = areaRect

--- a/src/modules/notes/NotesSidebar.test.tsx
+++ b/src/modules/notes/NotesSidebar.test.tsx
@@ -69,3 +69,31 @@ describe("NotesSidebar at pane capacity", () => {
     expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
   });
 });
+
+describe("NotesSidebar context menu: open in new tab", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+    useSettingsStore.setState({ notesFolderPath: "/notes" });
+    useNotesStore.setState({
+      tree: [
+        { kind: "note", name: "todo.md", title: "todo", path: "/notes/todo.md", isConflict: false },
+      ],
+    });
+  });
+
+  it("always opens a new tab via right-click, even when the note is already open", () => {
+    useTabsStore.getState().openEditorTab("/a.ts");
+    render(<NotesSidebar />);
+
+    fireEvent.contextMenu(screen.getByText("todo"));
+    fireEvent.click(screen.getByText("openInNewTab"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(2);
+    const newTab = useTabsStore.getState().tabs[1];
+    const pane = newTab.paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toMatchObject({
+      kind: "note",
+      noteId: "/notes/todo.md",
+    });
+  });
+});

--- a/src/modules/notes/NotesSidebar.test.tsx
+++ b/src/modules/notes/NotesSidebar.test.tsx
@@ -70,6 +70,33 @@ describe("NotesSidebar at pane capacity", () => {
   });
 });
 
+describe("NotesSidebar context menu: open in split pane", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+    useSettingsStore.setState({ notesFolderPath: "/notes" });
+    useNotesStore.setState({
+      tree: [
+        { kind: "note", name: "todo.md", title: "todo", path: "/notes/todo.md", isConflict: false },
+      ],
+    });
+  });
+
+  it("opens the note in split pane via right-click", () => {
+    render(<NotesSidebar />);
+
+    fireEvent.contextMenu(screen.getByText("todo"));
+    fireEvent.click(screen.getByText("open"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    const tab = useTabsStore.getState().tabs[0];
+    const pane = tab.paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toMatchObject({
+      kind: "note",
+      noteId: "/notes/todo.md",
+    });
+  });
+});
+
 describe("NotesSidebar context menu: open in new tab", () => {
   beforeEach(() => {
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });

--- a/src/modules/notes/NotesSidebar.test.tsx
+++ b/src/modules/notes/NotesSidebar.test.tsx
@@ -45,3 +45,27 @@ describe("NotesSidebar opening a note", () => {
     expect(tab.paneTree.kind).toBe("split");
   });
 });
+
+describe("NotesSidebar at pane capacity", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+    useSettingsStore.setState({ notesFolderPath: "/notes" });
+    useNotesStore.setState({
+      tree: [
+        { kind: "note", name: "todo.md", title: "todo", path: "/notes/todo.md", isConflict: false },
+      ],
+    });
+  });
+
+  it("shows an InfoDialog instead of opening a 9th pane", () => {
+    useTabsStore.getState().openEditorTab("/0.ts");
+    for (let i = 1; i < 8; i++) {
+      useTabsStore.getState().openFromSidebar({ kind: "editor", path: `/${i}.ts` });
+    }
+    render(<NotesSidebar />);
+
+    fireEvent.click(screen.getByText("todo"));
+
+    expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
+  });
+});

--- a/src/modules/notes/NotesSidebar.test.tsx
+++ b/src/modules/notes/NotesSidebar.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NotesSidebar } from "./NotesSidebar";
+import { useTabsStore } from "@/stores/tabsStore";
+import { useNotesStore } from "@/stores/notesStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("NotesSidebar opening a note", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+    useSettingsStore.setState({ notesFolderPath: "/notes" });
+    useNotesStore.setState({
+      tree: [
+        { kind: "note", name: "todo.md", title: "todo", path: "/notes/todo.md", isConflict: false },
+      ],
+    });
+  });
+
+  it("opens the clicked note via openFromSidebar instead of openNoteTab", () => {
+    render(<NotesSidebar />);
+
+    fireEvent.click(screen.getByText("todo"));
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    const pane = tabs[0].paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toMatchObject({
+      kind: "note",
+      noteId: "/notes/todo.md",
+    });
+  });
+
+  it("splits a second note next to an already-open one instead of focusing it", () => {
+    render(<NotesSidebar />);
+
+    fireEvent.click(screen.getByText("todo"));
+    fireEvent.click(screen.getByText("todo"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    const tab = useTabsStore.getState().tabs[0];
+    expect(tab.paneTree.kind).toBe("split");
+  });
+});

--- a/src/modules/notes/NotesSidebar.tsx
+++ b/src/modules/notes/NotesSidebar.tsx
@@ -103,7 +103,7 @@ function NoteRow({ note, depth }: { note: NoteNode; depth: number }) {
       )}
       {atCapacity && (
         <InfoDialog
-          title={t("newNote")}
+          title={t("open")}
           message={tCommon("paneCapacityAlert")}
           confirmLabel={tCommon("actions.confirm")}
           onConfirm={() => setAtCapacity(false)}

--- a/src/modules/notes/NotesSidebar.tsx
+++ b/src/modules/notes/NotesSidebar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   ChevronDown,
   ChevronRight,
+  Columns2,
   FilePlus,
   FolderPlus,
   FileText,
@@ -78,6 +79,18 @@ function NoteRow({ note, depth }: { note: NoteNode; depth: number }) {
           y={menu.y}
           onClose={() => setMenu(null)}
           items={[
+            {
+              id: "open",
+              label: t("open"),
+              icon: Columns2,
+              group: 0,
+              onSelect: () => {
+                const result = openFromSidebar({ kind: "note", noteId: note.path }, note.title || "Untitled");
+                if (result.status === "at-capacity") {
+                  setAtCapacity(true);
+                }
+              },
+            } satisfies ContextMenuItem,
             {
               id: "openInNewTab",
               label: t("openInNewTab"),

--- a/src/modules/notes/NotesSidebar.tsx
+++ b/src/modules/notes/NotesSidebar.tsx
@@ -18,7 +18,7 @@ import { beginNoteDrag, consumeNoteDragClick, useNoteDragStore } from "./lib/not
 
 function NoteRow({ note, depth }: { note: NoteNode; depth: number }) {
   const { t } = useTranslation("notes");
-  const openNoteTab = useTabsStore((s) => s.openNoteTab);
+  const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const deleteNote = useNotesStore((s) => s.deleteNote);
 
   return (
@@ -34,7 +34,7 @@ function NoteRow({ note, depth }: { note: NoteNode; depth: number }) {
           if (consumeNoteDragClick()) {
             return;
           }
-          openNoteTab(note.path, note.title || "Untitled");
+          openFromSidebar({ kind: "note", noteId: note.path }, note.title || "Untitled");
         }}
         style={{ paddingLeft: depth * 12 + 10 }}
         className="flex min-w-0 flex-1 items-center gap-2 py-1 pr-2 text-left text-sm text-fg-muted hover:text-fg"
@@ -67,7 +67,7 @@ function FolderRow({ folder, depth }: { folder: FolderNode; depth: number }) {
   const createNote = useNotesStore((s) => s.createNote);
   const renameFolder = useNotesStore((s) => s.renameFolder);
   const deleteNote = useNotesStore((s) => s.deleteNote);
-  const openNoteTab = useTabsStore((s) => s.openNoteTab);
+  const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const isOver = useNoteDragStore(
     (s) => s.hover?.kind === "folder" && s.hover.path === folder.path,
   );
@@ -79,7 +79,7 @@ function FolderRow({ folder, depth }: { folder: FolderNode; depth: number }) {
   function newNoteInFolder() {
     void (async () => {
       const path = await createNote(folder.path);
-      openNoteTab(path, "Untitled");
+      openFromSidebar({ kind: "note", noteId: path }, "Untitled");
     })();
   }
 
@@ -175,7 +175,7 @@ export function NotesSidebar() {
   const tree = useNotesStore((s) => s.tree);
   const createNote = useNotesStore((s) => s.createNote);
   const createFolder = useNotesStore((s) => s.createFolder);
-  const openNoteTab = useTabsStore((s) => s.openNoteTab);
+  const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const isOverRoot = useNoteDragStore((s) => s.hover?.kind === "root");
 
   if (!rootPath) {
@@ -188,7 +188,7 @@ export function NotesSidebar() {
     }
     void (async () => {
       const path = await createNote(rootPath);
-      openNoteTab(path, "Untitled");
+      openFromSidebar({ kind: "note", noteId: path }, "Untitled");
     })();
   }
 

--- a/src/modules/notes/NotesSidebar.tsx
+++ b/src/modules/notes/NotesSidebar.tsx
@@ -9,6 +9,7 @@ import {
   Folder,
   Trash2,
 } from "lucide-react";
+import { InfoDialog } from "@/components/InfoDialog";
 import { useNotesStore } from "@/stores/notesStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useTabsStore } from "@/stores/tabsStore";
@@ -18,8 +19,10 @@ import { beginNoteDrag, consumeNoteDragClick, useNoteDragStore } from "./lib/not
 
 function NoteRow({ note, depth }: { note: NoteNode; depth: number }) {
   const { t } = useTranslation("notes");
+  const { t: tCommon } = useTranslation("common");
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const deleteNote = useNotesStore((s) => s.deleteNote);
+  const [atCapacity, setAtCapacity] = useState(false);
 
   return (
     <li
@@ -34,7 +37,10 @@ function NoteRow({ note, depth }: { note: NoteNode; depth: number }) {
           if (consumeNoteDragClick()) {
             return;
           }
-          openFromSidebar({ kind: "note", noteId: note.path }, note.title || "Untitled");
+          const result = openFromSidebar({ kind: "note", noteId: note.path }, note.title || "Untitled");
+          if (result.status === "at-capacity") {
+            setAtCapacity(true);
+          }
         }}
         style={{ paddingLeft: depth * 12 + 10 }}
         className="flex min-w-0 flex-1 items-center gap-2 py-1 pr-2 text-left text-sm text-fg-muted hover:text-fg"
@@ -58,12 +64,21 @@ function NoteRow({ note, depth }: { note: NoteNode; depth: number }) {
       >
         <Trash2 size={13} />
       </button>
+      {atCapacity && (
+        <InfoDialog
+          title={t("newNote")}
+          message={tCommon("paneCapacityAlert")}
+          confirmLabel={tCommon("actions.confirm")}
+          onConfirm={() => setAtCapacity(false)}
+        />
+      )}
     </li>
   );
 }
 
 function FolderRow({ folder, depth }: { folder: FolderNode; depth: number }) {
   const { t } = useTranslation("notes");
+  const { t: tCommon } = useTranslation("common");
   const createNote = useNotesStore((s) => s.createNote);
   const renameFolder = useNotesStore((s) => s.renameFolder);
   const deleteNote = useNotesStore((s) => s.deleteNote);
@@ -75,11 +90,15 @@ function FolderRow({ folder, depth }: { folder: FolderNode; depth: number }) {
   const [collapsed, setCollapsed] = useState(false);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
+  const [atCapacity, setAtCapacity] = useState(false);
 
   function newNoteInFolder() {
     void (async () => {
       const path = await createNote(folder.path);
-      openFromSidebar({ kind: "note", noteId: path }, "Untitled");
+      const result = openFromSidebar({ kind: "note", noteId: path }, "Untitled");
+      if (result.status === "at-capacity") {
+        setAtCapacity(true);
+      }
     })();
   }
 
@@ -158,6 +177,14 @@ function FolderRow({ folder, depth }: { folder: FolderNode; depth: number }) {
           ))}
         </ul>
       )}
+      {atCapacity && (
+        <InfoDialog
+          title={t("newNote")}
+          message={tCommon("paneCapacityAlert")}
+          confirmLabel={tCommon("actions.confirm")}
+          onConfirm={() => setAtCapacity(false)}
+        />
+      )}
     </li>
   );
 }
@@ -171,12 +198,14 @@ function NodeRow({ node, depth }: { node: NotesNode; depth: number }) {
 
 export function NotesSidebar() {
   const { t } = useTranslation("notes");
+  const { t: tCommon } = useTranslation("common");
   const rootPath = useSettingsStore((s) => s.notesFolderPath);
   const tree = useNotesStore((s) => s.tree);
   const createNote = useNotesStore((s) => s.createNote);
   const createFolder = useNotesStore((s) => s.createFolder);
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const isOverRoot = useNoteDragStore((s) => s.hover?.kind === "root");
+  const [atCapacity, setAtCapacity] = useState(false);
 
   if (!rootPath) {
     return <NotesEmptyState />;
@@ -188,7 +217,10 @@ export function NotesSidebar() {
     }
     void (async () => {
       const path = await createNote(rootPath);
-      openFromSidebar({ kind: "note", noteId: path }, "Untitled");
+      const result = openFromSidebar({ kind: "note", noteId: path }, "Untitled");
+      if (result.status === "at-capacity") {
+        setAtCapacity(true);
+      }
     })();
   }
 
@@ -242,6 +274,15 @@ export function NotesSidebar() {
           ))}
         </ul>
       </div>
+
+      {atCapacity && (
+        <InfoDialog
+          title={t("newNote")}
+          message={tCommon("paneCapacityAlert")}
+          confirmLabel={tCommon("actions.confirm")}
+          onConfirm={() => setAtCapacity(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/modules/notes/NotesSidebar.tsx
+++ b/src/modules/notes/NotesSidebar.tsx
@@ -8,7 +8,9 @@ import {
   FileText,
   Folder,
   Trash2,
+  SquarePlus,
 } from "lucide-react";
+import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import { InfoDialog } from "@/components/InfoDialog";
 import { useNotesStore } from "@/stores/notesStore";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -21,13 +23,19 @@ function NoteRow({ note, depth }: { note: NoteNode; depth: number }) {
   const { t } = useTranslation("notes");
   const { t: tCommon } = useTranslation("common");
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
+  const openInNewTab = useTabsStore((s) => s.openInNewTab);
   const deleteNote = useNotesStore((s) => s.deleteNote);
   const [atCapacity, setAtCapacity] = useState(false);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
 
   return (
     <li
       data-note-path={note.path}
       onPointerDown={(e) => beginNoteDrag(note.path, note.title || "Untitled", e)}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setMenu({ x: e.clientX, y: e.clientY });
+      }}
       className="group flex items-center"
     >
       <button
@@ -64,6 +72,22 @@ function NoteRow({ note, depth }: { note: NoteNode; depth: number }) {
       >
         <Trash2 size={13} />
       </button>
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          onClose={() => setMenu(null)}
+          items={[
+            {
+              id: "openInNewTab",
+              label: t("openInNewTab"),
+              icon: SquarePlus,
+              group: 0,
+              onSelect: () => openInNewTab({ kind: "note", noteId: note.path }, note.title || "Untitled"),
+            } satisfies ContextMenuItem,
+          ]}
+        />
+      )}
       {atCapacity && (
         <InfoDialog
           title={t("newNote")}

--- a/src/modules/notes/lib/noteDrag.test.ts
+++ b/src/modules/notes/lib/noteDrag.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, it, vi } from "vitest";
-import { applyNoteDrop, isOverTabBar, resolveNoteDrop, useNoteDragStore } from "./noteDrag";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyNoteDrop,
+  beginNoteDrag,
+  isOverTabBar,
+  resolveNoteDrop,
+  useNoteDragStore,
+} from "./noteDrag";
+import { useTabsStore } from "@/stores/tabsStore";
+
+// jsdom has no PointerEvent constructor; a MouseEvent dispatched under the
+// pointermove/pointerup type names reaches the same window listeners since
+// beginNoteDrag's handlers only read clientX/clientY off the event.
+function firePointer(type: "pointermove" | "pointerup", clientX: number, clientY: number): void {
+  window.dispatchEvent(new MouseEvent(type, { clientX, clientY }));
+}
 
 describe("resolveNoteDrop", () => {
   it("resolves a folder header to a folder target carrying its path", () => {
@@ -84,5 +98,81 @@ describe("tab-bar drop priority", () => {
     const inner = document.createElement("div");
     outer.appendChild(inner);
     expect(isOverTabBar(inner)).toBe(true);
+  });
+});
+
+describe("beginNoteDrag tab-bar drop with insertion", () => {
+  beforeEach(() => {
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "One" }],
+      activeSpaceId: "s1",
+      tabs: [],
+      activeId: null,
+    });
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // @ts-expect-error jsdom has no native elementFromPoint; tests assign one directly.
+    delete document.elementFromPoint;
+    document.body.innerHTML = "";
+    useNoteDragStore.setState({ hover: null, paneHover: null, tabBarHover: null });
+  });
+
+  function setUpTabBarDom(tabIdA: string, tabIdB: string): { bar: Element } {
+    document.body.innerHTML = `
+      <div data-tab-bar>
+        <div role="tab" data-tab-id="${tabIdA}"></div>
+        <div role="tab" data-tab-id="${tabIdB}"></div>
+      </div>
+    `;
+    const bar = document.querySelector("[data-tab-bar]")!;
+    const [elA, elB] = Array.from(document.querySelectorAll('[role="tab"]'));
+    vi.spyOn(elA, "getBoundingClientRect").mockReturnValue({ left: 0, width: 100 } as DOMRect);
+    vi.spyOn(elB, "getBoundingClientRect").mockReturnValue({ left: 100, width: 100 } as DOMRect);
+    vi.spyOn(bar, "getBoundingClientRect").mockReturnValue({} as DOMRect);
+    return { bar };
+  }
+
+  it("reorders the newly-opened tab to land before the tab it was dropped nearest to", () => {
+    const tabIdA = useTabsStore.getState().newTerminalTab();
+    const tabIdB = useTabsStore.getState().newTerminalTab();
+    const { bar } = setUpTabBarDom(tabIdA, tabIdB);
+    document.elementFromPoint = vi.fn().mockReturnValue(bar);
+
+    const startEvent = { clientX: 500, clientY: 10, button: 0 } as unknown as React.PointerEvent;
+    beginNoteDrag("/root/n.md", "n.md", startEvent);
+
+    firePointer("pointermove", 10, 10);
+    firePointer("pointerup", 10, 10);
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(3);
+    const newTab = tabs.find((t) => t.kind === "note")!;
+    expect(newTab).toBeDefined();
+    const indexOfNew = tabs.findIndex((t) => t.id === newTab.id);
+    const indexOfA = tabs.findIndex((t) => t.id === tabIdA);
+    // The new tab lands immediately before tabIdA — it takes tabIdA's former
+    // slot and tabIdA shifts one place to the right.
+    expect(indexOfNew).toBe(indexOfA - 1);
+  });
+
+  it("leaves the new tab at the end (no reorder) when dropped past every tab's midpoint", () => {
+    const tabIdA = useTabsStore.getState().newTerminalTab();
+    const tabIdB = useTabsStore.getState().newTerminalTab();
+    const { bar } = setUpTabBarDom(tabIdA, tabIdB);
+    document.elementFromPoint = vi.fn().mockReturnValue(bar);
+
+    const startEvent = { clientX: 500, clientY: 10, button: 0 } as unknown as React.PointerEvent;
+    beginNoteDrag("/root/n.md", "n.md", startEvent);
+
+    firePointer("pointermove", 280, 10);
+    firePointer("pointerup", 280, 10);
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(3);
+    const newTab = tabs.find((t) => t.kind === "note")!;
+    expect(tabs[tabs.length - 1].id).toBe(newTab.id);
   });
 });

--- a/src/modules/notes/lib/noteDrag.test.ts
+++ b/src/modules/notes/lib/noteDrag.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { applyNoteDrop, resolveNoteDrop, useNoteDragStore } from "./noteDrag";
+import { applyNoteDrop, isOverTabBar, resolveNoteDrop, useNoteDragStore } from "./noteDrag";
 
 describe("resolveNoteDrop", () => {
   it("resolves a folder header to a folder target carrying its path", () => {
@@ -74,5 +74,15 @@ describe("applyNoteDrop", () => {
     const moveNote = vi.fn();
     applyNoteDrop(null, "/root/n.md", { moveNote });
     expect(moveNote).not.toHaveBeenCalled();
+  });
+});
+
+describe("tab-bar drop priority", () => {
+  it("isOverTabBar resolves true when the element is inside a data-tab-bar container", () => {
+    const outer = document.createElement("div");
+    outer.dataset.tabBar = "";
+    const inner = document.createElement("div");
+    outer.appendChild(inner);
+    expect(isOverTabBar(inner)).toBe(true);
   });
 });

--- a/src/modules/notes/lib/noteDrag.test.ts
+++ b/src/modules/notes/lib/noteDrag.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { applyNoteDrop, resolveNoteDrop } from "./noteDrag";
+import { applyNoteDrop, resolveNoteDrop, useNoteDragStore } from "./noteDrag";
 
 describe("resolveNoteDrop", () => {
   it("resolves a folder header to a folder target carrying its path", () => {
@@ -26,6 +26,34 @@ describe("resolveNoteDrop", () => {
   it("returns null when the cursor is outside any drop zone", () => {
     expect(resolveNoteDrop(document.createElement("div"))).toBeNull();
     expect(resolveNoteDrop(null)).toBeNull();
+  });
+});
+
+describe("resolveNoteDrop pane targeting", () => {
+  it("resolves a pane-leaf element to a pane target", () => {
+    const el = document.createElement("div");
+    el.dataset.paneLeaf = "leaf-1";
+    expect(resolveNoteDrop(el)).toEqual({ kind: "pane", leafId: "leaf-1" });
+  });
+
+  it("still prefers a folder over a pane when both markers are ancestors", () => {
+    const outer = document.createElement("div");
+    outer.dataset.paneLeaf = "leaf-1";
+    const inner = document.createElement("div");
+    inner.dataset.folderPath = "/notes/work";
+    outer.appendChild(inner);
+    expect(resolveNoteDrop(inner)).toEqual({ kind: "folder", path: "/notes/work" });
+  });
+
+  it("still returns null when nothing matches", () => {
+    expect(resolveNoteDrop(document.createElement("span"))).toBeNull();
+  });
+});
+
+describe("useNoteDragStore pane-drop fields", () => {
+  it("starts with paneHover and pendingPaneDrop both null", () => {
+    expect(useNoteDragStore.getState().paneHover).toBeNull();
+    expect(useNoteDragStore.getState().pendingPaneDrop).toBeNull();
   });
 });
 

--- a/src/modules/notes/lib/noteDrag.ts
+++ b/src/modules/notes/lib/noteDrag.ts
@@ -9,15 +9,17 @@ import type { PointerEvent as ReactPointerEvent } from "react";
 import { create } from "zustand";
 import { useNotesStore } from "@/stores/notesStore";
 
-/** Where a dragged note will land when released over the sidebar. */
+/** Where a dragged note will land when released: a sidebar folder/root (moves the note), or a pane (opens the note there). */
 export type NoteDropTarget =
   | { kind: "folder"; path: string }
-  | { kind: "root"; path: string };
+  | { kind: "root"; path: string }
+  | { kind: "pane"; leafId: string };
 
 /**
  * Resolve what the cursor is over (the element under the pointer) to a drop
- * target: a folder (`data-folder-path`) or the root container
- * (`data-notes-root` carrying the root path). A folder wins over the root.
+ * target: a folder (`data-folder-path`), the root container
+ * (`data-notes-root` carrying the root path), or a terminal pane
+ * (`data-pane-leaf`). A folder or root (sidebar) always wins over a pane.
  */
 export function resolveNoteDrop(el: Element | null): NoteDropTarget | null {
   const folder = el?.closest<HTMLElement>("[data-folder-path]");
@@ -27,6 +29,10 @@ export function resolveNoteDrop(el: Element | null): NoteDropTarget | null {
   const root = el?.closest<HTMLElement>("[data-notes-root]");
   if (root?.dataset.notesRoot) {
     return { kind: "root", path: root.dataset.notesRoot };
+  }
+  const pane = el?.closest<HTMLElement>("[data-pane-leaf]");
+  if (pane?.dataset.paneLeaf) {
+    return { kind: "pane", leafId: pane.dataset.paneLeaf };
   }
   return null;
 }
@@ -42,7 +48,7 @@ export function applyNoteDrop(
   notePath: string,
   actions: NoteDropActions,
 ): void {
-  if (!target) {
+  if (!target || target.kind === "pane") {
     return;
   }
   // Swallow a refused move (e.g. a name collision in the target folder); the
@@ -51,14 +57,22 @@ export function applyNoteDrop(
 }
 
 interface NoteDragState {
-  /** The drop target under the cursor, for the sidebar's hover indicator. */
+  /** The drop target under the cursor, for the sidebar's hover indicator (folder/root only). */
   hover: NoteDropTarget | null;
   setHover: (hover: NoteDropTarget | null) => void;
+  /** The pane under the cursor and the pointer's percentage position within it, when dragging over the pane area. Null whenever `hover` (folder/root) is set — they're mutually exclusive. */
+  paneHover: { leafId: string; xPct: number; yPct: number } | null;
+  /** A resolved pane drop waiting for its owning tab to consume it. */
+  pendingPaneDrop: { leafId: string; noteId: string; noteTitle: string; xPct: number; yPct: number } | null;
+  clearPendingPaneDrop: () => void;
 }
 
 export const useNoteDragStore = create<NoteDragState>((set) => ({
   hover: null,
   setHover: (hover) => set({ hover }),
+  paneHover: null,
+  pendingPaneDrop: null,
+  clearPendingPaneDrop: () => set({ pendingPaneDrop: null }),
 }));
 
 const DRAG_THRESHOLD = 5;
@@ -124,6 +138,26 @@ function targetAt(x: number, y: number): NoteDropTarget | null {
   return resolveNoteDrop(document.elementFromPoint(x, y));
 }
 
+// Duplicated from dragEntry.ts on purpose — noteDrag.ts and dragEntry.ts
+// already duplicate the ghost-label helpers rather than share them across
+// these sibling modules.
+function pointerToPaneAreaPct(
+  rect: { left: number; top: number; width: number; height: number },
+  clientX: number,
+  clientY: number,
+): { xPct: number; yPct: number } {
+  const xPct = rect.width > 0 ? ((clientX - rect.left) / rect.width) * 100 : 0;
+  const yPct = rect.height > 0 ? ((clientY - rect.top) / rect.height) * 100 : 0;
+  return { xPct: Math.min(100, Math.max(0, xPct)), yPct: Math.min(100, Math.max(0, yPct)) };
+}
+
+function paneAreaRectAt(x: number, y: number): DOMRect | null {
+  return (
+    document.elementFromPoint(x, y)?.closest<HTMLElement>("[data-pane-area]")?.getBoundingClientRect() ??
+    null
+  );
+}
+
 /**
  * Begin a pointer drag of a note. Tracks the cursor with pointer events, follows
  * it with a ghost label, highlights the drop target underneath, and on release
@@ -161,7 +195,18 @@ export function beginNoteDrag(
       showGhost(label, e.clientX, e.clientY);
     }
     moveGhost(e.clientX, e.clientY);
-    useNoteDragStore.getState().setHover(targetAt(e.clientX, e.clientY));
+    const target = targetAt(e.clientX, e.clientY);
+    if (target?.kind === "pane") {
+      const areaRect = paneAreaRectAt(e.clientX, e.clientY);
+      useNoteDragStore.setState({
+        hover: null,
+        paneHover: areaRect
+          ? { leafId: target.leafId, ...pointerToPaneAreaPct(areaRect, e.clientX, e.clientY) }
+          : null,
+      });
+    } else {
+      useNoteDragStore.setState({ hover: target, paneHover: null });
+    }
   };
 
   const onUp = (e: PointerEvent) => {
@@ -174,14 +219,25 @@ export function beginNoteDrag(
     setTimeout(() => {
       suppressClick = false;
     }, 0);
+    const target = targetAt(e.clientX, e.clientY);
+    if (target?.kind === "pane") {
+      const areaRect = paneAreaRectAt(e.clientX, e.clientY);
+      const pct = areaRect ? pointerToPaneAreaPct(areaRect, e.clientX, e.clientY) : { xPct: 0, yPct: 0 };
+      useNoteDragStore.setState({
+        hover: null,
+        paneHover: null,
+        pendingPaneDrop: { leafId: target.leafId, noteId: notePath, noteTitle: label, ...pct },
+      });
+      return;
+    }
     const { moveNote } = useNotesStore.getState();
-    applyNoteDrop(targetAt(e.clientX, e.clientY), notePath, { moveNote });
-    useNoteDragStore.setState({ hover: null });
+    applyNoteDrop(target, notePath, { moveNote });
+    useNoteDragStore.setState({ hover: null, paneHover: null });
   };
 
   const onCancel = () => {
     stop();
-    useNoteDragStore.setState({ hover: null });
+    useNoteDragStore.setState({ hover: null, paneHover: null });
   };
 
   window.addEventListener("pointermove", onMove);

--- a/src/modules/notes/lib/noteDrag.ts
+++ b/src/modules/notes/lib/noteDrag.ts
@@ -8,6 +8,7 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { create } from "zustand";
 import { useNotesStore } from "@/stores/notesStore";
+import { useTabsStore } from "@/stores/tabsStore";
 
 /** Where a dragged note will land when released: a sidebar folder/root (moves the note), or a pane (opens the note there). */
 export type NoteDropTarget =
@@ -158,6 +159,11 @@ function paneAreaRectAt(x: number, y: number): DOMRect | null {
   );
 }
 
+/** True when `el` (or an ancestor) is the tab bar — takes priority over any pane target. */
+export function isOverTabBar(el: Element | null): boolean {
+  return el?.closest("[data-tab-bar]") != null;
+}
+
 /**
  * Begin a pointer drag of a note. Tracks the cursor with pointer events, follows
  * it with a ghost label, highlights the drop target underneath, and on release
@@ -219,6 +225,11 @@ export function beginNoteDrag(
     setTimeout(() => {
       suppressClick = false;
     }, 0);
+    if (isOverTabBar(document.elementFromPoint(e.clientX, e.clientY))) {
+      useNoteDragStore.setState({ hover: null, paneHover: null });
+      useTabsStore.getState().openInNewTab({ kind: "note", noteId: notePath }, label);
+      return;
+    }
     const target = targetAt(e.clientX, e.clientY);
     if (target?.kind === "pane") {
       const areaRect = paneAreaRectAt(e.clientX, e.clientY);

--- a/src/modules/notes/lib/noteDrag.ts
+++ b/src/modules/notes/lib/noteDrag.ts
@@ -9,6 +9,7 @@ import type { PointerEvent as ReactPointerEvent } from "react";
 import { create } from "zustand";
 import { useNotesStore } from "@/stores/notesStore";
 import { useTabsStore } from "@/stores/tabsStore";
+import { nearestTabInsertion, tabRectsInTabBar } from "@/components/lib/tabBarDrop";
 
 /** Where a dragged note will land when released: a sidebar folder/root (moves the note), or a pane (opens the note there). */
 export type NoteDropTarget =
@@ -66,6 +67,8 @@ interface NoteDragState {
   /** A resolved pane drop waiting for its owning tab to consume it. */
   pendingPaneDrop: { leafId: string; noteId: string; noteTitle: string; xPct: number; yPct: number } | null;
   clearPendingPaneDrop: () => void;
+  /** Where a drop on the tab bar would insert a new tab, while dragging over it; null when not hovering the tab bar at all. */
+  tabBarHover: { insertBeforeId: string | null } | null;
 }
 
 export const useNoteDragStore = create<NoteDragState>((set) => ({
@@ -74,6 +77,7 @@ export const useNoteDragStore = create<NoteDragState>((set) => ({
   paneHover: null,
   pendingPaneDrop: null,
   clearPendingPaneDrop: () => set({ pendingPaneDrop: null }),
+  tabBarHover: null,
 }));
 
 const DRAG_THRESHOLD = 5;
@@ -201,6 +205,15 @@ export function beginNoteDrag(
       showGhost(label, e.clientX, e.clientY);
     }
     moveGhost(e.clientX, e.clientY);
+    if (isOverTabBar(document.elementFromPoint(e.clientX, e.clientY))) {
+      useNoteDragStore.setState({
+        hover: null,
+        paneHover: null,
+        tabBarHover: { insertBeforeId: nearestTabInsertion(tabRectsInTabBar(), e.clientX) },
+      });
+      return;
+    }
+    useNoteDragStore.setState({ tabBarHover: null });
     const target = targetAt(e.clientX, e.clientY);
     if (target?.kind === "pane") {
       const areaRect = paneAreaRectAt(e.clientX, e.clientY);
@@ -226,8 +239,15 @@ export function beginNoteDrag(
       suppressClick = false;
     }, 0);
     if (isOverTabBar(document.elementFromPoint(e.clientX, e.clientY))) {
-      useNoteDragStore.setState({ hover: null, paneHover: null });
-      useTabsStore.getState().openInNewTab({ kind: "note", noteId: notePath }, label);
+      const insertBeforeId = nearestTabInsertion(tabRectsInTabBar(), e.clientX);
+      useNoteDragStore.setState({ hover: null, paneHover: null, tabBarHover: null });
+      const result = useTabsStore.getState().openInNewTab({ kind: "note", noteId: notePath }, label);
+      if (result.status === "opened" && insertBeforeId !== null) {
+        const newTabId = useTabsStore.getState().activeId;
+        if (newTabId) {
+          useTabsStore.getState().reorderTab(newTabId, insertBeforeId);
+        }
+      }
       return;
     }
     const target = targetAt(e.clientX, e.clientY);
@@ -248,7 +268,7 @@ export function beginNoteDrag(
 
   const onCancel = () => {
     stop();
-    useNoteDragStore.setState({ hover: null, paneHover: null });
+    useNoteDragStore.setState({ hover: null, paneHover: null, tabBarHover: null });
   };
 
   window.addEventListener("pointermove", onMove);

--- a/src/modules/ssh/ConnectionsPanel.test.tsx
+++ b/src/modules/ssh/ConnectionsPanel.test.tsx
@@ -45,15 +45,27 @@ describe("ConnectionsPanel opening a connection", () => {
     });
   });
 
-  it("alerts and does not open a second connection when one is already open", () => {
-    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+  it("shows an InfoDialog and does not open a second connection when one is already open", () => {
     render(<ConnectionsPanel />);
 
     fireEvent.click(screen.getByText("prod-box"));
     fireEvent.click(screen.getByText("prod-box"));
 
     expect(useTabsStore.getState().tabs).toHaveLength(1);
-    expect(alertSpy).toHaveBeenCalledTimes(1);
-    expect(alertSpy).toHaveBeenCalledWith("connectionsPanel.alreadyOpenAlert:prod-box");
+    expect(
+      screen.getByText("connectionsPanel.alreadyOpenAlert:prod-box"),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the InfoDialog when its OK button is clicked", () => {
+    render(<ConnectionsPanel />);
+
+    fireEvent.click(screen.getByText("prod-box"));
+    fireEvent.click(screen.getByText("prod-box"));
+    fireEvent.click(screen.getByRole("button", { name: "actions.confirm" }));
+
+    expect(
+      screen.queryByText("connectionsPanel.alreadyOpenAlert:prod-box"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/modules/ssh/ConnectionsPanel.test.tsx
+++ b/src/modules/ssh/ConnectionsPanel.test.tsx
@@ -81,6 +81,32 @@ describe("ConnectionsPanel opening a connection", () => {
     expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
   });
 
+  it("opens the connection via right-click 'open in split pane' menu item", () => {
+    render(<ConnectionsPanel />);
+
+    fireEvent.contextMenu(screen.getByText("prod-box"));
+    fireEvent.click(screen.getByText("connectionsPanel.open"));
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    const pane = tabs[0].paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toMatchObject({
+      kind: "terminal",
+      ssh: { connectionId: "c1" },
+    });
+  });
+
+  it("shows 'already connected' dialog when right-clicking 'open in split pane' on an already-connected row", () => {
+    render(<ConnectionsPanel />);
+
+    fireEvent.click(screen.getByText("prod-box"));
+    fireEvent.contextMenu(screen.getByText("prod-box"));
+    fireEvent.click(screen.getByText("connectionsPanel.open"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    expect(screen.getByText("connectionsPanel.alreadyOpenAlert:prod-box")).toBeInTheDocument();
+  });
+
   it("always opens a new tab via right-click, even when the connection is already open", () => {
     useTabsStore.getState().openEditorTab("/a.ts");
     render(<ConnectionsPanel />);

--- a/src/modules/ssh/ConnectionsPanel.test.tsx
+++ b/src/modules/ssh/ConnectionsPanel.test.tsx
@@ -80,4 +80,25 @@ describe("ConnectionsPanel opening a connection", () => {
 
     expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
   });
+
+  it("always opens a new tab via right-click, even when the connection is already open", () => {
+    useTabsStore.getState().openEditorTab("/a.ts");
+    render(<ConnectionsPanel />);
+
+    fireEvent.contextMenu(screen.getByText("prod-box"));
+    fireEvent.click(screen.getByText("connectionsPanel.openInNewTab"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(2);
+  });
+
+  it("blocks a second connection via right-click when one is already open, showing the same InfoDialog", () => {
+    render(<ConnectionsPanel />);
+    fireEvent.click(screen.getByText("prod-box"));
+
+    fireEvent.contextMenu(screen.getByText("prod-box"));
+    fireEvent.click(screen.getByText("connectionsPanel.openInNewTab"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    expect(screen.getByText("connectionsPanel.alreadyOpenAlert:prod-box")).toBeInTheDocument();
+  });
 });

--- a/src/modules/ssh/ConnectionsPanel.test.tsx
+++ b/src/modules/ssh/ConnectionsPanel.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConnectionsPanel } from "./ConnectionsPanel";
+import { useTabsStore } from "@/stores/tabsStore";
+import { useConnectionsStore } from "@/stores/connectionsStore";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts?.name ? `${key}:${opts.name}` : key,
+  }),
+}));
+
+const CONNECTION = {
+  id: "c1",
+  name: "prod-box",
+  host: "prod.example.com",
+  port: 22,
+  user: "deploy",
+  authMethod: "password" as const,
+  rememberSecret: false,
+};
+
+describe("ConnectionsPanel opening a connection", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+    useConnectionsStore.setState({ connections: [CONNECTION] });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens the connection via openFromSidebar", () => {
+    render(<ConnectionsPanel />);
+
+    fireEvent.click(screen.getByText("prod-box"));
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    const pane = tabs[0].paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toMatchObject({
+      kind: "terminal",
+      ssh: { connectionId: "c1" },
+    });
+  });
+
+  it("alerts and does not open a second connection when one is already open", () => {
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    render(<ConnectionsPanel />);
+
+    fireEvent.click(screen.getByText("prod-box"));
+    fireEvent.click(screen.getByText("prod-box"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy).toHaveBeenCalledWith("connectionsPanel.alreadyOpenAlert:prod-box");
+  });
+});

--- a/src/modules/ssh/ConnectionsPanel.test.tsx
+++ b/src/modules/ssh/ConnectionsPanel.test.tsx
@@ -68,4 +68,16 @@ describe("ConnectionsPanel opening a connection", () => {
       screen.queryByText("connectionsPanel.alreadyOpenAlert:prod-box"),
     ).not.toBeInTheDocument();
   });
+
+  it("shows the capacity InfoDialog instead of opening a 9th pane", () => {
+    useTabsStore.getState().openEditorTab("/0.ts");
+    for (let i = 1; i < 8; i++) {
+      useTabsStore.getState().openFromSidebar({ kind: "editor", path: `/${i}.ts` });
+    }
+    render(<ConnectionsPanel />);
+
+    fireEvent.click(screen.getByText("prod-box"));
+
+    expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
+  });
 });

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
-import { Pencil, Plus, Server, Trash2 } from "lucide-react";
+import { Pencil, Plus, Server, SquarePlus, Trash2 } from "lucide-react";
 import { useConnectionsStore, type SshConnection, type PortForward } from "@/stores/connectionsStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { ConnectionForm } from "@/modules/ssh/ConnectionForm";
+import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import { InfoDialog } from "@/components/InfoDialog";
 import { useLiveSessionsStore } from "@/modules/ssh/lib/liveSessionsStore";
 import { useForwardStatusStore } from "@/modules/ssh/lib/forwardStatusStore";
@@ -132,8 +133,10 @@ interface ConnectionRowProps {
 function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   const { t } = useTranslation("common");
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
+  const openInNewTab = useTabsStore((s) => s.openInNewTab);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [dialog, setDialog] = useState<"none" | "already-connected" | "at-capacity">("none");
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
 
   // Subscribe to live sessions for this connection. Use a direct field lookup
   // with a stable EMPTY_SESSIONS fallback so the selector returns the same
@@ -177,8 +180,23 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
     onEdit(connection);
   }
 
+  function handleContextMenu(e: React.MouseEvent) {
+    e.preventDefault();
+    setMenu({ x: e.clientX, y: e.clientY });
+  }
+
+  function handleOpenInNewTab() {
+    const result = openInNewTab(
+      { kind: "terminal", ssh: { connectionId: connection.id } },
+      connection.name,
+    );
+    if (result.status === "already-connected") {
+      setDialog("already-connected");
+    }
+  }
+
   return (
-    <li>
+    <li onContextMenu={handleContextMenu}>
       <div className="group flex items-center">
         <button
           type="button"
@@ -249,6 +267,23 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
             />
           ))}
         </div>
+      )}
+
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          onClose={() => setMenu(null)}
+          items={[
+            {
+              id: "openInNewTab",
+              label: t("connectionsPanel.openInNewTab"),
+              icon: SquarePlus,
+              group: 0,
+              onSelect: handleOpenInNewTab,
+            } satisfies ContextMenuItem,
+          ]}
+        />
       )}
 
       {dialog === "already-connected" && (

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -130,7 +130,7 @@ interface ConnectionRowProps {
 
 function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   const { t } = useTranslation("common");
-  const openSshTab = useTabsStore((s) => s.openSshTab);
+  const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   // Subscribe to live sessions for this connection. Use a direct field lookup
@@ -143,7 +143,13 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   const showSessionLabels = sessionIds.length > 1;
 
   function handleRowClick() {
-    openSshTab(connection.id, connection.name);
+    const result = openFromSidebar(
+      { kind: "terminal", ssh: { connectionId: connection.id } },
+      connection.name,
+    );
+    if (result.status === "already-connected") {
+      window.alert(t("connectionsPanel.alreadyOpenAlert", { name: connection.name }));
+    }
   }
 
   function handleDeleteClick(e: React.MouseEvent) {

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -148,13 +148,16 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   const showForwards = hasLiveSessions && hasForwards;
   const showSessionLabels = sessionIds.length > 1;
 
-  const blockedConnectionId = useSshDragStore((s) => s.blockedConnectionId);
+  // A boolean selector, not the raw id, so only the row that actually
+  // matches re-renders when a drag is blocked or cleared — every other row
+  // would otherwise re-render on every change to this shared store field.
+  const isBlocked = useSshDragStore((s) => s.blockedConnectionId === connection.id);
   useEffect(() => {
-    if (blockedConnectionId === connection.id) {
+    if (isBlocked) {
       setDialog("already-connected");
       useSshDragStore.getState().clearBlockedConnectionId();
     }
-  }, [blockedConnectionId, connection.id]);
+  }, [isBlocked]);
 
   function handleRowClick() {
     if (consumeSshDragClick()) {

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -5,6 +5,7 @@ import { Pencil, Plus, Server, Trash2 } from "lucide-react";
 import { useConnectionsStore, type SshConnection, type PortForward } from "@/stores/connectionsStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { ConnectionForm } from "@/modules/ssh/ConnectionForm";
+import { InfoDialog } from "@/components/InfoDialog";
 import { useLiveSessionsStore } from "@/modules/ssh/lib/liveSessionsStore";
 import { useForwardStatusStore } from "@/modules/ssh/lib/forwardStatusStore";
 import { startForward, stopForward } from "@/modules/ssh/lib/ssh-bridge";
@@ -132,6 +133,7 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   const { t } = useTranslation("common");
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [alreadyOpenAlert, setAlreadyOpenAlert] = useState(false);
 
   // Subscribe to live sessions for this connection. Use a direct field lookup
   // with a stable EMPTY_SESSIONS fallback so the selector returns the same
@@ -148,7 +150,7 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
       connection.name,
     );
     if (result.status === "already-connected") {
-      window.alert(t("connectionsPanel.alreadyOpenAlert", { name: connection.name }));
+      setAlreadyOpenAlert(true);
     }
   }
 
@@ -245,6 +247,15 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
             />
           ))}
         </div>
+      )}
+
+      {alreadyOpenAlert && (
+        <InfoDialog
+          title={t("connectionsPanel.title")}
+          message={t("connectionsPanel.alreadyOpenAlert", { name: connection.name })}
+          confirmLabel={t("actions.confirm")}
+          onConfirm={() => setAlreadyOpenAlert(false)}
+        />
       )}
     </li>
   );

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { Columns2, Pencil, Plus, Server, SquarePlus, Trash2 } from "lucide-react";
@@ -10,7 +10,7 @@ import { InfoDialog } from "@/components/InfoDialog";
 import { useLiveSessionsStore } from "@/modules/ssh/lib/liveSessionsStore";
 import { useForwardStatusStore } from "@/modules/ssh/lib/forwardStatusStore";
 import { startForward, stopForward } from "@/modules/ssh/lib/ssh-bridge";
-import { beginSshDrag, consumeSshDragClick } from "@/modules/ssh/lib/sshDrag";
+import { beginSshDrag, consumeSshDragClick, useSshDragStore } from "@/modules/ssh/lib/sshDrag";
 
 // ─── Status dot ───────────────────────────────────────────────────────────────
 
@@ -147,6 +147,14 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   const hasForwards = (connection.portForwards?.length ?? 0) > 0;
   const showForwards = hasLiveSessions && hasForwards;
   const showSessionLabels = sessionIds.length > 1;
+
+  const blockedConnectionId = useSshDragStore((s) => s.blockedConnectionId);
+  useEffect(() => {
+    if (blockedConnectionId === connection.id) {
+      setDialog("already-connected");
+      useSshDragStore.getState().clearBlockedConnectionId();
+    }
+  }, [blockedConnectionId, connection.id]);
 
   function handleRowClick() {
     if (consumeSshDragClick()) {

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -133,7 +133,7 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   const { t } = useTranslation("common");
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
-  const [alreadyOpenAlert, setAlreadyOpenAlert] = useState(false);
+  const [dialog, setDialog] = useState<"none" | "already-connected" | "at-capacity">("none");
 
   // Subscribe to live sessions for this connection. Use a direct field lookup
   // with a stable EMPTY_SESSIONS fallback so the selector returns the same
@@ -150,7 +150,9 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
       connection.name,
     );
     if (result.status === "already-connected") {
-      setAlreadyOpenAlert(true);
+      setDialog("already-connected");
+    } else if (result.status === "at-capacity") {
+      setDialog("at-capacity");
     }
   }
 
@@ -249,12 +251,20 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
         </div>
       )}
 
-      {alreadyOpenAlert && (
+      {dialog === "already-connected" && (
         <InfoDialog
           title={t("connectionsPanel.title")}
           message={t("connectionsPanel.alreadyOpenAlert", { name: connection.name })}
           confirmLabel={t("actions.confirm")}
-          onConfirm={() => setAlreadyOpenAlert(false)}
+          onConfirm={() => setDialog("none")}
+        />
+      )}
+      {dialog === "at-capacity" && (
+        <InfoDialog
+          title={t("connectionsPanel.title")}
+          message={t("paneCapacityAlert")}
+          confirmLabel={t("actions.confirm")}
+          onConfirm={() => setDialog("none")}
         />
       )}
     </li>

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
-import { Pencil, Plus, Server, SquarePlus, Trash2 } from "lucide-react";
+import { Columns2, Pencil, Plus, Server, SquarePlus, Trash2 } from "lucide-react";
 import { useConnectionsStore, type SshConnection, type PortForward } from "@/stores/connectionsStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { ConnectionForm } from "@/modules/ssh/ConnectionForm";
@@ -275,6 +275,13 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
           y={menu.y}
           onClose={() => setMenu(null)}
           items={[
+            {
+              id: "open",
+              label: t("connectionsPanel.open"),
+              icon: Columns2,
+              group: 0,
+              onSelect: handleRowClick,
+            } satisfies ContextMenuItem,
             {
               id: "openInNewTab",
               label: t("connectionsPanel.openInNewTab"),

--- a/src/modules/ssh/ConnectionsPanel.tsx
+++ b/src/modules/ssh/ConnectionsPanel.tsx
@@ -10,6 +10,7 @@ import { InfoDialog } from "@/components/InfoDialog";
 import { useLiveSessionsStore } from "@/modules/ssh/lib/liveSessionsStore";
 import { useForwardStatusStore } from "@/modules/ssh/lib/forwardStatusStore";
 import { startForward, stopForward } from "@/modules/ssh/lib/ssh-bridge";
+import { beginSshDrag, consumeSshDragClick } from "@/modules/ssh/lib/sshDrag";
 
 // ─── Status dot ───────────────────────────────────────────────────────────────
 
@@ -148,6 +149,9 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   const showSessionLabels = sessionIds.length > 1;
 
   function handleRowClick() {
+    if (consumeSshDragClick()) {
+      return;
+    }
     const result = openFromSidebar(
       { kind: "terminal", ssh: { connectionId: connection.id } },
       connection.name,
@@ -196,7 +200,10 @@ function ConnectionRow({ connection, onEdit, onDelete }: ConnectionRowProps) {
   }
 
   return (
-    <li onContextMenu={handleContextMenu}>
+    <li
+      onContextMenu={handleContextMenu}
+      onPointerDown={(e) => beginSshDrag(connection.id, connection.name, e)}
+    >
       <div className="group flex items-center">
         <button
           type="button"

--- a/src/modules/ssh/lib/sshDrag.test.ts
+++ b/src/modules/ssh/lib/sshDrag.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { consumeSshDragClick, useSshDragStore } from "./sshDrag";
+
+describe("useSshDragStore", () => {
+  it("starts with paneHover and pendingPaneDrop both null", () => {
+    expect(useSshDragStore.getState().paneHover).toBeNull();
+    expect(useSshDragStore.getState().pendingPaneDrop).toBeNull();
+  });
+
+  it("clearPendingPaneDrop resets pendingPaneDrop to null", () => {
+    useSshDragStore.setState({
+      pendingPaneDrop: { leafId: "l1", connectionId: "c1", connectionName: "Prod", xPct: 50, yPct: 50 },
+    });
+    useSshDragStore.getState().clearPendingPaneDrop();
+    expect(useSshDragStore.getState().pendingPaneDrop).toBeNull();
+  });
+});
+
+describe("consumeSshDragClick", () => {
+  it("is false when no drag has just finished", () => {
+    expect(consumeSshDragClick()).toBe(false);
+  });
+});

--- a/src/modules/ssh/lib/sshDrag.test.ts
+++ b/src/modules/ssh/lib/sshDrag.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { consumeSshDragClick, useSshDragStore } from "./sshDrag";
+import { consumeSshDragClick, isOverTabBar, useSshDragStore } from "./sshDrag";
 
 describe("useSshDragStore", () => {
   it("starts with paneHover and pendingPaneDrop both null", () => {
@@ -19,5 +19,24 @@ describe("useSshDragStore", () => {
 describe("consumeSshDragClick", () => {
   it("is false when no drag has just finished", () => {
     expect(consumeSshDragClick()).toBe(false);
+  });
+});
+
+describe("tab-bar drop priority", () => {
+  it("isOverTabBar resolves true when the element is inside a data-tab-bar container", () => {
+    const outer = document.createElement("div");
+    outer.dataset.tabBar = "";
+    const inner = document.createElement("div");
+    outer.appendChild(inner);
+    expect(isOverTabBar(inner)).toBe(true);
+  });
+});
+
+describe("useSshDragStore blockedConnectionId", () => {
+  it("starts null and clearBlockedConnectionId resets it", () => {
+    expect(useSshDragStore.getState().blockedConnectionId).toBeNull();
+    useSshDragStore.setState({ blockedConnectionId: "conn-1" });
+    useSshDragStore.getState().clearBlockedConnectionId();
+    expect(useSshDragStore.getState().blockedConnectionId).toBeNull();
   });
 });

--- a/src/modules/ssh/lib/sshDrag.test.ts
+++ b/src/modules/ssh/lib/sshDrag.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { consumeSshDragClick, isOverTabBar, useSshDragStore } from "./sshDrag";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beginSshDrag, consumeSshDragClick, isOverTabBar, useSshDragStore } from "./sshDrag";
+import { useTabsStore } from "@/stores/tabsStore";
+import { leaf } from "@/modules/terminal/lib/terminalLayout";
+
+// jsdom has no PointerEvent constructor; a MouseEvent dispatched under the
+// pointermove/pointerup type names reaches the same window listeners since
+// beginSshDrag's handlers only read clientX/clientY off the event.
+function firePointer(type: "pointermove" | "pointerup", clientX: number, clientY: number): void {
+  window.dispatchEvent(new MouseEvent(type, { clientX, clientY }));
+}
 
 describe("useSshDragStore", () => {
   it("starts with paneHover and pendingPaneDrop both null", () => {
@@ -38,5 +47,105 @@ describe("useSshDragStore blockedConnectionId", () => {
     useSshDragStore.setState({ blockedConnectionId: "conn-1" });
     useSshDragStore.getState().clearBlockedConnectionId();
     expect(useSshDragStore.getState().blockedConnectionId).toBeNull();
+  });
+});
+
+describe("beginSshDrag tab-bar drop with insertion", () => {
+  beforeEach(() => {
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "One" }],
+      activeSpaceId: "s1",
+      tabs: [],
+      activeId: null,
+    });
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // @ts-expect-error jsdom has no native elementFromPoint; tests assign one directly.
+    delete document.elementFromPoint;
+    document.body.innerHTML = "";
+    useSshDragStore.setState({ paneHover: null, pendingPaneDrop: null, tabBarHover: null, blockedConnectionId: null });
+  });
+
+  function setUpTabBarDom(tabIdA: string, tabIdB: string): { bar: Element } {
+    document.body.innerHTML = `
+      <div data-tab-bar>
+        <div role="tab" data-tab-id="${tabIdA}"></div>
+        <div role="tab" data-tab-id="${tabIdB}"></div>
+      </div>
+    `;
+    const bar = document.querySelector("[data-tab-bar]")!;
+    const [elA, elB] = Array.from(document.querySelectorAll('[role="tab"]'));
+    vi.spyOn(elA, "getBoundingClientRect").mockReturnValue({ left: 0, width: 100 } as DOMRect);
+    vi.spyOn(elB, "getBoundingClientRect").mockReturnValue({ left: 100, width: 100 } as DOMRect);
+    vi.spyOn(bar, "getBoundingClientRect").mockReturnValue({} as DOMRect);
+    return { bar };
+  }
+
+  it("reorders the newly-opened tab to land before the tab it was dropped nearest to", () => {
+    const tabIdA = useTabsStore.getState().newTerminalTab();
+    const tabIdB = useTabsStore.getState().newTerminalTab();
+    const { bar } = setUpTabBarDom(tabIdA, tabIdB);
+    document.elementFromPoint = vi.fn().mockReturnValue(bar);
+
+    const startEvent = { clientX: 500, clientY: 10, button: 0 } as unknown as React.PointerEvent;
+    beginSshDrag("conn-1", "Prod", startEvent);
+
+    firePointer("pointermove", 10, 10);
+    firePointer("pointerup", 10, 10);
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(3);
+    const newTab = tabs.find((t) => t.kind === "terminal" && t.title === "Prod")!;
+    expect(newTab).toBeDefined();
+    const indexOfNew = tabs.findIndex((t) => t.id === newTab.id);
+    const indexOfA = tabs.findIndex((t) => t.id === tabIdA);
+    // The new tab lands immediately before tabIdA — it takes tabIdA's former
+    // slot and tabIdA shifts one place to the right.
+    expect(indexOfNew).toBe(indexOfA - 1);
+  });
+
+  it("leaves the new tab at the end (no reorder) when dropped past every tab's midpoint", () => {
+    const tabIdA = useTabsStore.getState().newTerminalTab();
+    const tabIdB = useTabsStore.getState().newTerminalTab();
+    const { bar } = setUpTabBarDom(tabIdA, tabIdB);
+    document.elementFromPoint = vi.fn().mockReturnValue(bar);
+
+    const startEvent = { clientX: 500, clientY: 10, button: 0 } as unknown as React.PointerEvent;
+    beginSshDrag("conn-1", "Prod", startEvent);
+
+    firePointer("pointermove", 280, 10);
+    firePointer("pointerup", 280, 10);
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(3);
+    const newTab = tabs.find((t) => t.kind === "terminal" && t.title === "Prod")!;
+    expect(tabs[tabs.length - 1].id).toBe(newTab.id);
+  });
+
+  it("does not reorder and sets blockedConnectionId when the connection is already open elsewhere in the space", () => {
+    const existingId = useTabsStore.getState().newTerminalTab();
+    useTabsStore.setState((state) => ({
+      tabs: state.tabs.map((t) =>
+        t.id === existingId
+          ? { ...t, paneTree: leaf(t.activeLeafId, { kind: "terminal", ssh: { connectionId: "conn-1" } }) }
+          : t,
+      ),
+    }));
+    const tabIdB = useTabsStore.getState().newTerminalTab();
+    const { bar } = setUpTabBarDom(existingId, tabIdB);
+    document.elementFromPoint = vi.fn().mockReturnValue(bar);
+
+    const startEvent = { clientX: 500, clientY: 10, button: 0 } as unknown as React.PointerEvent;
+    beginSshDrag("conn-1", "Prod", startEvent);
+
+    firePointer("pointermove", 10, 10);
+    firePointer("pointerup", 10, 10);
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(2);
+    expect(useSshDragStore.getState().blockedConnectionId).toBe("conn-1");
   });
 });

--- a/src/modules/ssh/lib/sshDrag.ts
+++ b/src/modules/ssh/lib/sshDrag.ts
@@ -8,6 +8,7 @@
  */
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { create } from "zustand";
+import { useTabsStore } from "@/stores/tabsStore";
 
 interface SshDragState {
   /** The pane under the cursor and the pointer's percentage position within it. */
@@ -17,12 +18,17 @@ interface SshDragState {
     | { leafId: string; connectionId: string; connectionName: string; xPct: number; yPct: number }
     | null;
   clearPendingPaneDrop: () => void;
+  /** Set when a tab-bar drop of this connection was blocked by the already-connected guard, for `ConnectionsPanel.tsx` to show its dialog. */
+  blockedConnectionId: string | null;
+  clearBlockedConnectionId: () => void;
 }
 
 export const useSshDragStore = create<SshDragState>((set) => ({
   paneHover: null,
   pendingPaneDrop: null,
   clearPendingPaneDrop: () => set({ pendingPaneDrop: null }),
+  blockedConnectionId: null,
+  clearBlockedConnectionId: () => set({ blockedConnectionId: null }),
 }));
 
 const DRAG_THRESHOLD = 5;
@@ -87,6 +93,11 @@ function paneAreaRectAt(x: number, y: number): DOMRect | null {
   );
 }
 
+/** True when `el` (or an ancestor) is the tab bar — takes priority over any pane target. */
+export function isOverTabBar(el: Element | null): boolean {
+  return el?.closest("[data-tab-bar]") != null;
+}
+
 /**
  * Begin a pointer drag of an SSH connection. Tracks the cursor with pointer
  * events, follows it with a ghost label, highlights the pane underneath, and
@@ -138,6 +149,16 @@ export function beginSshDrag(
     setTimeout(() => {
       suppressClick = false;
     }, 0);
+    if (isOverTabBar(document.elementFromPoint(e.clientX, e.clientY))) {
+      useSshDragStore.setState({ paneHover: null, pendingPaneDrop: null });
+      const result = useTabsStore
+        .getState()
+        .openInNewTab({ kind: "terminal", ssh: { connectionId } }, connectionName);
+      if (result.status === "already-connected") {
+        useSshDragStore.setState({ blockedConnectionId: connectionId });
+      }
+      return;
+    }
     const leafId = leafAt(e.clientX, e.clientY);
     const areaRect = paneAreaRectAt(e.clientX, e.clientY);
     const pct = areaRect ? pointerToPaneAreaPct(areaRect, e.clientX, e.clientY) : { xPct: 0, yPct: 0 };

--- a/src/modules/ssh/lib/sshDrag.ts
+++ b/src/modules/ssh/lib/sshDrag.ts
@@ -9,6 +9,7 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { create } from "zustand";
 import { useTabsStore } from "@/stores/tabsStore";
+import { nearestTabInsertion, tabRectsInTabBar } from "@/components/lib/tabBarDrop";
 
 interface SshDragState {
   /** The pane under the cursor and the pointer's percentage position within it. */
@@ -21,6 +22,8 @@ interface SshDragState {
   /** Set when a tab-bar drop of this connection was blocked by the already-connected guard, for `ConnectionsPanel.tsx` to show its dialog. */
   blockedConnectionId: string | null;
   clearBlockedConnectionId: () => void;
+  /** Where a drop on the tab bar would insert a new tab, while dragging over it; null when not hovering the tab bar at all. */
+  tabBarHover: { insertBeforeId: string | null } | null;
 }
 
 export const useSshDragStore = create<SshDragState>((set) => ({
@@ -29,6 +32,7 @@ export const useSshDragStore = create<SshDragState>((set) => ({
   clearPendingPaneDrop: () => set({ pendingPaneDrop: null }),
   blockedConnectionId: null,
   clearBlockedConnectionId: () => set({ blockedConnectionId: null }),
+  tabBarHover: null,
 }));
 
 const DRAG_THRESHOLD = 5;
@@ -133,6 +137,14 @@ export function beginSshDrag(
       showGhost(connectionName, e.clientX, e.clientY);
     }
     moveGhost(e.clientX, e.clientY);
+    if (isOverTabBar(document.elementFromPoint(e.clientX, e.clientY))) {
+      useSshDragStore.setState({
+        paneHover: null,
+        tabBarHover: { insertBeforeId: nearestTabInsertion(tabRectsInTabBar(), e.clientX) },
+      });
+      return;
+    }
+    useSshDragStore.setState({ tabBarHover: null });
     const leafId = leafAt(e.clientX, e.clientY);
     const areaRect = paneAreaRectAt(e.clientX, e.clientY);
     useSshDragStore.setState({
@@ -150,12 +162,20 @@ export function beginSshDrag(
       suppressClick = false;
     }, 0);
     if (isOverTabBar(document.elementFromPoint(e.clientX, e.clientY))) {
-      useSshDragStore.setState({ paneHover: null, pendingPaneDrop: null });
+      const insertBeforeId = nearestTabInsertion(tabRectsInTabBar(), e.clientX);
+      useSshDragStore.setState({ paneHover: null, pendingPaneDrop: null, tabBarHover: null });
       const result = useTabsStore
         .getState()
         .openInNewTab({ kind: "terminal", ssh: { connectionId } }, connectionName);
       if (result.status === "already-connected") {
         useSshDragStore.setState({ blockedConnectionId: connectionId });
+        return;
+      }
+      if (result.status === "opened" && insertBeforeId !== null) {
+        const newTabId = useTabsStore.getState().activeId;
+        if (newTabId) {
+          useTabsStore.getState().reorderTab(newTabId, insertBeforeId);
+        }
       }
       return;
     }
@@ -170,7 +190,7 @@ export function beginSshDrag(
 
   const onCancel = () => {
     stop();
-    useSshDragStore.setState({ paneHover: null });
+    useSshDragStore.setState({ paneHover: null, tabBarHover: null });
   };
 
   window.addEventListener("pointermove", onMove);

--- a/src/modules/ssh/lib/sshDrag.ts
+++ b/src/modules/ssh/lib/sshDrag.ts
@@ -1,0 +1,158 @@
+/**
+ * Pointer-based drag for an SSH connection row, onto a pane (or, from Phase
+ * 4's tab-bar addition, the tab bar). Same avoid-native-HTML5-drag reasoning
+ * as `dragEntry.ts`/`noteDrag.ts`: Tauri intercepts native drag events at the
+ * webview layer, so this tracks pointer events directly instead. Unlike
+ * files or notes, an SSH connection has no sidebar-internal drop target (no
+ * "move it to a folder") — it only ever targets a pane or the tab bar.
+ */
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { create } from "zustand";
+
+interface SshDragState {
+  /** The pane under the cursor and the pointer's percentage position within it. */
+  paneHover: { leafId: string; xPct: number; yPct: number } | null;
+  /** A resolved pane drop waiting for its owning tab to consume it. */
+  pendingPaneDrop:
+    | { leafId: string; connectionId: string; connectionName: string; xPct: number; yPct: number }
+    | null;
+  clearPendingPaneDrop: () => void;
+}
+
+export const useSshDragStore = create<SshDragState>((set) => ({
+  paneHover: null,
+  pendingPaneDrop: null,
+  clearPendingPaneDrop: () => set({ pendingPaneDrop: null }),
+}));
+
+const DRAG_THRESHOLD = 5;
+
+// A click fires right after a drag's pointerup; this lets the source row
+// swallow that one click so finishing a drag doesn't also open the connection.
+let suppressClick = false;
+export function consumeSshDragClick(): boolean {
+  if (!suppressClick) {
+    return false;
+  }
+  suppressClick = false;
+  return true;
+}
+
+let ghostEl: HTMLDivElement | null = null;
+
+function showGhost(label: string, x: number, y: number): void {
+  const el = document.createElement("div");
+  el.textContent = label;
+  el.style.cssText =
+    "position:fixed;left:0;top:0;z-index:9999;pointer-events:none;padding:2px 8px;" +
+    "border-radius:6px;font-size:12px;white-space:nowrap;" +
+    "background:var(--color-bg-elevated);color:var(--color-fg);" +
+    "border:1px solid var(--color-border-strong);box-shadow:0 4px 12px rgba(0,0,0,0.3);";
+  document.body.appendChild(el);
+  ghostEl = el;
+  moveGhost(x, y);
+}
+
+function moveGhost(x: number, y: number): void {
+  if (ghostEl) {
+    ghostEl.style.transform = `translate(${x + 12}px, ${y + 8}px)`;
+  }
+}
+
+function removeGhost(): void {
+  ghostEl?.remove();
+  ghostEl = null;
+}
+
+function leafAt(x: number, y: number): string | null {
+  return (
+    document.elementFromPoint(x, y)?.closest<HTMLElement>("[data-pane-leaf]")?.dataset.paneLeaf ?? null
+  );
+}
+
+function pointerToPaneAreaPct(
+  rect: { left: number; top: number; width: number; height: number },
+  clientX: number,
+  clientY: number,
+): { xPct: number; yPct: number } {
+  const xPct = rect.width > 0 ? ((clientX - rect.left) / rect.width) * 100 : 0;
+  const yPct = rect.height > 0 ? ((clientY - rect.top) / rect.height) * 100 : 0;
+  return { xPct: Math.min(100, Math.max(0, xPct)), yPct: Math.min(100, Math.max(0, yPct)) };
+}
+
+function paneAreaRectAt(x: number, y: number): DOMRect | null {
+  return (
+    document.elementFromPoint(x, y)?.closest<HTMLElement>("[data-pane-area]")?.getBoundingClientRect() ??
+    null
+  );
+}
+
+/**
+ * Begin a pointer drag of an SSH connection. Tracks the cursor with pointer
+ * events, follows it with a ghost label, highlights the pane underneath, and
+ * on release resolves the drop into the store for the owning pane to consume.
+ */
+export function beginSshDrag(
+  connectionId: string,
+  connectionName: string,
+  event: ReactPointerEvent,
+): void {
+  if (event.button !== 0) {
+    return;
+  }
+  const startX = event.clientX;
+  const startY = event.clientY;
+  let active = false;
+
+  const stop = () => {
+    window.removeEventListener("pointermove", onMove);
+    window.removeEventListener("pointerup", onUp);
+    window.removeEventListener("pointercancel", onCancel);
+    removeGhost();
+    document.body.style.userSelect = "";
+  };
+
+  const onMove = (e: PointerEvent) => {
+    if (!active) {
+      if (Math.hypot(e.clientX - startX, e.clientY - startY) < DRAG_THRESHOLD) {
+        return;
+      }
+      active = true;
+      document.body.style.userSelect = "none";
+      showGhost(connectionName, e.clientX, e.clientY);
+    }
+    moveGhost(e.clientX, e.clientY);
+    const leafId = leafAt(e.clientX, e.clientY);
+    const areaRect = paneAreaRectAt(e.clientX, e.clientY);
+    useSshDragStore.setState({
+      paneHover: leafId && areaRect ? { leafId, ...pointerToPaneAreaPct(areaRect, e.clientX, e.clientY) } : null,
+    });
+  };
+
+  const onUp = (e: PointerEvent) => {
+    stop();
+    if (!active) {
+      return;
+    }
+    suppressClick = true;
+    setTimeout(() => {
+      suppressClick = false;
+    }, 0);
+    const leafId = leafAt(e.clientX, e.clientY);
+    const areaRect = paneAreaRectAt(e.clientX, e.clientY);
+    const pct = areaRect ? pointerToPaneAreaPct(areaRect, e.clientX, e.clientY) : { xPct: 0, yPct: 0 };
+    useSshDragStore.setState({
+      paneHover: null,
+      pendingPaneDrop: leafId ? { leafId, connectionId, connectionName, ...pct } : null,
+    });
+  };
+
+  const onCancel = () => {
+    stop();
+    useSshDragStore.setState({ paneHover: null });
+  };
+
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp);
+  window.addEventListener("pointercancel", onCancel);
+}

--- a/src/modules/terminal/PaneTabContent.test.tsx
+++ b/src/modules/terminal/PaneTabContent.test.tsx
@@ -5,10 +5,14 @@ import { PaneTabContent } from "./PaneTabContent";
 import { useTabsStore } from "@/stores/tabsStore";
 import { useEntryDragStore } from "@/modules/explorer/lib/dragEntry";
 import { useNoteDragStore } from "@/modules/notes/lib/noteDrag";
+import { useSshDragStore } from "@/modules/ssh/lib/sshDrag";
 import { leaf, splitLeaf } from "./lib/terminalLayout";
 
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts?.name ? `${key}:${opts.name}` : key,
+  }),
 }));
 
 // TerminalView (rendered by every pane here) calls getCurrentWebview() on mount
@@ -214,5 +218,75 @@ describe("PaneTabContent note-drop dispatch", () => {
       const second = updated.paneTree.children[1];
       expect(second.kind === "leaf" && second.pane).toEqual({ kind: "note", noteId: "/notes/todo.md" });
     }
+  });
+});
+
+describe("PaneTabContent SSH-drop dispatch", () => {
+  beforeEach(() => {
+    useSshDragStore.setState({ paneHover: null, pendingPaneDrop: null });
+  });
+
+  it("center drop replaces the pane with the SSH terminal when not already connected", () => {
+    const { tabId, leafId } = makeSinglePaneTab();
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    render(<PaneTabContent tab={tab} />);
+
+    act(() => {
+      useSshDragStore.setState({
+        pendingPaneDrop: { leafId, connectionId: "conn-1", connectionName: "Prod", xPct: 50, yPct: 50 },
+      });
+    });
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree).toEqual({
+      kind: "leaf",
+      id: leafId,
+      pane: { kind: "terminal", ssh: { connectionId: "conn-1" } },
+    });
+  });
+
+  it("blocks the drop and shows the already-connected InfoDialog when the connection is open elsewhere", () => {
+    const { tabId, leafId } = makeSinglePaneTab();
+    useTabsStore.getState().splitPaneWith(
+      tabId,
+      leafId,
+      { kind: "terminal", ssh: { connectionId: "conn-1" } },
+      "row",
+    );
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    const untouchedTree = tab.paneTree;
+    render(<PaneTabContent tab={tab} />);
+
+    act(() => {
+      useSshDragStore.setState({
+        pendingPaneDrop: { leafId, connectionId: "conn-1", connectionName: "Prod", xPct: 50, yPct: 50 },
+      });
+    });
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree).toEqual(untouchedTree);
+    expect(screen.getByText("connectionsPanel.alreadyOpenAlert:Prod")).toBeInTheDocument();
+  });
+
+  it("blocks an edge-split too, not just center, when already connected", () => {
+    const { tabId, leafId } = makeSinglePaneTab();
+    useTabsStore.getState().splitPaneWith(
+      tabId,
+      leafId,
+      { kind: "terminal", ssh: { connectionId: "conn-1" } },
+      "row",
+    );
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    const untouchedTree = tab.paneTree;
+    render(<PaneTabContent tab={tab} />);
+
+    act(() => {
+      useSshDragStore.setState({
+        pendingPaneDrop: { leafId, connectionId: "conn-1", connectionName: "Prod", xPct: 5, yPct: 50 },
+      });
+    });
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree).toEqual(untouchedTree);
   });
 });

--- a/src/modules/terminal/PaneTabContent.test.tsx
+++ b/src/modules/terminal/PaneTabContent.test.tsx
@@ -1,0 +1,171 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { PaneTabContent } from "./PaneTabContent";
+import { useTabsStore } from "@/stores/tabsStore";
+import { useEntryDragStore } from "@/modules/explorer/lib/dragEntry";
+import { leaf, splitLeaf } from "./lib/terminalLayout";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// TerminalView (rendered by every pane here) calls getCurrentWebview() on mount
+// to listen for native OS file drags — no Tauri runtime exists in jsdom.
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: () => Promise.resolve(() => {}),
+  }),
+}));
+
+function makeSinglePaneTab() {
+  const tabId = useTabsStore.getState().newTerminalTab();
+  const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+  return { tabId, leafId: tab.activeLeafId };
+}
+
+describe("PaneTabContent file-drop dispatch", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+    useEntryDragStore.setState({
+      entry: null,
+      dragging: false,
+      hoverLeafId: null,
+      hoverPointerPct: null,
+      pendingDrop: null,
+    });
+  });
+
+  it("center drop on an editor pane replaces its content (existing per-kind behavior, unchanged)", () => {
+    const { tabId, leafId } = makeSinglePaneTab();
+    useTabsStore.getState().setPaneContent(tabId, leafId, { kind: "editor", path: "/old.ts" });
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    render(<PaneTabContent tab={tab} />);
+
+    act(() => {
+      useEntryDragStore.setState({
+        pendingDrop: {
+          leafId,
+          entry: { path: "/new.ts", name: "new.ts", isDir: false },
+          xPct: 50,
+          yPct: 50,
+        },
+      });
+    });
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree).toEqual({ kind: "leaf", id: leafId, pane: { kind: "editor", path: "/new.ts" } });
+  });
+
+  it("left-edge drop on a single-pane tab splits row with the new editor pane before the existing one", () => {
+    const { tabId, leafId } = makeSinglePaneTab();
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    render(<PaneTabContent tab={tab} />);
+
+    act(() => {
+      useEntryDragStore.setState({
+        pendingDrop: {
+          leafId,
+          entry: { path: "/new.ts", name: "new.ts", isDir: false },
+          xPct: 5,
+          yPct: 50,
+        },
+      });
+    });
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree.kind).toBe("split");
+    if (updated.paneTree.kind === "split") {
+      expect(updated.paneTree.direction).toBe("row");
+      const [first, second] = updated.paneTree.children;
+      expect(first.kind === "leaf" && first.pane).toEqual({ kind: "editor", path: "/new.ts" });
+      expect(second.kind === "leaf" && second.id).toBe(leafId);
+    }
+  });
+
+  it("outer-left drop on a 2-pane row tab wraps the whole tree instead of splitting one pane", () => {
+    const { tabId, leafId } = makeSinglePaneTab();
+    useTabsStore.getState().splitPaneWith(tabId, leafId, { kind: "editor", path: "/b.ts" }, "row");
+    const tabBeforeDrop = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    const existingTree = tabBeforeDrop.paneTree;
+    render(<PaneTabContent tab={tabBeforeDrop} />);
+
+    act(() => {
+      useEntryDragStore.setState({
+        pendingDrop: {
+          leafId,
+          entry: { path: "/new.ts", name: "new.ts", isDir: false },
+          xPct: 2,
+          yPct: 50,
+        },
+      });
+    });
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree.kind).toBe("split");
+    if (updated.paneTree.kind === "split") {
+      expect(updated.paneTree.direction).toBe("row");
+      const [first, second] = updated.paneTree.children;
+      expect(first.kind === "leaf" && first.pane).toEqual({ kind: "editor", path: "/new.ts" });
+      expect(second).toEqual(existingTree);
+    }
+  });
+
+  it("dropping a folder at an edge falls back to center (folder exception)", () => {
+    const { tabId, leafId } = makeSinglePaneTab();
+    useTabsStore.getState().setPaneContent(tabId, leafId, { kind: "terminal" });
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    render(<PaneTabContent tab={tab} />);
+
+    act(() => {
+      useEntryDragStore.setState({
+        pendingDrop: {
+          leafId,
+          entry: { path: "/somedir", name: "somedir", isDir: true },
+          xPct: 5,
+          yPct: 50,
+        },
+      });
+    });
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    // Still one leaf — no split happened — and the terminal pane's existing
+    // center behavior (drop path text) ran instead.
+    expect(updated.paneTree.kind).toBe("leaf");
+  });
+
+  it("shows the at-capacity InfoDialog and does not split when the tab already has 8 panes", () => {
+    const { tabId, leafId } = makeSinglePaneTab();
+    let tree = leaf(leafId);
+    let lastId = leafId;
+    for (let i = 0; i < 7; i++) {
+      const nextId = `p${i}`;
+      tree = splitLeaf(tree, lastId, "row", nextId);
+      lastId = nextId;
+    }
+    useTabsStore.setState((state) => ({
+      tabs: state.tabs.map((t) =>
+        t.id === tabId
+          ? { ...t, paneTree: tree, paneOrder: [leafId, "p0", "p1", "p2", "p3", "p4", "p5", "p6"] }
+          : t,
+      ),
+    }));
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    render(<PaneTabContent tab={tab} />);
+
+    act(() => {
+      useEntryDragStore.setState({
+        pendingDrop: {
+          leafId,
+          entry: { path: "/new.ts", name: "new.ts", isDir: false },
+          xPct: 5,
+          yPct: 50,
+        },
+      });
+    });
+
+    expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneOrder).toHaveLength(8);
+  });
+});

--- a/src/modules/terminal/PaneTabContent.test.tsx
+++ b/src/modules/terminal/PaneTabContent.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react";
 import { PaneTabContent } from "./PaneTabContent";
 import { useTabsStore } from "@/stores/tabsStore";
 import { useEntryDragStore } from "@/modules/explorer/lib/dragEntry";
+import { useNoteDragStore } from "@/modules/notes/lib/noteDrag";
 import { leaf, splitLeaf } from "./lib/terminalLayout";
 
 vi.mock("react-i18next", () => ({
@@ -167,5 +168,51 @@ describe("PaneTabContent file-drop dispatch", () => {
     expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
     const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
     expect(updated.paneOrder).toHaveLength(8);
+  });
+});
+
+describe("PaneTabContent note-drop dispatch", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+    useNoteDragStore.setState({ hover: null, paneHover: null, pendingPaneDrop: null });
+  });
+
+  it("center drop always replaces the pane with the note (no per-target-kind branching)", () => {
+    const { tabId, leafId } = makeSinglePaneTab();
+    useTabsStore.getState().setPaneContent(tabId, leafId, { kind: "editor", path: "/old.ts" });
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    render(<PaneTabContent tab={tab} />);
+
+    act(() => {
+      useNoteDragStore.setState({
+        pendingPaneDrop: { leafId, noteId: "/notes/todo.md", noteTitle: "Todo", xPct: 50, yPct: 50 },
+      });
+    });
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree).toEqual({
+      kind: "leaf",
+      id: leafId,
+      pane: { kind: "note", noteId: "/notes/todo.md" },
+    });
+  });
+
+  it("right-edge drop splits row with the note pane after the existing one", () => {
+    const { tabId, leafId } = makeSinglePaneTab();
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    render(<PaneTabContent tab={tab} />);
+
+    act(() => {
+      useNoteDragStore.setState({
+        pendingPaneDrop: { leafId, noteId: "/notes/todo.md", noteTitle: "Todo", xPct: 95, yPct: 50 },
+      });
+    });
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree.kind).toBe("split");
+    if (updated.paneTree.kind === "split") {
+      const second = updated.paneTree.children[1];
+      expect(second.kind === "leaf" && second.pane).toEqual({ kind: "note", noteId: "/notes/todo.md" });
+    }
   });
 });

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -40,6 +40,7 @@ import {
   type DraggedEntry,
 } from "@/modules/explorer/lib/dragEntry";
 import { insertLinkIntoNote } from "@/modules/notes/lib/noteBus";
+import { useNoteDragStore } from "@/modules/notes/lib/noteDrag";
 import { deleteTerminalHistory } from "./lib/terminalHistory";
 import { useTabsStore, type Tab } from "@/stores/tabsStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -87,6 +88,8 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   const hoverLeaf = useEntryDragStore((s) => s.hoverLeafId);
   const hoverPointerPct = useEntryDragStore((s) => s.hoverPointerPct);
   const pendingDrop = useEntryDragStore((s) => s.pendingDrop);
+  const pendingNotePaneDrop = useNoteDragStore((s) => s.pendingPaneDrop);
+  const notePaneHover = useNoteDragStore((s) => s.paneHover);
   // New terminal panes (incl. splits) start in the explorer's current dir, not
   // the tab's original cwd — so a split follows where you've navigated to.
   const rootPath = useWorkspaceStore((s) => s.rootPath);
@@ -104,7 +107,17 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
           pointerYPct: hoverPointerPct.yPct,
           isFolder: draggedEntry?.isDir ?? false,
         })
-      : null;
+      : notePaneHover
+        ? resolveDropZone({
+            paneRect: panes.find((p) => p.id === notePaneHover.leafId)?.rect ?? { left: 0, top: 0, width: 100, height: 100 },
+            rootDirection,
+            pointerXPct: notePaneHover.xPct,
+            pointerYPct: notePaneHover.yPct,
+            isFolder: false,
+          })
+        : null;
+  const activeHoverLeaf = hoverLeaf ?? notePaneHover?.leafId ?? null;
+  const anyDragging = dragging || notePaneHover !== null;
 
   // When this tab's active pane is an SSH terminal, point the file explorer at
   // that host's remote files. A local (or non-active) pane yields null, so the
@@ -218,6 +231,43 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
     }
     useEntryDragStore.getState().clearPendingDrop();
   }, [pendingDrop, rootDirection, tab.id, tab.paneOrder.length]);
+
+  // Parallel to the file-drop effect above, but for notes dragged out of the
+  // Notes sidebar: there's no per-target-kind center behavior for notes, so
+  // center always just replaces the pane's content with the note.
+  useEffect(() => {
+    if (!pendingNotePaneDrop) {
+      return;
+    }
+    const pane = panesRef.current.find((p) => p.id === pendingNotePaneDrop.leafId);
+    if (!pane) {
+      return;
+    }
+    const zone = resolveDropZone({
+      paneRect: pane.rect,
+      rootDirection,
+      pointerXPct: pendingNotePaneDrop.xPct,
+      pointerYPct: pendingNotePaneDrop.yPct,
+      isFolder: false,
+    });
+    const newContent: PaneContent = { kind: "note", noteId: pendingNotePaneDrop.noteId };
+    if (zone.kind === "center") {
+      setPaneContent(tab.id, pendingNotePaneDrop.leafId, newContent);
+      useNoteDragStore.getState().clearPendingPaneDrop();
+      return;
+    }
+    if (tab.paneOrder.length >= 8) {
+      setAtCapacity(true);
+      useNoteDragStore.getState().clearPendingPaneDrop();
+      return;
+    }
+    if (zone.scope === "individual") {
+      splitPaneWith(tab.id, pendingNotePaneDrop.leafId, newContent, zone.direction, zone.anchor);
+    } else {
+      wrapPaneWith(tab.id, newContent, zone.direction, zone.anchor);
+    }
+    useNoteDragStore.getState().clearPendingPaneDrop();
+  }, [pendingNotePaneDrop, rootDirection, tab.id, tab.paneOrder.length]);
 
   function startDrag(e: ReactMouseEvent, splitter: SplitterInfo) {
     e.preventDefault();
@@ -367,14 +417,14 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                   explorer entry. The drop itself is handled by the document-level
                   drag/dragend listeners above, since WKWebView swallows the
                   webview's own HTML5 drop events when dragDropEnabled is on. */}
-              {dragging && pane.id === hoverLeaf && (hoverZone === null || hoverZone.kind !== "split" || hoverZone.scope !== "outer") && (
+              {anyDragging && pane.id === activeHoverLeaf && (hoverZone === null || hoverZone.kind !== "split" || hoverZone.scope !== "outer") && (
                 <div className={dropOverlayClassName(hoverZone, dropOk)} />
               )}
             </div>
           );
         })}
 
-        {dragging && hoverZone?.kind === "split" && hoverZone.scope === "outer" && (
+        {anyDragging && hoverZone?.kind === "split" && hoverZone.scope === "outer" && (
           <div className={outerBandOverlayClassName(hoverZone.direction, hoverZone.anchor)} />
         )}
 

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -6,7 +6,9 @@ import { dropPathsIntoTerminal, writeToTerminal } from "./lib/terminalBus";
 import {
   computeLayout,
   computeSplitters,
+  resolveDropZone,
   resolveTerminalCwd,
+  type DropZone,
   type PaneContent,
   type SplitterInfo,
 } from "./lib/terminalLayout";
@@ -29,7 +31,8 @@ const GitGraphTabContent = lazy(() =>
   })),
 );
 import { LauncherPanel } from "@/components/LauncherPanel";
-import { dropOverlayClassName } from "@/components/EntryDropOverlay";
+import { dropOverlayClassName, outerBandOverlayClassName } from "@/components/EntryDropOverlay";
+import { InfoDialog } from "@/components/InfoDialog";
 import {
   fileUrl,
   shellQuotePath,
@@ -57,6 +60,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   const setActiveLeaf = useTabsStore((s) => s.setActiveLeaf);
   const resizePane = useTabsStore((s) => s.resizePane);
   const splitPaneWith = useTabsStore((s) => s.splitPaneWith);
+  const wrapPaneWith = useTabsStore((s) => s.wrapPaneWith);
   const setPaneContent = useTabsStore((s) => s.setPaneContent);
   const navigatePreview = useTabsStore((s) => s.navigatePreview);
   const setTerminalCwd = useTabsStore((s) => s.setTerminalCwd);
@@ -72,11 +76,16 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   // group-hover) because the hairline lives in a child element and group-hover
   // doesn't reach it reliably in the app's WebView.
   const [hoveredSplitterId, setHoveredSplitterId] = useState<string | null>(null);
+  // Whether a file drop attempted a split while the tab was already at its
+  // 8-pane cap, so the at-capacity dialog shows instead.
+  const [atCapacity, setAtCapacity] = useState(false);
+  const rootDirection = tab.paneTree.kind === "split" ? tab.paneTree.direction : null;
   // Pointer-drag state lives in the explorer drag store (see dragEntry.ts): the
   // entry being dragged, which pane it's over, and a resolved drop to consume.
   const dragging = useEntryDragStore((s) => s.dragging);
   const draggedEntry = useEntryDragStore((s) => s.entry);
   const hoverLeaf = useEntryDragStore((s) => s.hoverLeafId);
+  const hoverPointerPct = useEntryDragStore((s) => s.hoverPointerPct);
   const pendingDrop = useEntryDragStore((s) => s.pendingDrop);
   // New terminal panes (incl. splits) start in the explorer's current dir, not
   // the tab's original cwd — so a split follows where you've navigated to.
@@ -85,6 +94,17 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   const panes = computeLayout(tab.paneTree);
   const splitters = computeSplitters(tab.paneTree);
   const multiple = panes.length > 1;
+
+  const hoverZone: DropZone | null =
+    hoverLeaf && hoverPointerPct
+      ? resolveDropZone({
+          paneRect: panes.find((p) => p.id === hoverLeaf)?.rect ?? { left: 0, top: 0, width: 100, height: 100 },
+          rootDirection,
+          pointerXPct: hoverPointerPct.xPct,
+          pointerYPct: hoverPointerPct.yPct,
+          isFolder: draggedEntry?.isDir ?? false,
+        })
+      : null;
 
   // When this tab's active pane is an SSH terminal, point the file explorer at
   // that host's remote files. A local (or non-active) pane yields null, so the
@@ -153,6 +173,9 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
 
   // A pointer drag resolves its drop target into the store; the tab that owns
   // that pane runs the drop and clears it. Other tabs ignore it (pane not found).
+  // The drop position decides center (per-kind replace, unchanged) vs. an
+  // edge/outer zone (split the pane, or wrap the whole tree, with a new
+  // editor pane) — see terminalLayout.ts's resolveDropZone.
   useEffect(() => {
     if (!pendingDrop) {
       return;
@@ -161,11 +184,40 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
     if (!pane) {
       return;
     }
-    if (canDropRef.current(pane.content, pendingDrop.entry)) {
-      handleDropRef.current(pane.content, pendingDrop.leafId, pendingDrop.entry);
+    const zone = resolveDropZone({
+      paneRect: pane.rect,
+      rootDirection,
+      pointerXPct: pendingDrop.xPct,
+      pointerYPct: pendingDrop.yPct,
+      isFolder: pendingDrop.entry.isDir,
+    });
+    if (zone.kind === "center") {
+      if (canDropRef.current(pane.content, pendingDrop.entry)) {
+        handleDropRef.current(pane.content, pendingDrop.leafId, pendingDrop.entry);
+      }
+      useEntryDragStore.getState().clearPendingDrop();
+      return;
+    }
+    if (pendingDrop.entry.isDir) {
+      // Folder exception: edge/outer zones never apply to folders, so this
+      // should already be unreachable (resolveDropZone always returns center
+      // for isFolder), but guard defensively rather than split on a folder.
+      useEntryDragStore.getState().clearPendingDrop();
+      return;
+    }
+    if (tab.paneOrder.length >= 8) {
+      setAtCapacity(true);
+      useEntryDragStore.getState().clearPendingDrop();
+      return;
+    }
+    const newContent: PaneContent = { kind: "editor", path: pendingDrop.entry.path };
+    if (zone.scope === "individual") {
+      splitPaneWith(tab.id, pendingDrop.leafId, newContent, zone.direction, zone.anchor);
+    } else {
+      wrapPaneWith(tab.id, newContent, zone.direction, zone.anchor);
     }
     useEntryDragStore.getState().clearPendingDrop();
-  }, [pendingDrop]);
+  }, [pendingDrop, rootDirection, tab.id, tab.paneOrder.length]);
 
   function startDrag(e: ReactMouseEvent, splitter: SplitterInfo) {
     e.preventDefault();
@@ -206,7 +258,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
 
   return (
     <div className="flex h-full flex-col bg-bg-inset">
-      <div ref={paneAreaRef} className="relative min-h-0 flex-1">
+      <div ref={paneAreaRef} data-pane-area className="relative min-h-0 flex-1">
         {panes.map((pane) => {
           const active = pane.id === tab.activeLeafId;
           const dropOk = draggedEntry ? canDrop(pane.content, draggedEntry) : false;
@@ -315,12 +367,16 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                   explorer entry. The drop itself is handled by the document-level
                   drag/dragend listeners above, since WKWebView swallows the
                   webview's own HTML5 drop events when dragDropEnabled is on. */}
-              {dragging && pane.id === hoverLeaf && (
-                <div className={dropOverlayClassName(dropOk)} />
+              {dragging && pane.id === hoverLeaf && (hoverZone === null || hoverZone.kind !== "split" || hoverZone.scope !== "outer") && (
+                <div className={dropOverlayClassName(hoverZone, dropOk)} />
               )}
             </div>
           );
         })}
+
+        {dragging && hoverZone?.kind === "split" && hoverZone.scope === "outer" && (
+          <div className={outerBandOverlayClassName(hoverZone.direction, hoverZone.anchor)} />
+        )}
 
         {/* Draggable dividers, one per split, sitting on the pane borders */}
         {splitters.map((splitter) => {
@@ -394,6 +450,15 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
           />
         )}
       </div>
+
+      {atCapacity && (
+        <InfoDialog
+          title={t("workspace.splitRight")}
+          message={t("paneCapacityAlert")}
+          confirmLabel={t("actions.confirm")}
+          onConfirm={() => setAtCapacity(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -41,8 +41,9 @@ import {
 } from "@/modules/explorer/lib/dragEntry";
 import { insertLinkIntoNote } from "@/modules/notes/lib/noteBus";
 import { useNoteDragStore } from "@/modules/notes/lib/noteDrag";
+import { useSshDragStore } from "@/modules/ssh/lib/sshDrag";
 import { deleteTerminalHistory } from "./lib/terminalHistory";
-import { useTabsStore, type Tab } from "@/stores/tabsStore";
+import { sshAlreadyOpen, useTabsStore, type Tab } from "@/stores/tabsStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useUiStore, selectAnyOverlayOpen } from "@/stores/uiStore";
 import { shouldShowPreview } from "@/modules/preview/lib/previewWebview";
@@ -90,6 +91,14 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   const pendingDrop = useEntryDragStore((s) => s.pendingDrop);
   const pendingNotePaneDrop = useNoteDragStore((s) => s.pendingPaneDrop);
   const notePaneHover = useNoteDragStore((s) => s.paneHover);
+  const pendingSshPaneDrop = useSshDragStore((s) => s.pendingPaneDrop);
+  const sshPaneHover = useSshDragStore((s) => s.paneHover);
+  // Whether a dragged-in SSH connection is already open elsewhere in this
+  // space, so the drop gets blocked and this dialog explains why. The
+  // connection's name is cached alongside the flag because pendingSshPaneDrop
+  // is cleared (and its name with it) as soon as the drop is resolved.
+  const [sshAlreadyConnected, setSshAlreadyConnected] = useState(false);
+  const [sshAlreadyConnectedName, setSshAlreadyConnectedName] = useState("");
   // New terminal panes (incl. splits) start in the explorer's current dir, not
   // the tab's original cwd — so a split follows where you've navigated to.
   const rootPath = useWorkspaceStore((s) => s.rootPath);
@@ -115,9 +124,17 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
             pointerYPct: notePaneHover.yPct,
             isFolder: false,
           })
-        : null;
-  const activeHoverLeaf = hoverLeaf ?? notePaneHover?.leafId ?? null;
-  const anyDragging = dragging || notePaneHover !== null;
+        : sshPaneHover
+          ? resolveDropZone({
+              paneRect: panes.find((p) => p.id === sshPaneHover.leafId)?.rect ?? { left: 0, top: 0, width: 100, height: 100 },
+              rootDirection,
+              pointerXPct: sshPaneHover.xPct,
+              pointerYPct: sshPaneHover.yPct,
+              isFolder: false,
+            })
+          : null;
+  const activeHoverLeaf = hoverLeaf ?? notePaneHover?.leafId ?? sshPaneHover?.leafId ?? null;
+  const anyDragging = dragging || notePaneHover !== null || sshPaneHover !== null;
 
   // When this tab's active pane is an SSH terminal, point the file explorer at
   // that host's remote files. A local (or non-active) pane yields null, so the
@@ -268,6 +285,54 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
     }
     useNoteDragStore.getState().clearPendingPaneDrop();
   }, [pendingNotePaneDrop, rootDirection, tab.id, tab.paneOrder.length]);
+
+  // Parallel to the file/note-drop effects above, but for SSH connections
+  // dragged out of the Connections sidebar. Unlike files and notes, a
+  // duplicate connection is blocked outright (opening the same connection
+  // twice would race for the same forwarded ports) — checked before any zone
+  // resolution, so a blocked drop never touches the pane tree at all.
+  useEffect(() => {
+    if (!pendingSshPaneDrop) {
+      return;
+    }
+    const pane = panesRef.current.find((p) => p.id === pendingSshPaneDrop.leafId);
+    if (!pane) {
+      return;
+    }
+    if (sshAlreadyOpen(useTabsStore.getState().tabs, tab.spaceId, pendingSshPaneDrop.connectionId)) {
+      setSshAlreadyConnected(true);
+      setSshAlreadyConnectedName(pendingSshPaneDrop.connectionName);
+      useSshDragStore.getState().clearPendingPaneDrop();
+      return;
+    }
+    const zone = resolveDropZone({
+      paneRect: pane.rect,
+      rootDirection,
+      pointerXPct: pendingSshPaneDrop.xPct,
+      pointerYPct: pendingSshPaneDrop.yPct,
+      isFolder: false,
+    });
+    const newContent: PaneContent = {
+      kind: "terminal",
+      ssh: { connectionId: pendingSshPaneDrop.connectionId },
+    };
+    if (zone.kind === "center") {
+      setPaneContent(tab.id, pendingSshPaneDrop.leafId, newContent);
+      useSshDragStore.getState().clearPendingPaneDrop();
+      return;
+    }
+    if (tab.paneOrder.length >= 8) {
+      setAtCapacity(true);
+      useSshDragStore.getState().clearPendingPaneDrop();
+      return;
+    }
+    if (zone.scope === "individual") {
+      splitPaneWith(tab.id, pendingSshPaneDrop.leafId, newContent, zone.direction, zone.anchor);
+    } else {
+      wrapPaneWith(tab.id, newContent, zone.direction, zone.anchor);
+    }
+    useSshDragStore.getState().clearPendingPaneDrop();
+  }, [pendingSshPaneDrop, rootDirection, tab.id, tab.spaceId, tab.paneOrder.length]);
 
   function startDrag(e: ReactMouseEvent, splitter: SplitterInfo) {
     e.preventDefault();
@@ -507,6 +572,15 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
           message={t("paneCapacityAlert")}
           confirmLabel={t("actions.confirm")}
           onConfirm={() => setAtCapacity(false)}
+        />
+      )}
+
+      {sshAlreadyConnected && (
+        <InfoDialog
+          title={t("connectionsPanel.title")}
+          message={t("connectionsPanel.alreadyOpenAlert", { name: sshAlreadyConnectedName })}
+          confirmLabel={t("actions.confirm")}
+          onConfirm={() => setSshAlreadyConnected(false)}
         />
       )}
     </div>

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -1307,7 +1307,7 @@ export function TerminalView({
         });
       }}
     >
-      {externalFileDragging && <div className={dropOverlayClassName(true)} />}
+      {externalFileDragging && <div className={dropOverlayClassName(null, true)} />}
       {contextMenu && (
         <ContextMenu
           x={contextMenu.x}

--- a/src/modules/terminal/lib/terminalLayout.test.ts
+++ b/src/modules/terminal/lib/terminalLayout.test.ts
@@ -4,6 +4,7 @@ import {
   computeSplitters,
   findPaneContent,
   firstLeafId,
+  gridLayout,
   leaf,
   leafIds,
   paneIdAt,
@@ -13,6 +14,7 @@ import {
   splitId,
   splitLeaf,
   type LayoutNode,
+  type OrderedPane,
 } from "./terminalLayout";
 
 describe("resolveTerminalCwd", () => {
@@ -176,5 +178,80 @@ describe("git-graph pane content", () => {
     const tree = splitLeaf(leaf("a"), "a", "row", "b", { kind: "git-graph" });
     const panes = computeLayout(tree);
     expect(panes.some((p) => p.content.kind === "git-graph")).toBe(true);
+  });
+});
+
+describe("gridLayout", () => {
+  function pane(id: string, path: string): OrderedPane {
+    return { id, content: { kind: "editor", path } };
+  }
+
+  it("places a single pane as the whole tree", () => {
+    const tree = gridLayout([pane("a", "/a.ts")]);
+    expect(tree).toEqual(leaf("a", { kind: "editor", path: "/a.ts" }));
+  });
+
+  it("splits two panes into two equal-width columns, left to right in add-order", () => {
+    const tree = gridLayout([pane("a", "/a.ts"), pane("b", "/b.ts")]);
+    const panes = computeLayout(tree);
+    const sorted = panes.slice().sort((x, y) => x.rect.left - y.rect.left);
+    expect(sorted.map((p) => p.id)).toEqual(["a", "b"]);
+    expect(sorted[0].rect.width).toBeCloseTo(50, 5);
+    expect(sorted[1].rect.width).toBeCloseTo(50, 5);
+  });
+
+  it("splits four panes into four equal-width columns", () => {
+    const tree = gridLayout(["a", "b", "c", "d"].map((id) => pane(id, `/${id}.ts`)));
+    const panes = computeLayout(tree);
+    const sorted = panes.slice().sort((x, y) => x.rect.left - y.rect.left);
+    expect(sorted.map((p) => p.id)).toEqual(["a", "b", "c", "d"]);
+    for (const p of sorted) {
+      expect(p.rect.width).toBeCloseTo(25, 5);
+    }
+  });
+
+  it("stacks the 5th pane under the 1st column, leaving columns 2-4 single", () => {
+    const tree = gridLayout(["a", "b", "c", "d", "e"].map((id) => pane(id, `/${id}.ts`)));
+    const panes = computeLayout(tree);
+    const columns = new Map<number, typeof panes>();
+    for (const p of panes) {
+      const col = Math.round(p.rect.left);
+      columns.set(col, [...(columns.get(col) ?? []), p]);
+    }
+    // 4 distinct column positions (0, 25, 50, 75), each 25 wide.
+    expect([...columns.keys()].sort((x, y) => x - y)).toEqual([0, 25, 50, 75]);
+    const firstColumn = columns.get(0)!;
+    expect(firstColumn).toHaveLength(2);
+    const sortedFirstColumn = firstColumn.slice().sort((x, y) => x.rect.top - y.rect.top);
+    expect(sortedFirstColumn.map((p) => p.id)).toEqual(["a", "e"]);
+    expect(sortedFirstColumn[0].rect.height).toBeCloseTo(50, 5);
+    expect(sortedFirstColumn[1].rect.height).toBeCloseTo(50, 5);
+    // Columns 2-4 remain single panes at full height.
+    expect(columns.get(25)).toHaveLength(1);
+    expect(columns.get(50)).toHaveLength(1);
+    expect(columns.get(75)).toHaveLength(1);
+  });
+
+  it("stacks the 6th, 7th, and 8th panes under columns 2, 3, and 4 respectively", () => {
+    const ids = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    const tree = gridLayout(ids.map((id) => pane(id, `/${id}.ts`)));
+    const panes = computeLayout(tree);
+    expect(panes).toHaveLength(8);
+    const byId = new Map(panes.map((p) => [p.id, p]));
+    // Each of the 4 columns has exactly 2 panes sharing the same left edge.
+    const pairs: [string, string][] = [
+      ["a", "e"],
+      ["b", "f"],
+      ["c", "g"],
+      ["d", "h"],
+    ];
+    for (const [topId, bottomId] of pairs) {
+      const top = byId.get(topId)!;
+      const bottom = byId.get(bottomId)!;
+      expect(top.rect.left).toBeCloseTo(bottom.rect.left, 5);
+      expect(top.rect.top).toBeLessThan(bottom.rect.top);
+      expect(top.rect.height).toBeCloseTo(50, 5);
+      expect(bottom.rect.height).toBeCloseTo(50, 5);
+    }
   });
 });

--- a/src/modules/terminal/lib/terminalLayout.test.ts
+++ b/src/modules/terminal/lib/terminalLayout.test.ts
@@ -9,10 +9,12 @@ import {
   leafIds,
   paneIdAt,
   removeLeaf,
+  resolveDropZone,
   resolveTerminalCwd,
   setSizesById,
   splitId,
   splitLeaf,
+  type DropZoneInput,
   type LayoutNode,
   type OrderedPane,
 } from "./terminalLayout";
@@ -253,5 +255,228 @@ describe("gridLayout", () => {
       expect(top.rect.height).toBeCloseTo(50, 5);
       expect(bottom.rect.height).toBeCloseTo(50, 5);
     }
+  });
+});
+
+describe("resolveDropZone", () => {
+  const singlePaneRect = { left: 0, top: 0, width: 100, height: 100 };
+
+  it("single pane: center when the pointer is far from any edge", () => {
+    const input: DropZoneInput = {
+      paneRect: singlePaneRect,
+      rootDirection: null,
+      pointerXPct: 50,
+      pointerYPct: 50,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({ kind: "center" });
+  });
+
+  it("single pane: left edge splits row with the new pane before the existing one", () => {
+    const input: DropZoneInput = {
+      paneRect: singlePaneRect,
+      rootDirection: null,
+      pointerXPct: 10,
+      pointerYPct: 50,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({
+      kind: "split",
+      scope: "individual",
+      direction: "row",
+      anchor: "before",
+    });
+  });
+
+  it("single pane: right edge splits row with the new pane after the existing one", () => {
+    const input: DropZoneInput = {
+      paneRect: singlePaneRect,
+      rootDirection: null,
+      pointerXPct: 90,
+      pointerYPct: 50,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({
+      kind: "split",
+      scope: "individual",
+      direction: "row",
+      anchor: "after",
+    });
+  });
+
+  it("single pane: never returns a top/bottom zone, even near the top edge", () => {
+    const input: DropZoneInput = {
+      paneRect: singlePaneRect,
+      rootDirection: null,
+      pointerXPct: 50,
+      pointerYPct: 2,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({ kind: "center" });
+  });
+
+  it("single pane: a dragged folder always resolves to center, even at an edge", () => {
+    const input: DropZoneInput = {
+      paneRect: singlePaneRect,
+      rootDirection: null,
+      pointerXPct: 5,
+      pointerYPct: 50,
+      isFolder: true,
+    };
+    expect(resolveDropZone(input)).toEqual({ kind: "center" });
+  });
+
+  it("row-oriented multi-pane: top edge of the hovered pane splits col, new pane before", () => {
+    const input: DropZoneInput = {
+      paneRect: { left: 0, top: 0, width: 50, height: 100 },
+      rootDirection: "row",
+      pointerXPct: 25,
+      pointerYPct: 5,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({
+      kind: "split",
+      scope: "individual",
+      direction: "col",
+      anchor: "before",
+    });
+  });
+
+  it("row-oriented multi-pane: bottom edge of a stacked (half-height) pane splits col, new pane after", () => {
+    const input: DropZoneInput = {
+      paneRect: { left: 0, top: 50, width: 50, height: 50 },
+      rootDirection: "row",
+      pointerXPct: 25,
+      pointerYPct: 97,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({
+      kind: "split",
+      scope: "individual",
+      direction: "col",
+      anchor: "after",
+    });
+  });
+
+  it("row-oriented multi-pane: near the container's absolute left edge is outer-before, not individual", () => {
+    const input: DropZoneInput = {
+      paneRect: { left: 0, top: 0, width: 50, height: 100 },
+      rootDirection: "row",
+      pointerXPct: 3,
+      pointerYPct: 50,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({
+      kind: "split",
+      scope: "outer",
+      direction: "row",
+      anchor: "before",
+    });
+  });
+
+  it("row-oriented multi-pane: near the container's absolute right edge is outer-after", () => {
+    const input: DropZoneInput = {
+      paneRect: { left: 50, top: 0, width: 50, height: 100 },
+      rootDirection: "row",
+      pointerXPct: 97,
+      pointerYPct: 50,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({
+      kind: "split",
+      scope: "outer",
+      direction: "row",
+      anchor: "after",
+    });
+  });
+
+  it("row-oriented multi-pane: an internal boundary between two panes (not the absolute edge) is center", () => {
+    const input: DropZoneInput = {
+      paneRect: { left: 0, top: 0, width: 50, height: 100 },
+      rootDirection: "row",
+      pointerXPct: 49,
+      pointerYPct: 50,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({ kind: "center" });
+  });
+
+  it("row-oriented multi-pane: a folder near an edge still falls back to center", () => {
+    const input: DropZoneInput = {
+      paneRect: { left: 0, top: 0, width: 50, height: 100 },
+      rootDirection: "row",
+      pointerXPct: 25,
+      pointerYPct: 3,
+      isFolder: true,
+    };
+    expect(resolveDropZone(input)).toEqual({ kind: "center" });
+  });
+
+  it("row-oriented multi-pane, top-left corner: outer-left wins when it is the closer edge", () => {
+    // pane spans the full height here (not stacked), so its own top edge sits
+    // at y=0, exactly tied with the container's top — but there is no
+    // outer-top zone in row orientation, so only outer-left (x=1) and
+    // individual-top (y=1) compete; outer-left is closer in this case only
+    // because INDIVIDUAL_EDGE zones use a smaller absolute band near a
+    // half-height pane — use a full-height pane and a point closer on the x axis.
+    const input: DropZoneInput = {
+      paneRect: { left: 0, top: 0, width: 50, height: 100 },
+      rootDirection: "row",
+      pointerXPct: 2,
+      pointerYPct: 8,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({
+      kind: "split",
+      scope: "outer",
+      direction: "row",
+      anchor: "before",
+    });
+  });
+
+  it("row-oriented multi-pane, top-left corner: individual-top wins when it is the closer edge", () => {
+    const input: DropZoneInput = {
+      paneRect: { left: 0, top: 0, width: 50, height: 100 },
+      rootDirection: "row",
+      pointerXPct: 8,
+      pointerYPct: 2,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({
+      kind: "split",
+      scope: "individual",
+      direction: "col",
+      anchor: "before",
+    });
+  });
+
+  it("col-oriented multi-pane: rules rotate 90 degrees — left/right become individual, top/bottom become outer", () => {
+    const leftEdgeOfTopRow: DropZoneInput = {
+      paneRect: { left: 0, top: 0, width: 100, height: 50 },
+      rootDirection: "col",
+      pointerXPct: 5,
+      pointerYPct: 25,
+      isFolder: false,
+    };
+    expect(resolveDropZone(leftEdgeOfTopRow)).toEqual({
+      kind: "split",
+      scope: "individual",
+      direction: "row",
+      anchor: "before",
+    });
+
+    const outerTop: DropZoneInput = {
+      paneRect: { left: 0, top: 0, width: 100, height: 50 },
+      rootDirection: "col",
+      pointerXPct: 50,
+      pointerYPct: 3,
+      isFolder: false,
+    };
+    expect(resolveDropZone(outerTop)).toEqual({
+      kind: "split",
+      scope: "outer",
+      direction: "col",
+      anchor: "before",
+    });
   });
 });

--- a/src/modules/terminal/lib/terminalLayout.test.ts
+++ b/src/modules/terminal/lib/terminalLayout.test.ts
@@ -193,6 +193,10 @@ describe("gridLayout", () => {
     expect(tree).toEqual(leaf("a", { kind: "editor", path: "/a.ts" }));
   });
 
+  it("throws instead of recursing forever when called with no panes at all", () => {
+    expect(() => gridLayout([])).toThrow();
+  });
+
   it("splits two panes into two equal-width columns, left to right in add-order", () => {
     const tree = gridLayout([pane("a", "/a.ts"), pane("b", "/b.ts")]);
     const panes = computeLayout(tree);
@@ -356,6 +360,20 @@ describe("resolveDropZone", () => {
       direction: "col",
       anchor: "after",
     });
+  });
+
+  it("row-oriented multi-pane: the exact center of a stacked (half-height) pane resolves to center, not a split", () => {
+    // A stacked pane's own span (50) is only twice INDIVIDUAL_EDGE_PCT (25),
+    // so an edge threshold measured as an absolute container percentage would
+    // cover the pane's entire height and make its center unreachable.
+    const input: DropZoneInput = {
+      paneRect: { left: 0, top: 50, width: 50, height: 50 },
+      rootDirection: "row",
+      pointerXPct: 25,
+      pointerYPct: 75,
+      isFolder: false,
+    };
+    expect(resolveDropZone(input)).toEqual({ kind: "center" });
   });
 
   it("row-oriented multi-pane: near the container's absolute left edge is outer-before, not individual", () => {

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -73,24 +73,49 @@ export function splitLeaf(
   direction: SplitDirection,
   newId: string,
   newPane: PaneContent = TERMINAL_PANE,
+  anchor: "before" | "after" = "after",
 ): LayoutNode {
   if (node.kind === "leaf") {
     if (node.id !== targetId) {
       return node;
     }
+    const existing = leaf(targetId, paneOf(node));
+    const added = leaf(newId, newPane);
     return {
       kind: "split",
       direction,
-      children: [leaf(targetId, paneOf(node)), leaf(newId, newPane)],
+      children: anchor === "before" ? [added, existing] : [existing, added],
       sizes: [0.5, 0.5],
     };
   }
   return {
     ...node,
     children: [
-      splitLeaf(node.children[0], targetId, direction, newId, newPane),
-      splitLeaf(node.children[1], targetId, direction, newId, newPane),
+      splitLeaf(node.children[0], targetId, direction, newId, newPane, anchor),
+      splitLeaf(node.children[1], targetId, direction, newId, newPane, anchor),
     ],
+  };
+}
+
+/**
+ * Wrap the whole tree as one side of a brand-new top-level split, with the
+ * new pane on the other side. Used for the outer-edge drop zone, which adds
+ * an entirely new column/row alongside everything else rather than carving
+ * up any single existing pane.
+ */
+export function wrapTree(
+  tree: LayoutNode,
+  newId: string,
+  newPane: PaneContent,
+  direction: SplitDirection,
+  anchor: "before" | "after",
+): LayoutNode {
+  const added = leaf(newId, newPane);
+  return {
+    kind: "split",
+    direction,
+    children: anchor === "before" ? [added, tree] : [tree, added],
+    sizes: [0.5, 0.5],
   };
 }
 
@@ -204,6 +229,130 @@ export interface PaneRect {
   id: string;
   rect: Rect;
   content: PaneContent;
+}
+
+/**
+ * Where a drop lands relative to the pane it's over. `center` keeps the
+ * pane's own drop behavior (unchanged from before Phase 4). `split` always
+ * needs a fresh leaf id from the caller: `scope: "individual"` splits just
+ * the hovered pane (only it moves); `scope: "outer"` wraps the *whole* tree
+ * as one side of a brand-new top-level split, so every existing pane shifts
+ * over together instead of any single pane being carved up.
+ */
+export type DropZone =
+  | { kind: "center" }
+  | {
+      kind: "split";
+      scope: "individual" | "outer";
+      direction: SplitDirection;
+      anchor: "before" | "after";
+    };
+
+export interface DropZoneInput {
+  /** The percentage rect (from `computeLayout`) of the pane under the pointer. */
+  paneRect: Rect;
+  /** The tab's root split direction, or null when the tab is a single leaf. */
+  rootDirection: SplitDirection | null;
+  /** Pointer position in the same 0-100 percentage space as `paneRect`. */
+  pointerXPct: number;
+  pointerYPct: number;
+  /** True when the dragged source is a folder — disables every edge/outer zone. */
+  isFolder: boolean;
+}
+
+/** Single-pane tabs: how close to the left/right edge (as % of the pane, which fills the container) counts as a split zone. */
+const SINGLE_PANE_EDGE_PCT = 33;
+/** Multi-pane tabs: how close to a pane's own perpendicular edge counts as an individual split zone. */
+const INDIVIDUAL_EDGE_PCT = 25;
+/** Multi-pane tabs: how close to the whole container's along-axis edge counts as the outer insert zone. */
+const OUTER_BAND_PCT = 12;
+
+interface DropZoneCandidate {
+  /** Percentage-point distance to the edge line — comparable across zones because both paneRect and the container share the same 0-100 space. */
+  distancePct: number;
+  zone: DropZone;
+}
+
+function nearestZone(candidates: DropZoneCandidate[]): DropZone {
+  if (candidates.length === 0) {
+    return { kind: "center" };
+  }
+  return candidates.reduce((best, c) => (c.distancePct < best.distancePct ? c : best)).zone;
+}
+
+/**
+ * Resolve a drop position into a zone. See spec section C for the full rule
+ * table; this implements it directly: single-pane tabs only ever offer
+ * left/right (never top/bottom); multi-pane tabs layer an individual
+ * per-pane edge (perpendicular to the root direction) under a whole-area
+ * outer band (along the root direction), rotating 90 degrees when the root
+ * is `"col"`. A corner where two zones would both qualify resolves to
+ * whichever edge line the pointer is numerically closer to.
+ */
+export function resolveDropZone(input: DropZoneInput): DropZone {
+  const { paneRect, rootDirection, pointerXPct, pointerYPct, isFolder } = input;
+  if (isFolder) {
+    return { kind: "center" };
+  }
+
+  if (rootDirection === null) {
+    const leftDist = pointerXPct - paneRect.left;
+    const rightDist = paneRect.left + paneRect.width - pointerXPct;
+    const candidates: DropZoneCandidate[] = [];
+    if (leftDist <= SINGLE_PANE_EDGE_PCT) {
+      candidates.push({
+        distancePct: leftDist,
+        zone: { kind: "split", scope: "individual", direction: "row", anchor: "before" },
+      });
+    }
+    if (rightDist <= SINGLE_PANE_EDGE_PCT) {
+      candidates.push({
+        distancePct: rightDist,
+        zone: { kind: "split", scope: "individual", direction: "row", anchor: "after" },
+      });
+    }
+    return nearestZone(candidates);
+  }
+
+  const rowOriented = rootDirection === "row";
+  const candidates: DropZoneCandidate[] = [];
+
+  const outerPointerPct = rowOriented ? pointerXPct : pointerYPct;
+  const outerBeforeDist = outerPointerPct;
+  const outerAfterDist = 100 - outerPointerPct;
+  if (outerBeforeDist <= OUTER_BAND_PCT) {
+    candidates.push({
+      distancePct: outerBeforeDist,
+      zone: { kind: "split", scope: "outer", direction: rootDirection, anchor: "before" },
+    });
+  }
+  if (outerAfterDist <= OUTER_BAND_PCT) {
+    candidates.push({
+      distancePct: outerAfterDist,
+      zone: { kind: "split", scope: "outer", direction: rootDirection, anchor: "after" },
+    });
+  }
+
+  const individualDirection: SplitDirection = rowOriented ? "col" : "row";
+  const paneStart = rowOriented ? paneRect.top : paneRect.left;
+  const paneSpan = rowOriented ? paneRect.height : paneRect.width;
+  const pointerOnAxis = rowOriented ? pointerYPct : pointerXPct;
+  const individualBeforeDist = pointerOnAxis - paneStart;
+  const individualAfterDist = paneStart + paneSpan - pointerOnAxis;
+  if (individualBeforeDist <= INDIVIDUAL_EDGE_PCT) {
+    candidates.push({
+      distancePct: individualBeforeDist,
+      zone: { kind: "split", scope: "individual", direction: individualDirection, anchor: "before" },
+    });
+  }
+  if (individualAfterDist <= INDIVIDUAL_EDGE_PCT) {
+    candidates.push({
+      distancePct: individualAfterDist,
+      zone: { kind: "split", scope: "individual", direction: individualDirection, anchor: "after" },
+    });
+  }
+
+  return nearestZone(candidates);
 }
 
 const FULL: Rect = { left: 0, top: 0, width: 100, height: 100 };

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -339,13 +339,17 @@ export function resolveDropZone(input: DropZoneInput): DropZone {
   const pointerOnAxis = rowOriented ? pointerYPct : pointerXPct;
   const individualBeforeDist = pointerOnAxis - paneStart;
   const individualAfterDist = paneStart + paneSpan - pointerOnAxis;
-  if (individualBeforeDist <= INDIVIDUAL_EDGE_PCT) {
+  // Relative to this pane's own span, not the whole container — a stacked
+  // pane's span can be as little as 50, and an absolute threshold that large
+  // would swallow its entire center, making it impossible to ever drop there.
+  const individualThreshold = paneSpan * (INDIVIDUAL_EDGE_PCT / 100);
+  if (individualBeforeDist <= individualThreshold) {
     candidates.push({
       distancePct: individualBeforeDist,
       zone: { kind: "split", scope: "individual", direction: individualDirection, anchor: "before" },
     });
   }
-  if (individualAfterDist <= INDIVIDUAL_EDGE_PCT) {
+  if (individualAfterDist <= individualThreshold) {
     candidates.push({
       distancePct: individualAfterDist,
       zone: { kind: "split", scope: "individual", direction: individualDirection, anchor: "after" },
@@ -493,6 +497,9 @@ export function gridLayout(panes: OrderedPane[]): LayoutNode {
 /** Nest `nodes` left to right as equal-width row splits ([1/n, (n-1)/n] at
  * each level, so `computeLayout` gives every node the same width). */
 function combineEqualRow(nodes: LayoutNode[]): LayoutNode {
+  if (nodes.length === 0) {
+    throw new Error("combineEqualRow requires at least one node");
+  }
   if (nodes.length === 1) {
     return nodes[0];
   }

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -305,3 +305,53 @@ export function computeSplitters(node: LayoutNode, rect: Rect = FULL): SplitterI
     }),
   ];
 }
+
+/** One pane in add-order, paired with its content, for `gridLayout`. */
+export interface OrderedPane {
+  id: string;
+  content: PaneContent;
+}
+
+/**
+ * Arrange 1-8 panes into a fixed grid: up to 4 equal-width columns, each
+ * holding up to 2 equal-height stacked panes. `panes[0..3]` each get their
+ * own column; `panes[4..7]` stack under columns 0-3 respectively. The caller
+ * must cap input at 8 entries — this function does not validate or throw
+ * on more.
+ */
+export function gridLayout(panes: OrderedPane[]): LayoutNode {
+  const columnCount = Math.min(panes.length, 4);
+  const columns: LayoutNode[] = [];
+  for (let col = 0; col < columnCount; col++) {
+    const bottomIndex = col + 4;
+    if (bottomIndex < panes.length) {
+      columns.push({
+        kind: "split",
+        direction: "col",
+        children: [
+          leaf(panes[col].id, panes[col].content),
+          leaf(panes[bottomIndex].id, panes[bottomIndex].content),
+        ],
+        sizes: [0.5, 0.5],
+      });
+    } else {
+      columns.push(leaf(panes[col].id, panes[col].content));
+    }
+  }
+  return combineEqualRow(columns);
+}
+
+/** Nest `nodes` left to right as equal-width row splits ([1/n, (n-1)/n] at
+ * each level, so `computeLayout` gives every node the same width). */
+function combineEqualRow(nodes: LayoutNode[]): LayoutNode {
+  if (nodes.length === 1) {
+    return nodes[0];
+  }
+  const [first, ...rest] = nodes;
+  return {
+    kind: "split",
+    direction: "row",
+    children: [first, combineEqualRow(rest)],
+    sizes: [1 / nodes.length, (nodes.length - 1) / nodes.length],
+  };
+}

--- a/src/modules/workspace/WorkspacePanel.test.tsx
+++ b/src/modules/workspace/WorkspacePanel.test.tsx
@@ -34,6 +34,7 @@ beforeEach(() => {
         kind: "terminal",
         paneTree: leaf("p1", { kind: "terminal", cwd: "/a" }),
         activeLeafId: "p1",
+        paneOrder: ["p1"],
       },
       {
         id: "t2",
@@ -42,6 +43,7 @@ beforeEach(() => {
         kind: "terminal",
         paneTree: leaf("p2", { kind: "terminal", cwd: "/b" }),
         activeLeafId: "p2",
+        paneOrder: ["p2"],
       },
     ],
   });
@@ -172,6 +174,7 @@ describe("WorkspacePanel", () => {
             ],
           },
           activeLeafId: "p1",
+          paneOrder: ["p1", "p2"],
         },
       ],
     });
@@ -260,6 +263,7 @@ describe("WorkspacePanel", () => {
           kind: "terminal",
           paneTree: leaf("p1", { kind: "terminal", cwd: "/a" }),
           activeLeafId: "p1",
+          paneOrder: ["p1"],
         },
       ],
     });
@@ -321,6 +325,7 @@ describe("WorkspacePanel", () => {
           kind: "editor",
           paneTree: leaf("p2", { kind: "editor", path: "/file.ts" }),
           activeLeafId: "p2",
+          paneOrder: ["p2"],
         },
       ],
     });

--- a/src/modules/workspace/lib/tabSessions.test.ts
+++ b/src/modules/workspace/lib/tabSessions.test.ts
@@ -11,6 +11,7 @@ function tabWith(paneTree: LayoutNode, cwd?: string): Tab {
     kind: "terminal",
     paneTree,
     activeLeafId: "L1",
+    paneOrder: ["L1"],
     cwd,
   };
 }

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -570,6 +570,41 @@ describe("migratePersistedTabs", () => {
     expect(byId("t2").title).toBe("b.ts");
     expect(byId("t2").activeLeafId).toBe(leafIds(byId("t2").paneTree)[0]);
   });
+
+  it("preserves a non-terminal tab's real multi-leaf split when it survives migration", () => {
+    const multiLeafTree = splitLeaf(
+      leaf("e1", { kind: "editor", path: "/a/b.ts" }),
+      "e1",
+      "row",
+      "t1",
+      { kind: "terminal" },
+    );
+
+    const v1WithoutPaneOrder = {
+      spaces: [{ id: "s1", name: "W" }],
+      activeSpaceId: "s1",
+      activeId: "tab1",
+      tabs: [
+        {
+          id: "tab1",
+          spaceId: "s1",
+          kind: "editor",
+          title: "split-editor",
+          path: "/a/b.ts",
+          paneTree: multiLeafTree,
+          activeLeafId: "e1",
+          // no paneOrder — simulating pre-paneOrder v1 persisted data
+        },
+      ],
+    };
+
+    const migrated = migratePersistedTabs(v1WithoutPaneOrder, 0) as { tabs: Tab[] };
+    const tab = migrated.tabs[0]!;
+
+    expect(tab.paneTree).toBe(multiLeafTree);
+    expect(tab.activeLeafId).toBe("e1");
+    expect(tab.paneOrder).toEqual(leafIds(multiLeafTree));
+  });
 });
 
 describe("tabHasDirtyEditor", () => {

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -689,6 +689,75 @@ describe("splitPaneWith", () => {
   });
 });
 
+describe("openFromSidebar", () => {
+  beforeEach(reset);
+
+  it("opens a brand-new tab when there is no active tab", () => {
+    const result = useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/a.ts" });
+    expect(result).toEqual({ status: "opened" });
+    const tab = activeTab();
+    expect(firstLeafContent(tab)).toMatchObject({ kind: "editor", path: "/a.ts" });
+    expect(tab.title).toBe("a.ts");
+  });
+
+  it("closes the launcher tab and opens a fresh one when the active tab is a launcher", () => {
+    // openLauncherTab's tab is identified by kind === "launcher" — TabsArea.tsx
+    // renders LauncherPanel for it directly and never looks at its paneTree, so
+    // "opening into" a launcher tab means replacing the whole tab, the same way
+    // LauncherPanel's own newTab actions do (open elsewhere, close this one).
+    const launcherId = useTabsStore.getState().openLauncherTab();
+    const result = useTabsStore
+      .getState()
+      .openFromSidebar({ kind: "editor", path: "/a.ts" }, "a.ts");
+    expect(result).toEqual({ status: "opened" });
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].id).not.toBe(launcherId);
+    expect(tabs[0].kind).toBe("editor");
+    expect(firstLeafContent(tabs[0])).toMatchObject({ kind: "editor", path: "/a.ts" });
+    expect(tabs[0].title).toBe("a.ts");
+    expect(useTabsStore.getState().activeId).toBe(tabs[0].id);
+  });
+
+  it("splits a new pane to the right when the active tab already has content", () => {
+    useTabsStore.getState().openEditorTab("/a.ts");
+    const result = useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/b.ts" });
+    expect(result).toEqual({ status: "opened" });
+    const tab = activeTab();
+    const panes = computeLayout(tab.paneTree);
+    expect(panes).toHaveLength(2);
+    const rightmost = panes.reduce((a, b) =>
+      b.rect.left + b.rect.width > a.rect.left + a.rect.width ? b : a,
+    );
+    expect(rightmost.content).toMatchObject({ kind: "editor", path: "/b.ts" });
+    expect(tab.activeLeafId).toBe(rightmost.id);
+  });
+
+  it("keeps splitting to the right on repeated calls, leaving earlier panes untouched", () => {
+    useTabsStore.getState().openEditorTab("/a.ts");
+    useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/b.ts" });
+    useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/c.ts" });
+    const tab = activeTab();
+    const panes = computeLayout(tab.paneTree);
+    expect(panes).toHaveLength(3);
+    const sorted = panes.slice().sort((a, b) => a.rect.left - b.rect.left);
+    expect(sorted.map((p) => p.content)).toMatchObject([
+      { kind: "editor", path: "/a.ts" },
+      { kind: "editor", path: "/b.ts" },
+      { kind: "editor", path: "/c.ts" },
+    ]);
+  });
+
+  it("allows the same content to open as a separate pane instead of focusing the existing one", () => {
+    useTabsStore.getState().openEditorTab("/a.ts");
+    useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/a.ts" });
+    const tab = activeTab();
+    const panes = computeLayout(tab.paneTree);
+    expect(panes).toHaveLength(2);
+    expect(panes.filter((p) => p.content.kind === "editor" && p.content.path === "/a.ts")).toHaveLength(2);
+  });
+});
+
 describe("localPreviewFilePaths", () => {
   it("includes the decoded local path for a file:// preview pane", () => {
     const tab: Tab = {

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -757,6 +757,21 @@ describe("splitPaneWith", () => {
   });
 });
 
+describe("splitPaneWith keeps paneOrder in sync", () => {
+  beforeEach(reset);
+
+  it("appends the new leaf id to paneOrder", () => {
+    const tabId = useTabsStore.getState().openEditorTab("/a.ts");
+    const original = activeTab();
+    const newLeafId = useTabsStore
+      .getState()
+      .splitPaneWith(tabId, original.activeLeafId, { kind: "editor", path: "/b.ts" }, "row");
+
+    const updated = activeTab();
+    expect(updated.paneOrder).toEqual([original.activeLeafId, newLeafId]);
+  });
+});
+
 describe("openFromSidebar", () => {
   beforeEach(reset);
 
@@ -862,6 +877,26 @@ describe("openFromSidebar with ssh content", () => {
       .openFromSidebar({ kind: "terminal", ssh: { connectionId: "c1" } }, "prod-box");
     const tab = activeTab();
     expect(consumeFreshSshLeaf(tab.activeLeafId)).toBe(true);
+  });
+});
+
+describe("closePane keeps paneOrder in sync", () => {
+  beforeEach(reset);
+
+  it("removes the closed leaf id from paneOrder, preserving the order of survivors", () => {
+    const tabId = useTabsStore.getState().openEditorTab("/a.ts");
+    const first = activeTab().activeLeafId;
+    const second = useTabsStore
+      .getState()
+      .splitPaneWith(tabId, first, { kind: "editor", path: "/b.ts" }, "row");
+    const third = useTabsStore
+      .getState()
+      .splitPaneWith(tabId, second, { kind: "editor", path: "/c.ts" }, "row");
+
+    useTabsStore.getState().closePane(tabId, second);
+
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(tab.paneOrder).toEqual([first, third]);
   });
 });
 

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -17,6 +17,7 @@ import {
   splitLeaf,
   type LayoutNode,
 } from "@/modules/terminal/lib/terminalLayout";
+import { consumeFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 
 function reset() {
   useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
@@ -755,6 +756,45 @@ describe("openFromSidebar", () => {
     const panes = computeLayout(tab.paneTree);
     expect(panes).toHaveLength(2);
     expect(panes.filter((p) => p.content.kind === "editor" && p.content.path === "/a.ts")).toHaveLength(2);
+  });
+});
+
+describe("openFromSidebar with ssh content", () => {
+  beforeEach(reset);
+
+  it("returns already-connected and does not create a tab when the connection is already open", () => {
+    useTabsStore
+      .getState()
+      .openFromSidebar({ kind: "terminal", ssh: { connectionId: "c1" } }, "prod-box");
+    const before = useTabsStore.getState().tabs.length;
+
+    const result = useTabsStore
+      .getState()
+      .openFromSidebar({ kind: "terminal", ssh: { connectionId: "c1" } }, "prod-box");
+
+    expect(result).toEqual({ status: "already-connected" });
+    expect(useTabsStore.getState().tabs).toHaveLength(before);
+  });
+
+  it("opens a new connection normally when it is not already open", () => {
+    const result = useTabsStore
+      .getState()
+      .openFromSidebar({ kind: "terminal", ssh: { connectionId: "c1" } }, "prod-box");
+    expect(result).toEqual({ status: "opened" });
+    const tab = activeTab();
+    expect(firstLeafContent(tab)).toMatchObject({
+      kind: "terminal",
+      ssh: { connectionId: "c1" },
+    });
+  });
+
+  it("marks a freshly split ssh pane so it auto-connects", () => {
+    useTabsStore.getState().openEditorTab("/a.ts");
+    useTabsStore
+      .getState()
+      .openFromSidebar({ kind: "terminal", ssh: { connectionId: "c1" } }, "prod-box");
+    const tab = activeTab();
+    expect(consumeFreshSshLeaf(tab.activeLeafId)).toBe(true);
   });
 });
 

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -948,6 +948,47 @@ describe("closePane keeps paneOrder in sync", () => {
   });
 });
 
+describe("splitActivePane keeps paneOrder in sync (regression: Phase 2 final review)", () => {
+  beforeEach(reset);
+
+  it("appends the new leaf to paneOrder", () => {
+    const tabId = useTabsStore.getState().openEditorTab("/a.ts");
+    useTabsStore.getState().splitActivePane("row");
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(tab.paneOrder).toHaveLength(2);
+  });
+
+  it("does not lose the Cmd+D pane when a sidebar click runs the grid rebuild afterward", () => {
+    useTabsStore.getState().openEditorTab("/a.ts");
+    useTabsStore.getState().splitActivePane("row");
+    const afterSplit = activeTab();
+    expect(afterSplit.paneOrder).toHaveLength(2);
+
+    useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/b.ts" });
+    const afterSidebarClick = activeTab();
+    expect(afterSidebarClick.paneOrder).toHaveLength(3);
+    const panes = computeLayout(afterSidebarClick.paneTree);
+    expect(panes).toHaveLength(3);
+    // The Cmd+D pane (a fresh launcher leaf) must still be present, not dropped.
+    expect(panes.some((p) => p.content.kind === "launcher")).toBe(true);
+  });
+
+  it("does not add a 9th pane when the tab already has 8", () => {
+    useTabsStore.getState().openEditorTab("/0.ts");
+    for (let i = 1; i < 8; i++) {
+      useTabsStore.getState().openFromSidebar({ kind: "editor", path: `/${i}.ts` });
+    }
+    const before = activeTab();
+    expect(before.paneOrder).toHaveLength(8);
+
+    useTabsStore.getState().splitActivePane("row");
+
+    const after = activeTab();
+    expect(after.paneOrder).toEqual(before.paneOrder);
+    expect(computeLayout(after.paneTree)).toHaveLength(8);
+  });
+});
+
 describe("localPreviewFilePaths", () => {
   it("includes the decoded local path for a file:// preview pane", () => {
     const tab: Tab = {

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -839,6 +839,54 @@ describe("openFromSidebar", () => {
     expect(panes).toHaveLength(2);
     expect(panes.filter((p) => p.content.kind === "editor" && p.content.path === "/a.ts")).toHaveLength(2);
   });
+
+  describe("openFromSidebar grid layout for 5+ panes", () => {
+    beforeEach(reset);
+
+    function openN(n: number) {
+      useTabsStore.getState().openEditorTab("/1.ts");
+      for (let i = 2; i <= n; i++) {
+        useTabsStore.getState().openFromSidebar({ kind: "editor", path: `/${i}.ts` });
+      }
+    }
+
+    it("stacks the 5th pane under the 1st column instead of adding a 5th column", () => {
+      openN(5);
+      const tab = activeTab();
+      const panes = computeLayout(tab.paneTree);
+      expect(panes).toHaveLength(5);
+      const columns = new Set(panes.map((p) => Math.round(p.rect.left)));
+      expect(columns.size).toBe(4);
+    });
+
+    it("keeps stacking the 6th, 7th, and 8th panes under columns 2, 3, and 4", () => {
+      openN(8);
+      const tab = activeTab();
+      const panes = computeLayout(tab.paneTree);
+      expect(panes).toHaveLength(8);
+      const columns = new Set(panes.map((p) => Math.round(p.rect.left)));
+      expect(columns.size).toBe(4);
+    });
+
+    it("blocks a 9th pane and does not mutate the tab", () => {
+      openN(8);
+      const before = activeTab();
+      const result = useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/9.ts" });
+      expect(result).toEqual({ status: "at-capacity" });
+      const after = activeTab();
+      expect(after.paneOrder).toEqual(before.paneOrder);
+      expect(computeLayout(after.paneTree)).toHaveLength(8);
+    });
+
+    it("recalculates the grid when a pane closes, going from 5 back to a clean 4 columns", () => {
+      openN(5);
+      const tab = activeTab();
+      const fifthLeafId = tab.paneOrder[4];
+      useTabsStore.getState().closePane(tab.id, fifthLeafId);
+      const after = activeTab();
+      expect(computeLayout(after.paneTree)).toHaveLength(4);
+    });
+  });
 });
 
 describe("openFromSidebar with ssh content", () => {

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -3,6 +3,7 @@ import {
   activeEditorPath,
   localPreviewFilePaths,
   openEditorPaths,
+  sshAlreadyOpen,
   tabHasDirtyEditor,
   useTabsStore,
   migratePersistedTabs,
@@ -754,6 +755,86 @@ describe("splitPaneWith", () => {
       kind: "editor",
       path: "/b.ts",
     });
+  });
+});
+
+describe("splitPaneWith anchor", () => {
+  beforeEach(reset);
+
+  it("defaults to placing the new pane after the existing one (unchanged behavior)", () => {
+    const tabId = useTabsStore.getState().newTerminalTab();
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    const newId = useTabsStore.getState().splitPaneWith(
+      tabId,
+      tab.activeLeafId,
+      { kind: "editor", path: "/a.ts" },
+      "row",
+    );
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree).toEqual({
+      kind: "split",
+      direction: "row",
+      children: [
+        { kind: "leaf", id: tab.activeLeafId, pane: { kind: "terminal" } },
+        { kind: "leaf", id: newId, pane: { kind: "editor", path: "/a.ts" } },
+      ],
+      sizes: [0.5, 0.5],
+    });
+  });
+
+  it("places the new pane before the existing one when anchor is \"before\"", () => {
+    const tabId = useTabsStore.getState().newTerminalTab();
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    const newId = useTabsStore.getState().splitPaneWith(
+      tabId,
+      tab.activeLeafId,
+      { kind: "editor", path: "/a.ts" },
+      "row",
+      "before",
+    );
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree).toEqual({
+      kind: "split",
+      direction: "row",
+      children: [
+        { kind: "leaf", id: newId, pane: { kind: "editor", path: "/a.ts" } },
+        { kind: "leaf", id: tab.activeLeafId, pane: { kind: "terminal" } },
+      ],
+      sizes: [0.5, 0.5],
+    });
+  });
+});
+
+describe("wrapPaneWith", () => {
+  beforeEach(reset);
+
+  it("wraps the whole existing tree as the second child, new pane first, for anchor \"before\"", () => {
+    const tabId = useTabsStore.getState().newTerminalTab();
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    const existingTree = tab.paneTree;
+    const newId = useTabsStore
+      .getState()
+      .wrapPaneWith(tabId, { kind: "editor", path: "/a.ts" }, "row", "before");
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    expect(updated.paneTree).toEqual({
+      kind: "split",
+      direction: "row",
+      children: [
+        { kind: "leaf", id: newId, pane: { kind: "editor", path: "/a.ts" } },
+        existingTree,
+      ],
+      sizes: [0.5, 0.5],
+    });
+    expect(updated.activeLeafId).toBe(newId);
+    expect(updated.paneOrder).toContain(newId);
+  });
+});
+
+describe("sshAlreadyOpen (exported)", () => {
+  beforeEach(reset);
+
+  it("is importable and reports false for a connection nobody has opened", () => {
+    expect(sshAlreadyOpen(useTabsStore.getState().tabs, "space-1", "conn-x")).toBe(false);
   });
 });
 

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -928,6 +928,58 @@ describe("openFromSidebar with ssh content", () => {
   });
 });
 
+describe("openInNewTab", () => {
+  beforeEach(reset);
+
+  it("always creates a brand-new tab even when there is content already open", () => {
+    useTabsStore.getState().openEditorTab("/a.ts");
+    const result = useTabsStore.getState().openInNewTab({ kind: "editor", path: "/a.ts" });
+    expect(result).toEqual({ status: "opened" });
+    expect(useTabsStore.getState().tabs).toHaveLength(2);
+  });
+
+  it("does not split into the active tab, even when the active tab has room", () => {
+    useTabsStore.getState().openEditorTab("/a.ts");
+    useTabsStore.getState().openInNewTab({ kind: "note", noteId: "/n.md" }, "note");
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(2);
+    expect(computeLayout(tabs[0].paneTree)).toHaveLength(1);
+    expect(computeLayout(tabs[1].paneTree)).toHaveLength(1);
+  });
+
+  it("initializes paneOrder on the new tab", () => {
+    useTabsStore.getState().openInNewTab({ kind: "editor", path: "/a.ts" });
+    const tab = activeTab();
+    expect(tab.paneOrder).toEqual([tab.activeLeafId]);
+  });
+
+  it("does not touch or close an existing Launcher tab", () => {
+    const launcherId = useTabsStore.getState().openLauncherTab();
+    useTabsStore.getState().openInNewTab({ kind: "editor", path: "/a.ts" });
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(2);
+    expect(tabs.some((t) => t.id === launcherId)).toBe(true);
+  });
+
+  it("blocks and returns already-connected for an ssh connection already open, without creating a tab", () => {
+    useTabsStore.getState().openInNewTab({ kind: "terminal", ssh: { connectionId: "c1" } }, "box");
+    const before = useTabsStore.getState().tabs.length;
+
+    const result = useTabsStore
+      .getState()
+      .openInNewTab({ kind: "terminal", ssh: { connectionId: "c1" } }, "box");
+
+    expect(result).toEqual({ status: "already-connected" });
+    expect(useTabsStore.getState().tabs).toHaveLength(before);
+  });
+
+  it("marks a freshly opened ssh pane so it auto-connects", () => {
+    useTabsStore.getState().openInNewTab({ kind: "terminal", ssh: { connectionId: "c1" } }, "box");
+    const tab = activeTab();
+    expect(consumeFreshSshLeaf(tab.activeLeafId)).toBe(true);
+  });
+});
+
 describe("closePane keeps paneOrder in sync", () => {
   beforeEach(reset);
 

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -506,6 +506,35 @@ describe("openSshTab", () => {
   });
 });
 
+describe("paneOrder on tab creation", () => {
+  beforeEach(reset);
+
+  it("initializes paneOrder to the sole leaf for every tab-creating action", () => {
+    const cases: Array<() => string> = [
+      () => useTabsStore.getState().newTerminalTab(),
+      () => useTabsStore.getState().openSshTab("c1", "box"),
+      () => useTabsStore.getState().openLauncherTab(),
+      () => useTabsStore.getState().openEditorTab("/a.ts"),
+      () => useTabsStore.getState().openNoteTab("/n.md", "note"),
+      () => useTabsStore.getState().openPreviewTab("http://localhost"),
+      () => useTabsStore.getState().openGitGraphTab(),
+    ];
+    for (const create of cases) {
+      reset();
+      const tabId = create();
+      const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+      expect(tab.paneOrder).toEqual([tab.activeLeafId]);
+    }
+  });
+
+  it("initializes paneOrder for a tab opened via openFromSidebar", () => {
+    useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/a.ts" });
+    const tab = activeTab();
+    expect(tab.id).toBe(useTabsStore.getState().activeId);
+    expect(tab.paneOrder).toEqual([tab.activeLeafId]);
+  });
+});
+
 describe("migratePersistedTabs", () => {
   it("migrates v0 simple tabs into single-leaf pane tabs", () => {
     const v0 = {
@@ -552,6 +581,7 @@ describe("tabHasDirtyEditor", () => {
       kind: "editor",
       paneTree: leaf(leafId, { kind: "editor", path }),
       activeLeafId: leafId,
+      paneOrder: [leafId],
     };
   }
 
@@ -563,6 +593,7 @@ describe("tabHasDirtyEditor", () => {
       kind: "terminal",
       paneTree: leaf("l1", { kind: "terminal" }),
       activeLeafId: "l1",
+      paneOrder: ["l1"],
     };
     expect(tabHasDirtyEditor(tab, {})).toBe(false);
   });
@@ -599,6 +630,7 @@ describe("tabHasDirtyEditor", () => {
       kind: "editor",
       paneTree: tree,
       activeLeafId: "l1",
+      paneOrder: ["l1", "l2"],
     };
     const buffers = {
       "/a/clean.ts": { content: "ok", baseline: "ok" },
@@ -807,6 +839,7 @@ describe("localPreviewFilePaths", () => {
       kind: "preview",
       paneTree: leaf("l1", { kind: "preview", url: "file:///proj/a.html" }),
       activeLeafId: "l1",
+      paneOrder: ["l1"],
     };
     expect(localPreviewFilePaths([tab])).toContain("/proj/a.html");
   });
@@ -819,6 +852,7 @@ describe("localPreviewFilePaths", () => {
       kind: "preview",
       paneTree: leaf("l2", { kind: "preview", url: "http://localhost:3000" }),
       activeLeafId: "l2",
+      paneOrder: ["l2"],
     };
     expect(localPreviewFilePaths([tab])).toHaveLength(0);
   });
@@ -831,6 +865,7 @@ describe("localPreviewFilePaths", () => {
       kind: "terminal",
       paneTree: leaf("l3", { kind: "terminal" }),
       activeLeafId: "l3",
+      paneOrder: ["l3"],
     };
     expect(localPreviewFilePaths([tab])).toHaveLength(0);
   });
@@ -845,6 +880,7 @@ describe("activeEditorPath", () => {
       kind: "editor",
       paneTree: leaf(leafId, { kind: "editor", path }),
       activeLeafId: leafId,
+      paneOrder: [leafId],
     };
   }
 
@@ -861,6 +897,7 @@ describe("activeEditorPath", () => {
       kind: "terminal",
       paneTree: leaf("l1", { kind: "terminal" }),
       activeLeafId: "l1",
+      paneOrder: ["l1"],
     };
     expect(activeEditorPath([tab], "t1")).toBeNull();
   });
@@ -887,6 +924,7 @@ describe("activeEditorPath", () => {
       kind: "editor",
       paneTree: tree,
       activeLeafId: "l1",
+      paneOrder: ["l1", "l2"],
     };
     expect(activeEditorPath([tab], "t1")).toBe("/repo/App.vue");
     expect(activeEditorPath([{ ...tab, activeLeafId: "l2" }], "t1")).toBeNull();

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -670,6 +670,25 @@ describe("openHtmlPreview", () => {
   });
 });
 
+describe("splitPaneWith", () => {
+  beforeEach(reset);
+
+  it("returns the id of the newly created leaf", () => {
+    const tabId = useTabsStore.getState().openEditorTab("/a.ts");
+    const original = activeTab();
+    const newLeafId = useTabsStore
+      .getState()
+      .splitPaneWith(tabId, original.activeLeafId, { kind: "editor", path: "/b.ts" }, "row");
+
+    const updated = activeTab();
+    expect(updated.activeLeafId).toBe(newLeafId);
+    expect(findPaneContent(updated.paneTree, newLeafId)).toMatchObject({
+      kind: "editor",
+      path: "/b.ts",
+    });
+  });
+});
+
 describe("localPreviewFilePaths", () => {
   it("includes the decoded local path for a file:// preview pane", () => {
     const tab: Tab = {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -797,13 +797,12 @@ export const useTabsStore = create<TabsState>()(
     })),
 
   splitPaneWith: (tabId, fromLeafId, content, direction) => {
-    let newId: string | undefined;
+    const newId = nextPaneId();
     set((state) => ({
       tabs: state.tabs.map((tab) => {
         if (tab.id !== tabId) {
           return tab;
         }
-        newId = nextPaneId();
         return {
           ...tab,
           paneTree: splitLeaf(tab.paneTree, fromLeafId, direction, newId, content),
@@ -811,7 +810,7 @@ export const useTabsStore = create<TabsState>()(
         };
       }),
     }));
-    return newId!;
+    return newId;
   },
 
   setPaneContent: (tabId, leafId, content) =>

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -535,6 +535,27 @@ export const useTabsStore = create<TabsState>()(
 
   openFromSidebar: (content, title) => {
     const spaceId = get().ensureSpace();
+    // Checked separately from the discriminated narrowing below: TypeScript
+    // can't carry `content.kind === "terminal" && content.ssh` through a
+    // boolean variable, so the two later branches that only need a yes/no
+    // (not `content.ssh.connectionId` itself) read this flag instead of
+    // re-narrowing `content` each time.
+    const isFreshSsh = content.kind === "terminal" && !!content.ssh;
+
+    if (content.kind === "terminal" && content.ssh) {
+      const connectionId = content.ssh.connectionId;
+      const alreadyOpen = get().tabs.some(
+        (t) =>
+          t.spaceId === spaceId &&
+          computeLayout(t.paneTree).some(
+            (p) => p.content.kind === "terminal" && p.content.ssh?.connectionId === connectionId,
+          ),
+      );
+      if (alreadyOpen) {
+        return { status: "already-connected" };
+      }
+    }
+
     const resolvedTitle =
       title ?? (content.kind === "editor" ? basename(content.path) : "Untitled");
     const activeTab = get().tabs.find((t) => t.id === get().activeId);
@@ -542,6 +563,9 @@ export const useTabsStore = create<TabsState>()(
     if (!activeTab || activeTab.kind === "launcher") {
       const id = nextTabId();
       const paneId = nextPaneId();
+      if (isFreshSsh) {
+        markFreshSshLeaf(paneId);
+      }
       const tab: Tab = {
         id,
         spaceId,
@@ -549,6 +573,7 @@ export const useTabsStore = create<TabsState>()(
         title: resolvedTitle,
         paneTree: leaf(paneId, content),
         activeLeafId: paneId,
+        ...(isFreshSsh ? { renamed: true } : {}),
       };
       set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
       if (activeTab) {
@@ -560,7 +585,10 @@ export const useTabsStore = create<TabsState>()(
     const rightmost = computeLayout(activeTab.paneTree).reduce((a, b) =>
       b.rect.left + b.rect.width > a.rect.left + a.rect.width ? b : a,
     );
-    get().splitPaneWith(activeTab.id, rightmost.id, content, "row");
+    const newLeafId = get().splitPaneWith(activeTab.id, rightmost.id, content, "row");
+    if (isFreshSsh) {
+      markFreshSshLeaf(newLeafId);
+    }
     return { status: "opened" };
   },
 

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -782,23 +782,31 @@ export const useTabsStore = create<TabsState>()(
       return { tabs };
     }),
 
-  splitActivePane: (direction) =>
+  splitActivePane: (_direction) => {
+    const tab = get().tabs.find((t) => t.id === get().activeId);
+    if (!tab) {
+      return;
+    }
+    if (tab.paneOrder.length >= 8) {
+      return;
+    }
+    const newId = nextPaneId();
+    const panes: OrderedPane[] = [
+      ...tab.paneOrder.map((id) => ({
+        id,
+        content: findPaneContent(tab.paneTree, id)!,
+      })),
+      { id: newId, content: { kind: "launcher" } },
+    ];
+    const paneTree = gridLayout(panes);
     set((state) => ({
-      tabs: state.tabs.map((tab) => {
-        if (tab.id !== state.activeId) {
-          return tab;
-        }
-        const newId = nextPaneId();
-        return {
-          ...tab,
-          // A fresh split shows the launcher so the user picks what goes in it.
-          paneTree: splitLeaf(tab.paneTree, tab.activeLeafId, direction, newId, {
-            kind: "launcher",
-          }),
-          activeLeafId: newId,
-        };
-      }),
-    })),
+      tabs: state.tabs.map((t) =>
+        t.id === tab.id
+          ? { ...t, paneTree, paneOrder: [...tab.paneOrder, newId], activeLeafId: newId }
+          : t,
+      ),
+    }));
+  },
 
   setActiveLeaf: (tabId, leafId) =>
     set((state) => ({

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -17,6 +17,7 @@ import {
   setLeafPane,
   setSizesById,
   splitLeaf,
+  wrapTree,
   type LayoutNode,
   type OrderedPane,
   type PaneContent,
@@ -133,6 +134,20 @@ interface TabsState {
     fromLeafId: string,
     content: PaneContent,
     direction: SplitDirection,
+    anchor?: "before" | "after",
+  ) => string;
+  /**
+   * Wrap the tab's whole current pane tree as one side of a brand-new
+   * top-level split, with `content` on the other side. Used for the
+   * outer-edge drop zone (spec section C) — every existing pane shifts over
+   * as a block instead of any single pane being split. Returns the new
+   * leaf's id.
+   */
+  wrapPaneWith: (
+    tabId: string,
+    content: PaneContent,
+    direction: SplitDirection,
+    anchor: "before" | "after",
   ) => string;
   /**
    * Follow an in-preview navigation: update the pane's previewed url, and when
@@ -262,7 +277,7 @@ function singleLeafContentEquals(tab: Tab, content: PaneContent): boolean {
 }
 
 /** True when `connectionId` is already open in some pane of some tab in `spaceId`. */
-function sshAlreadyOpen(tabs: Tab[], spaceId: string, connectionId: string): boolean {
+export function sshAlreadyOpen(tabs: Tab[], spaceId: string, connectionId: string): boolean {
   return tabs.some(
     (t) =>
       t.spaceId === spaceId &&
@@ -887,7 +902,7 @@ export const useTabsStore = create<TabsState>()(
       ),
     })),
 
-  splitPaneWith: (tabId, fromLeafId, content, direction) => {
+  splitPaneWith: (tabId, fromLeafId, content, direction, anchor = "after") => {
     const newId = nextPaneId();
     set((state) => ({
       tabs: state.tabs.map((tab) => {
@@ -896,11 +911,28 @@ export const useTabsStore = create<TabsState>()(
         }
         return {
           ...tab,
-          paneTree: splitLeaf(tab.paneTree, fromLeafId, direction, newId, content),
+          paneTree: splitLeaf(tab.paneTree, fromLeafId, direction, newId, content, anchor),
           activeLeafId: newId,
           paneOrder: [...tab.paneOrder, newId],
         };
       }),
+    }));
+    return newId;
+  },
+
+  wrapPaneWith: (tabId, content, direction, anchor) => {
+    const newId = nextPaneId();
+    set((state) => ({
+      tabs: state.tabs.map((tab) =>
+        tab.id === tabId
+          ? {
+              ...tab,
+              paneTree: wrapTree(tab.paneTree, newId, content, direction, anchor),
+              activeLeafId: newId,
+              paneOrder: [...tab.paneOrder, newId],
+            }
+          : tab,
+      ),
     }));
     return newId;
   },

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -782,31 +782,31 @@ export const useTabsStore = create<TabsState>()(
       return { tabs };
     }),
 
-  splitActivePane: (_direction) => {
-    const tab = get().tabs.find((t) => t.id === get().activeId);
-    if (!tab) {
-      return;
-    }
-    if (tab.paneOrder.length >= 8) {
-      return;
-    }
-    const newId = nextPaneId();
-    const panes: OrderedPane[] = [
-      ...tab.paneOrder.map((id) => ({
-        id,
-        content: findPaneContent(tab.paneTree, id)!,
-      })),
-      { id: newId, content: { kind: "launcher" } },
-    ];
-    const paneTree = gridLayout(panes);
-    set((state) => ({
-      tabs: state.tabs.map((t) =>
-        t.id === tab.id
-          ? { ...t, paneTree, paneOrder: [...tab.paneOrder, newId], activeLeafId: newId }
-          : t,
-      ),
-    }));
-  },
+  splitActivePane: (direction) =>
+    set((state) => {
+      const tab = state.tabs.find((t) => t.id === state.activeId);
+      if (!tab || tab.paneOrder.length >= 8) {
+        return state;
+      }
+      const newId = nextPaneId();
+      return {
+        tabs: state.tabs.map((t) =>
+          t.id === tab.id
+            ? {
+                ...t,
+                // A fresh split shows the launcher so the user picks what goes in it.
+                // Directional and pane-specific (unlike openFromSidebar's grid rebuild)
+                // — the user is choosing exactly which pane to split and which way.
+                paneTree: splitLeaf(t.paneTree, t.activeLeafId, direction, newId, {
+                  kind: "launcher",
+                }),
+                activeLeafId: newId,
+                paneOrder: [...t.paneOrder, newId],
+              }
+            : t,
+        ),
+      };
+    }),
 
   setActiveLeaf: (tabId, leafId) =>
     set((state) => ({

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -49,6 +49,10 @@ export interface Tab {
   kind: TabKind;
   paneTree: LayoutNode;
   activeLeafId: string;
+  /** Leaf ids in the order they were added to this tab — independent of the
+   * tree's own left-right shape, which the grid layout's stacking scrambles.
+   * Drives `gridLayout`'s column/row assignment. */
+  paneOrder: string[];
   /** Starting directory for new terminal panes created inside this tab. */
   cwd?: string;
   /** True once the user renames the tab, so cwd changes stop overwriting it. */
@@ -260,12 +264,15 @@ interface PersistedV0Tab {
   cwd?: string;
 }
 
-/** Convert pre-paneTree (v0) persisted tabs into the unified Tab shape. */
+/** Convert pre-paneTree (v0) persisted tabs into the unified Tab shape, and
+ * backfill `paneOrder` (v1→v2) for tabs persisted before it existed — a
+ * one-time best-effort guess from the tree's own left-right leaf order, since
+ * the true add-order was never recorded before this field existed. */
 export function migratePersistedTabs(persisted: unknown, _version: number): unknown {
   if (!persisted || typeof persisted !== "object") {
     return persisted;
   }
-  const state = persisted as { tabs?: PersistedV0Tab[] };
+  const state = persisted as { tabs?: (PersistedV0Tab & { paneOrder?: string[] })[] };
   if (!Array.isArray(state.tabs)) {
     return persisted;
   }
@@ -278,6 +285,7 @@ export function migratePersistedTabs(persisted: unknown, _version: number): unkn
         kind: "terminal",
         paneTree: t.paneTree,
         activeLeafId: t.activeLeafId,
+        paneOrder: t.paneOrder ?? leafIds(t.paneTree),
         cwd: t.cwd,
       };
     }
@@ -299,13 +307,16 @@ export function migratePersistedTabs(persisted: unknown, _version: number): unkn
       default:
         content = { kind: "terminal" };
     }
+    const paneTree = t.paneTree ?? leaf(paneId, content);
+    const activeLeafId = t.activeLeafId ?? paneId;
     return {
       id: t.id,
       spaceId: t.spaceId,
       title: t.title,
       kind: t.kind,
-      paneTree: leaf(paneId, content),
-      activeLeafId: paneId,
+      paneTree,
+      activeLeafId,
+      paneOrder: t.paneOrder ?? leafIds(paneTree),
       cwd: t.cwd,
     };
   });
@@ -376,6 +387,7 @@ export const useTabsStore = create<TabsState>()(
       title: cwd ? basename(cwd) : `Terminal ${count}`,
       paneTree: leaf(paneId, { kind: "terminal" }),
       activeLeafId: paneId,
+      paneOrder: [paneId],
       cwd,
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
@@ -408,6 +420,7 @@ export const useTabsStore = create<TabsState>()(
       title: name,
       paneTree: leaf(paneId, { kind: "terminal", ssh: { connectionId } }),
       activeLeafId: paneId,
+      paneOrder: [paneId],
       renamed: true,
     };
     // Mark this leaf as freshly user-opened so TerminalView auto-connects on mount.
@@ -434,6 +447,7 @@ export const useTabsStore = create<TabsState>()(
       title: "New Tab",
       paneTree: leaf(paneId, { kind: "terminal" }),
       activeLeafId: paneId,
+      paneOrder: [paneId],
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return id;
@@ -460,6 +474,7 @@ export const useTabsStore = create<TabsState>()(
       title: basename(path),
       paneTree: leaf(paneId, { kind: "editor", path }),
       activeLeafId: paneId,
+      paneOrder: [paneId],
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return id;
@@ -486,6 +501,7 @@ export const useTabsStore = create<TabsState>()(
       title: title || "Untitled",
       paneTree: leaf(paneId, { kind: "note", noteId }),
       activeLeafId: paneId,
+      paneOrder: [paneId],
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return id;
@@ -502,6 +518,7 @@ export const useTabsStore = create<TabsState>()(
       title: previewTitle(url),
       paneTree: leaf(paneId, { kind: "preview", url }),
       activeLeafId: paneId,
+      paneOrder: [paneId],
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return id;
@@ -528,6 +545,7 @@ export const useTabsStore = create<TabsState>()(
       title: "Git Graph",
       paneTree: leaf(paneId, { kind: "git-graph" }),
       activeLeafId: paneId,
+      paneOrder: [paneId],
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return id;
@@ -573,6 +591,7 @@ export const useTabsStore = create<TabsState>()(
         title: resolvedTitle,
         paneTree: leaf(paneId, content),
         activeLeafId: paneId,
+        paneOrder: [paneId],
         ...(isFreshSsh ? { renamed: true } : {}),
       };
       set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
@@ -648,6 +667,7 @@ export const useTabsStore = create<TabsState>()(
       title,
       paneTree: leaf(paneId, { kind: "preview", url }),
       activeLeafId: paneId,
+      paneOrder: [paneId],
     };
     set((state) => ({ tabs: [...state.tabs, newTab], activeId: id }));
   },
@@ -910,7 +930,7 @@ export const useTabsStore = create<TabsState>()(
     {
       name: TABS_STORAGE_KEY,
       storage: createJSONStorage(() => perWindowStorage()),
-      version: 1,
+      version: 2,
       migrate: migratePersistedTabs,
       partialize: (state) => ({
         spaces: state.spaces,

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -33,6 +33,8 @@ export interface Space {
   name: string;
 }
 
+export type OpenFromSidebarResult = { status: "opened" } | { status: "already-connected" };
+
 export type TabKind = "terminal" | "editor" | "note" | "preview" | "git-graph" | "launcher";
 
 /**
@@ -72,6 +74,19 @@ interface TabsState {
   openNoteTab: (noteId: string, title: string) => string;
   openPreviewTab: (url: string) => string;
   openGitGraphTab: () => string;
+  /**
+   * Open sidebar content (explorer file, note, or SSH connection). When the
+   * active tab is a real working tab, this splits beside its current
+   * right-most pane. When there is no active tab, or the active tab is a
+   * Launcher tab (kind === "launcher" — TabsArea.tsx renders LauncherPanel
+   * for those directly and ignores their paneTree), this opens a fresh tab
+   * and, for the launcher case, closes the old one — the same two-step
+   * LauncherPanel's own newTab actions already do. Unlike openEditorTab /
+   * openNoteTab / openSshTab, this never focuses an existing pane showing the
+   * same content — duplicates are allowed. SSH content is checked for an
+   * already-open connection in a later task.
+   */
+  openFromSidebar: (content: PaneContent, title?: string) => OpenFromSidebarResult;
   /**
    * Open the web preview of a local HTML file with a smart target: reuse an
    * existing preview pane in this tab, else split beside a single-pane editor,
@@ -516,6 +531,37 @@ export const useTabsStore = create<TabsState>()(
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return id;
+  },
+
+  openFromSidebar: (content, title) => {
+    const spaceId = get().ensureSpace();
+    const resolvedTitle =
+      title ?? (content.kind === "editor" ? basename(content.path) : "Untitled");
+    const activeTab = get().tabs.find((t) => t.id === get().activeId);
+
+    if (!activeTab || activeTab.kind === "launcher") {
+      const id = nextTabId();
+      const paneId = nextPaneId();
+      const tab: Tab = {
+        id,
+        spaceId,
+        kind: content.kind,
+        title: resolvedTitle,
+        paneTree: leaf(paneId, content),
+        activeLeafId: paneId,
+      };
+      set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
+      if (activeTab) {
+        get().closeTab(activeTab.id);
+      }
+      return { status: "opened" };
+    }
+
+    const rightmost = computeLayout(activeTab.paneTree).reduce((a, b) =>
+      b.rect.left + b.rect.width > a.rect.left + a.rect.width ? b : a,
+    );
+    get().splitPaneWith(activeTab.id, rightmost.id, content, "row");
+    return { status: "opened" };
   },
 
   openHtmlPreview: (tabId, fromLeafId, filePath) => {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -827,6 +827,7 @@ export const useTabsStore = create<TabsState>()(
           ...tab,
           paneTree: splitLeaf(tab.paneTree, fromLeafId, direction, newId, content),
           activeLeafId: newId,
+          paneOrder: [...tab.paneOrder, newId],
         };
       }),
     }));
@@ -922,7 +923,9 @@ export const useTabsStore = create<TabsState>()(
         tab.activeLeafId === leafId ? (firstLeafId(paneTree) ?? tab.activeLeafId) : tab.activeLeafId;
       return {
         tabs: state.tabs.map((t) =>
-          t.id === tabId ? { ...t, paneTree, activeLeafId } : t,
+          t.id === tabId
+            ? { ...t, paneTree, activeLeafId, paneOrder: t.paneOrder.filter((id) => id !== leafId) }
+            : t,
         ),
       };
     }),

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -9,6 +9,7 @@ import {
   computeLayout,
   findPaneContent,
   firstLeafId,
+  gridLayout,
   leaf,
   leafIds,
   paneOf,
@@ -17,6 +18,7 @@ import {
   setSizesById,
   splitLeaf,
   type LayoutNode,
+  type OrderedPane,
   type PaneContent,
   type SplitDirection,
 } from "@/modules/terminal/lib/terminalLayout";
@@ -33,7 +35,10 @@ export interface Space {
   name: string;
 }
 
-export type OpenFromSidebarResult = { status: "opened" } | { status: "already-connected" };
+export type OpenFromSidebarResult =
+  | { status: "opened" }
+  | { status: "already-connected" }
+  | { status: "at-capacity" };
 
 export type TabKind = "terminal" | "editor" | "note" | "preview" | "git-graph" | "launcher";
 
@@ -601,13 +606,29 @@ export const useTabsStore = create<TabsState>()(
       return { status: "opened" };
     }
 
-    const rightmost = computeLayout(activeTab.paneTree).reduce((a, b) =>
-      b.rect.left + b.rect.width > a.rect.left + a.rect.width ? b : a,
-    );
-    const newLeafId = get().splitPaneWith(activeTab.id, rightmost.id, content, "row");
-    if (isFreshSsh) {
-      markFreshSshLeaf(newLeafId);
+    if (activeTab.paneOrder.length >= 8) {
+      return { status: "at-capacity" };
     }
+
+    const newId = nextPaneId();
+    if (isFreshSsh) {
+      markFreshSshLeaf(newId);
+    }
+    const panes: OrderedPane[] = [
+      ...activeTab.paneOrder.map((id) => ({
+        id,
+        content: findPaneContent(activeTab.paneTree, id)!,
+      })),
+      { id: newId, content },
+    ];
+    const paneTree = gridLayout(panes);
+    set((state) => ({
+      tabs: state.tabs.map((t) =>
+        t.id === activeTab.id
+          ? { ...t, paneTree, paneOrder: [...activeTab.paneOrder, newId], activeLeafId: newId }
+          : t,
+      ),
+    }));
     return { status: "opened" };
   },
 

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -97,6 +97,14 @@ interface TabsState {
    */
   openFromSidebar: (content: PaneContent, title?: string) => OpenFromSidebarResult;
   /**
+   * Open sidebar content in a brand-new tab, unconditionally — never splits
+   * into the active tab, never touches/closes a Launcher tab. The explicit
+   * escape hatch from openFromSidebar's default splitting behavior. SSH
+   * content is still blocked from duplicating a connection already open
+   * anywhere in the space, same guard as openFromSidebar.
+   */
+  openInNewTab: (content: PaneContent, title?: string) => OpenFromSidebarResult;
+  /**
    * Open the web preview of a local HTML file with a smart target: reuse an
    * existing preview pane in this tab, else split beside a single-pane editor,
    * else open/reuse a per-space preview tab.
@@ -251,6 +259,17 @@ function singleLeafContentEquals(tab: Tab, content: PaneContent): boolean {
     return pane.url === content.url;
   }
   return true;
+}
+
+/** True when `connectionId` is already open in some pane of some tab in `spaceId`. */
+function sshAlreadyOpen(tabs: Tab[], spaceId: string, connectionId: string): boolean {
+  return tabs.some(
+    (t) =>
+      t.spaceId === spaceId &&
+      computeLayout(t.paneTree).some(
+        (p) => p.content.kind === "terminal" && p.content.ssh?.connectionId === connectionId,
+      ),
+  );
 }
 
 export const TABS_STORAGE_KEY = "tempoterm-tabs";
@@ -566,15 +585,7 @@ export const useTabsStore = create<TabsState>()(
     const isFreshSsh = content.kind === "terminal" && !!content.ssh;
 
     if (content.kind === "terminal" && content.ssh) {
-      const connectionId = content.ssh.connectionId;
-      const alreadyOpen = get().tabs.some(
-        (t) =>
-          t.spaceId === spaceId &&
-          computeLayout(t.paneTree).some(
-            (p) => p.content.kind === "terminal" && p.content.ssh?.connectionId === connectionId,
-          ),
-      );
-      if (alreadyOpen) {
+      if (sshAlreadyOpen(get().tabs, spaceId, content.ssh.connectionId)) {
         return { status: "already-connected" };
       }
     }
@@ -629,6 +640,37 @@ export const useTabsStore = create<TabsState>()(
           : t,
       ),
     }));
+    return { status: "opened" };
+  },
+
+  openInNewTab: (content, title) => {
+    const spaceId = get().ensureSpace();
+    const isFreshSsh = content.kind === "terminal" && !!content.ssh;
+
+    if (content.kind === "terminal" && content.ssh) {
+      if (sshAlreadyOpen(get().tabs, spaceId, content.ssh.connectionId)) {
+        return { status: "already-connected" };
+      }
+    }
+
+    const resolvedTitle =
+      title ?? (content.kind === "editor" ? basename(content.path) : "Untitled");
+    const id = nextTabId();
+    const paneId = nextPaneId();
+    if (isFreshSsh) {
+      markFreshSshLeaf(paneId);
+    }
+    const tab: Tab = {
+      id,
+      spaceId,
+      kind: content.kind,
+      title: resolvedTitle,
+      paneTree: leaf(paneId, content),
+      activeLeafId: paneId,
+      paneOrder: [paneId],
+      ...(isFreshSsh ? { renamed: true } : {}),
+    };
+    set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return { status: "opened" };
   },
 

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -95,13 +95,13 @@ interface TabsState {
   /** Cycle the active tab's focused pane to the next leaf (⌘`); wraps around. */
   focusNextPane: () => void;
   resizePane: (tabId: string, splitId: string, sizes: [number, number]) => void;
-  /** Split a pane and show `content` (terminal/editor/note/preview) in the new half. */
+  /** Split a pane and show `content` (terminal/editor/note/preview) in the new half. Returns the new leaf's id. */
   splitPaneWith: (
     tabId: string,
     fromLeafId: string,
     content: PaneContent,
     direction: SplitDirection,
-  ) => void;
+  ) => string;
   /**
    * Follow an in-preview navigation: update the pane's previewed url, and when
    * the preview is the tab's whole content (single pane, not user-renamed),
@@ -722,20 +722,23 @@ export const useTabsStore = create<TabsState>()(
       ),
     })),
 
-  splitPaneWith: (tabId, fromLeafId, content, direction) =>
+  splitPaneWith: (tabId, fromLeafId, content, direction) => {
+    let newId: string | undefined;
     set((state) => ({
       tabs: state.tabs.map((tab) => {
         if (tab.id !== tabId) {
           return tab;
         }
-        const newId = nextPaneId();
+        newId = nextPaneId();
         return {
           ...tab,
           paneTree: splitLeaf(tab.paneTree, fromLeafId, direction, newId, content),
           activeLeafId: newId,
         };
       }),
-    })),
+    }));
+    return newId!;
+  },
 
   setPaneContent: (tabId, leafId, content) =>
     set((state) => ({

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
 import { configDefaults } from "vitest/config";
 
-// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary

Unifies how the three sidebars (Explorer, Notes, SSH connections) open content and how terminal panes split, across four phases on one branch:

- **Phase 1** — sidebar single-click always splits into the active tab, with an SSH already-connected exception (dedupe so the same connection never opens twice).
- **Phase 2** — panes auto-arrange into a fixed 4-column/8-pane-cap grid as they're added, replacing the old uneven right-only splitting.
- **Phase 3** — right-click "open in new tab" on all three sidebars, plus a follow-up "open in split pane" item so both behaviors are explicit choices.
- **Phase 4** — position-aware pane drop targets (center/edge/outer-band) replacing "drag always replaces the whole pane," including building drag-to-pane from scratch for Notes and SSH connections, plus dropping any source onto the tab bar to open a new tab — with a real insertion-line indicator showing exactly where it will land.

Each phase was individually planned, implemented task-by-task with fresh review per task, and whole-phase/whole-branch reviewed before merge. Full history in `.superpowers/sdd/progress.md` (git-ignored, local only) if useful context survives; the commit log itself carries the same story.

## Test plan

- [x] Full automated suite green (993 tests) and `tsc --noEmit` clean at HEAD
- [x] Manual: Phase 1+2 (click-to-split, grid arrangement, 8-pane cap) verified via local build
- [x] Manual: Phase 3 (right-click open-in-new-tab / open-in-split-pane on all three sidebars) verified via local build
- [x] Manual: Phase 4 pane drop targets (center/edge/outer, folder exception, 8-cap dialog, SSH already-connected guard) verified via local build
- [x] Manual: Phase 4 tab-bar drop + insertion line (all three sources, all four drop spots, folder no-op) verified via local build

## Notes for reviewers

- Spec doc (not tracked, for context only): `docs/superpowers/specs/2026-07-01-sidebar-open-split-behavior-design.md`
- An unrelated pre-existing gap was fixed in passing: `tsc -b` (project-reference mode) was missing Node types for `vite.config.ts` — harmless but fixed since it was already found (`cb1a677`).
- A separate, unrelated bug found during manual testing (Ctrl/Cmd+W closes the whole app instead of the focused pane/tab) was filed as its own issue (#104), not fixed on this branch.