### PR TITLE
fix: stop Cmd+W from closing the whole app instead of the focused pane

### DIFF
--- a/src-tauri/src/modules/menu.rs
+++ b/src-tauri/src/modules/menu.rs
@@ -3,6 +3,7 @@ use tauri::window::Color;
 use tauri::{App, AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 
 const NEW_WINDOW_ID: &str = "new-window";
+const CLOSE_WINDOW_ID: &str = "close-window";
 
 /// Build the menu (Tauri's default plus a New Window item injected into File),
 /// set it as the app menu, and wire the menu-event handler.
@@ -18,19 +19,54 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
         true,
         Some("CmdOrCtrl+N"),
     )?;
+    // Tauri's default menu bundles TWO separate native "Close Window" items
+    // bound to Cmd+W (the OS's standard accelerator) — one in "File", one in
+    // "Window". Either one closes the actual window directly at the
+    // Tauri-runtime level, bypassing the frontend's own close-pane-or-tab
+    // keydown handler (src/App.tsx's `key === "w"` branch) entirely — and
+    // since this app is usually a single window, closing it quits the whole
+    // app. Both must be removed (removing only one still leaves Cmd+W
+    // captured by the other) so Cmd+W reaches the frontend handler. Closing
+    // the actual window moves to Shift+Cmd+W instead, wired below as a
+    // custom item since PredefinedMenuItem::close_window has no accelerator
+    // override.
+    let close_window = MenuItem::with_id(
+        &handle,
+        CLOSE_WINDOW_ID,
+        "Close Window",
+        true,
+        Some("Shift+CmdOrCtrl+W"),
+    )?;
+    let mut inserted_close_window = false;
     for item in menu.items()? {
         if let MenuItemKind::Submenu(submenu) = item {
+            for sub_item in submenu.items()? {
+                if let MenuItemKind::Predefined(predefined) = &sub_item {
+                    if predefined.text()? == "Close Window" {
+                        submenu.remove(predefined)?;
+                    }
+                }
+            }
             if submenu.text()? == "File" {
                 submenu.insert(&new_window, 0)?;
                 submenu.insert(&PredefinedMenuItem::separator(&handle)?, 1)?;
-                break;
+                submenu.append(&close_window)?;
+                inserted_close_window = true;
             }
         }
     }
+    debug_assert!(
+        inserted_close_window,
+        "menu default no longer has a File submenu to attach Close Window to"
+    );
     app.set_menu(menu)?;
     app.on_menu_event(|app, event| {
         if event.id() == NEW_WINDOW_ID {
             let _ = create_new_window(app);
+        } else if event.id() == CLOSE_WINDOW_ID {
+            if let Some(window) = app.get_focused_window() {
+                let _ = window.close();
+            }
         }
     });
     Ok(())

--- a/src-tauri/src/modules/menu.rs
+++ b/src-tauri/src/modules/menu.rs
@@ -20,16 +20,27 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
         Some("CmdOrCtrl+N"),
     )?;
     // Tauri's default menu bundles TWO separate native "Close Window" items
-    // bound to Cmd+W (the OS's standard accelerator) — one in "File", one in
-    // "Window". Either one closes the actual window directly at the
-    // Tauri-runtime level, bypassing the frontend's own close-pane-or-tab
-    // keydown handler (src/App.tsx's `key === "w"` branch) entirely — and
-    // since this app is usually a single window, closing it quits the whole
-    // app. Both must be removed (removing only one still leaves Cmd+W
-    // captured by the other) so Cmd+W reaches the frontend handler. Closing
-    // the actual window moves to Shift+Cmd+W instead, wired below as a
-    // custom item since PredefinedMenuItem::close_window has no accelerator
-    // override.
+    // bound to Cmd+W (the OS's standard accelerator) — the last item in
+    // "File" (its only item) and the last item in "Window" (after
+    // Minimize/Maximize/separator). Either one closes the actual window
+    // directly at the Tauri-runtime level, bypassing the frontend's own
+    // close-pane-or-tab keydown handler (src/App.tsx's `key === "w"`
+    // branch) entirely — and since this app is usually a single window,
+    // closing it quits the whole app. Both must be removed (removing only
+    // one still leaves Cmd+W captured by the other) so Cmd+W reaches the
+    // frontend handler. Closing the actual window moves to Shift+Cmd+W
+    // instead, wired below as a custom item since
+    // PredefinedMenuItem::close_window has no accelerator override.
+    //
+    // Removal matches by POSITION, not by the item's text — predefined
+    // items are localized by the OS (e.g. "Fermer la fenêtre" in French),
+    // so a text match would silently fail on non-English systems, and their
+    // `MenuId` is a random per-instance counter (confirmed by reading
+    // muda's source), not a stable value tied to which predefined action
+    // they represent, so an id match doesn't work either. The exact
+    // position was confirmed empirically for this tauri/muda version via a
+    // temporary runtime diagnostic dump of the actual default menu
+    // structure, not just from documentation.
     let close_window = MenuItem::with_id(
         &handle,
         CLOSE_WINDOW_ID,
@@ -40,14 +51,14 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
     let mut inserted_close_window = false;
     for item in menu.items()? {
         if let MenuItemKind::Submenu(submenu) = item {
-            for sub_item in submenu.items()? {
-                if let MenuItemKind::Predefined(predefined) = &sub_item {
-                    if predefined.text()? == "Close Window" {
-                        submenu.remove(predefined)?;
-                    }
+            let text = submenu.text()?;
+            if text == "File" || text == "Window" {
+                let items = submenu.items()?;
+                if matches!(items.last(), Some(MenuItemKind::Predefined(_))) {
+                    submenu.remove_at(items.len() - 1)?;
                 }
             }
-            if submenu.text()? == "File" {
+            if text == "File" {
                 submenu.insert(&new_window, 0)?;
                 submenu.insert(&PredefinedMenuItem::separator(&handle)?, 1)?;
                 submenu.append(&close_window)?;


### PR DESCRIPTION
## Summary

Fixes #104. Pressing Cmd+W was quitting the entire app instead of closing just the focused pane or tab, as `App.tsx`'s own keydown handler (`closePaneOrTab`) already implements correctly.

## Root cause

Tauri's default macOS menu bundles **two separate** native "Close Window" items bound to Cmd+W (the OS's standard accelerator) — one in the **File** submenu, one in the **Window** submenu. Either one closes the actual OS window directly at the Tauri-runtime level, completely bypassing the frontend's keydown handler. Since this app is usually a single window, closing it exits the whole process.

Confirmed empirically (not just from docs, which turned out to be inaccurate about which submenu each item lives in): added a temporary diagnostic dump of the live menu structure in a local dev build, which showed both copies (`File > Close Window` and `Window > Close Window`) side by side.

An earlier fix attempt only removed the `File` copy and still failed — Cmd+W stayed captured by the surviving `Window` copy. Removing both fixed it.

## Fix

- Remove every native "Close Window" predefined item found while walking the default menu's submenus.
- Add a custom "Close Window" menu item (since `PredefinedMenuItem::close_window` has no accelerator override) bound to **Shift+Cmd+W** instead, wired to close the currently focused window — so the capability isn't lost, just moved off the shortcut the frontend now owns.

## Test plan

- [x] `cargo check` clean
- [x] Manually verified via a local build: opened multiple tabs/split panes, Cmd+W closes only the focused pane/tab (not the app)
- [x] Manually verified: Shift+Cmd+W closes the actual window
- [ ] No automated test added — this is native Tauri menu-construction code and the project has no `tauri::test` mocking infrastructure yet; verified instead via the diagnostic-dump + manual build/click testing described above.