### PR TITLE
fix(tabs): focus the first remaining pane after closing the active one

### DIFF
--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -342,14 +342,14 @@ describe("tabsStore", () => {
     expect(leafIds(tab.paneTree)).toEqual([firstLeaf]);
   });
 
-  it("focuses the last remaining pane after closing the active pane", () => {
+  it("focuses the first remaining pane after closing the active pane", () => {
     const id = useTabsStore.getState().newTerminalTab();
     useTabsStore.getState().splitActivePane("row");
     useTabsStore.getState().splitActivePane("row");
     const ids = leafIds(activeTab().paneTree);
     expect(ids).toHaveLength(3);
-    // Focus and close the middle pane; focus must land on the last remaining
-    // pane, not the first.
+    // Focus and close the middle pane; focus must land on the first remaining
+    // pane, not the last.
     useTabsStore.setState({
       tabs: useTabsStore.getState().tabs.map((t) =>
         t.id === id ? { ...t, activeLeafId: ids[1] } : t,
@@ -357,7 +357,7 @@ describe("tabsStore", () => {
     });
     useTabsStore.getState().closePane(id, ids[1]);
     expect(leafIds(activeTab().paneTree)).toEqual([ids[0], ids[2]]);
-    expect(activeTab().activeLeafId).toBe(ids[2]);
+    expect(activeTab().activeLeafId).toBe(ids[0]);
   });
 
   it("activates a neighbour when the active tab closes", () => {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -1049,14 +1049,11 @@ export const useTabsStore = create<TabsState>()(
         }
         return { tabs, activeId };
       }
-      // When the focused pane is the one closing, move focus to the LAST
-      // remaining pane (reading order) rather than the first, so closing a pane
-      // keeps focus near where it was instead of jumping to the leftmost pane.
+      // When the focused pane is the one closing, move focus to the first
+      // remaining pane.
       const remaining = leafIds(paneTree);
       const activeLeafId =
-        tab.activeLeafId === leafId
-          ? (remaining[remaining.length - 1] ?? tab.activeLeafId)
-          : tab.activeLeafId;
+        tab.activeLeafId === leafId ? (remaining[0] ?? tab.activeLeafId) : tab.activeLeafId;
       return {
         tabs: state.tabs.map((t) =>
           t.id === tabId


### PR DESCRIPTION
## Summary

- `closePane`'s focus target changed in #103 from the first remaining pane to the last one — an undocumented side effect bundled with the preview tab feature, not something reviewed or discussed as an intentional UX decision for pane closing in general.
- Revert to focusing the first remaining pane after closing the active one.

## Test plan

- ✅ `pnpm typecheck`
- ✅ `pnpm test` (1001 tests, including the updated `focuses the first remaining pane after closing the active pane` test)