### PR TITLE
feat(git): side-by-side diff tab, sidebar actions, and git graph row fixes

### DIFF
--- a/docs/superpowers/plans/2026-07-02-git-panel-batch1.md
+++ b/docs/superpowers/plans/2026-07-02-git-panel-batch1.md
@@ -1,0 +1,312 @@
+# Git Panel Batch 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Source-control sidebar becomes actionable (context menu, discard, side-by-side diff tab) and two Git Graph papercuts are fixed — spec: `docs/superpowers/specs/2026-07-02-git-panel-batch1-design.md`.
+
+**Architecture:** A new `diff` pane kind renders a read-only `@codemirror/merge` MergeView comparing a git revision (HEAD or index, fetched via a new `git_file_at_rev` command) against the working tree / index. The sidebar file rows gain left-click (open diff), a hover discard button, and a shared-ContextMenu right-click menu; discard calls a new `git_restore_file` command behind a ConfirmDialog.
+
+**Tech Stack:** React 18 + TS, zustand tabsStore, CodeMirror 6 (`@codemirror/merge` — new dep), Rust `run_git` wrappers, vitest + RTL, Rust `#[cfg(test)]` temp-repo fixtures.
+
+## Global Constraints
+
+- Branch: `feat/git-panel-batch1` (already checked out). English commits/comments; conventional commits.
+- Every git-facing Rust command validates args with `ensure_not_flag` and passes paths after `--`.
+- All UI strings go through i18n (`en` + `zh-Hant`); tooltips use the shared `Tooltip` (default side top).
+- Dialogs use `ConfirmDialog`/`InfoDialog`, never window.confirm.
+- After each task: `pnpm test && pnpm typecheck`; Rust tasks also `cargo test -p tempo-term` (run in `src-tauri`).
+
+---
+
+### Task 1: Rust commands `git_file_at_rev` + `git_restore_file`
+
+**Files:**
+- Modify: `src-tauri/src/modules/git/mod.rs` (functions near `diff()` ~line 335; commands near `git_diff` ~line 897; tests in the existing `#[cfg(test)]` module)
+- Modify: `src-tauri/src/lib.rs` (register both in `invoke_handler!`)
+
+**Interfaces:**
+- Produces: `git_file_at_rev(repoPath, rev, path) -> String` where `rev ∈ {"HEAD", ":"}`; returns `""` when the file doesn't exist at that rev. `git_restore_file(repoPath, path) -> ()`.
+
+- [ ] **Step 1: Write failing Rust tests** (in the existing test module, reusing its `temp_repo_dir` fixture style):
+
+```rust
+#[test]
+fn file_at_rev_reads_head_and_index_versions() {
+    let dir = temp_repo_dir("file_at_rev");
+    let path = dir.to_string_lossy().to_string();
+    run_git(&path, &["init"]).unwrap();
+    run_git(&path, &["config", "user.name", "Test"]).unwrap();
+    run_git(&path, &["config", "user.email", "test@example.com"]).unwrap();
+    std::fs::write(dir.join("a.txt"), "committed\n").unwrap();
+    run_git(&path, &["add", "a.txt"]).unwrap();
+    run_git(&path, &["commit", "-m", "c1"]).unwrap();
+    std::fs::write(dir.join("a.txt"), "staged\n").unwrap();
+    run_git(&path, &["add", "a.txt"]).unwrap();
+
+    assert_eq!(file_at_rev(&path, "HEAD", "a.txt").unwrap(), "committed\n");
+    assert_eq!(file_at_rev(&path, ":", "a.txt").unwrap(), "staged\n");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn file_at_rev_missing_file_is_empty_and_bad_rev_rejected() {
+    let dir = temp_repo_dir("file_at_rev_missing");
+    let path = dir.to_string_lossy().to_string();
+    run_git(&path, &["init"]).unwrap();
+    assert_eq!(file_at_rev(&path, "HEAD", "nope.txt").unwrap(), "");
+    assert!(file_at_rev(&path, "HEAD~1", "a.txt").is_err());
+    assert!(file_at_rev(&path, "HEAD", "--evil").is_err());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn restore_file_reverts_unstaged_change() {
+    let dir = temp_repo_dir("restore_file");
+    let path = dir.to_string_lossy().to_string();
+    run_git(&path, &["init"]).unwrap();
+    run_git(&path, &["config", "user.name", "Test"]).unwrap();
+    run_git(&path, &["config", "user.email", "test@example.com"]).unwrap();
+    std::fs::write(dir.join("a.txt"), "original\n").unwrap();
+    run_git(&path, &["add", "a.txt"]).unwrap();
+    run_git(&path, &["commit", "-m", "c1"]).unwrap();
+    std::fs::write(dir.join("a.txt"), "dirty\n").unwrap();
+
+    restore_file(&path, "a.txt").unwrap();
+    assert_eq!(std::fs::read_to_string(dir.join("a.txt")).unwrap(), "original\n");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — `cd src-tauri && cargo test file_at_rev restore_file` → compile error (functions missing).
+- [ ] **Step 3: Implement**
+
+```rust
+/// Content of `path` at `rev`, where rev is limited to "HEAD" (last commit)
+/// or ":" (the index). A file missing at that rev is an empty document, not
+/// an error, so new files diff as all-added.
+pub fn file_at_rev(repo_path: &str, rev: &str, path: &str) -> Result<String, String> {
+    if rev != "HEAD" && rev != ":" {
+        return Err(format!("unsupported rev: {rev}"));
+    }
+    ensure_not_flag(path)?;
+    match run_git(repo_path, &["show", &format!("{rev}:{path}")]) {
+        Ok(content) => Ok(content),
+        Err(err) if err.contains("does not exist") || err.contains("exists on disk, but not in") => {
+            Ok(String::new())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Discard unstaged changes to one tracked file (`git restore -- <path>`).
+pub fn restore_file(repo_path: &str, path: &str) -> Result<(), String> {
+    ensure_not_flag(path)?;
+    run_git(repo_path, &["restore", "--", path]).map(|_| ())
+}
+```
+
+Commands (beside `git_diff`):
+
+```rust
+#[tauri::command]
+pub fn git_file_at_rev(repo_path: String, rev: String, path: String) -> Result<String, String> {
+    file_at_rev(&repo_path, &rev, &path)
+}
+
+#[tauri::command]
+pub fn git_restore_file(repo_path: String, path: String) -> Result<(), String> {
+    restore_file(&repo_path, &path)
+}
+```
+
+Register both names in `lib.rs`'s `invoke_handler!` list next to `git_diff`. Adjust the missing-file error match to whatever message the tests reveal (`git show` wording differs by version — make the test drive the exact patterns; falling back to treating any "fatal: path ..." error as empty is acceptable if scoped to the `show` call).
+
+- [ ] **Step 4: Run tests** — `cargo test file_at_rev restore_file` → PASS; `cargo test` (module) still green.
+- [ ] **Step 5: Frontend bridge** — append to `src/modules/source-control/lib/gitBridge.ts`:
+
+```ts
+/** rev is "HEAD" (last commit) or ":" (the index). Missing at rev = "". */
+export function gitFileAtRev(repoPath: string, rev: "HEAD" | ":", path: string): Promise<string> {
+  return invoke<string>("git_file_at_rev", { repoPath, rev, path });
+}
+
+export function gitRestoreFile(repoPath: string, path: string): Promise<void> {
+  return invoke<void>("git_restore_file", { repoPath, path });
+}
+```
+
+- [ ] **Step 6: Verify + commit**
+
+```bash
+pnpm typecheck && git add -A src-tauri src/modules/source-control/lib/gitBridge.ts
+git commit -m "feat(git): add file-at-rev and restore-file commands"
+```
+
+---
+
+### Task 2: `diff` pane kind + `openDiffTab`
+
+**Files:**
+- Modify: `src/modules/terminal/lib/terminalLayout.ts:14-20` (PaneContent union)
+- Modify: `src/stores/tabsStore.ts` (TabKind:43, restore switch ~348, `singleLeafContentEquals` ~264, new `openDiffTab` beside `openGitGraphTab` ~571; persistence mapping if tabs serialize `path`)
+- Modify: `src/components/TabBar.tsx` + `src/modules/workspace/WorkspacePanel.tsx` `tabIcon` switches (add `case "diff": return GitCompare` from lucide)
+- Test: `src/stores/tabsStore.test.ts` (or the existing tabsStore test file — extend)
+
+**Interfaces:**
+- Produces: `PaneContent` variant `{ kind: "diff"; path: string; staged: boolean }`; `openDiffTab(path: string, staged: boolean): string` with focus-existing dedup on `path`+`staged`; TabKind gains `"diff"`.
+
+- [ ] **Step 1: Write failing test** (mirror the existing openGitGraphTab tests' store setup):
+
+```ts
+describe("openDiffTab", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("creates a diff tab titled by basename and focuses the same file on re-open", () => {
+    const first = useTabsStore.getState().openDiffTab("/repo/src/App.tsx", false);
+    expect(useTabsStore.getState().tabs[0].title).toBe("App.tsx");
+    const again = useTabsStore.getState().openDiffTab("/repo/src/App.tsx", false);
+    expect(again).toBe(first);
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+  });
+
+  it("treats staged and unstaged diffs of the same file as distinct tabs", () => {
+    useTabsStore.getState().openDiffTab("/repo/a.ts", false);
+    useTabsStore.getState().openDiffTab("/repo/a.ts", true);
+    expect(useTabsStore.getState().tabs).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Verify failure** — `pnpm vitest run src/stores` → openDiffTab undefined.
+- [ ] **Step 3: Implement** — add the union member; extend `singleLeafContentEquals` with `if (pane.kind === "diff" && content.kind === "diff") return pane.path === content.path && pane.staged === content.staged;`; add `"diff"` to TabKind and the restore switch (`content = { kind: "diff", path: t.path ?? "", staged: t.staged ?? false }` — persist `staged` alongside `path` the same way editor persists `path`); implement `openDiffTab` cloning the `openGitGraphTab` body with the dedup predicate `t.kind === "diff" && singleLeafContentEquals(t, { kind: "diff", path, staged })`, title `path.split(/[\\/]/).pop() ?? path`.
+- [ ] **Step 4: Icon switches** — both `tabIcon` functions gain `case "diff": return GitCompare;` (import from lucide-react). TypeScript exhaustiveness will point at any missed switch.
+- [ ] **Step 5: Verify + commit** — `pnpm test && pnpm typecheck`; `git commit -am "feat(tabs): add diff pane kind with focus-existing open"`.
+
+---
+
+### Task 3: DiffTabContent (MergeView) + pane wiring
+
+**Files:**
+- Create: `src/modules/diff/DiffTabContent.tsx`
+- Create: `src/modules/diff/DiffTabContent.test.tsx`
+- Modify: `src/modules/terminal/PaneTabContent.tsx` (lazy import + render branch beside the `git-graph` branch at ~451)
+- Modify: `package.json` (add `@codemirror/merge`)
+- Modify: `src/i18n/locales/{en,zh-Hant}/sourceControl.json` (keys below)
+
+**Interfaces:**
+- Consumes: `gitFileAtRev`, `gitResolveRepo`, `gitStatus` (Task 1 bridge + existing), `fsReadFile` (`src/modules/explorer/lib/fsBridge.ts:33`), `loadLanguageExtension` (`src/modules/editor/lib/language.ts`), fontFamily/fontSize stores as used in `EditorTabContent.tsx:89-105`.
+- Produces: `<DiffTabContent path={string} staged={boolean} />`.
+
+- [ ] **Step 1: Install dep** — `pnpm add @codemirror/merge`.
+- [ ] **Step 2: Write failing test** (jsdom can't measure MergeView; test the data contract):
+
+```tsx
+// mocks: gitBridge (gitResolveRepo→"/repo", gitFileAtRev), fsBridge (fsReadFile)
+it("loads index vs worktree for an unstaged diff", async () => {
+  vi.mocked(gitFileAtRev).mockResolvedValue("old\n");
+  vi.mocked(fsReadFile).mockResolvedValue("new\n");
+  render(<DiffTabContent path="/repo/a.ts" staged={false} />);
+  await waitFor(() => expect(gitFileAtRev).toHaveBeenCalledWith("/repo", ":", "a.ts"));
+  expect(fsReadFile).toHaveBeenCalledWith("/repo/a.ts");
+});
+
+it("loads HEAD vs index for a staged diff", async () => {
+  vi.mocked(gitFileAtRev).mockResolvedValue("x");
+  render(<DiffTabContent path="/repo/a.ts" staged={true} />);
+  await waitFor(() =>
+    expect(gitFileAtRev).toHaveBeenNthCalledWith(1, "/repo", "HEAD", "a.ts"));
+  expect(gitFileAtRev).toHaveBeenNthCalledWith(2, "/repo", ":", "a.ts");
+});
+```
+
+- [ ] **Step 3: Verify failure**, **Step 4: Implement**:
+
+```tsx
+/**
+ * Read-only side-by-side comparison for one file's uncommitted changes.
+ * Unstaged tab: index (left) vs working tree (right). Staged tab: HEAD (left)
+ * vs index (right). Contents load on mount; MergeView computes the diff.
+ */
+export function DiffTabContent({ path, staged }: { path: string; staged: boolean }) { ... }
+```
+
+Implementation notes (concrete, follow in order):
+1. Resolve the repo once: `gitResolveRepo(dirname(path))` — reuse `dirname` from `src/modules/explorer/lib/paths.ts`; compute the repo-relative path by stripping `repo + "/"` prefix.
+2. Fetch left/right: unstaged → `[gitFileAtRev(repo, ":", rel), fsReadFile(path).catch(() => "")]`; staged → `[gitFileAtRev(repo, "HEAD", rel), gitFileAtRev(repo, ":", rel)]`.
+3. Build the view in a `useEffect`: `new MergeView({ a: { doc: left, extensions }, b: { doc: right, extensions }, parent: containerRef.current, gutter: true })` where `extensions = [EditorState.readOnly.of(true), EditorView.editable.of(false), theme, languageExt]`; theme mirrors `EditorTabContent.tsx:91-94` (fontSize/fontFamily from the same stores); `languageExt` from `await loadLanguageExtension(path)` resolved before constructing (single async load, then build). Destroy the view in the effect cleanup.
+4. Header bar above the view: filename + a badge `t("sourceControl:diffStaged")` / `t("sourceControl:diffUnstaged")` so the two tab variants are distinguishable.
+5. Re-fetch on window focus (`focus` event listener) per spec — rebuild docs via `view.a.dispatch({changes: {from: 0, to: view.a.state.doc.length, insert: next}})` style updates, or simplest: re-run the load effect keyed on a `refreshKey` state bumped by the focus listener.
+
+i18n keys (both locales): `diffStaged` ("Staged" / "已暫存"), `diffUnstaged` ("Working tree" / "工作區"), `diffLoadError` ("Couldn't load the comparison" / "無法載入比對內容").
+
+- [ ] **Step 5: Wire the pane** — in `PaneTabContent.tsx` add a lazy import mirroring GitGraphTabContent (line 28) and a render branch: `pane.content.kind === "diff" ? <DiffTabContent path={pane.content.path} staged={pane.content.staged} /> : ...`.
+- [ ] **Step 6: Verify + commit** — `pnpm test && pnpm typecheck`; `git commit -am "feat(diff): add side-by-side diff tab backed by @codemirror/merge"`.
+
+---
+
+### Task 4: Sidebar interactions (context menu, discard, left-click)
+
+**Files:**
+- Modify: `src/modules/source-control/SourceControlView.tsx` (StatusRow ~49-88, FileList ~101, history list ~446-460, panel root ~281)
+- Modify: `src/i18n/locales/{en,zh-Hant}/sourceControl.json`
+- Test: `src/modules/source-control/SourceControlView.test.tsx` (extend existing)
+
+**Interfaces:**
+- Consumes: `openDiffTab` (Task 2), `gitRestoreFile` (Task 1), shared `ContextMenu` (`src/components/ContextMenu.tsx` — usage pattern `FileTree.tsx:56,285-288,339-346`), `ConfirmDialog`, `fsReveal` (`src/modules/explorer/lib/fsBridge.ts`), `openFromSidebar`/`openInNewTab` (tabsStore), `relativePath` (`src/modules/explorer/lib/paths.ts`).
+
+Behavior to implement (StatusRow gains `staged: boolean` and `repoPath: string` props, or a context object — pick the smallest prop set):
+1. Row `<li>` gets `onClick={() => openDiffTab(absPath, staged)}` (absPath = `repoPath + "/" + file.path`), `cursor-pointer`, and `onContextMenu` opening the shared ContextMenu at cursor.
+2. Menu items (per spec grouping): 開啟檔案 (`openFromSidebar({kind:"editor",path:absPath})`), 在新分頁開啟 (`openInNewTab`), 顯示 diff (`openDiffTab`); 暫存/取消暫存 (existing handlers); 複製路徑 / 複製相對路徑 / 在 Finder 顯示 (`navigator.clipboard.writeText`, `fsReveal`); danger group 捨棄變更 — only when `!staged && file.status !== "?"`.
+3. Hover discard button (lucide `Undo2`, Tooltip label 捨棄變更) in the unstaged section next to `+` — hidden for untracked (`file.status === "?"`) rows; opens the same ConfirmDialog.
+4. ConfirmDialog: title `discardTitle`, message `discardMessage` (interpolate filename, state irreversibility), confirm label `discardConfirm` (danger), on confirm → `gitRestoreFile(repoPath, file.path)` then `refresh()`.
+5. History rows: `onContextMenu` menu with 複製 hash (`commit.id`) and 複製提交訊息 (`commit.summary`).
+6. Panel root div: `onContextMenu={(e) => e.preventDefault()}` so misses don't show the system menu (row handlers stopPropagation to layer their menu).
+
+i18n keys (en / zh-Hant): `menuOpenFile` "Open File"/"開啟檔案", `menuOpenInNewTab` "Open in New Tab"/"在新分頁開啟", `menuShowDiff` "Show Diff"/"顯示 diff", `menuCopyPath` "Copy Path"/"複製路徑", `menuCopyRelativePath` "Copy Relative Path"/"複製相對路徑", `menuRevealFinder` "Reveal in Finder"/"在 Finder 顯示", `discard` "Discard Changes"/"捨棄變更", `discardTitle` "Discard Changes"/"捨棄變更", `discardMessage` "Discard changes to {{name}}? This cannot be undone."/"要捨棄 {{name}} 的變更嗎？這個動作無法復原", `discardConfirm` "Discard"/"捨棄", `menuCopyHash` "Copy Hash"/"複製 hash", `menuCopyMessage` "Copy Message"/"複製提交訊息".
+
+- [ ] **Step 1..n (TDD, one behavior at a time):** for each behavior write the RTL test first, watch it fail, implement, watch it pass. Required tests at minimum:
+
+```tsx
+it("opens a diff tab when a changed file row is clicked", ...)        // asserts openDiffTab spy / tabs state
+it("shows discard only for tracked unstaged rows", ...)               // untracked row lacks the button & menu item
+it("confirms before discarding and calls gitRestoreFile", ...)        // ConfirmDialog flow
+it("right-click opens the custom menu with stage/copy items", ...)    // menuitem roles
+it("history row right-click offers copy hash", ...)
+```
+
+- [ ] **Final step: Verify + commit** — `pnpm test && pnpm typecheck`; `git commit -am "feat(source-control): clickable rows, context menus and per-file discard"`.
+
+---
+
+### Task 5: Git Graph full-row click
+
+**Files:**
+- Modify: `src/modules/git-graph/GitGraph.tsx:218-230` (row positioning)
+- Test: `src/modules/git-graph/GitGraph.test.tsx` (extend if present; else assert via GitGraphTabContent test utilities)
+
+- [ ] **Step 1: Failing test** — render a graph with one commit, click at the row element (which should now span from the left edge), assert `onSelectCommit` fires. Concretely: change assertion target to the row's computed class (`left-0`) or click the row and check selection state.
+- [ ] **Step 2: Implement** — row div: `left-[100px]` → `left-0`, add `pl-[100px]` to preserve text alignment (padding container already has `px-3`; fold the paddings: keep `pr-3 py-1`, replace `px-3` with `pl-[112px] pr-3` — 100px gutter + original 12px). Node buttons are `z-10` (`GitGraph.tsx:181`) and remain above the row hover background; the SVG is `pointer-events-none` so row clicks in the gutter land on the row.
+- [ ] **Step 3: Visual check in the running app** — hover tint spans the lane gutter; lanes stay legible; node click still selects.
+- [ ] **Step 4: Verify + commit** — `pnpm test && pnpm typecheck`; `git commit -am "fix(git-graph): make the full commit row clickable"`.
+
+---
+
+### Task 6: Compact "⋯" toolbar verification
+
+**Files:**
+- Possibly modify: `src/modules/git-graph/GitGraphToolbar.tsx`
+
+- [ ] **Step 1: Reproduce** — run the app, narrow the Git Graph pane below 620px, open "⋯". Compare available actions against roomy mode (branch filter, remote toggle, search, tags/stashes/order, refresh, fetch).
+- [ ] **Step 2: Decide** — if an action is genuinely unreachable in compact mode (suspect: branch filter while search is expanded, per `showBranchControls` logic ~line 157), move it into the overflow menu with a matching row; if everything is reachable, note the finding for the PR body / issue comment instead.
+- [ ] **Step 3: If code changed:** add a test in `GitGraphToolbar.test.tsx` (compact-mode tests exist ~line 99) asserting the recovered action appears in the menu; `pnpm test && pnpm typecheck`; `git commit -am "fix(git-graph): expose <action> from the compact overflow menu"`.
+
+---
+
+### Task 7: Reviews, verification, build
+
+- [ ] **Step 1:** `pnpm test && pnpm typecheck && (cd src-tauri && cargo test)` — full green.
+- [ ] **Step 2:** Run `/code-review` and `/tauri-review`; fix CRITICAL/HIGH (and reasonable MEDIUM) findings; re-run until clean.
+- [ ] **Step 3:** Verify in the running app (`pnpm tauri dev`): click a changed file → side-by-side diff tab; staged vs unstaged variants; discard flow end-to-end on a scratch repo; context menus; Git Graph row click; compact toolbar.
+- [ ] **Step 4:** Local build for owner testing: `export TAURI_SIGNING_PRIVATE_KEY="$(cat ~/.tauri/tempo-term.key)" TAURI_SIGNING_PRIVATE_KEY_PASSWORD="" && pnpm tauri build`, then open the bundled app.

--- a/docs/superpowers/specs/2026-07-02-git-panel-batch1-design.md
+++ b/docs/superpowers/specs/2026-07-02-git-panel-batch1-design.md
@@ -1,0 +1,75 @@
+# Git Panel Batch 1 Design (issues #93 / #94, first slice)
+
+Status: approved in conversation on 2026-07-02 (owner: mukiwu)
+Scope source: issue #93 items 2–3, issue #94 items 1 and 6, plus an owner-requested side-by-side diff tab that supersedes the issue's "jump to Git Graph" idea for viewing uncommitted changes.
+
+## Goal
+
+Make the source-control sidebar actionable (context menu, discard, diff viewing) and fix two Git Graph interaction papercuts. Batches 2–3 (Working copy node, cross-panel navigation, branch/worktree switching, tree view) are out of scope and tracked separately.
+
+## Decisions already made by the owner
+
+- Context menu on file rows modeled on VS Code's source-control menu, localized wording:
+  暫存 / 取消暫存、捨棄變更、開啟檔案、在新分頁開啟、在 Finder 顯示、複製路徑、複製相對路徑、顯示 diff.
+- "顯示 diff" opens a **new tab with a side-by-side comparison** — explicitly NOT wired to Git Graph.
+- Left-click on a file row opens that diff tab (VS Code behavior). Re-clicking the same file focuses the existing tab.
+- 捨棄變更 (discard) applies to **tracked files only**, restores the file to HEAD, and always confirms first. Untracked files get no discard action in this batch.
+- Discard appears only in the 變更 (unstaged) section, matching VS Code where the staged section offers only Unstage.
+
+## Components
+
+### 1. Diff tab (new pane kind)
+
+- `PaneContent` gains `{ kind: "diff"; path: string; staged: boolean }` (`src/modules/terminal/lib/terminalLayout.ts`). `singleLeafContentEquals` compares `path` + `staged`.
+- New `openDiffTab(path, staged)` in `tabsStore` following the `openGitGraphTab` focus-existing-or-create pattern. Tab title: file basename; icon: `GitCompare` (lucide).
+- Viewer: `@codemirror/merge` `MergeView` (new dependency, same CodeMirror 6 stack as the editor), read-only both sides, reusing the editor's existing language/highlight configuration by file extension and the app theme.
+- Comparison semantics (VS Code parity):
+  - Row from 變更 (unstaged) section → left = index version (`git show :<path>`), right = working-tree file from disk.
+  - Row from 暫存 (staged) section → left = HEAD version (`git show HEAD:<path>`), right = index version.
+  - Untracked file → left = empty document, right = disk content (renders as all-added).
+- The diff tab loads content on mount and re-reads when the tab regains focus; no live file watching in this batch.
+- Deleted files: left = prior version, right = empty document.
+
+### 2. Backend commands (Rust, `src-tauri/src/modules/git/mod.rs`)
+
+- `git_file_at_rev(repo_path, rev, path) -> String`: wraps `git show <rev>:<path>` with `rev` limited to the literal values `HEAD` or `:` (reject anything else — the frontend only ever needs these two), `ensure_not_flag(path)`, and path passed after `--` where applicable. Missing-at-rev (new file) returns empty string rather than an error.
+- `git_restore_file(repo_path, path) -> ()`: wraps `git restore -- <path>`. Tracked-unstaged only by contract; the frontend never calls it for untracked or staged rows.
+- Both registered in `lib.rs`, both with unit tests beside the existing ones (temp repo fixtures already exist in the test module).
+- Frontend bridge functions `gitFileAtRev`, `gitRestoreFile` added to `src/modules/source-control/lib/gitBridge.ts`.
+
+### 3. Source-control panel interactions (`SourceControlView.tsx`)
+
+- **File row context menu** via the shared `ContextMenu` component (same usage pattern as `FileTree.tsx`), items grouped:
+  - group 0: 開啟檔案 (`openFromSidebar` editor), 在新分頁開啟 (`openInNewTab` editor), 顯示 diff (`openDiffTab`)
+  - group 1: 暫存 or 取消暫存 (section-dependent)
+  - group 2: 複製路徑, 複製相對路徑 (absolute = repo root + path)
+  - group 3 (danger): 捨棄變更 — unstaged tracked rows only
+  - 在 Finder 顯示 (`fsReveal`) sits in group 2 with the copy actions.
+- **Row hover action**: the 變更 section gains a discard icon button (lucide `Undo2`) next to the existing `+`, per the issue's request to mirror the stage buttons. Staged section keeps `−` only.
+- **Left-click on a file row** → `openDiffTab(path, stagedSection)`.
+- **Discard confirmation**: existing `ConfirmDialog`, danger-styled confirm, message naming the file and stating the change cannot be undone.
+- **Commit row context menu** (近期提交): 複製 hash, 複製提交訊息 — copy-only in this batch; "view in Git Graph" arrives with batch 2. `git_log` already returns the short hash and the summary line; message copy copies the summary (the one-line subject), which is all the sidebar has.
+- **Suppress the system context menu** on the panel container (`onContextMenu` preventDefault at the panel root) so right-clicks that miss a row don't show the WebView menu.
+
+### 4. Git Graph papercuts
+
+- **Full-row click** (`GitGraph.tsx`): commit rows currently start at `left-[100px]`, leaving the node-lane gutter inert. Extend each row's hit area to the full width (row at `left-0` with `pl-[100px]`; hover background spans the lane area — visually verify the SVG lanes remain legible under the hover tint, `z`-order keeps node buttons clickable above the row).
+- **Compact "⋯" menu** (`GitGraphToolbar.tsx`): investigation shows the overflow menu already contains refresh / fetch / remote toggle / tags / stashes / order. Task is to reproduce the issue's screenshot state, identify any genuinely unreachable action in compact mode (branch filter while searching is one suspect), fix the gap if real, otherwise document the finding on the issue.
+
+## Error handling
+
+- Backend command failures (e.g. file deleted between status refresh and action) surface via the existing error surfacing used by stage/unstage — refresh status afterwards so stale rows disappear.
+- `git_restore_file` refreshes the status list on success; the diff tab for that file, if open, shows the restored (now unchanged) content on next focus.
+
+## Testing
+
+- Rust: unit tests for `git_file_at_rev` (HEAD version, index version, new file empty, flag-smuggling rejected) and `git_restore_file` (modified file restored, exercised in a temp repo).
+- Frontend (vitest + RTL): context-menu items render per section (staged vs unstaged vs untracked), discard flows through ConfirmDialog before calling the bridge, left-click calls `openDiffTab`, `openDiffTab` dedups on same path+staged, Git Graph row click registers in the former gutter area.
+- MergeView rendering is verified manually in the running app (jsdom cannot measure CodeMirror layout).
+
+## Out of scope (explicitly)
+
+- Open File (HEAD), Reveal in Explorer View (no file-locating mechanism in the explorer yet)
+- Working copy node in Git Graph, cross-panel jump, branch/worktree switching, tree view of changed files (batches 2–3)
+- Discard for untracked files (delete semantics deferred)
+- Live-updating diff tab contents while files change on disk

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@codemirror/lang-rust": "^6.0.2",
     "@codemirror/language": "^6.12.3",
     "@codemirror/language-data": "^6.5.2",
+    "@codemirror/merge": "^6.12.2",
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@codemirror/language-data':
         specifier: ^6.5.2
         version: 6.5.2
+      '@codemirror/merge':
+        specifier: ^6.12.2
+        version: 6.12.2
       '@codemirror/state':
         specifier: ^6.6.0
         version: 6.6.0
@@ -398,6 +401,9 @@ packages:
 
   '@codemirror/lint@6.9.7':
     resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/merge@6.12.2':
+    resolution: {integrity: sha512-V8JvyAPjHbPupqP7BeMcsdsYCbyPij74jxIbaIJDORI+VZzW44zFmon8bF+oxGWvOKhcRmkiUMXd8MxHr3YA2w==}
 
   '@codemirror/search@6.7.0':
     resolution: {integrity: sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==}
@@ -2930,6 +2936,14 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
       crelt: 1.0.6
+
+  '@codemirror/merge@6.12.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/highlight': 1.2.3
+      style-mod: 4.1.3
 
   '@codemirror/search@6.7.0':
     dependencies:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,9 +22,9 @@ use modules::clipboard::{
 use modules::git::{
     git_branch_checkout, git_branch_checkout_track, git_branch_create_at, git_branch_delete,
     git_branches, git_cherry_pick, git_commit, git_commit_details, git_commit_file_diff, git_diff,
-    git_fetch, git_graph_log, git_log, git_merge, git_pull, git_push, git_push_delete, git_rebase,
-    git_reset, git_resolve_repo, git_revert, git_stage, git_status, git_tag_create, git_tag_delete,
-    git_unstage, git_worktree_info,
+    git_fetch, git_file_at_rev, git_graph_log, git_log, git_merge, git_pull, git_push,
+    git_push_delete, git_rebase, git_reset, git_resolve_repo, git_restore_file, git_revert,
+    git_stage, git_status, git_tag_create, git_tag_delete, git_unstage, git_worktree_info,
 };
 use modules::pr::{gh_available, pr_via_api, pr_via_gh};
 use modules::preview::{
@@ -172,6 +172,8 @@ pub fn run() {
             git_commit,
             git_log,
             git_diff,
+            git_file_at_rev,
+            git_restore_file,
             git_push,
             git_fetch,
             git_graph_log,

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -451,6 +451,38 @@ pub fn diff(repo_path: &str, staged: bool) -> Result<String, String> {
     }
 }
 
+/// Content of `path` at `rev`, where rev is limited to "HEAD" (last commit)
+/// or ":" (the index) — the only two versions the diff tab compares against.
+/// A file missing at that rev is an empty document, not an error, so new
+/// files diff as all-added.
+pub fn file_at_rev(repo_path: &str, rev: &str, path: &str) -> Result<String, String> {
+    if rev != "HEAD" && rev != ":" {
+        return Err(format!("unsupported rev: {rev}"));
+    }
+    ensure_not_flag(path)?;
+    // "HEAD:path" names the committed version; ":path" (single colon) names
+    // the index version — the colon separator is already part of that rev.
+    let spec = if rev == ":" {
+        format!(":{path}")
+    } else {
+        format!("{rev}:{path}")
+    };
+    match run_git(repo_path, &["show", &spec]) {
+        Ok(content) => Ok(content),
+        // `git show` wording varies by rev kind and version ("does not exist",
+        // "exists on disk, but not in", "is in the index, but not at stage").
+        // Any path-shaped failure means "no such file at that rev" → empty.
+        Err(err) if err.contains(path) => Ok(String::new()),
+        Err(err) => Err(err),
+    }
+}
+
+/// Discard unstaged changes to one tracked file (`git restore -- <path>`).
+pub fn restore_file(repo_path: &str, path: &str) -> Result<(), String> {
+    ensure_not_flag(path)?;
+    run_git(repo_path, &["restore", "--", path]).map(|_| ())
+}
+
 /// Push the current branch to its remote.
 pub fn push(repo_path: &str) -> Result<String, String> {
     run_git(repo_path, &["push"])
@@ -897,6 +929,16 @@ pub fn git_log(repo_path: String, limit: Option<usize>) -> Result<Vec<CommitInfo
 #[tauri::command]
 pub fn git_diff(repo_path: String, staged: bool) -> Result<String, String> {
     diff(&repo_path, staged)
+}
+
+#[tauri::command]
+pub fn git_file_at_rev(repo_path: String, rev: String, path: String) -> Result<String, String> {
+    file_at_rev(&repo_path, &rev, &path)
+}
+
+#[tauri::command]
+pub fn git_restore_file(repo_path: String, path: String) -> Result<(), String> {
+    restore_file(&repo_path, &path)
 }
 
 #[tauri::command]
@@ -1376,6 +1418,65 @@ mod tests {
         let staged_diff = diff(&path, true).unwrap();
         assert!(staged_diff.contains("a.txt"));
         assert!(staged_diff.contains("+hello world"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn file_at_rev_reads_head_and_index_versions() {
+        let dir = temp_repo_dir("file_at_rev");
+        let path = dir.to_string_lossy().to_string();
+        run_git(&path, &["init"]).unwrap();
+        run_git(&path, &["config", "user.name", "Test"]).unwrap();
+        run_git(&path, &["config", "user.email", "test@example.com"]).unwrap();
+        std::fs::write(dir.join("a.txt"), "committed\n").unwrap();
+        run_git(&path, &["add", "a.txt"]).unwrap();
+        run_git(&path, &["commit", "-m", "c1"]).unwrap();
+        std::fs::write(dir.join("a.txt"), "staged\n").unwrap();
+        run_git(&path, &["add", "a.txt"]).unwrap();
+
+        assert_eq!(file_at_rev(&path, "HEAD", "a.txt").unwrap(), "committed\n");
+        assert_eq!(file_at_rev(&path, ":", "a.txt").unwrap(), "staged\n");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn file_at_rev_missing_file_is_empty_and_bad_args_rejected() {
+        let dir = temp_repo_dir("file_at_rev_missing");
+        let path = dir.to_string_lossy().to_string();
+        run_git(&path, &["init"]).unwrap();
+        run_git(&path, &["config", "user.name", "Test"]).unwrap();
+        run_git(&path, &["config", "user.email", "test@example.com"]).unwrap();
+        std::fs::write(dir.join("a.txt"), "x\n").unwrap();
+        run_git(&path, &["add", "a.txt"]).unwrap();
+        run_git(&path, &["commit", "-m", "c1"]).unwrap();
+
+        assert_eq!(file_at_rev(&path, "HEAD", "nope.txt").unwrap(), "");
+        assert_eq!(file_at_rev(&path, ":", "nope.txt").unwrap(), "");
+        assert!(file_at_rev(&path, "HEAD~1", "a.txt").is_err());
+        assert!(file_at_rev(&path, "HEAD", "--evil").is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn restore_file_reverts_unstaged_change() {
+        let dir = temp_repo_dir("restore_file");
+        let path = dir.to_string_lossy().to_string();
+        run_git(&path, &["init"]).unwrap();
+        run_git(&path, &["config", "user.name", "Test"]).unwrap();
+        run_git(&path, &["config", "user.email", "test@example.com"]).unwrap();
+        std::fs::write(dir.join("a.txt"), "original\n").unwrap();
+        run_git(&path, &["add", "a.txt"]).unwrap();
+        run_git(&path, &["commit", "-m", "c1"]).unwrap();
+        std::fs::write(dir.join("a.txt"), "dirty\n").unwrap();
+
+        restore_file(&path, "a.txt").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("a.txt")).unwrap(),
+            "original\n"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -472,10 +472,13 @@ pub fn file_at_rev(repo_path: &str, rev: &str, path: &str) -> Result<String, Str
         // `git show` wording varies by rev kind and version; match the known
         // "no such file at that rev" messages so a genuine failure (corrupt
         // object, bad repo) still surfaces instead of reading as empty.
+        // "invalid object name 'HEAD'" is the unborn-HEAD case (fresh repo,
+        // nothing committed yet): every file is new, so HEAD-side is empty.
         Err(err)
             if err.contains("does not exist")
                 || err.contains("exists on disk, but not in")
-                || err.contains("is in the index, but not at stage") =>
+                || err.contains("is in the index, but not at stage")
+                || err.contains("invalid object name 'HEAD'") =>
         {
             Ok(String::new())
         }
@@ -1464,6 +1467,22 @@ mod tests {
         assert_eq!(file_at_rev(&path, ":", "nope.txt").unwrap(), "");
         assert!(file_at_rev(&path, "HEAD~1", "a.txt").is_err());
         assert!(file_at_rev(&path, "HEAD", "--evil").is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn file_at_rev_unborn_head_reads_as_empty() {
+        let dir = temp_repo_dir("file_at_rev_unborn");
+        let path = dir.to_string_lossy().to_string();
+        run_git(&path, &["init"]).unwrap();
+        std::fs::write(dir.join("a.txt"), "staged\n").unwrap();
+        run_git(&path, &["add", "a.txt"]).unwrap();
+
+        // No commits yet: HEAD is unborn, so the HEAD side is an empty doc
+        // (all-added diff), not an error.
+        assert_eq!(file_at_rev(&path, "HEAD", "a.txt").unwrap(), "");
+        assert_eq!(file_at_rev(&path, ":", "a.txt").unwrap(), "staged\n");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -469,18 +469,26 @@ pub fn file_at_rev(repo_path: &str, rev: &str, path: &str) -> Result<String, Str
     };
     match run_git(repo_path, &["show", &spec]) {
         Ok(content) => Ok(content),
-        // `git show` wording varies by rev kind and version ("does not exist",
-        // "exists on disk, but not in", "is in the index, but not at stage").
-        // Any path-shaped failure means "no such file at that rev" → empty.
-        Err(err) if err.contains(path) => Ok(String::new()),
+        // `git show` wording varies by rev kind and version; match the known
+        // "no such file at that rev" messages so a genuine failure (corrupt
+        // object, bad repo) still surfaces instead of reading as empty.
+        Err(err)
+            if err.contains("does not exist")
+                || err.contains("exists on disk, but not in")
+                || err.contains("is in the index, but not at stage") =>
+        {
+            Ok(String::new())
+        }
         Err(err) => Err(err),
     }
 }
 
-/// Discard unstaged changes to one tracked file (`git restore -- <path>`).
+/// Discard unstaged changes to one tracked file (`git restore`). The pathspec
+/// is wrapped in `:(literal)` so git magic like `:/` or `:(glob)` in a crafted
+/// path cannot widen the restore beyond the named file.
 pub fn restore_file(repo_path: &str, path: &str) -> Result<(), String> {
     ensure_not_flag(path)?;
-    run_git(repo_path, &["restore", "--", path]).map(|_| ())
+    run_git(repo_path, &["restore", "--", &format!(":(literal){path}")]).map(|_| ())
 }
 
 /// Push the current branch to its remote.

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -64,6 +64,14 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
       ref={menuRef}
       role="menu"
       style={{ position: "fixed", left: x, top: y }}
+      // Portal events still bubble through the REACT tree, so without this a
+      // menu-item click would also fire the owning row's onClick (e.g. a
+      // source-control row opening its diff tab on "Copy Path").
+      onClick={(e) => e.stopPropagation()}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
       className="z-[200] min-w-[200px] overflow-hidden rounded-md border border-border-strong bg-bg-elevated py-1 text-[13px] shadow-lg"
     >
       {items.map((item, index) => {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -4,6 +4,7 @@ import {
   FileCode,
   FileText,
   GitBranch,
+  GitCompare,
   Globe,
   LayoutGrid,
   PanelLeft,
@@ -57,6 +58,8 @@ function tabIcon(kind: Tab["kind"]): LucideIcon {
       return Globe;
     case "git-graph":
       return GitBranch;
+    case "diff":
+      return GitCompare;
     case "launcher":
       return LayoutGrid;
   }

--- a/src/i18n/locales/en/sourceControl.json
+++ b/src/i18n/locales/en/sourceControl.json
@@ -40,5 +40,6 @@
   "menuCopyMessage": "Copy Message",
   "discardFailed": "Couldn't discard changes to {{name}}. The file may be locked or the repository is in an unexpected state.",
   "diffPrevChange": "Previous Change",
-  "diffNextChange": "Next Change"
+  "diffNextChange": "Next Change",
+  "diffUnchangedLines": "$ unchanged lines"
 }

--- a/src/i18n/locales/en/sourceControl.json
+++ b/src/i18n/locales/en/sourceControl.json
@@ -22,5 +22,8 @@
   "generating": "Generating…",
   "refresh": "Refresh",
   "history": "Recent commits",
-  "nothingToCommit": "Stage changes and write a message to commit"
+  "nothingToCommit": "Stage changes and write a message to commit",
+  "diffStaged": "Staged",
+  "diffUnstaged": "Working tree",
+  "diffLoadError": "Couldn't load the comparison"
 }

--- a/src/i18n/locales/en/sourceControl.json
+++ b/src/i18n/locales/en/sourceControl.json
@@ -38,5 +38,7 @@
   "menuRevealFinder": "Reveal in Finder",
   "menuCopyHash": "Copy Hash",
   "menuCopyMessage": "Copy Message",
-  "discardFailed": "Couldn't discard changes to {{name}}. The file may be locked or the repository is in an unexpected state."
+  "discardFailed": "Couldn't discard changes to {{name}}. The file may be locked or the repository is in an unexpected state.",
+  "diffPrevChange": "Previous Change",
+  "diffNextChange": "Next Change"
 }

--- a/src/i18n/locales/en/sourceControl.json
+++ b/src/i18n/locales/en/sourceControl.json
@@ -37,5 +37,6 @@
   "menuCopyRelativePath": "Copy Relative Path",
   "menuRevealFinder": "Reveal in Finder",
   "menuCopyHash": "Copy Hash",
-  "menuCopyMessage": "Copy Message"
+  "menuCopyMessage": "Copy Message",
+  "discardFailed": "Couldn't discard changes to {{name}}. The file may be locked or the repository is in an unexpected state."
 }

--- a/src/i18n/locales/en/sourceControl.json
+++ b/src/i18n/locales/en/sourceControl.json
@@ -25,5 +25,17 @@
   "nothingToCommit": "Stage changes and write a message to commit",
   "diffStaged": "Staged",
   "diffUnstaged": "Working tree",
-  "diffLoadError": "Couldn't load the comparison"
+  "diffLoadError": "Couldn't load the comparison",
+  "discard": "Discard Changes",
+  "discardTitle": "Discard Changes",
+  "discardMessage": "Discard changes to {{name}}? This cannot be undone.",
+  "discardConfirm": "Discard",
+  "menuOpenFile": "Open File",
+  "menuOpenInNewTab": "Open in New Tab",
+  "menuShowDiff": "Show Diff",
+  "menuCopyPath": "Copy Path",
+  "menuCopyRelativePath": "Copy Relative Path",
+  "menuRevealFinder": "Reveal in Finder",
+  "menuCopyHash": "Copy Hash",
+  "menuCopyMessage": "Copy Message"
 }

--- a/src/i18n/locales/zh-Hant/sourceControl.json
+++ b/src/i18n/locales/zh-Hant/sourceControl.json
@@ -38,5 +38,7 @@
   "menuRevealFinder": "在 Finder 顯示",
   "menuCopyHash": "複製 hash",
   "menuCopyMessage": "複製提交訊息",
-  "discardFailed": "無法捨棄 {{name}} 的變更，檔案可能被鎖定或儲存庫狀態異常"
+  "discardFailed": "無法捨棄 {{name}} 的變更，檔案可能被鎖定或儲存庫狀態異常",
+  "diffPrevChange": "上一個變更",
+  "diffNextChange": "下一個變更"
 }

--- a/src/i18n/locales/zh-Hant/sourceControl.json
+++ b/src/i18n/locales/zh-Hant/sourceControl.json
@@ -22,5 +22,8 @@
   "generating": "產生中⋯",
   "refresh": "重新整理",
   "history": "近期提交",
-  "nothingToCommit": "先暫存變更並輸入訊息才能提交"
+  "nothingToCommit": "先暫存變更並輸入訊息才能提交",
+  "diffStaged": "已暫存",
+  "diffUnstaged": "工作區",
+  "diffLoadError": "無法載入比對內容"
 }

--- a/src/i18n/locales/zh-Hant/sourceControl.json
+++ b/src/i18n/locales/zh-Hant/sourceControl.json
@@ -40,5 +40,6 @@
   "menuCopyMessage": "複製提交訊息",
   "discardFailed": "無法捨棄 {{name}} 的變更，檔案可能被鎖定或儲存庫狀態異常",
   "diffPrevChange": "上一個變更",
-  "diffNextChange": "下一個變更"
+  "diffNextChange": "下一個變更",
+  "diffUnchangedLines": "$ 行未變更"
 }

--- a/src/i18n/locales/zh-Hant/sourceControl.json
+++ b/src/i18n/locales/zh-Hant/sourceControl.json
@@ -37,5 +37,6 @@
   "menuCopyRelativePath": "複製相對路徑",
   "menuRevealFinder": "在 Finder 顯示",
   "menuCopyHash": "複製 hash",
-  "menuCopyMessage": "複製提交訊息"
+  "menuCopyMessage": "複製提交訊息",
+  "discardFailed": "無法捨棄 {{name}} 的變更，檔案可能被鎖定或儲存庫狀態異常"
 }

--- a/src/i18n/locales/zh-Hant/sourceControl.json
+++ b/src/i18n/locales/zh-Hant/sourceControl.json
@@ -25,5 +25,17 @@
   "nothingToCommit": "先暫存變更並輸入訊息才能提交",
   "diffStaged": "已暫存",
   "diffUnstaged": "工作區",
-  "diffLoadError": "無法載入比對內容"
+  "diffLoadError": "無法載入比對內容",
+  "discard": "捨棄變更",
+  "discardTitle": "捨棄變更",
+  "discardMessage": "要捨棄 {{name}} 的變更嗎？這個動作無法復原",
+  "discardConfirm": "捨棄",
+  "menuOpenFile": "開啟檔案",
+  "menuOpenInNewTab": "在新分頁開啟",
+  "menuShowDiff": "顯示 diff",
+  "menuCopyPath": "複製路徑",
+  "menuCopyRelativePath": "複製相對路徑",
+  "menuRevealFinder": "在 Finder 顯示",
+  "menuCopyHash": "複製 hash",
+  "menuCopyMessage": "複製提交訊息"
 }

--- a/src/index.css
+++ b/src/index.css
@@ -208,31 +208,37 @@ textarea:focus-visible,
   padding: 4px 8px;
   box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
-/* Diff tab (@codemirror/merge): VS Code-style markers instead of the
-   library's underline gradients — full-line tints, solid word-level blocks,
-   and a bold gutter color bar per changed line. merge-a = old side (red),
-   merge-b = new side (green). */
+/* Diff tab (@codemirror/merge): match the Git Graph diff's look — the same
+   success/danger semantic tokens for full-line tints, solid word-level
+   blocks, and a bold gutter color bar per changed line. merge-a = old side
+   (danger), merge-b = new side (success). */
 .diff-merge-view .cm-mergeView { height: 100%; }
 .diff-merge-view .cm-mergeViewEditors { height: 100%; }
-.diff-merge-view .cm-merge-a .cm-changedLine { background: rgba(229, 83, 75, 0.1); }
-.diff-merge-view .cm-merge-b .cm-changedLine { background: rgba(81, 166, 90, 0.12); }
+.diff-merge-view .cm-merge-a .cm-changedLine {
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+}
+.diff-merge-view .cm-merge-b .cm-changedLine {
+  background: color-mix(in srgb, var(--color-success) 10%, transparent);
+}
 .diff-merge-view .cm-merge-a .cm-changedText {
-  background: rgba(229, 83, 75, 0.32);
+  background: color-mix(in srgb, var(--color-danger) 32%, transparent);
   border-radius: 2px;
 }
 .diff-merge-view .cm-merge-b .cm-changedText {
-  background: rgba(81, 166, 90, 0.34);
+  background: color-mix(in srgb, var(--color-success) 32%, transparent);
   border-radius: 2px;
 }
-.diff-merge-view .cm-deletedChunk { background: rgba(229, 83, 75, 0.1); }
+.diff-merge-view .cm-deletedChunk {
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+}
 .diff-merge-view .cm-deletedChunk .cm-deletedText {
-  background: rgba(229, 83, 75, 0.32);
+  background: color-mix(in srgb, var(--color-danger) 32%, transparent);
   border-radius: 2px;
 }
 .diff-merge-view .cm-changeGutter { width: 4px; }
-.diff-merge-view .cm-merge-a .cm-changedLineGutter { background: #e5534b; }
-.diff-merge-view .cm-merge-b .cm-changedLineGutter { background: #51a65a; }
-.diff-merge-view .cm-deletedLineGutter { background: #e5534b; }
+.diff-merge-view .cm-merge-a .cm-changedLineGutter { background: var(--color-danger); }
+.diff-merge-view .cm-merge-b .cm-changedLineGutter { background: var(--color-success); }
+.diff-merge-view .cm-deletedLineGutter { background: var(--color-danger); }
 
 .note-md strong { font-weight: 700; }
 .note-md em { font-style: italic; }

--- a/src/index.css
+++ b/src/index.css
@@ -208,6 +208,32 @@ textarea:focus-visible,
   padding: 4px 8px;
   box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
+/* Diff tab (@codemirror/merge): VS Code-style markers instead of the
+   library's underline gradients — full-line tints, solid word-level blocks,
+   and a bold gutter color bar per changed line. merge-a = old side (red),
+   merge-b = new side (green). */
+.diff-merge-view .cm-mergeView { height: 100%; }
+.diff-merge-view .cm-mergeViewEditors { height: 100%; }
+.diff-merge-view .cm-merge-a .cm-changedLine { background: rgba(229, 83, 75, 0.1); }
+.diff-merge-view .cm-merge-b .cm-changedLine { background: rgba(81, 166, 90, 0.12); }
+.diff-merge-view .cm-merge-a .cm-changedText {
+  background: rgba(229, 83, 75, 0.32);
+  border-radius: 2px;
+}
+.diff-merge-view .cm-merge-b .cm-changedText {
+  background: rgba(81, 166, 90, 0.34);
+  border-radius: 2px;
+}
+.diff-merge-view .cm-deletedChunk { background: rgba(229, 83, 75, 0.1); }
+.diff-merge-view .cm-deletedChunk .cm-deletedText {
+  background: rgba(229, 83, 75, 0.32);
+  border-radius: 2px;
+}
+.diff-merge-view .cm-changeGutter { width: 4px; }
+.diff-merge-view .cm-merge-a .cm-changedLineGutter { background: #e5534b; }
+.diff-merge-view .cm-merge-b .cm-changedLineGutter { background: #51a65a; }
+.diff-merge-view .cm-deletedLineGutter { background: #e5534b; }
+
 .note-md strong { font-weight: 700; }
 .note-md em { font-style: italic; }
 .note-md blockquote {

--- a/src/index.css
+++ b/src/index.css
@@ -260,6 +260,16 @@ textarea:focus-visible,
   content: "−";
   color: var(--color-danger);
 }
+/* Collapsed unchanged regions: a quiet, clickable divider bar. */
+.diff-merge-view .cm-collapsedLines {
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-subtle);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  padding: 3px 12px;
+  cursor: pointer;
+}
+.diff-merge-view .cm-collapsedLines:hover { color: var(--color-fg); }
 
 .note-md strong { font-weight: 700; }
 .note-md em { font-style: italic; }

--- a/src/index.css
+++ b/src/index.css
@@ -212,8 +212,11 @@ textarea:focus-visible,
    success/danger semantic tokens for full-line tints, solid word-level
    blocks, and a bold gutter color bar per changed line. merge-a = old side
    (danger), merge-b = new side (success). */
+/* The merge view scrolls as one container (its own base theme sets
+   overflow:auto and forces the inner editors to auto height); it only needs
+   a bounded height. Don't constrain the inner editor layers — that empties
+   the scroll area and makes long diffs unscrollable. */
 .diff-merge-view .cm-mergeView { height: 100%; }
-.diff-merge-view .cm-mergeViewEditors { height: 100%; }
 .diff-merge-view .cm-merge-a .cm-changedLine {
   background: color-mix(in srgb, var(--color-danger) 10%, transparent);
 }
@@ -235,10 +238,28 @@ textarea:focus-visible,
   background: color-mix(in srgb, var(--color-danger) 32%, transparent);
   border-radius: 2px;
 }
-.diff-merge-view .cm-changeGutter { width: 4px; }
-.diff-merge-view .cm-merge-a .cm-changedLineGutter { background: var(--color-danger); }
-.diff-merge-view .cm-merge-b .cm-changedLineGutter { background: var(--color-success); }
-.diff-merge-view .cm-deletedLineGutter { background: var(--color-danger); }
+/* The change gutter shows explicit +/− marks (like a unified diff) instead
+   of the library's default color blobs. */
+.diff-merge-view .cm-changeGutter { width: 18px; }
+.diff-merge-view .cm-changedLineGutter,
+.diff-merge-view .cm-deletedLineGutter {
+  background: transparent !important;
+  text-align: center;
+  font-weight: 700;
+  line-height: inherit;
+}
+.diff-merge-view .cm-merge-a .cm-changedLineGutter::before {
+  content: "−";
+  color: var(--color-danger);
+}
+.diff-merge-view .cm-merge-b .cm-changedLineGutter::before {
+  content: "+";
+  color: var(--color-success);
+}
+.diff-merge-view .cm-deletedLineGutter::before {
+  content: "−";
+  color: var(--color-danger);
+}
 
 .note-md strong { font-weight: 700; }
 .note-md em { font-style: italic; }

--- a/src/modules/diff/DiffTabContent.test.tsx
+++ b/src/modules/diff/DiffTabContent.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DiffTabContent } from "./DiffTabContent";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/modules/source-control/lib/gitBridge", () => ({
+  gitResolveRepo: vi.fn(),
+  gitFileAtRev: vi.fn(),
+}));
+
+vi.mock("@/modules/explorer/lib/fsBridge", () => ({
+  fsReadFile: vi.fn(),
+}));
+
+import { gitFileAtRev, gitResolveRepo } from "@/modules/source-control/lib/gitBridge";
+import { fsReadFile } from "@/modules/explorer/lib/fsBridge";
+
+describe("DiffTabContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(gitResolveRepo).mockResolvedValue("/repo");
+  });
+
+  it("compares index vs working tree for an unstaged diff", async () => {
+    vi.mocked(gitFileAtRev).mockResolvedValue("old\n");
+    vi.mocked(fsReadFile).mockResolvedValue("new\n");
+
+    render(<DiffTabContent path="/repo/src/a.ts" staged={false} />);
+
+    await waitFor(() =>
+      expect(gitFileAtRev).toHaveBeenCalledWith("/repo", ":", "src/a.ts"),
+    );
+    expect(fsReadFile).toHaveBeenCalledWith("/repo/src/a.ts");
+    expect(screen.getByText("diffUnstaged")).toBeInTheDocument();
+  });
+
+  it("compares HEAD vs index for a staged diff", async () => {
+    vi.mocked(gitFileAtRev).mockResolvedValue("x\n");
+
+    render(<DiffTabContent path="/repo/a.ts" staged={true} />);
+
+    await waitFor(() => expect(gitFileAtRev).toHaveBeenCalledTimes(2));
+    expect(gitFileAtRev).toHaveBeenCalledWith("/repo", "HEAD", "a.ts");
+    expect(gitFileAtRev).toHaveBeenCalledWith("/repo", ":", "a.ts");
+    expect(fsReadFile).not.toHaveBeenCalled();
+    expect(screen.getByText("diffStaged")).toBeInTheDocument();
+  });
+
+  it("treats an unreadable working file as empty (deleted file)", async () => {
+    vi.mocked(gitFileAtRev).mockResolvedValue("was here\n");
+    vi.mocked(fsReadFile).mockRejectedValue(new Error("gone"));
+
+    render(<DiffTabContent path="/repo/a.ts" staged={false} />);
+
+    await waitFor(() => expect(fsReadFile).toHaveBeenCalled());
+    // No error surface — the diff simply renders against an empty right side.
+    expect(screen.queryByText("diffLoadError")).not.toBeInTheDocument();
+  });
+});

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { MergeView } from "@codemirror/merge";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { gitFileAtRev, gitResolveRepo } from "@/modules/source-control/lib/gitBridge";
+import { fsReadFile } from "@/modules/explorer/lib/fsBridge";
+import { loadLanguageExtension } from "@/modules/editor/lib/language";
+import { dirname, relativePath } from "@/modules/explorer/lib/paths";
+import { editorSyntaxTheme } from "@/themes/editorTheme";
+import { selectTerminalFontFamily, useFontStore } from "@/stores/fontStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+interface DiffTabContentProps {
+  /** Absolute path of the file being compared. */
+  path: string;
+  /** true = HEAD vs index (staged tab); false = index vs working tree. */
+  staged: boolean;
+}
+
+interface DiffDocs {
+  left: string;
+  right: string;
+}
+
+/**
+ * Read-only side-by-side comparison of one file's uncommitted changes.
+ * Unstaged tab: index (left) vs working tree (right). Staged tab: HEAD (left)
+ * vs index (right). MergeView computes the highlighting from the two full
+ * documents; contents reload when the window regains focus so the tab stays
+ * roughly current without a file watcher.
+ */
+export function DiffTabContent({ path, staged }: DiffTabContentProps) {
+  const { t } = useTranslation("sourceControl");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const fontFamily = useFontStore(selectTerminalFontFamily);
+  const fontSize = useFontStore((s) => s.fontSize);
+  const themeId = useSettingsStore((s) => s.themeId);
+  const [docs, setDocs] = useState<DiffDocs | null>(null);
+  const [error, setError] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // Re-read both sides when the window regains focus (e.g. after staging or
+  // editing elsewhere); cheap enough that no file watcher is needed.
+  useEffect(() => {
+    const bump = () => setRefreshKey((k) => k + 1);
+    window.addEventListener("focus", bump);
+    return () => window.removeEventListener("focus", bump);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const repo = await gitResolveRepo(dirname(path));
+        if (!repo) {
+          throw new Error("not a git repository");
+        }
+        const rel = relativePath(path, repo);
+        const [left, right] = await Promise.all(
+          staged
+            ? [gitFileAtRev(repo, "HEAD", rel), gitFileAtRev(repo, ":", rel)]
+            : [gitFileAtRev(repo, ":", rel), fsReadFile(path).catch(() => "")],
+        );
+        if (!cancelled) {
+          setError(false);
+          setDocs({ left, right });
+        }
+      } catch {
+        if (!cancelled) {
+          setError(true);
+        }
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [path, staged, refreshKey]);
+
+  useEffect(() => {
+    const parent = containerRef.current;
+    if (!docs || !parent) {
+      return;
+    }
+    let view: MergeView | null = null;
+    let cancelled = false;
+    void loadLanguageExtension(path).then((language) => {
+      if (cancelled) {
+        return;
+      }
+      const extensions = [
+        EditorState.readOnly.of(true),
+        EditorView.editable.of(false),
+        editorSyntaxTheme(themeId),
+        EditorView.theme({
+          "&": { fontSize: `${fontSize}px` },
+          ".cm-content, .cm-gutters, .cm-scroller": { fontFamily },
+        }),
+        ...language,
+      ];
+      view = new MergeView({
+        a: { doc: docs.left, extensions },
+        b: { doc: docs.right, extensions },
+        parent,
+        gutter: true,
+      });
+    });
+    return () => {
+      cancelled = true;
+      view?.destroy();
+    };
+  }, [docs, path, themeId, fontSize, fontFamily]);
+
+  const name = path.split(/[\\/]/).pop() ?? path;
+
+  return (
+    <div className="flex h-full flex-col bg-bg">
+      <div className="flex h-8 shrink-0 items-center gap-2 border-b border-border px-3">
+        <span className="min-w-0 truncate text-xs text-fg-muted">{name}</span>
+        <span className="shrink-0 rounded bg-bg-elevated px-1.5 py-0.5 text-[10px] font-medium uppercase text-fg-subtle">
+          {staged ? t("diffStaged") : t("diffUnstaged")}
+        </span>
+      </div>
+      {error ? (
+        <p className="px-3 py-2 text-xs text-danger">{t("diffLoadError")}</p>
+      ) : (
+        <div ref={containerRef} className="diff-merge-view min-h-0 flex-1 overflow-auto" />
+      )}
+    </div>
+  );
+}

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, ChevronUp, WrapText } from "lucide-react";
-import { goToNextChunk, goToPreviousChunk, MergeView } from "@codemirror/merge";
+import { getChunks, goToNextChunk, goToPreviousChunk, MergeView } from "@codemirror/merge";
 import { EditorState } from "@codemirror/state";
 import { EditorView, lineNumbers } from "@codemirror/view";
 import { Tooltip } from "@/components/Tooltip";
@@ -45,6 +45,8 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
   const [docs, setDocs] = useState<DiffDocs | null>(null);
   const [error, setError] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  // 1-based position of the chunk the cursor sits in (0 = before the first).
+  const [chunkPos, setChunkPos] = useState({ current: 0, total: 0 });
 
   // Re-read both sides when the window regains focus (e.g. after staging or
   // editing elsewhere); cheap enough that no file watcher is needed.
@@ -102,6 +104,8 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
       const extensions = [
         EditorState.readOnly.of(true),
         EditorView.editable.of(false),
+        // Localizes the collapsed-region bar ("$ unchanged lines").
+        EditorState.phrases.of({ "$ unchanged lines": t("diffUnchangedLines") }),
         editorSyntaxTheme(themeId),
         // Fixed 13px to match the Git Graph diff view's type size. Height and
         // scrolling belong to the outer .cm-mergeView container (the merge
@@ -119,8 +123,12 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
         b: { doc: docs.right, extensions },
         parent,
         gutter: true,
+        // Collapse long unchanged stretches into an expandable bar (VS Code
+        // style), so a large file reads as just its changes.
+        collapseUnchanged: { margin: 3, minSize: 5 },
       });
       mergeViewRef.current = view;
+      setChunkPos({ current: 0, total: getChunks(view.b.state)?.chunks.length ?? 0 });
     });
     return () => {
       cancelled = true;
@@ -129,7 +137,9 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
     };
   }, [docs, path, themeId, fontFamily, wordWrap]);
 
-  // Jump the selection (and scroll) to the previous/next changed chunk.
+  // Jump the selection to the previous/next changed chunk, pin the target to
+  // the top of the view (the default lands it at the bottom edge, easy to
+  // miss), and update the "current/total" indicator.
   function goToChunk(direction: "prev" | "next") {
     const view = mergeViewRef.current;
     if (!view) {
@@ -137,6 +147,26 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
     }
     const command = direction === "next" ? goToNextChunk : goToPreviousChunk;
     command(view.b);
+    const head = view.b.state.selection.main.head;
+    // The real scroll container is the outer .cm-mergeView (not the editors'
+    // own scrollers), so pin the target line to its top by hand once the
+    // command's own scrolling has settled.
+    requestAnimationFrame(() => {
+      const coords = view.b.coordsAtPos(head);
+      const scroller = containerRef.current?.querySelector(".cm-mergeView");
+      if (coords && scroller) {
+        const rect = scroller.getBoundingClientRect();
+        scroller.scrollTop += coords.top - rect.top - 8;
+      }
+    });
+    const chunks = getChunks(view.b.state)?.chunks ?? [];
+    let current = 0;
+    for (let i = 0; i < chunks.length; i++) {
+      if (head >= chunks[i].fromB) {
+        current = i + 1;
+      }
+    }
+    setChunkPos({ current, total: chunks.length });
   }
 
   const name = path.split(/[\\/]/).pop() ?? path;
@@ -144,11 +174,19 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
   return (
     <div className="flex h-full flex-col bg-bg">
       <div className="flex h-8 shrink-0 items-center gap-2 border-b border-border px-3">
+        {/* The controls sit at the end of the left half — the visual middle of
+            the two panes — where they are easy to spot. */}
+        <div className="flex w-1/2 items-center gap-2">
         <span className="min-w-0 truncate text-xs text-fg-muted">{name}</span>
         <span className="shrink-0 rounded bg-bg-elevated px-1.5 py-0.5 text-[10px] font-medium uppercase text-fg-subtle">
           {staged ? t("diffStaged") : t("diffUnstaged")}
         </span>
         <div className="ml-auto flex shrink-0 items-center gap-0.5">
+          {chunkPos.total > 0 && (
+            <span className="mr-1 font-mono text-[11px] text-fg-subtle">
+              {chunkPos.current}/{chunkPos.total}
+            </span>
+          )}
           <Tooltip label={t("diffPrevChange")}>
             <button
               type="button"
@@ -184,6 +222,7 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
               <WrapText size={14} />
             </button>
           </Tooltip>
+        </div>
         </div>
       </div>
       {error ? (

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -97,7 +97,11 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
     }
     let view: MergeView | null = null;
     let cancelled = false;
-    void loadLanguageExtension(path).then((language) => {
+    // A failed grammar load falls back to plain text instead of leaving the
+    // tab stuck without a MergeView.
+    void loadLanguageExtension(path)
+      .catch(() => [])
+      .then((language) => {
       if (cancelled) {
         return;
       }
@@ -167,14 +171,12 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
     if (chunks.length === 0) {
       return;
     }
-    setChunkPos(({ current }) => {
-      const next =
-        direction === "next"
-          ? Math.min(current + 1, chunks.length)
-          : Math.max(current - 1, 1);
-      scrollToChunk(view, chunks[next - 1]);
-      return { current: next, total: chunks.length };
-    });
+    const next =
+      direction === "next"
+        ? Math.min(chunkPos.current + 1, chunks.length)
+        : Math.max(chunkPos.current - 1, 1);
+    scrollToChunk(view, chunks[next - 1]);
+    setChunkPos({ current: next, total: chunks.length });
   }
 
   const name = path.split(/[\\/]/).pop() ?? path;

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, ChevronUp, WrapText } from "lucide-react";
-import { getChunks, goToNextChunk, goToPreviousChunk, MergeView } from "@codemirror/merge";
+import { getChunks, MergeView, type Chunk } from "@codemirror/merge";
 import { EditorState } from "@codemirror/state";
 import { EditorView, lineNumbers } from "@codemirror/view";
 import { Tooltip } from "@/components/Tooltip";
@@ -128,7 +128,13 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
         collapseUnchanged: { margin: 3, minSize: 5 },
       });
       mergeViewRef.current = view;
-      setChunkPos({ current: 0, total: getChunks(view.b.state)?.chunks.length ?? 0 });
+      // Land on the first change right away so the counter starts at 1/N and
+      // the change is pinned in view.
+      const chunks = getChunks(view.b.state)?.chunks ?? [];
+      setChunkPos({ current: chunks.length > 0 ? 1 : 0, total: chunks.length });
+      if (chunks.length > 0) {
+        scrollToChunk(view, chunks[0]);
+      }
     });
     return () => {
       cancelled = true;
@@ -137,36 +143,38 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
     };
   }, [docs, path, themeId, fontFamily, wordWrap]);
 
-  // Jump the selection to the previous/next changed chunk, pin the target to
-  // the top of the view (the default lands it at the bottom edge, easy to
-  // miss), and update the "current/total" indicator.
+  // Pin a chunk's first line to the top of the real scroll container (the
+  // outer .cm-mergeView). lineBlockAt gives document geometry without needing
+  // the line to be rendered, so this works across collapsed regions too.
+  function scrollToChunk(view: MergeView, chunk: Chunk) {
+    const pos = Math.min(chunk.fromB, view.b.state.doc.length);
+    const top = view.b.lineBlockAt(pos).top;
+    const scroller = containerRef.current?.querySelector(".cm-mergeView");
+    if (scroller) {
+      scroller.scrollTop = Math.max(0, top - 8);
+    }
+  }
+
+  // Step the current/total counter and bring that chunk into view. Navigation
+  // is index-based (not selection-based): a read-only diff has no visible
+  // cursor, and with collapsed regions everything may already fit on screen.
   function goToChunk(direction: "prev" | "next") {
     const view = mergeViewRef.current;
     if (!view) {
       return;
     }
-    const command = direction === "next" ? goToNextChunk : goToPreviousChunk;
-    command(view.b);
-    const head = view.b.state.selection.main.head;
-    // The real scroll container is the outer .cm-mergeView (not the editors'
-    // own scrollers), so pin the target line to its top by hand once the
-    // command's own scrolling has settled.
-    requestAnimationFrame(() => {
-      const coords = view.b.coordsAtPos(head);
-      const scroller = containerRef.current?.querySelector(".cm-mergeView");
-      if (coords && scroller) {
-        const rect = scroller.getBoundingClientRect();
-        scroller.scrollTop += coords.top - rect.top - 8;
-      }
-    });
     const chunks = getChunks(view.b.state)?.chunks ?? [];
-    let current = 0;
-    for (let i = 0; i < chunks.length; i++) {
-      if (head >= chunks[i].fromB) {
-        current = i + 1;
-      }
+    if (chunks.length === 0) {
+      return;
     }
-    setChunkPos({ current, total: chunks.length });
+    setChunkPos(({ current }) => {
+      const next =
+        direction === "next"
+          ? Math.min(current + 1, chunks.length)
+          : Math.max(current - 1, 1);
+      scrollToChunk(view, chunks[next - 1]);
+      return { current: next, total: chunks.length };
+    });
   }
 
   const name = path.split(/[\\/]/).pop() ?? path;

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -34,7 +34,6 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
   const { t } = useTranslation("sourceControl");
   const containerRef = useRef<HTMLDivElement>(null);
   const fontFamily = useFontStore(selectTerminalFontFamily);
-  const fontSize = useFontStore((s) => s.fontSize);
   const themeId = useSettingsStore((s) => s.themeId);
   const [docs, setDocs] = useState<DiffDocs | null>(null);
   const [error, setError] = useState(false);
@@ -97,8 +96,9 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
         EditorState.readOnly.of(true),
         EditorView.editable.of(false),
         editorSyntaxTheme(themeId),
+        // Fixed 13px to match the Git Graph diff view's type size.
         EditorView.theme({
-          "&": { fontSize: `${fontSize}px` },
+          "&": { fontSize: "13px" },
           ".cm-content, .cm-gutters, .cm-scroller": { fontFamily },
         }),
         ...language,
@@ -114,7 +114,7 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
       cancelled = true;
       view?.destroy();
     };
-  }, [docs, path, themeId, fontSize, fontFamily]);
+  }, [docs, path, themeId, fontFamily]);
 
   const name = path.split(/[\\/]/).pop() ?? path;
 

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { MergeView } from "@codemirror/merge";
+import { ChevronDown, ChevronUp, WrapText } from "lucide-react";
+import { goToNextChunk, goToPreviousChunk, MergeView } from "@codemirror/merge";
 import { EditorState } from "@codemirror/state";
-import { EditorView } from "@codemirror/view";
+import { EditorView, lineNumbers } from "@codemirror/view";
+import { Tooltip } from "@/components/Tooltip";
 import { gitFileAtRev, gitResolveRepo } from "@/modules/source-control/lib/gitBridge";
 import { fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import { loadLanguageExtension } from "@/modules/editor/lib/language";
@@ -32,9 +34,14 @@ interface DiffDocs {
  */
 export function DiffTabContent({ path, staged }: DiffTabContentProps) {
   const { t } = useTranslation("sourceControl");
+  const { t: tEditor } = useTranslation("editor");
   const containerRef = useRef<HTMLDivElement>(null);
+  const mergeViewRef = useRef<MergeView | null>(null);
   const fontFamily = useFontStore(selectTerminalFontFamily);
   const themeId = useSettingsStore((s) => s.themeId);
+  // Shares the editor's word-wrap setting so both surfaces toggle together.
+  const wordWrap = useSettingsStore((s) => s.wordWrap);
+  const toggleWordWrap = useSettingsStore((s) => s.toggleWordWrap);
   const [docs, setDocs] = useState<DiffDocs | null>(null);
   const [error, setError] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -103,6 +110,8 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
           "&": { fontSize: "13px" },
           ".cm-content, .cm-gutters, .cm-scroller": { fontFamily },
         }),
+        lineNumbers(),
+        ...(wordWrap ? [EditorView.lineWrapping] : []),
         ...language,
       ];
       view = new MergeView({
@@ -111,12 +120,24 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
         parent,
         gutter: true,
       });
+      mergeViewRef.current = view;
     });
     return () => {
       cancelled = true;
+      mergeViewRef.current = null;
       view?.destroy();
     };
-  }, [docs, path, themeId, fontFamily]);
+  }, [docs, path, themeId, fontFamily, wordWrap]);
+
+  // Jump the selection (and scroll) to the previous/next changed chunk.
+  function goToChunk(direction: "prev" | "next") {
+    const view = mergeViewRef.current;
+    if (!view) {
+      return;
+    }
+    const command = direction === "next" ? goToNextChunk : goToPreviousChunk;
+    command(view.b);
+  }
 
   const name = path.split(/[\\/]/).pop() ?? path;
 
@@ -127,6 +148,43 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
         <span className="shrink-0 rounded bg-bg-elevated px-1.5 py-0.5 text-[10px] font-medium uppercase text-fg-subtle">
           {staged ? t("diffStaged") : t("diffUnstaged")}
         </span>
+        <div className="ml-auto flex shrink-0 items-center gap-0.5">
+          <Tooltip label={t("diffPrevChange")}>
+            <button
+              type="button"
+              aria-label={t("diffPrevChange")}
+              onClick={() => goToChunk("prev")}
+              className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+            >
+              <ChevronUp size={14} />
+            </button>
+          </Tooltip>
+          <Tooltip label={t("diffNextChange")}>
+            <button
+              type="button"
+              aria-label={t("diffNextChange")}
+              onClick={() => goToChunk("next")}
+              className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+            >
+              <ChevronDown size={14} />
+            </button>
+          </Tooltip>
+          <Tooltip label={tEditor("wrap")}>
+            <button
+              type="button"
+              aria-label={tEditor("wrap")}
+              aria-pressed={wordWrap}
+              onClick={toggleWordWrap}
+              className={`rounded p-1 ${
+                wordWrap
+                  ? "bg-bg-elevated text-fg"
+                  : "text-fg-muted hover:bg-bg-elevated hover:text-fg"
+              }`}
+            >
+              <WrapText size={14} />
+            </button>
+          </Tooltip>
+        </div>
       </div>
       {error ? (
         <p className="px-3 py-2 text-xs text-danger">{t("diffLoadError")}</p>

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -64,7 +64,11 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
         );
         if (!cancelled) {
           setError(false);
-          setDocs({ left, right });
+          // Keep the previous object when nothing changed so the MergeView
+          // effect doesn't tear down and lose scroll position on refocus.
+          setDocs((prev) =>
+            prev && prev.left === left && prev.right === right ? prev : { left, right },
+          );
         }
       } catch {
         if (!cancelled) {

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -96,7 +96,9 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
         EditorState.readOnly.of(true),
         EditorView.editable.of(false),
         editorSyntaxTheme(themeId),
-        // Fixed 13px to match the Git Graph diff view's type size.
+        // Fixed 13px to match the Git Graph diff view's type size. Height and
+        // scrolling belong to the outer .cm-mergeView container (the merge
+        // package forces the editors themselves to auto height).
         EditorView.theme({
           "&": { fontSize: "13px" },
           ".cm-content, .cm-gutters, .cm-scroller": { fontFamily },
@@ -129,7 +131,7 @@ export function DiffTabContent({ path, staged }: DiffTabContentProps) {
       {error ? (
         <p className="px-3 py-2 text-xs text-danger">{t("diffLoadError")}</p>
       ) : (
-        <div ref={containerRef} className="diff-merge-view min-h-0 flex-1 overflow-auto" />
+        <div ref={containerRef} className="diff-merge-view min-h-0 flex-1 overflow-hidden" />
       )}
     </div>
   );

--- a/src/modules/git-graph/CommitDetailsPanel.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.tsx
@@ -182,7 +182,7 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
           style={{ width: `${leftWidth}px` }}
           className="relative shrink-0 overflow-auto px-3 py-2"
         >
-          <div className="flex flex-wrap gap-x-4 gap-y-0.5 font-mono text-[11px] text-fg-subtle">
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 font-mono text-[13px] text-fg-subtle">
             <span>
               {labels.author}: {commit.author}
             </span>
@@ -191,15 +191,15 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
             </span>
           </div>
           {details && (
-            <pre className="mt-2 whitespace-pre-wrap font-sans text-xs text-fg">
+            <pre className="mt-2 whitespace-pre-wrap font-sans text-[13px] text-fg">
               {details.message}
             </pre>
           )}
-          <div className="mt-2 text-[11px] font-medium text-fg-subtle">
+          <div className="mt-2 text-[13px] font-medium text-fg-subtle">
             {labels.changedFiles} ({details?.files.length ?? 0})
           </div>
           {details && files.length === 0 ? (
-            <div className="mt-1 text-[11px] text-fg-subtle">{labels.noChanges}</div>
+            <div className="mt-1 text-[13px] text-fg-subtle">{labels.noChanges}</div>
           ) : (
             <div
               ref={fileListRef}
@@ -213,7 +213,7 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
                     type="button"
                     onClick={() => setSelectedFile(f.path)}
                     style={{ height: `${FILE_ROW_HEIGHT}px` }}
-                    className={`flex w-full items-center gap-2 rounded px-2 text-left font-mono text-[11px] ${
+                    className={`flex w-full items-center gap-2 rounded px-2 text-left font-mono text-[13px] ${
                       selectedFile === f.path
                         ? "bg-bg-elevated text-fg"
                         : "text-fg-muted hover:bg-bg-elevated/50"
@@ -248,7 +248,7 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
                 <button
                   type="button"
                   onClick={() => setTab("diff")}
-                  className={`rounded px-2 py-0.5 text-[11px] ${
+                  className={`rounded px-2 py-0.5 text-[13px] ${
                     tab === "diff"
                       ? "bg-bg-elevated text-fg"
                       : "text-fg-subtle hover:text-fg"
@@ -259,7 +259,7 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
                 <button
                   type="button"
                   onClick={() => setTab("ai")}
-                  className={`rounded px-2 py-0.5 text-[11px] ${
+                  className={`rounded px-2 py-0.5 text-[13px] ${
                     tab === "ai"
                       ? "bg-bg-elevated text-fg"
                       : "text-fg-subtle hover:text-fg"
@@ -292,7 +292,7 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
               </div>
             </>
           ) : (
-            <div className="flex h-full items-center justify-center text-xs text-fg-subtle">
+            <div className="flex h-full items-center justify-center text-[13px] text-fg-subtle">
               {labels.noFileSelected}
             </div>
           )}

--- a/src/modules/git-graph/DiffExplain.tsx
+++ b/src/modules/git-graph/DiffExplain.tsx
@@ -83,7 +83,7 @@ export function DiffExplain({
 
   if (diffText.trim() === "") {
     return (
-      <div className="flex h-full items-center justify-center text-xs text-fg-subtle">
+      <div className="flex h-full items-center justify-center text-[13px] text-fg-subtle">
         {labels.empty}
       </div>
     );
@@ -93,7 +93,7 @@ export function DiffExplain({
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 text-fg-subtle">
         <Loader2 className="h-6 w-6 animate-spin text-accent" />
-        <p className="text-xs">{labels.explaining}</p>
+        <p className="text-[13px]">{labels.explaining}</p>
       </div>
     );
   }
@@ -101,13 +101,13 @@ export function DiffExplain({
   if (error) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 px-4 text-center">
-        <p className="text-xs text-danger" role="alert">
+        <p className="text-[13px] text-danger" role="alert">
           {error}
         </p>
         <button
           type="button"
           onClick={() => void run()}
-          className="rounded border border-border-strong px-2 py-1 text-xs text-fg-muted hover:bg-bg-elevated hover:text-fg"
+          className="rounded border border-border-strong px-2 py-1 text-[13px] text-fg-muted hover:bg-bg-elevated hover:text-fg"
         >
           {labels.regenerate}
         </button>
@@ -121,7 +121,7 @@ export function DiffExplain({
         <button
           type="button"
           onClick={() => void run()}
-          className="flex items-center gap-1.5 rounded border border-border-strong bg-bg-elevated px-3 py-1.5 text-xs text-fg hover:bg-bg-inset"
+          className="flex items-center gap-1.5 rounded border border-border-strong bg-bg-elevated px-3 py-1.5 text-[13px] text-fg hover:bg-bg-inset"
         >
           <Sparkles className="h-3.5 w-3.5 text-accent" />
           {labels.generate}
@@ -136,13 +136,13 @@ export function DiffExplain({
         <button
           type="button"
           onClick={regenerate}
-          className="flex items-center gap-1 rounded p-1 text-[11px] text-fg-subtle hover:bg-bg-elevated hover:text-fg"
+          className="flex items-center gap-1 rounded p-1 text-[13px] text-fg-subtle hover:bg-bg-elevated hover:text-fg"
         >
           <RefreshCw className="h-3 w-3" />
           {labels.regenerate}
         </button>
       </div>
-      <div className="px-3 pb-3 text-xs">
+      <div className="px-3 pb-3 text-[13px]">
         <ChatMarkdown content={explanation} />
       </div>
     </div>

--- a/src/modules/git-graph/DiffView.tsx
+++ b/src/modules/git-graph/DiffView.tsx
@@ -33,7 +33,7 @@ export function DiffView({ lines, emptyLabel }: DiffViewProps) {
 
   if (lines.length === 0) {
     return (
-      <div className="flex h-full items-center justify-center text-xs text-fg-subtle">
+      <div className="flex h-full items-center justify-center text-[13px] text-fg-subtle">
         {emptyLabel}
       </div>
     );
@@ -45,7 +45,7 @@ export function DiffView({ lines, emptyLabel }: DiffViewProps) {
     <div
       ref={scrollRef}
       onScroll={onScroll}
-      className="h-full overflow-auto font-mono text-[12px]"
+      className="h-full overflow-auto font-mono text-[13px]"
     >
       <div style={{ height: `${totalHeight}px` }} className="relative">
         <div style={{ transform: `translateY(${offsetTop}px)` }}>

--- a/src/modules/git-graph/GitGraph.test.tsx
+++ b/src/modules/git-graph/GitGraph.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GitGraph } from "./GitGraph";
+import type { CommitNode } from "./types";
+
+const LABELS = {
+  emptyTitle: "No commits",
+  emptyHint: "",
+  loadMore: "Load more",
+  refHint: "{{name}}",
+} as never;
+
+const COMMIT: CommitNode = {
+  hash: "abc1234",
+  parents: [],
+  author: "a",
+  date: "today",
+  message: "feat: x",
+  refs: [],
+};
+
+describe("GitGraph row click area", () => {
+  it("selects the commit when clicking the row, including the lane gutter area", () => {
+    const onSelect = vi.fn();
+    render(
+      <GitGraph
+        commits={[COMMIT]}
+        selectedCommit={null}
+        onSelectCommit={onSelect}
+        labels={LABELS}
+      />,
+    );
+
+    const row = screen.getByText("feat: x").closest("div[class*='absolute']");
+    expect(row).not.toBeNull();
+    // The row must span from the container's left edge so clicks beside the
+    // node dot (in the lane gutter) still open the commit detail.
+    expect(row!.className).toContain("left-0");
+    fireEvent.click(row!);
+    expect(onSelect).toHaveBeenCalledWith(COMMIT);
+  });
+});

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -209,15 +209,14 @@ export function GitGraph({
               // The HEAD commit is marked at its graph node (filled accent + glow);
               // its row stays calm and only brightens to full foreground, so the
               // list reads uniformly. Selection keeps its own filled style.
-              // Hover styles use group-hover: the hit area (outer div) spans
-              // the full row including the lane gutter, while the painted
-              // background (inner div) starts after the lanes so the SVG
-              // branch lines are never covered.
+              // The row (hit area, border and background) spans the full
+              // width including the lane gutter; backgrounds stay translucent
+              // so the SVG branch lines remain visible underneath.
               const rowState = isSelected
-                ? "border-border-strong bg-bg-elevated text-fg shadow-sm"
+                ? "border-border-strong bg-bg-elevated/60 text-fg shadow-sm"
                 : isCurrent
-                  ? "border-transparent text-fg group-hover:bg-bg-elevated/50"
-                  : "border-transparent text-fg-muted group-hover:bg-bg-elevated/50 group-hover:text-fg";
+                  ? "border-transparent text-fg hover:bg-bg-elevated/40"
+                  : "border-transparent text-fg-muted hover:bg-bg-elevated/40 hover:text-fg";
               return (
                 <div
                   key={commit.hash}
@@ -230,11 +229,8 @@ export function GitGraph({
                     height: `${ROW_HEIGHT}px`,
                     top: `${layout.y - ROW_HEIGHT / 2}px`,
                   }}
-                  className="group absolute left-0 right-4 cursor-pointer"
+                  className={`absolute left-0 right-4 flex cursor-pointer items-center justify-between rounded border py-1 pl-[112px] pr-3 transition-all ${rowState}`}
                 >
-                  <div
-                    className={`ml-[100px] flex h-full items-center justify-between rounded border py-1 pl-3 pr-3 transition-all ${rowState}`}
-                  >
                   <div className="flex items-center space-x-3 overflow-hidden pr-2">
                     <span className="select-all font-mono text-xs font-semibold text-accent">
                       {commit.hash}
@@ -292,7 +288,6 @@ export function GitGraph({
                       <Clock className="h-3 w-3" />
                       <span>{commit.date}</span>
                     </div>
-                  </div>
                   </div>
                 </div>
               );

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -106,7 +106,7 @@ export function GitGraph({
       <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border p-8 py-16 text-center">
         <GitBranch className="mb-3 h-10 w-10 animate-pulse text-fg-subtle" />
         <p className="font-medium text-fg">{labels.emptyTitle}</p>
-        <p className="mt-1 max-w-sm text-xs text-fg-subtle">{labels.emptyHint}</p>
+        <p className="mt-1 max-w-sm text-[13px] text-fg-subtle">{labels.emptyHint}</p>
       </div>
     );
   }
@@ -274,12 +274,12 @@ export function GitGraph({
                       );
                     })}
 
-                    <span className="truncate font-sans text-xs font-medium text-fg">
+                    <span className="truncate font-sans text-[13px] font-medium text-fg">
                       {commit.message}
                     </span>
                   </div>
 
-                  <div className="flex shrink-0 items-center space-x-4 font-mono text-[12px] text-fg-subtle">
+                  <div className="flex shrink-0 items-center space-x-4 font-mono text-[13px] text-fg-subtle">
                     <div className="flex items-center space-x-1">
                       <User className="h-3 w-3" />
                       <span className="max-w-[70px] truncate">{commit.author}</span>

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -226,7 +226,10 @@ export function GitGraph({
                     height: `${ROW_HEIGHT}px`,
                     top: `${layout.y - ROW_HEIGHT / 2}px`,
                   }}
-                  className={`absolute left-[100px] right-4 flex cursor-pointer items-center justify-between rounded border px-3 py-1 transition-all ${rowState}`}
+                  // Spans the full width (including the lane gutter) so a
+                  // click beside the node dot still opens the commit; the
+                  // text content stays where left-[100px] used to put it.
+                  className={`absolute left-0 right-4 flex cursor-pointer items-center justify-between rounded border py-1 pl-[112px] pr-3 transition-all ${rowState}`}
                 >
                   <div className="flex items-center space-x-3 overflow-hidden pr-2">
                     <span className="select-all font-mono text-xs font-semibold text-accent">

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -209,11 +209,15 @@ export function GitGraph({
               // The HEAD commit is marked at its graph node (filled accent + glow);
               // its row stays calm and only brightens to full foreground, so the
               // list reads uniformly. Selection keeps its own filled style.
+              // Hover styles use group-hover: the hit area (outer div) spans
+              // the full row including the lane gutter, while the painted
+              // background (inner div) starts after the lanes so the SVG
+              // branch lines are never covered.
               const rowState = isSelected
                 ? "border-border-strong bg-bg-elevated text-fg shadow-sm"
                 : isCurrent
-                  ? "border-transparent text-fg hover:bg-bg-elevated/50"
-                  : "border-transparent text-fg-muted hover:bg-bg-elevated/50 hover:text-fg";
+                  ? "border-transparent text-fg group-hover:bg-bg-elevated/50"
+                  : "border-transparent text-fg-muted group-hover:bg-bg-elevated/50 group-hover:text-fg";
               return (
                 <div
                   key={commit.hash}
@@ -226,11 +230,11 @@ export function GitGraph({
                     height: `${ROW_HEIGHT}px`,
                     top: `${layout.y - ROW_HEIGHT / 2}px`,
                   }}
-                  // Spans the full width (including the lane gutter) so a
-                  // click beside the node dot still opens the commit; the
-                  // text content stays where left-[100px] used to put it.
-                  className={`absolute left-0 right-4 flex cursor-pointer items-center justify-between rounded border py-1 pl-[112px] pr-3 transition-all ${rowState}`}
+                  className="group absolute left-0 right-4 cursor-pointer"
                 >
+                  <div
+                    className={`ml-[100px] flex h-full items-center justify-between rounded border py-1 pl-3 pr-3 transition-all ${rowState}`}
+                  >
                   <div className="flex items-center space-x-3 overflow-hidden pr-2">
                     <span className="select-all font-mono text-xs font-semibold text-accent">
                       {commit.hash}
@@ -288,6 +292,7 @@ export function GitGraph({
                       <Clock className="h-3 w-3" />
                       <span>{commit.date}</span>
                     </div>
+                  </div>
                   </div>
                 </div>
               );

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -75,6 +75,16 @@ describe("SourceControlView row interactions", () => {
     expect(screen.getByRole("menuitem", { name: "Discard Changes" })).toBeInTheDocument();
   });
 
+  it("does not open a diff tab when a context-menu item is clicked", async () => {
+    // jsdom has no clipboard; the menu action calls writeText.
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+    render(<SourceControlView />);
+    fireEvent.contextMenu(await screen.findByText("src/a.ts"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Path" }));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(0);
+  });
+
   it("stages the file from the context menu", async () => {
     render(<SourceControlView />);
     fireEvent.contextMenu(await screen.findByText("src/a.ts"));

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -12,6 +12,8 @@ vi.mock("./lib/gitBridge", () => ({
   gitUnstage: vi.fn().mockResolvedValue(undefined),
   gitCommit: vi.fn().mockResolvedValue(undefined),
   gitPush: vi.fn().mockResolvedValue(undefined),
+  gitFileAtRev: vi.fn().mockResolvedValue(""),
+  gitRestoreFile: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("./lib/aiCommit", () => ({
@@ -21,6 +23,89 @@ vi.mock("./lib/aiCommit", () => ({
 import { SourceControlView } from "./SourceControlView";
 import * as gitBridge from "./lib/gitBridge";
 import type { GitStatus } from "./lib/gitBridge";
+import { useTabsStore } from "@/stores/tabsStore";
+
+const STATUS_ONE_MODIFIED: GitStatus = {
+  branch: "main",
+  staged: [],
+  unstaged: [{ path: "src/a.ts", staged: false, status: "M" }],
+};
+
+describe("SourceControlView row interactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(gitBridge.gitResolveRepo).mockResolvedValue("/repo");
+    vi.mocked(gitBridge.gitLog).mockResolvedValue([]);
+    vi.mocked(gitBridge.gitStatus).mockResolvedValue(STATUS_ONE_MODIFIED);
+    useWorkspaceStore.getState().setRoot("/repo");
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("opens a diff tab when a changed file row is clicked", async () => {
+    render(<SourceControlView />);
+    fireEvent.click(await screen.findByText("src/a.ts"));
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].kind).toBe("diff");
+    expect(tabs[0].title).toBe("a.ts");
+  });
+
+  it("confirms before discarding and calls gitRestoreFile", async () => {
+    render(<SourceControlView />);
+    await screen.findByText("src/a.ts");
+
+    fireEvent.click(screen.getByRole("button", { name: "Discard Changes" }));
+    expect(gitBridge.gitRestoreFile).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+    await waitFor(() =>
+      expect(gitBridge.gitRestoreFile).toHaveBeenCalledWith("/repo", "src/a.ts"),
+    );
+  });
+
+  it("right-click opens a custom menu with open, stage, copy and discard items", async () => {
+    render(<SourceControlView />);
+    fireEvent.contextMenu(await screen.findByText("src/a.ts"));
+
+    expect(screen.getByRole("menuitem", { name: "Open File" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Show Diff" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Stage" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Copy Path" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Discard Changes" })).toBeInTheDocument();
+  });
+
+  it("stages the file from the context menu", async () => {
+    render(<SourceControlView />);
+    fireEvent.contextMenu(await screen.findByText("src/a.ts"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Stage" }));
+
+    await waitFor(() => expect(gitBridge.gitStage).toHaveBeenCalledWith("/repo", "src/a.ts"));
+  });
+
+  it("history row right-click offers copy hash", async () => {
+    vi.mocked(gitBridge.gitLog).mockResolvedValue([
+      { id: "abc1234", summary: "feat: x", author: "a", timestamp: 1 },
+    ]);
+    render(<SourceControlView />);
+    fireEvent.contextMenu(await screen.findByText("feat: x"));
+
+    expect(screen.getByRole("menuitem", { name: "Copy Hash" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Copy Message" })).toBeInTheDocument();
+  });
+
+  it("offers no discard button for untracked or staged rows", async () => {
+    vi.mocked(gitBridge.gitStatus).mockResolvedValue({
+      branch: "main",
+      staged: [{ path: "staged.ts", staged: true, status: "M" }],
+      unstaged: [{ path: "new.ts", staged: false, status: "?" }],
+    });
+    render(<SourceControlView />);
+    await screen.findByText("new.ts");
+
+    expect(screen.queryByRole("button", { name: "Discard Changes" })).not.toBeInTheDocument();
+  });
+});
 
 describe("SourceControlView folder view", () => {
   beforeEach(() => {

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -20,6 +20,7 @@ import {
   UploadCloud,
 } from "lucide-react";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { InfoDialog } from "@/components/InfoDialog";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import { fsReveal } from "@/modules/explorer/lib/fsBridge";
 import {
@@ -366,6 +367,8 @@ export function SourceControlView() {
   const openDiffTab = useTabsStore((s) => s.openDiffTab);
   // Repo-relative path of the file awaiting discard confirmation, if any.
   const [discardTarget, setDiscardTarget] = useState<string | null>(null);
+  // Basename of a file whose discard failed, shown in an error dialog.
+  const [discardError, setDiscardError] = useState<string | null>(null);
 
   // Rows report repo-relative paths; the diff tab (like the editor) wants an
   // absolute path so it can resolve the repo on its own.
@@ -468,10 +471,16 @@ export function SourceControlView() {
 
   return (
     // Suppress the WebView's own context menu anywhere in the panel; rows
-    // layer the app ContextMenu on top via their own handlers.
+    // layer the app ContextMenu on top via their own handlers. Text inputs
+    // keep the native menu — it's how right-click paste works.
     <div
       className="flex h-full flex-col bg-bg-inset"
-      onContextMenu={(e) => e.preventDefault()}
+      onContextMenu={(e) => {
+        const el = e.target as HTMLElement;
+        if (!(el instanceof HTMLTextAreaElement) && !(el instanceof HTMLInputElement)) {
+          e.preventDefault();
+        }
+      }}
     >
       <div className="flex h-9 shrink-0 items-center justify-between border-b border-border px-3">
         <span className="text-xs font-semibold uppercase tracking-wide text-fg-subtle">
@@ -660,9 +669,23 @@ export function SourceControlView() {
           onConfirm={() => {
             const target = discardTarget;
             setDiscardTarget(null);
-            void withRepo((repo) => gitRestoreFile(repo, target));
+            // A destructive action must never fail silently: surface the
+            // error and refresh so the list reflects whatever really happened.
+            withRepo((repo) => gitRestoreFile(repo, target)).catch(() => {
+              setDiscardError(basename(target));
+              void refresh();
+            });
           }}
           onCancel={() => setDiscardTarget(null)}
+        />
+      )}
+
+      {discardError && (
+        <InfoDialog
+          title={t("discardTitle")}
+          message={t("discardFailed", { name: discardError })}
+          confirmLabel={tCommon("actions.confirm")}
+          onConfirm={() => setDiscardError(null)}
         />
       )}
     </div>

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -1,23 +1,34 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  Clipboard,
+  ClipboardList,
+  File,
   Folder,
+  FolderOpen,
   FolderTree,
   GitBranch,
+  GitCompare,
   List,
   Loader2,
   Minus,
   Plus,
   RefreshCw,
   Sparkles,
+  SquarePlus,
+  Undo2,
   UploadCloud,
 } from "lucide-react";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
+import { fsReveal } from "@/modules/explorer/lib/fsBridge";
 import {
   gitCommit,
   gitDiff,
   gitLog,
   gitPush,
   gitResolveRepo,
+  gitRestoreFile,
   gitStage,
   gitStatus,
   gitUnstage,
@@ -30,6 +41,7 @@ import { groupByFolder } from "./lib/groupByFolder";
 import { generateCommitMessage } from "./lib/aiCommit";
 import { withMinDuration } from "@/lib/withMinDuration";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useTabsStore } from "@/stores/tabsStore";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 
 type ViewMode = "flat" | "folder";
@@ -49,18 +61,102 @@ const STATUS_COLOR: Record<string, string> = {
 function StatusRow({
   file,
   displayPath,
+  repoPath,
   actionIcon: ActionIcon,
   actionLabel,
   onAction,
+  onOpen,
+  onRequestDiscard,
 }: {
   file: FileStatus;
   displayPath?: string;
+  repoPath: string;
   actionIcon: typeof Plus;
   actionLabel: string;
   onAction: (path: string) => void;
+  /** Left-click on the row: open this file's diff tab. */
+  onOpen: (path: string) => void;
+  /** Present on tracked unstaged rows only: ask to discard this file. */
+  onRequestDiscard?: (path: string) => void;
 }) {
+  const { t } = useTranslation("sourceControl");
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const discardable = onRequestDiscard && file.status !== "?";
+  const absPath = `${repoPath}/${file.path}`;
+
+  const menuItems: ContextMenuItem[] = [
+    {
+      id: "openFile",
+      label: t("menuOpenFile"),
+      icon: File,
+      group: 0,
+      onSelect: () => useTabsStore.getState().openFromSidebar({ kind: "editor", path: absPath }),
+    },
+    {
+      id: "openInNewTab",
+      label: t("menuOpenInNewTab"),
+      icon: SquarePlus,
+      group: 0,
+      onSelect: () => useTabsStore.getState().openInNewTab({ kind: "editor", path: absPath }),
+    },
+    {
+      id: "showDiff",
+      label: t("menuShowDiff"),
+      icon: GitCompare,
+      group: 0,
+      onSelect: () => onOpen(file.path),
+    },
+    {
+      id: "stageAction",
+      label: actionLabel,
+      icon: ActionIcon,
+      group: 1,
+      onSelect: () => onAction(file.path),
+    },
+    {
+      id: "copyPath",
+      label: t("menuCopyPath"),
+      icon: Clipboard,
+      group: 2,
+      onSelect: () => void navigator.clipboard.writeText(absPath),
+    },
+    {
+      id: "copyRelativePath",
+      label: t("menuCopyRelativePath"),
+      icon: ClipboardList,
+      group: 2,
+      onSelect: () => void navigator.clipboard.writeText(file.path),
+    },
+    {
+      id: "reveal",
+      label: t("menuRevealFinder"),
+      icon: FolderOpen,
+      group: 2,
+      onSelect: () => void fsReveal(absPath),
+    },
+    ...(discardable
+      ? [
+          {
+            id: "discard",
+            label: t("discard"),
+            icon: Undo2,
+            group: 3,
+            danger: true,
+            onSelect: () => onRequestDiscard(file.path),
+          } satisfies ContextMenuItem,
+        ]
+      : []),
+  ];
+
   return (
-    <li className="group flex items-center gap-2 px-3 py-1 text-sm hover:bg-bg-elevated/60">
+    <li
+      onClick={() => onOpen(file.path)}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setMenu({ x: e.clientX, y: e.clientY });
+      }}
+      className="group flex cursor-pointer items-center gap-2 px-3 py-1 text-sm hover:bg-bg-elevated/60"
+    >
       <span
         className={`w-3 shrink-0 text-center font-mono text-xs ${
           STATUS_COLOR[file.status] ?? "text-fg-muted"
@@ -73,16 +169,77 @@ function StatusRow({
           {displayPath ?? file.path}
         </span>
       </Tooltip>
+      {discardable && (
+        <Tooltip label={t("discard")}>
+          <button
+            type="button"
+            aria-label={t("discard")}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRequestDiscard(file.path);
+            }}
+            className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-danger"
+          >
+            <Undo2 size={14} />
+          </button>
+        </Tooltip>
+      )}
       <Tooltip label={actionLabel}>
         <button
           type="button"
           aria-label={actionLabel}
-          onClick={() => onAction(file.path)}
+          onClick={(e) => {
+            e.stopPropagation();
+            onAction(file.path);
+          }}
           className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
         >
           <ActionIcon size={14} />
         </button>
       </Tooltip>
+      {menu && (
+        <ContextMenu x={menu.x} y={menu.y} items={menuItems} onClose={() => setMenu(null)} />
+      )}
+    </li>
+  );
+}
+
+function HistoryRow({ commit }: { commit: CommitInfo }) {
+  const { t } = useTranslation("sourceControl");
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  return (
+    <li
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setMenu({ x: e.clientX, y: e.clientY });
+      }}
+      className="py-1 text-xs"
+    >
+      <span className="font-mono text-fg-subtle">{commit.id}</span>
+      <span className="ml-2 text-fg-muted">{commit.summary}</span>
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          items={[
+            {
+              id: "copyHash",
+              label: t("menuCopyHash"),
+              icon: Clipboard,
+              group: 0,
+              onSelect: () => void navigator.clipboard.writeText(commit.id),
+            },
+            {
+              id: "copyMessage",
+              label: t("menuCopyMessage"),
+              icon: ClipboardList,
+              group: 0,
+              onSelect: () => void navigator.clipboard.writeText(commit.summary),
+            },
+          ]}
+          onClose={() => setMenu(null)}
+        />
+      )}
     </li>
   );
 }
@@ -109,8 +266,11 @@ function FileList({
   actionIcon,
   actionLabel,
   folderActionLabel,
+  repoPath,
   onFileAction,
   onFolderAction,
+  onFileOpen,
+  onRequestDiscard,
 }: {
   files: FileStatus[];
   viewMode: ViewMode;
@@ -118,8 +278,11 @@ function FileList({
   actionIcon: typeof Plus;
   actionLabel: string;
   folderActionLabel: string;
+  repoPath: string;
   onFileAction: (path: string) => void;
   onFolderAction: (paths: string[]) => void;
+  onFileOpen: (path: string) => void;
+  onRequestDiscard?: (path: string) => void;
 }) {
   if (viewMode === "flat") {
     return (
@@ -128,9 +291,12 @@ function FileList({
           <StatusRow
             key={file.path}
             file={file}
+            repoPath={repoPath}
             actionIcon={actionIcon}
             actionLabel={actionLabel}
             onAction={onFileAction}
+            onOpen={onFileOpen}
+            onRequestDiscard={onRequestDiscard}
           />
         ))}
       </ul>
@@ -166,9 +332,12 @@ function FileList({
                   key={file.path}
                   file={file}
                   displayPath={basename(file.path)}
+                  repoPath={repoPath}
                   actionIcon={actionIcon}
                   actionLabel={actionLabel}
                   onAction={onFileAction}
+                  onOpen={onFileOpen}
+                  onRequestDiscard={onRequestDiscard}
                 />
               ))}
             </ul>
@@ -181,6 +350,7 @@ function FileList({
 
 export function SourceControlView() {
   const { t } = useTranslation("sourceControl");
+  const { t: tCommon } = useTranslation("common");
   const rootPath = useWorkspaceStore((s) => s.rootPath);
   const [repoPath, setRepoPath] = useState<string | null>(null);
   const [resolved, setResolved] = useState(false);
@@ -193,6 +363,20 @@ export function SourceControlView() {
   const [refreshing, setRefreshing] = useState(false);
   const providerId = useChatStore((s) => s.providerId);
   const model = useChatStore((s) => s.model);
+  const openDiffTab = useTabsStore((s) => s.openDiffTab);
+  // Repo-relative path of the file awaiting discard confirmation, if any.
+  const [discardTarget, setDiscardTarget] = useState<string | null>(null);
+
+  // Rows report repo-relative paths; the diff tab (like the editor) wants an
+  // absolute path so it can resolve the repo on its own.
+  const openDiff = useCallback(
+    (path: string, staged: boolean) => {
+      if (repoPath) {
+        openDiffTab(`${repoPath}/${path}`, staged);
+      }
+    },
+    [repoPath, openDiffTab],
+  );
 
   const refresh = useCallback(async () => {
     if (!repoPath) {
@@ -283,7 +467,12 @@ export function SourceControlView() {
   }
 
   return (
-    <div className="flex h-full flex-col bg-bg-inset">
+    // Suppress the WebView's own context menu anywhere in the panel; rows
+    // layer the app ContextMenu on top via their own handlers.
+    <div
+      className="flex h-full flex-col bg-bg-inset"
+      onContextMenu={(e) => e.preventDefault()}
+    >
       <div className="flex h-9 shrink-0 items-center justify-between border-b border-border px-3">
         <span className="text-xs font-semibold uppercase tracking-wide text-fg-subtle">
           {t("title")}
@@ -396,6 +585,8 @@ export function SourceControlView() {
                   }
                 })
               }
+              onFileOpen={(path) => openDiff(path, true)}
+              repoPath={repoPath ?? ""}
             />
           </section>
         )}
@@ -439,6 +630,9 @@ export function SourceControlView() {
                   }
                 })
               }
+              onFileOpen={(path) => openDiff(path, false)}
+              onRequestDiscard={setDiscardTarget}
+              repoPath={repoPath ?? ""}
             />
           )}
         </section>
@@ -450,15 +644,27 @@ export function SourceControlView() {
             </h3>
             <ul className="px-3">
               {history.map((commit) => (
-                <li key={commit.id} className="py-1 text-xs">
-                  <span className="font-mono text-fg-subtle">{commit.id}</span>
-                  <span className="ml-2 text-fg-muted">{commit.summary}</span>
-                </li>
+                <HistoryRow key={commit.id} commit={commit} />
               ))}
             </ul>
           </section>
         )}
       </div>
+
+      {discardTarget && (
+        <ConfirmDialog
+          title={t("discardTitle")}
+          message={t("discardMessage", { name: basename(discardTarget) })}
+          confirmLabel={t("discardConfirm")}
+          cancelLabel={tCommon("actions.cancel")}
+          onConfirm={() => {
+            const target = discardTarget;
+            setDiscardTarget(null);
+            void withRepo((repo) => gitRestoreFile(repo, target));
+          }}
+          onCancel={() => setDiscardTarget(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/modules/source-control/lib/gitBridge.ts
+++ b/src/modules/source-control/lib/gitBridge.ts
@@ -50,3 +50,13 @@ export function gitDiff(repoPath: string, staged: boolean): Promise<string> {
 export function gitPush(repoPath: string): Promise<string> {
   return invoke<string>("git_push", { repoPath });
 }
+
+/** rev is "HEAD" (last commit) or ":" (the index). Missing at rev = "". */
+export function gitFileAtRev(repoPath: string, rev: "HEAD" | ":", path: string): Promise<string> {
+  return invoke<string>("git_file_at_rev", { repoPath, rev, path });
+}
+
+/** Discard unstaged changes to one tracked file (git restore). */
+export function gitRestoreFile(repoPath: string, path: string): Promise<void> {
+  return invoke<void>("git_restore_file", { repoPath, path });
+}

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -30,6 +30,9 @@ const GitGraphTabContent = lazy(() =>
     default: m.GitGraphTabContent,
   })),
 );
+const DiffTabContent = lazy(() =>
+  import("@/modules/diff/DiffTabContent").then((m) => ({ default: m.DiffTabContent })),
+);
 import { LauncherPanel } from "@/components/LauncherPanel";
 import { dropOverlayClassName, outerBandOverlayClassName } from "@/components/EntryDropOverlay";
 import { InfoDialog } from "@/components/InfoDialog";
@@ -450,6 +453,8 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                   />
                 ) : pane.content.kind === "git-graph" ? (
                   <GitGraphTabContent />
+                ) : pane.content.kind === "diff" ? (
+                  <DiffTabContent path={pane.content.path} staged={pane.content.staged} />
                 ) : pane.content.kind === "launcher" ? (
                   <LauncherPanel
                     target={{ mode: "replacePane", tabId: tab.id, leafId: pane.id }}

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -157,8 +157,12 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
     : undefined;
 
   // Single-file panes reject folders; terminal/note take both. Dropping a file
-  // onto a launcher pane opens it, so a launcher accepts a file too.
+  // onto a launcher pane opens it, so a launcher accepts a file too. A diff
+  // pane is a read-only comparison with no drop action, so it accepts nothing.
   function canDrop(content: PaneContent, entry: DraggedEntry): boolean {
+    if (content.kind === "diff") {
+      return false;
+    }
     if (
       content.kind === "editor" ||
       content.kind === "preview" ||

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -9,7 +9,8 @@ export type SplitDirection = "row" | "col";
 
 /**
  * What a leaf pane shows: a terminal, an open file, a note, a preview, the git
- * graph, or the launcher (a freshly split pane that hasn't been chosen yet).
+ * graph, a file's uncommitted diff, or the launcher (a freshly split pane that
+ * hasn't been chosen yet).
  */
 export type PaneContent =
   | { kind: "terminal"; cwd?: string; ssh?: { connectionId: string } }
@@ -17,6 +18,7 @@ export type PaneContent =
   | { kind: "note"; noteId: string }
   | { kind: "preview"; url: string }
   | { kind: "git-graph" }
+  | { kind: "diff"; path: string; staged: boolean }
   | { kind: "launcher" };
 
 export const TERMINAL_PANE: PaneContent = { kind: "terminal" };

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   Folder,
   GitBranch,
+  GitCompare,
   GitPullRequest,
   Globe,
   LayoutGrid,
@@ -52,6 +53,8 @@ function tabIcon(kind: TabKind): LucideIcon {
       return Globe;
     case "git-graph":
       return GitBranch;
+    case "diff":
+      return GitCompare;
     case "launcher":
       return LayoutGrid;
   }

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -307,6 +307,25 @@ describe("tabsStore", () => {
     expect(leafIds(activeTab().paneTree)).toHaveLength(1);
   });
 
+  it("creates a diff tab titled by basename and focuses the same file on re-open", () => {
+    const first = useTabsStore.getState().openDiffTab("/repo/src/App.tsx", false);
+    expect(activeTab().title).toBe("App.tsx");
+    expect(firstLeafContent(activeTab())).toEqual({
+      kind: "diff",
+      path: "/repo/src/App.tsx",
+      staged: false,
+    });
+    const again = useTabsStore.getState().openDiffTab("/repo/src/App.tsx", false);
+    expect(again).toBe(first);
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+  });
+
+  it("treats staged and unstaged diffs of the same file as distinct tabs", () => {
+    useTabsStore.getState().openDiffTab("/repo/a.ts", false);
+    useTabsStore.getState().openDiffTab("/repo/a.ts", true);
+    expect(useTabsStore.getState().tabs).toHaveLength(2);
+  });
+
   it("dedupes note tabs by id and git-graph as a singleton", () => {
     const first = useTabsStore.getState().openNoteTab("note-1", "X");
     const again = useTabsStore.getState().openNoteTab("note-1", "X");

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -40,7 +40,7 @@ export type OpenFromSidebarResult =
   | { status: "already-connected" }
   | { status: "at-capacity" };
 
-export type TabKind = "terminal" | "editor" | "note" | "preview" | "git-graph" | "launcher";
+export type TabKind = "terminal" | "editor" | "note" | "preview" | "git-graph" | "diff" | "launcher";
 
 /**
  * A single tab. `kind` is only the tab's creation type, used for the tab-bar
@@ -83,6 +83,7 @@ interface TabsState {
   openNoteTab: (noteId: string, title: string) => string;
   openPreviewTab: (url: string) => string;
   openGitGraphTab: () => string;
+  openDiffTab: (path: string, staged: boolean) => string;
   /**
    * Open sidebar content (explorer file, note, or SSH connection). When the
    * active tab is a real working tab, this splits beside its current
@@ -277,6 +278,9 @@ function singleLeafContentEquals(tab: Tab, content: PaneContent): boolean {
   }
   if (pane.kind === "preview" && content.kind === "preview") {
     return pane.url === content.url;
+  }
+  if (pane.kind === "diff" && content.kind === "diff") {
+    return pane.path === content.path && pane.staged === content.staged;
   }
   return true;
 }
@@ -588,6 +592,33 @@ export const useTabsStore = create<TabsState>()(
       kind: "git-graph",
       title: "Git Graph",
       paneTree: leaf(paneId, { kind: "git-graph" }),
+      activeLeafId: paneId,
+      paneOrder: [paneId],
+    };
+    set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
+    return id;
+  },
+
+  openDiffTab: (path, staged) => {
+    const spaceId = get().ensureSpace();
+    const existing = get().tabs.find(
+      (t) =>
+        t.kind === "diff" &&
+        t.spaceId === spaceId &&
+        singleLeafContentEquals(t, { kind: "diff", path, staged }),
+    );
+    if (existing) {
+      set({ activeId: existing.id });
+      return existing.id;
+    }
+    const id = nextTabId();
+    const paneId = nextPaneId();
+    const tab: Tab = {
+      id,
+      spaceId,
+      kind: "diff",
+      title: path.split(/[\\/]/).pop() ?? path,
+      paneTree: leaf(paneId, { kind: "diff", path, staged }),
       activeLeafId: paneId,
       paneOrder: [paneId],
     };


### PR DESCRIPTION
## Summary

First batch of #93 / #94 (spec: `docs/superpowers/specs/2026-07-02-git-panel-batch1-design.md`).

### Source-control sidebar (#93)

- **Click a changed file → side-by-side diff tab** (`@codemirror/merge`): unstaged rows compare index vs working tree, staged rows HEAD vs index, new files render all-added. Same file+side focuses the existing tab.
- **Diff tab UX** (iterated with the owner): VS Code-style palette using the app's success/danger tokens, +/− gutter signs, line numbers, word-wrap toggle (shared with the editor setting), unchanged regions collapse into an expandable localized bar, and index-based prev/next-change navigation with a current/total counter that starts on the first change and pins each target to the top.
- **Per-file discard** (`git restore`, tracked unstaged files only) via a hover button and context menu, behind a ConfirmDialog; failures surface an error dialog.
- **Context menus**: file rows get open / open in new tab / show diff / stage-unstage / copy path / copy relative path / reveal in Finder / discard; history rows get copy hash / copy message. The panel suppresses the WebView menu except over text inputs (right-click paste still works in the commit box).

### Git Graph (#94)

- **Full-row click** (#94-1): the whole commit row — including the lane gutter — selects the commit; selection/hover frames the full row with translucent backgrounds so lane lines stay visible.
- **CJK legibility**: content-bearing text (messages, author/date, details panel, diff, AI explanation) bumped to 13px.
- **Compact "⋯" menu** (#94-6): verified in the running app — the overflow menu already contains refresh / fetch / remote / tags / stashes / ordering, matching the full toolbar. No gap found; commenting on the issue instead.

### Backend

Two new commands with `ensure_not_flag`, `--` separation and unit tests: `git_file_at_rev` (rev allowlisted to `HEAD`/`:`, missing-at-rev and unborn-HEAD read as empty) and `git_restore_file` (pathspec wrapped in `:(literal)`).

## Reviews

- `/tauri-review`: PASS (0 critical/high/medium; both actionable LOW findings fixed: literal pathspec, error-message matching).
- `/code-review` (xhigh): all confirmed findings fixed — unborn-HEAD staged diffs, silent discard failures, MergeView rebuild losing scroll position on refocus, dead drop-target on diff panes, commit-box context menu, lane lines under row backgrounds, and ContextMenu click bubbling through React portals (fixed in the shared component).

## Test plan

- [x] `pnpm test` (1021) and `cargo test` (197) green; `pnpm typecheck` clean.
- [x] Runtime verification on a scratch repo: staged/unstaged/untracked rows, diff tabs both sides, discard end-to-end (file restored, list refreshed), context menus, full-row graph click, compact toolbar.
- [x] Scroll/navigation/collapse behavior verified in an isolated CodeMirror harness (300-line fixtures) and by the owner in the built app.

Part of #93, #94 (batch 2 — working-copy node and cross-panel navigation — tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)