### PR TITLE
feat(git-graph): worktree selector and branch-switch menu

### DIFF
--- a/docs/superpowers/plans/2026-07-03-git-panel-batch3.md
+++ b/docs/superpowers/plans/2026-07-03-git-panel-batch3.md
@@ -1,0 +1,717 @@
+# Git Panel Batch 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Git Graph toolbar gains a worktree selector (switches the app's workspace root) and a branch-switch menu behind the "HEAD: branch" display — spec: `docs/superpowers/specs/2026-07-03-git-panel-batch3-design.md`.
+
+**Architecture:** One new backend command (`git_worktree_list`, parses `git worktree list --porcelain`) is the only new backend surface. The toolbar renders a second labeled Combobox for worktrees (hidden for single-worktree repos) whose selection calls `useWorkspaceStore.setRoot` — the existing root-change effect in `GitGraphTabContent` does all the reloading. The "HEAD: branch" text becomes a button opening a popover of local + remote branches; checkout reuses the existing `runAction`/`gitBranchCheckout`/tracking-modal flows from the ref context menu.
+
+**Tech Stack:** Rust (git subprocess via existing `run_git`), React 18 + TS, zustand, vitest + RTL, existing `Combobox`/`Tooltip` components.
+
+## Global Constraints
+
+- Branch: `feat/git-panel-batch3` (created from `feat/git-panel-batch2`; rebase onto master once PR #117 merges).
+- English commits/comments; conventional commits. i18n strings in both `en` and `zh-Hant`.
+- After each task: `pnpm test && pnpm typecheck`; Task 1 also `cargo test` in `src-tauri`.
+- Backend addition is one read-only command; no capability/config changes. Pure `git` CLI parsing, no platform-specific code (must compile on Windows CI).
+
+---
+
+### Task 1: Backend — `worktree_list` + `git_worktree_list` command
+
+**Files:**
+- Modify: `src-tauri/src/modules/git/mod.rs` (types near `WorktreeInfo` ~line 225, impl near `worktree_info` ~line 256, command wrapper near `git_worktree_info` ~line 385, tests in the existing `mod tests`)
+- Modify: `src-tauri/src/lib.rs` (import list ~line 27, invoke handler list ~line 169)
+
+**Interfaces:**
+- Produces (Task 2 consumes): command `git_worktree_list(path: String) -> Result<Vec<WorktreeListItem>, String>` where `WorktreeListItem` serializes as `{ path: string, branch: string | null }`.
+
+- [ ] **Step 1: Write the failing tests** (append inside `mod tests` in `mod.rs`, following the `worktree_info_*` fixture style):
+
+```rust
+#[test]
+fn worktree_list_reports_main_and_linked_worktrees() {
+    let dir = temp_repo_dir("wtl-main");
+    let path = dir.to_string_lossy().to_string();
+    run_git(&path, &["init", "-b", "main"]).unwrap();
+    run_git(&path, &["config", "user.email", "t@t.dev"]).unwrap();
+    run_git(&path, &["config", "user.name", "Tester"]).unwrap();
+    std::fs::write(dir.join("a.txt"), "hi").unwrap();
+    run_git(&path, &["add", "."]).unwrap();
+    run_git(&path, &["commit", "-m", "init"]).unwrap();
+
+    let wt_dir = std::env::temp_dir().join(format!("tempoterm-git-wtl-linked-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&wt_dir);
+    let wt_path = wt_dir.to_string_lossy().to_string();
+    run_git(&path, &["worktree", "add", "-b", "feature", &wt_path]).unwrap();
+
+    let items = worktree_list(&path).unwrap();
+    assert_eq!(items.len(), 2);
+    // Paths from git are canonicalized (e.g. /private/var vs /var on macOS),
+    // so assert on the unambiguous basename instead of full equality.
+    assert!(items[0].path.ends_with("wtl-main") || items[0].path.contains("wtl-main"));
+    assert_eq!(items[0].branch.as_deref(), Some("main"));
+    assert_eq!(items[1].branch.as_deref(), Some("feature"));
+
+    run_git(&path, &["worktree", "remove", "--force", &wt_path]).unwrap();
+    let _ = std::fs::remove_dir_all(&wt_dir);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn worktree_list_reports_detached_worktree_without_branch() {
+    let dir = temp_repo_dir("wtl-detached");
+    let path = dir.to_string_lossy().to_string();
+    run_git(&path, &["init", "-b", "main"]).unwrap();
+    run_git(&path, &["config", "user.email", "t@t.dev"]).unwrap();
+    run_git(&path, &["config", "user.name", "Tester"]).unwrap();
+    std::fs::write(dir.join("a.txt"), "hi").unwrap();
+    run_git(&path, &["add", "."]).unwrap();
+    run_git(&path, &["commit", "-m", "init"]).unwrap();
+
+    let wt_dir = std::env::temp_dir().join(format!("tempoterm-git-wtl-det-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&wt_dir);
+    let wt_path = wt_dir.to_string_lossy().to_string();
+    run_git(&path, &["worktree", "add", "--detach", &wt_path]).unwrap();
+
+    let items = worktree_list(&path).unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[1].branch, None);
+
+    run_git(&path, &["worktree", "remove", "--force", &wt_path]).unwrap();
+    let _ = std::fs::remove_dir_all(&wt_dir);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn worktree_list_returns_single_item_for_a_plain_repo() {
+    let dir = temp_repo_dir("wtl-single");
+    let path = dir.to_string_lossy().to_string();
+    run_git(&path, &["init", "-b", "main"]).unwrap();
+    run_git(&path, &["config", "user.email", "t@t.dev"]).unwrap();
+    run_git(&path, &["config", "user.name", "Tester"]).unwrap();
+    std::fs::write(dir.join("a.txt"), "hi").unwrap();
+    run_git(&path, &["add", "."]).unwrap();
+    run_git(&path, &["commit", "-m", "init"]).unwrap();
+
+    let items = worktree_list(&path).unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].branch.as_deref(), Some("main"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — `cd src-tauri && cargo test worktree_list` → FAIL (function not found).
+- [ ] **Step 3: Implement** (place the struct next to `WorktreeInfo`, the function next to `worktree_info`, the command next to `git_worktree_info`):
+
+```rust
+/// One entry of `git worktree list`: the worktree's absolute path and its
+/// checked-out branch (None on a detached HEAD). Bare entries are skipped.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeListItem {
+    pub path: String,
+    pub branch: Option<String>,
+}
+
+/// Lists every worktree of the repository via `git worktree list --porcelain`:
+/// blank-line-separated blocks of `worktree <path>`, `HEAD <sha>`, then
+/// `branch refs/heads/<name>` or `detached`. A `bare` block has no working
+/// tree to switch to, so it is dropped.
+pub fn worktree_list(repo_path: &str) -> Result<Vec<WorktreeListItem>, String> {
+    let stdout = run_git(repo_path, &["worktree", "list", "--porcelain"])?;
+    let mut items = Vec::new();
+    let mut path: Option<String> = None;
+    let mut branch: Option<String> = None;
+    let mut bare = false;
+
+    let mut flush = |path: &mut Option<String>, branch: &mut Option<String>, bare: &mut bool, items: &mut Vec<WorktreeListItem>| {
+        if let Some(p) = path.take() {
+            if !*bare {
+                items.push(WorktreeListItem { path: p, branch: branch.take() });
+            }
+        }
+        *branch = None;
+        *bare = false;
+    };
+
+    for line in stdout.lines() {
+        if line.is_empty() {
+            flush(&mut path, &mut branch, &mut bare, &mut items);
+        } else if let Some(rest) = line.strip_prefix("worktree ") {
+            path = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("branch ") {
+            branch = Some(rest.strip_prefix("refs/heads/").unwrap_or(rest).to_string());
+        } else if line == "bare" {
+            bare = true;
+        }
+        // `HEAD <sha>` and `detached` lines are ignored: branch simply stays
+        // None for a detached worktree.
+    }
+    flush(&mut path, &mut branch, &mut bare, &mut items);
+    Ok(items)
+}
+```
+
+Command wrapper (next to `git_worktree_info`, same spawn_blocking rationale):
+
+```rust
+#[tauri::command]
+pub async fn git_worktree_list(path: String) -> Result<Vec<WorktreeListItem>, String> {
+    tauri::async_runtime::spawn_blocking(move || worktree_list(&path))
+        .await
+        .map_err(|e| e.to_string())?
+}
+```
+
+In `src-tauri/src/lib.rs`: add `git_worktree_list` to the `use ...::git::{...}` import list (alphabetical, next to `git_worktree_info`) and to the `tauri::generate_handler![...]` list (same neighborhood).
+
+- [ ] **Step 4: Run tests** — `cd src-tauri && cargo test worktree_list` → 3 PASS. Then `cargo test` (full) → PASS.
+- [ ] **Step 5: Typecheck frontend untouched, commit**
+
+```bash
+cd src-tauri && cargo fmt
+git add src-tauri/src/modules/git/mod.rs src-tauri/src/lib.rs
+git commit -m "feat(git): add git_worktree_list command"
+```
+
+---
+
+### Task 2: Worktree selector in the Git Graph toolbar
+
+**Files:**
+- Modify: `src/modules/git-graph/lib/gitGraphBridge.ts` (new bridge fn + type)
+- Modify: `src/modules/git-graph/GitGraphToolbar.tsx` (selector UI + labels)
+- Modify: `src/modules/git-graph/GitGraphTabContent.tsx` (fetch + wiring)
+- Modify: `src/i18n/locales/en/gitGraph.json`, `src/i18n/locales/zh-Hant/gitGraph.json`
+- Test: `src/modules/git-graph/GitGraphToolbar.test.tsx` (extend), `src/modules/git-graph/GitGraphTabContent.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `git_worktree_list` (Task 1).
+- Produces: `GitGraphToolbar` props gain `worktrees: WorktreeItem[]`, `currentWorktreePath: string | null`, `onSelectWorktree: (path: string) => void`; labels gain `worktree: string`. Bridge exports `interface WorktreeItem { path: string; branch: string | null }` and `gitWorktreeList(repo: string): Promise<WorktreeItem[]>`.
+
+- [ ] **Step 1: Write the failing toolbar tests** (append to `GitGraphToolbar.test.tsx`; extend the `labels` fixture with `worktree: "Worktree"` and add the new props to `renderToolbar`'s defaults: `worktrees: []`, `currentWorktreePath: null`, `onSelectWorktree: vi.fn()`):
+
+```tsx
+describe("worktree selector", () => {
+  const twoWorktrees = [
+    { path: "/repos/app", branch: "master" },
+    { path: "/repos/app-dev", branch: "feature" },
+  ];
+
+  it("is hidden when the repo has a single worktree", () => {
+    renderToolbar({ worktrees: [{ path: "/repos/app", branch: "master" }], currentWorktreePath: "/repos/app" });
+    expect(screen.queryByText("Worktree:")).not.toBeInTheDocument();
+  });
+
+  it("shows the current worktree as the selected value when there are several", () => {
+    renderToolbar({ worktrees: twoWorktrees, currentWorktreePath: "/repos/app" });
+    expect(screen.getByText("Worktree:")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Worktree" })).toHaveTextContent("app (master)");
+  });
+
+  it("selecting another worktree reports its path", () => {
+    const onSelectWorktree = vi.fn();
+    renderToolbar({ worktrees: twoWorktrees, currentWorktreePath: "/repos/app", onSelectWorktree });
+
+    fireEvent.click(screen.getByRole("button", { name: "Worktree" }));
+    fireEvent.click(screen.getByText("app-dev (feature)"));
+
+    expect(onSelectWorktree).toHaveBeenCalledWith("/repos/app-dev");
+  });
+
+  it("falls back to full paths when two options would collide", () => {
+    renderToolbar({
+      worktrees: [
+        { path: "/a/repo", branch: "main" },
+        { path: "/b/repo", branch: "main" },
+      ],
+      currentWorktreePath: "/a/repo",
+    });
+    expect(screen.getByRole("button", { name: "Worktree" })).toHaveTextContent("/a/repo");
+  });
+});
+```
+
+Note: the `Combobox` trigger renders as a button whose accessible name comes from `ariaLabel` — check the existing branch-filter tests in this file for the exact query convention and mirror it; adjust the `getByRole` queries above if the component exposes a different role (e.g. the trigger may need `{ name: "Worktree" }` on a `button` with `aria-label`).
+
+- [ ] **Step 2: Run to verify failure** — `pnpm vitest run src/modules/git-graph/GitGraphToolbar.test.tsx` → new tests FAIL (no worktree UI; missing props cause TS errors in the test file first — that is the expected RED).
+- [ ] **Step 3: Implement the bridge** (append to `gitGraphBridge.ts`, following its existing style):
+
+```ts
+export interface WorktreeItem {
+  path: string;
+  /** Checked-out branch, or null when the worktree is on a detached HEAD. */
+  branch: string | null;
+}
+
+export function gitWorktreeList(repo: string): Promise<WorktreeItem[]> {
+  return invoke<WorktreeItem[]>("git_worktree_list", { path: repo });
+}
+```
+
+- [ ] **Step 4: Implement the toolbar selector.** In `GitGraphToolbar.tsx`:
+
+Extend the labels interface and props:
+
+```ts
+export interface GitGraphToolbarLabels {
+  // ...existing fields...
+  worktree: string;
+}
+
+interface GitGraphToolbarProps {
+  // ...existing fields...
+  worktrees: WorktreeItem[];
+  currentWorktreePath: string | null;
+  onSelectWorktree: (path: string) => void;
+}
+```
+
+Import the type: `import type { WorktreeItem } from "./lib/gitGraphBridge";`
+
+Add option-building above the component (module scope, exported for nothing — plain helpers):
+
+```ts
+/** Last path segment; handles both / and \ separators (git on Windows may
+ * print either). */
+function worktreeBasename(path: string): string {
+  const segments = path.split(/[\\/]/).filter(Boolean);
+  return segments[segments.length - 1] ?? path;
+}
+
+interface WorktreeOption {
+  label: string;
+  path: string;
+}
+
+/** "basename (branch)" per worktree; colliding labels fall back to the full
+ * path so every Combobox option string stays unique (selection maps back by
+ * string value). */
+function buildWorktreeOptions(worktrees: WorktreeItem[]): WorktreeOption[] {
+  const base = worktrees.map((w) => ({
+    label: w.branch ? `${worktreeBasename(w.path)} (${w.branch})` : worktreeBasename(w.path),
+    path: w.path,
+  }));
+  const counts = new Map<string, number>();
+  for (const option of base) {
+    counts.set(option.label, (counts.get(option.label) ?? 0) + 1);
+  }
+  return base.map((option) =>
+    (counts.get(option.label) ?? 0) > 1 ? { ...option, label: option.path } : option,
+  );
+}
+
+/** Trailing-slash-insensitive path equality (resolve_repo trims, git doesn't). */
+function samePath(a: string, b: string): boolean {
+  return a.replace(/[\\/]+$/, "") === b.replace(/[\\/]+$/, "");
+}
+```
+
+Inside the component, after `branchOptions`:
+
+```ts
+const worktreeOptions = buildWorktreeOptions(worktrees);
+const currentWorktree =
+  currentWorktreePath === null
+    ? undefined
+    : worktreeOptions.find((o) => samePath(o.path, currentWorktreePath));
+const showWorktreeControls = showBranchControls && worktreeOptions.length > 1;
+```
+
+Render, inside the left `<div className="flex min-w-0 items-center gap-3">`, directly after the `showBranchControls && (...)` branch block (so it sits next to the branch filter and also steps aside for compact search):
+
+```tsx
+{showWorktreeControls && (
+  <div className="flex min-w-0 items-center gap-1.5 text-xs text-fg-subtle">
+    <span className="shrink-0">{labels.worktree}:</span>
+    <Combobox
+      value={currentWorktree?.label ?? (currentWorktreePath ? worktreeBasename(currentWorktreePath) : "")}
+      options={worktreeOptions.map((o) => o.label)}
+      onChange={(label) => {
+        const picked = worktreeOptions.find((o) => o.label === label);
+        if (picked && (!currentWorktree || picked.path !== currentWorktree.path)) {
+          onSelectWorktree(picked.path);
+        }
+      }}
+      ariaLabel={labels.worktree}
+      className="w-44"
+    />
+  </div>
+)}
+```
+
+- [ ] **Step 5: Wire the tab content.** In `GitGraphTabContent.tsx`:
+
+Add `gitWorktreeList` and the type to the existing bridge import; add state + fetch effect next to the repo-resolve effect:
+
+```ts
+const [worktrees, setWorktrees] = useState<WorktreeItem[]>([]);
+
+// The worktree set only changes on external `git worktree add/remove`, so
+// fetch once per resolved repo; a failure (not a repo) just hides the control.
+useEffect(() => {
+  if (!repo) {
+    setWorktrees([]);
+    return;
+  }
+  let cancelled = false;
+  gitWorktreeList(repo)
+    .then((list) => {
+      if (!cancelled) {
+        setWorktrees(list);
+      }
+    })
+    .catch(() => {
+      if (!cancelled) {
+        setWorktrees([]);
+      }
+    });
+  return () => {
+    cancelled = true;
+  };
+}, [repo]);
+
+const handleSelectWorktree = useCallback((path: string) => {
+  // Switching worktree = switching the app's workspace root; the rootPath
+  // effect above re-resolves the repo and reloads everything.
+  useWorkspaceStore.getState().setRoot(path);
+}, []);
+```
+
+Toolbar wiring (new props on `<GitGraphToolbar ...>`): `worktrees={worktrees}`, `currentWorktreePath={repo}` (resolve_repo returns the current worktree's own toplevel — verified against `Repository::discover` + `workdir()`), `onSelectWorktree={handleSelectWorktree}`.
+
+Labels: add `worktree: t("toolbar.worktree"),` to `toolbarLabels`.
+
+- [ ] **Step 6: i18n.** Add under `toolbar` in both locales: en `"worktree": "Worktree"`, zh-Hant `"worktree": "Worktree"` (proper noun, untranslated per the spec).
+- [ ] **Step 7: Write the failing tab-content test** (append to `GitGraphTabContent.test.tsx`; add `gitWorktreeList: vi.fn().mockResolvedValue([])` to the existing `./lib/gitGraphBridge` mock so other tests keep passing):
+
+```tsx
+describe("worktree selector wiring", () => {
+  it("switches the workspace root when another worktree is picked", async () => {
+    vi.mocked(gitGraphLog).mockResolvedValue(commitList(["aaa1111"], false));
+    vi.mocked(gitWorktreeList).mockResolvedValue([
+      { path: "/repo", branch: "master" },
+      { path: "/repo-dev", branch: "feature" },
+    ]);
+
+    render(<GitGraphTabContent />);
+    fireEvent.click(await screen.findByRole("button", { name: "Worktree" }));
+    fireEvent.click(screen.getByText("repo-dev (feature)"));
+
+    await waitFor(() => expect(useWorkspaceStore.getState().rootPath).toBe("/repo-dev"));
+  });
+});
+```
+
+(Import `gitWorktreeList` alongside the other mocked bridge fns; the toolbar aria-label comes from the real i18n key, so use the English string the `en` locale produces — check what `t("toolbar.worktree")` renders in this test setup and match it.)
+
+- [ ] **Step 8: Run all touched tests** — `pnpm vitest run src/modules/git-graph` → PASS.
+- [ ] **Step 9: Verify + commit**
+
+```bash
+pnpm test && pnpm typecheck
+git add -A src
+git commit -m "feat(git-graph): worktree selector that switches the workspace root
+
+Lists the repo's worktrees (new git_worktree_list command) in a second
+labeled Combobox next to the branch filter, hidden for single-worktree
+repos. Picking one calls setRoot, and the existing root-change effect
+re-resolves and reloads the graph; sidebar and file explorer follow the
+same store. Colliding display labels fall back to full paths."
+```
+
+---
+
+### Task 3: Branch-switch menu behind "HEAD: branch"
+
+**Files:**
+- Modify: `src/modules/git-graph/GitGraphToolbar.tsx` (HEAD button + `BranchMenu` popover, roomy + compact)
+- Modify: `src/modules/git-graph/GitGraphTabContent.tsx` (checkout wiring; extract `openCheckoutRemoteModal` shared with the ref menu)
+- Modify: `src/i18n/locales/en/gitGraph.json`, `src/i18n/locales/zh-Hant/gitGraph.json`
+- Test: `src/modules/git-graph/GitGraphToolbar.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: existing `gitBranchCheckout`, `gitBranchCheckoutTrack`, `runAction`, `setModal`, `splitRemoteRef` (all already in `GitGraphTabContent.tsx`).
+- Produces: `GitGraphToolbar` props gain `onCheckoutBranch: (name: string) => void` and `onCheckoutRemoteBranch: (name: string) => void`; labels gain `switchBranch: string`.
+
+- [ ] **Step 1: Write the failing toolbar tests** (append; extend `labels` fixture with `switchBranch: "Switch Branch"` and `renderToolbar` defaults with `onCheckoutBranch: vi.fn()`, `onCheckoutRemoteBranch: vi.fn()`; widen the `branches` fixture with a second local branch `{ name: "dev", isRemote: false }`):
+
+```tsx
+describe("branch-switch menu", () => {
+  it("opens from the HEAD button and lists local branches with the current one checked", () => {
+    renderToolbar({ currentBranch: "master" });
+    setToolbarWidth(800);
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch Branch" }));
+
+    const menu = screen.getByRole("menu");
+    expect(within(menu).getByText("master")).toBeInTheDocument();
+    expect(within(menu).getByText("dev")).toBeInTheDocument();
+  });
+
+  it("clicking another local branch checks it out", () => {
+    const onCheckoutBranch = vi.fn();
+    renderToolbar({ currentBranch: "master", onCheckoutBranch });
+    setToolbarWidth(800);
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch Branch" }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("dev"));
+
+    expect(onCheckoutBranch).toHaveBeenCalledWith("dev");
+  });
+
+  it("clicking the current branch closes without checking out", () => {
+    const onCheckoutBranch = vi.fn();
+    renderToolbar({ currentBranch: "master", onCheckoutBranch });
+    setToolbarWidth(800);
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch Branch" }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("master"));
+
+    expect(onCheckoutBranch).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("clicking a remote branch routes to the tracking flow", () => {
+    const onCheckoutRemoteBranch = vi.fn();
+    renderToolbar({ currentBranch: "master", onCheckoutRemoteBranch });
+    setToolbarWidth(800);
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch Branch" }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("origin/master"));
+
+    expect(onCheckoutRemoteBranch).toHaveBeenCalledWith("origin/master");
+  });
+
+  it("compact mode reaches the same menu through the overflow HEAD row", () => {
+    const onCheckoutBranch = vi.fn();
+    renderToolbar({ currentBranch: "master", onCheckoutBranch });
+    setToolbarWidth(400);
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    fireEvent.click(screen.getByRole("button", { name: "Switch Branch" }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("dev"));
+
+    expect(onCheckoutBranch).toHaveBeenCalledWith("dev");
+  });
+});
+```
+
+(Existing tests that assert the HEAD text via plain text queries may need updating from a `<span>` to a `<button>` — run and adjust queries, not behavior.)
+
+- [ ] **Step 2: Run to verify failure** — `pnpm vitest run src/modules/git-graph/GitGraphToolbar.test.tsx` → new tests FAIL.
+- [ ] **Step 3: Implement in `GitGraphToolbar.tsx`.**
+
+Labels + props:
+
+```ts
+export interface GitGraphToolbarLabels {
+  // ...existing + worktree...
+  switchBranch: string;
+}
+
+interface GitGraphToolbarProps {
+  // ...existing + worktree props...
+  onCheckoutBranch: (name: string) => void;
+  onCheckoutRemoteBranch: (name: string) => void;
+}
+```
+
+State: `const [branchMenuOpen, setBranchMenuOpen] = useState(false);`
+
+New popover component at the bottom of the file (next to `ActionRow`):
+
+```tsx
+interface BranchMenuProps {
+  locals: Branch[];
+  remotes: Branch[];
+  currentBranch: string;
+  onCheckoutBranch: (name: string) => void;
+  onCheckoutRemoteBranch: (name: string) => void;
+  onClose: () => void;
+}
+
+/** The checkout popover behind the HEAD display. Locals check out directly;
+ * remotes route to the create-tracking-branch modal owned by the tab. */
+function BranchMenu({
+  locals,
+  remotes,
+  currentBranch,
+  onCheckoutBranch,
+  onCheckoutRemoteBranch,
+  onClose,
+}: BranchMenuProps) {
+  return (
+    <>
+      <div className="fixed inset-0 z-20" onClick={onClose} aria-hidden="true" />
+      <div
+        role="menu"
+        className="absolute right-0 z-30 mt-1 max-h-72 w-56 overflow-y-auto rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg"
+      >
+        {locals.map((b) => (
+          <button
+            key={b.name}
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              onClose();
+              if (b.name !== currentBranch) {
+                onCheckoutBranch(b.name);
+              }
+            }}
+            className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-xs text-fg-muted hover:bg-bg-inset hover:text-fg"
+          >
+            <span className="truncate font-mono">{b.name}</span>
+            {b.name === currentBranch && <Check className="h-3.5 w-3.5 shrink-0 text-accent" />}
+          </button>
+        ))}
+        {remotes.length > 0 && (
+          <>
+            <div className="my-1 border-t border-border" />
+            {remotes.map((b) => (
+              <button
+                key={b.name}
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  onClose();
+                  onCheckoutRemoteBranch(b.name);
+                }}
+                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-fg-muted hover:bg-bg-inset hover:text-fg"
+              >
+                <span className="truncate font-mono">{b.name}</span>
+              </button>
+            ))}
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+```
+
+Roomy mode: replace the HEAD `<span>` (currently `className="ml-1 whitespace-nowrap font-mono text-[11px] text-fg-subtle"`) with a button + anchored menu:
+
+```tsx
+<div className="relative">
+  <Tooltip label={labels.switchBranch}>
+    <button
+      type="button"
+      aria-label={labels.switchBranch}
+      aria-expanded={branchMenuOpen}
+      onClick={() => setBranchMenuOpen((v) => !v)}
+      className="ml-1 whitespace-nowrap rounded px-1 py-0.5 font-mono text-[11px] text-fg-subtle hover:bg-bg-elevated hover:text-fg"
+    >
+      {labels.head}: {currentBranch}
+    </button>
+  </Tooltip>
+  {branchMenuOpen && (
+    <BranchMenu
+      locals={locals}
+      remotes={remotes}
+      currentBranch={currentBranch}
+      onCheckoutBranch={onCheckoutBranch}
+      onCheckoutRemoteBranch={onCheckoutRemoteBranch}
+      onClose={() => setBranchMenuOpen(false)}
+    />
+  )}
+</div>
+```
+
+Compact mode: turn the overflow menu's HEAD text `<div>` into a button that hands off to the branch menu, and render the menu inside the same relative container as the ⋯ button (a sibling of the overflow popover):
+
+```tsx
+{/* inside the overflow popover, replacing the plain HEAD div */}
+<button
+  type="button"
+  aria-label={labels.switchBranch}
+  onClick={() => {
+    setOverflowOpen(false);
+    setBranchMenuOpen(true);
+  }}
+  className="flex w-full items-center rounded px-2 py-1.5 text-left font-mono text-[11px] text-fg-subtle hover:bg-bg-inset hover:text-fg"
+>
+  {labels.head}: {currentBranch}
+</button>
+```
+
+```tsx
+{/* sibling of the overflow popover, inside the compact-mode relative div */}
+{branchMenuOpen && (
+  <BranchMenu
+    locals={locals}
+    remotes={remotes}
+    currentBranch={currentBranch}
+    onCheckoutBranch={onCheckoutBranch}
+    onCheckoutRemoteBranch={onCheckoutRemoteBranch}
+    onClose={() => setBranchMenuOpen(false)}
+  />
+)}
+```
+
+- [ ] **Step 4: Wire the tab content.** In `GitGraphTabContent.tsx`, extract the remote-checkout modal (used today only inside `refMenuItems`, `onCheckoutRemote`) into a shared callback placed next to `handleFetch`:
+
+```ts
+// Shared by the ref context menu and the toolbar's branch menu: prompt for a
+// local name, then create the tracking branch.
+const openCheckoutRemoteModal = useCallback(
+  (refName: string) => {
+    const { branch } = splitRemoteRef(refName);
+    setModal({
+      title: t("modal.checkoutRemote.title"),
+      confirmLabel: t("modal.checkoutRemote.confirm"),
+      fields: [
+        {
+          key: "name",
+          label: t("modal.branchName"),
+          placeholder: t("modal.branchPlaceholder"),
+          required: true,
+          defaultValue: branch,
+        },
+      ],
+      onConfirm: (values) =>
+        void runAction(() => gitBranchCheckoutTrack(repo!, values.name, refName)),
+    });
+  },
+  [t, runAction, repo],
+);
+```
+
+Replace the inline body of `onCheckoutRemote` in `refMenuItems` with `openCheckoutRemoteModal(ref.name)`, and pass to the toolbar:
+
+```tsx
+onCheckoutBranch={(name) => void runAction(() => gitBranchCheckout(repo!, name))}
+onCheckoutRemoteBranch={openCheckoutRemoteModal}
+```
+
+Labels: `switchBranch: t("toolbar.switchBranch"),`.
+
+- [ ] **Step 5: i18n.** Under `toolbar` in both locales: en `"switchBranch": "Switch Branch"`, zh-Hant `"switchBranch": "切換分支"`.
+- [ ] **Step 6: Run tests** — `pnpm vitest run src/modules/git-graph` → PASS (fix any pre-existing HEAD-text queries per Step 1's note).
+- [ ] **Step 7: Verify + commit**
+
+```bash
+pnpm test && pnpm typecheck
+git add -A src
+git commit -m "feat(git-graph): branch-switch menu behind the HEAD display
+
+The toolbar's HEAD text becomes a button (roomy) and the overflow HEAD
+row a trigger (compact), both opening a popover of local and remote
+branches. Locals check out via the existing runAction flow; remotes
+reuse the ref menu's create-tracking-branch modal, now extracted into a
+shared openCheckoutRemoteModal. The branch filter dropdown remains a
+pure display filter."
+```
+
+---
+
+### Task 4: Reviews, verification, build
+
+- [ ] **Step 1:** `pnpm test && pnpm typecheck` and `cd src-tauri && cargo test` — full green.
+- [ ] **Step 2:** Run `/code-review`; fix CRITICAL/HIGH (and reasonable MEDIUM) findings; re-run until clean. Run `/tauri-review` for the new backend command (read-only, no capability changes expected).
+- [ ] **Step 3:** Verify in the running app (`pnpm tauri dev`) on this repo itself (create a scratch worktree first: `git worktree add ../tempo-term-scratch -b scratch-test`):
+  - Worktree selector appears with two entries; picking the scratch one switches the file explorer, sidebar and graph; picking back returns. Selector hidden after `git worktree remove ../tempo-term-scratch` + refresh (re-open tab or switch root).
+  - HEAD button opens the branch menu in roomy width; checkout of another local branch reloads the graph and updates HEAD; checkout with dirty tree shows git's error inline; remote branch opens the tracking modal.
+  - Narrow the pane below 620px: ⋯ → HEAD row → same menu works. Also confirm the worktree selector + branch filter side-by-side layout doesn't crowd the toolbar (the deferred confusion concern — note the verdict for the owner).
+- [ ] **Step 4:** Local build for owner testing: `export TAURI_SIGNING_PRIVATE_KEY="$(cat ~/.tauri/tempo-term.key)" TAURI_SIGNING_PRIVATE_KEY_PASSWORD="" && pnpm tauri build`, then open the bundled app.

--- a/docs/superpowers/specs/2026-07-03-git-panel-batch3-design.md
+++ b/docs/superpowers/specs/2026-07-03-git-panel-batch3-design.md
@@ -1,0 +1,87 @@
+# Git Panel Batch 3 Design (issue #94, final slice)
+
+Status: approved in conversation on 2026-07-03 (owner: mukiwu)
+Scope source: issue #94 item 4 (worktree switching) and item 5 (branch checkout entry point). This batch resolves the last two open items of #94; together with batches 1 (PR #116) and 2 (PR #117) it closes #93 and #94 entirely.
+
+## Goal
+
+Two toolbar-level additions to the Git Graph tab: (1) a worktree selector that lists the repository's worktrees and switches the whole app's workspace root to the chosen one, and (2) a branch-switch menu behind the existing "HEAD: branch" display that actually checks out the chosen branch (the existing branch dropdown remains a pure display filter).
+
+## Decisions already made by the owner
+
+- **Worktree switching means switching the workspace root.** The issue author's stated goal was to see another worktree's staged files; since the sidebar's source-control panel follows the workspace root, switching the root delivers that with no parallel "peek at another repo" state system. Staging/discard semantics stay unambiguous: operations always act on the worktree you are in.
+- **Both new controls live in the Git Graph toolbar** (the issue was filed against the Git Graph tab). The worktree selector sits next to the existing branch filter as a second labeled Combobox; the checkout entry reuses the "HEAD: branch" text, which becomes clickable.
+- **Known concern, deliberately deferred to manual testing:** a worktree Combobox and a branch-filter Combobox side by side could be confusing (the very worry recorded against #94 item 5 in the batch 2 spec). Mitigation for now is the label text ("分支:" vs "Worktree:") plus the fact that the worktree control is hidden for single-worktree repos. Re-evaluate placement after using the built app; moving the selector is a cheap follow-up if it reads badly.
+- **No confirmation dialog on worktree switch.** Switching the root is fully reversible (click back); terminals keep their own cwd and are unaffected. This matches the existing "open folder" behavior.
+- **Checkout failure handling is git's own error surfaced through the existing error display** (same as the ref context menu's checkout today). No auto-stash.
+- **Branch from `feat/git-panel-batch2`** (PR #117 is open but unmerged; this batch touches the same Git Graph files). Rebase onto master once #117 merges.
+
+## Current state (verified in code)
+
+- `GitGraphTabContent.tsx:67` subscribes to `useWorkspaceStore` `rootPath`; the effect at lines 132-157 re-resolves the repo and reloads the graph whenever the root changes. Worktree switching therefore needs no new linkage: `setRoot(path)` is the whole mechanism.
+- Backend already has `git_branch_checkout` and `git_branch_checkout_track`; the Git Graph ref/commit context menus already check out via `runAction` (reload + error surface). The toolbar menu reuses all of it.
+- Backend has `git_worktree_info` (single-path introspection for workspace cards) but nothing that lists all worktrees of a repo. That is the only new backend surface in this batch.
+- The toolbar shows "HEAD: {currentBranch}" as plain text in roomy mode (GitGraphToolbar.tsx:354) and as a plain text row inside the "⋯" overflow menu in compact mode (GitGraphToolbar.tsx:257).
+
+## Components
+
+### 1. Backend: `git_worktree_list` (new command)
+
+In `src-tauri/src/modules/git/mod.rs`, following the existing `run_git` + `spawn_blocking` + `#[tauri::command]` pattern:
+
+```rust
+#[derive(Serialize)]
+pub struct WorktreeListItem {
+    pub path: String,
+    /// Short branch name, or None when the worktree is on a detached HEAD.
+    pub branch: Option<String>,
+}
+
+pub fn worktree_list(repo_path: &str) -> Result<Vec<WorktreeListItem>, String>;
+// command wrapper: git_worktree_list(path: String)
+```
+
+Parses `git worktree list --porcelain`: entries are blank-line-separated blocks of `worktree <path>`, `HEAD <sha>`, then `branch refs/heads/<name>` or `detached`. Strip the `refs/heads/` prefix for the branch field. `bare` blocks (a bare main repo) are skipped: they have no working tree to switch to. Pure git CLI, no platform-specific code (Windows-safe).
+
+Which item is "current" is computed on the frontend by comparing each `path` against the repo path already resolved from the workspace root, so the backend stays a stateless list.
+
+### 2. Worktree selector (Git Graph toolbar)
+
+- New bridge fn `gitWorktreeList(repo)` in `src/modules/git-graph/lib/gitGraphBridge.ts`.
+- `GitGraphTabContent` fetches the list whenever the resolved repo changes (same effect family as the branches fetch) and passes `worktrees`, `currentWorktreePath`, and `onSelectWorktree` down to `GitGraphToolbar`.
+- Toolbar renders a second labeled Combobox ("Worktree:") next to the branch filter, only when `worktrees.length > 1`. Options display `basename(path) (branch)`, mapped back to paths by index. If two options would render the same string (same folder name and same branch), fall back to the full path for the colliding entries so every option stays unique (the Combobox maps selections by string value). The current worktree is the selected value.
+- Selecting another worktree calls `useWorkspaceStore.getState().setRoot(path)`. Root change re-resolves the repo, reloads the graph, refetches the worktree list (updating the "current" mark), and the sidebar/file explorer follow automatically.
+- Compact mode: same treatment as the branch filter, which stays directly visible in compact mode. No overflow-menu row needed.
+
+### 3. Branch-switch menu (clickable HEAD)
+
+- Roomy mode: the "HEAD: branch" text becomes a button. Clicking opens a popover (same styling as the toolbar's existing gear/overflow popovers) listing local branches and remote branches in two groups.
+  - Current branch row shows a check mark; clicking it just closes the menu.
+  - Clicking another local branch runs the existing `runAction(() => gitBranchCheckout(repo, name))` (graph reloads on success, git's error shows on failure).
+  - Clicking a remote branch opens the existing "create tracking branch" modal flow (`gitBranchCheckoutTrack`), exactly as the ref context menu does today.
+  - Both groups are always listed (checking out a remote branch is valid even when remote refs are hidden from the graph display).
+- Compact mode: the HEAD row inside the "⋯" overflow menu becomes the same trigger; clicking it closes the overflow menu and opens the branch popover.
+- Detached HEAD: the display shows whatever `currentBranch` shows today; the menu itself works unchanged (no row is marked current).
+
+### 4. i18n
+
+`gitGraph` namespace, both locales: `worktree` "Worktree" / "Worktree" (label), `switchBranch` "Switch Branch" / "切換分支" (aria-label/tooltip for the HEAD button), plus the remote-checkout modal strings already exist. Worktree option text is path/branch data, not translated.
+
+## Error handling
+
+- `git worktree list` failure (not a repo, git missing): bridge rejects; the toolbar simply renders no worktree selector (same silent degradation as other optional toolbar data).
+- Checkout rejected by git (dirty tree, conflicts): existing `runAction` error surface shows git's message verbatim. No retry, no auto-stash.
+- Worktree path no longer exists on disk (stale worktree): `setRoot` to a missing path degrades the same way opening a deleted folder does today; git also reports such worktrees as `prunable`, but handling that is out of scope.
+
+## Testing
+
+- Rust: `worktree_list` parses a porcelain fixture with a main worktree + linked worktree + detached-HEAD worktree; skips `bare`; strips `refs/heads/`; single-worktree repo returns one item.
+- Toolbar: selector hidden at `worktrees.length <= 1`, shown with current selected at > 1; selecting another option calls `setRoot` with the mapped path; HEAD button opens the menu in roomy mode; overflow HEAD row opens it in compact mode.
+- Tab content: local-branch click invokes `gitBranchCheckout` and reloads; remote-branch click opens the tracking modal; checkout error renders in the existing error surface.
+
+## Out of scope (explicitly)
+
+- Creating, removing, or pruning worktrees.
+- Branch create/delete/rename from the new menu (the ref context menu already covers these).
+- Auto-stash or any dirty-tree assistance on checkout.
+- Moving the worktree selector elsewhere if the side-by-side Combobox layout tests badly (cheap follow-up, not designed in advance).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ use modules::git::{
     git_fetch, git_file_at_rev, git_graph_log, git_log, git_merge, git_pull, git_push,
     git_push_delete, git_rebase, git_reset, git_resolve_repo, git_restore_file, git_revert,
     git_stage, git_status, git_tag_create, git_tag_delete, git_unstage, git_worktree_info,
+    git_worktree_list,
 };
 use modules::pr::{gh_available, pr_via_api, pr_via_gh};
 use modules::preview::{
@@ -167,6 +168,7 @@ pub fn run() {
             git_resolve_repo,
             git_status,
             git_worktree_info,
+            git_worktree_list,
             git_stage,
             git_unstage,
             git_commit,

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -306,18 +306,20 @@ pub struct WorktreeListItem {
 /// Lists every worktree of the repository via `git worktree list --porcelain`:
 /// blank-line-separated blocks of `worktree <path>`, `HEAD <sha>`, then
 /// `branch refs/heads/<name>` or `detached`. A `bare` block has no working
-/// tree to switch to, so it is dropped.
+/// tree to switch to and a `prunable` one no longer exists on disk, so both
+/// are dropped — offering either as a switch target would strand the app's
+/// workspace root somewhere unusable.
 pub fn worktree_list(repo_path: &str) -> Result<Vec<WorktreeListItem>, String> {
     let stdout = run_git(repo_path, &["worktree", "list", "--porcelain"])?;
     let mut items = Vec::new();
     let mut path: Option<String> = None;
     let mut branch: Option<String> = None;
-    let mut bare = false;
+    let mut skip = false;
 
     for line in stdout.lines().chain(std::iter::once("")) {
         if line.is_empty() {
             if let Some(p) = path.take() {
-                if !bare {
+                if !skip {
                     items.push(WorktreeListItem {
                         path: p,
                         branch: branch.take(),
@@ -325,13 +327,13 @@ pub fn worktree_list(repo_path: &str) -> Result<Vec<WorktreeListItem>, String> {
                 }
             }
             branch = None;
-            bare = false;
+            skip = false;
         } else if let Some(rest) = line.strip_prefix("worktree ") {
             path = Some(rest.to_string());
         } else if let Some(rest) = line.strip_prefix("branch ") {
             branch = Some(rest.strip_prefix("refs/heads/").unwrap_or(rest).to_string());
-        } else if line == "bare" {
-            bare = true;
+        } else if line == "bare" || line == "prunable" || line.starts_with("prunable ") {
+            skip = true;
         }
         // `HEAD <sha>` and `detached` lines are ignored: branch simply stays
         // None for a detached worktree.
@@ -1238,6 +1240,34 @@ mod tests {
         let items = worktree_list(&main_path).unwrap();
         assert_eq!(items.len(), 2);
         assert_eq!(items[1].branch, None);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn worktree_list_skips_prunable_worktrees_whose_directory_is_gone() {
+        let root = temp_repo_dir("wtl-prunable");
+        let main = root.join("main");
+        std::fs::create_dir_all(&main).unwrap();
+        let main_path = main.to_string_lossy().to_string();
+        run_git(&main_path, &["init", "-b", "main"]).unwrap();
+        run_git(&main_path, &["config", "user.email", "t@t.dev"]).unwrap();
+        run_git(&main_path, &["config", "user.name", "Tester"]).unwrap();
+        std::fs::write(main.join("a.txt"), "hi").unwrap();
+        run_git(&main_path, &["add", "."]).unwrap();
+        run_git(&main_path, &["commit", "-m", "init"]).unwrap();
+        let wt = root.join("wt");
+        let wt_path = wt.to_string_lossy().to_string();
+        run_git(&main_path, &["worktree", "add", &wt_path, "-b", "feature"]).unwrap();
+
+        // Delete the worktree directory without `git worktree prune` — git
+        // still reports the entry, marked `prunable`, and switching the app
+        // to a nonexistent directory would strand the workspace root there.
+        std::fs::remove_dir_all(&wt).unwrap();
+
+        let items = worktree_list(&main_path).unwrap();
+        assert_eq!(items.len(), 1);
+        assert!(items[0].path.ends_with("/main"));
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -295,6 +295,50 @@ pub fn worktree_info(path: &str) -> Result<WorktreeInfo, String> {
     })
 }
 
+/// One entry of `git worktree list`: the worktree's absolute path and its
+/// checked-out branch (None on a detached HEAD). Bare entries are skipped.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeListItem {
+    pub path: String,
+    pub branch: Option<String>,
+}
+
+/// Lists every worktree of the repository via `git worktree list --porcelain`:
+/// blank-line-separated blocks of `worktree <path>`, `HEAD <sha>`, then
+/// `branch refs/heads/<name>` or `detached`. A `bare` block has no working
+/// tree to switch to, so it is dropped.
+pub fn worktree_list(repo_path: &str) -> Result<Vec<WorktreeListItem>, String> {
+    let stdout = run_git(repo_path, &["worktree", "list", "--porcelain"])?;
+    let mut items = Vec::new();
+    let mut path: Option<String> = None;
+    let mut branch: Option<String> = None;
+    let mut bare = false;
+
+    for line in stdout.lines().chain(std::iter::once("")) {
+        if line.is_empty() {
+            if let Some(p) = path.take() {
+                if !bare {
+                    items.push(WorktreeListItem {
+                        path: p,
+                        branch: branch.take(),
+                    });
+                }
+            }
+            branch = None;
+            bare = false;
+        } else if let Some(rest) = line.strip_prefix("worktree ") {
+            path = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("branch ") {
+            branch = Some(rest.strip_prefix("refs/heads/").unwrap_or(rest).to_string());
+        } else if line == "bare" {
+            bare = true;
+        }
+        // `HEAD <sha>` and `detached` lines are ignored: branch simply stays
+        // None for a detached worktree.
+    }
+    Ok(items)
+}
+
 pub fn stage(repo_path: &str, path: &str) -> Result<(), String> {
     let repo = Repository::open(repo_path).map_err(|e| e.message().to_string())?;
     let mut index = repo.index().map_err(|e| e.message().to_string())?;
@@ -386,6 +430,15 @@ pub async fn git_worktree_info(path: String) -> Result<WorktreeInfo, String> {
     // Spawns a git subprocess per call; run it off the main thread so a slow repo
     // (or several at once when the workspace panel mounts) never freezes the UI.
     tauri::async_runtime::spawn_blocking(move || worktree_info(&path))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn git_worktree_list(path: String) -> Result<Vec<WorktreeListItem>, String> {
+    // Spawns a git subprocess; run it off the main thread so a slow repo never
+    // freezes the UI (same rationale as git_worktree_info above).
+    tauri::async_runtime::spawn_blocking(move || worktree_list(&path))
         .await
         .map_err(|e| e.to_string())?
 }
@@ -1135,6 +1188,75 @@ mod tests {
     fn worktree_info_errors_outside_a_repo() {
         let dir = temp_repo_dir("wt-norepo");
         assert!(worktree_info(&dir.to_string_lossy()).is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn worktree_list_reports_main_and_linked_worktrees() {
+        let root = temp_repo_dir("wtl-linked");
+        let main = root.join("main");
+        std::fs::create_dir_all(&main).unwrap();
+        let main_path = main.to_string_lossy().to_string();
+        run_git(&main_path, &["init", "-b", "main"]).unwrap();
+        run_git(&main_path, &["config", "user.email", "t@t.dev"]).unwrap();
+        run_git(&main_path, &["config", "user.name", "Tester"]).unwrap();
+        std::fs::write(main.join("a.txt"), "hi").unwrap();
+        run_git(&main_path, &["add", "."]).unwrap();
+        run_git(&main_path, &["commit", "-m", "init"]).unwrap();
+        let wt = root.join("wt");
+        let wt_path = wt.to_string_lossy().to_string();
+        run_git(&main_path, &["worktree", "add", &wt_path, "-b", "feature"]).unwrap();
+
+        let items = worktree_list(&main_path).unwrap();
+        assert_eq!(items.len(), 2);
+        // git prints canonicalized absolute paths (e.g. /private/var vs /var on
+        // macOS temp dirs), so assert on the unambiguous path suffix.
+        assert!(items[0].path.ends_with("/main"));
+        assert_eq!(items[0].branch.as_deref(), Some("main"));
+        assert!(items[1].path.ends_with("/wt"));
+        assert_eq!(items[1].branch.as_deref(), Some("feature"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn worktree_list_reports_detached_worktree_without_branch() {
+        let root = temp_repo_dir("wtl-detached");
+        let main = root.join("main");
+        std::fs::create_dir_all(&main).unwrap();
+        let main_path = main.to_string_lossy().to_string();
+        run_git(&main_path, &["init", "-b", "main"]).unwrap();
+        run_git(&main_path, &["config", "user.email", "t@t.dev"]).unwrap();
+        run_git(&main_path, &["config", "user.name", "Tester"]).unwrap();
+        std::fs::write(main.join("a.txt"), "hi").unwrap();
+        run_git(&main_path, &["add", "."]).unwrap();
+        run_git(&main_path, &["commit", "-m", "init"]).unwrap();
+        let wt = root.join("wt");
+        let wt_path = wt.to_string_lossy().to_string();
+        run_git(&main_path, &["worktree", "add", "--detach", &wt_path]).unwrap();
+
+        let items = worktree_list(&main_path).unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[1].branch, None);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn worktree_list_returns_single_item_for_a_plain_repo() {
+        let dir = temp_repo_dir("wtl-single");
+        let path = dir.to_string_lossy().to_string();
+        run_git(&path, &["init", "-b", "main"]).unwrap();
+        run_git(&path, &["config", "user.email", "t@t.dev"]).unwrap();
+        run_git(&path, &["config", "user.name", "Tester"]).unwrap();
+        std::fs::write(dir.join("a.txt"), "hi").unwrap();
+        run_git(&path, &["add", "."]).unwrap();
+        run_git(&path, &["commit", "-m", "init"]).unwrap();
+
+        let items = worktree_list(&path).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].branch.as_deref(), Some("main"));
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { StatusBar } from "@/components/StatusBar";
 import { SettingsModal } from "@/components/SettingsModal";
 import { UpdateModal } from "@/components/UpdateModal";
 import { UpdateToast } from "@/components/UpdateToast";
+import { NotifyToast } from "@/components/NotifyToast";
 import { TabsArea } from "@/components/TabsArea";
 import { useUiStore } from "@/stores/uiStore";
 import { useUpdaterStore } from "@/stores/updaterStore";
@@ -436,6 +437,7 @@ function App() {
       {settingsOpen && <SettingsModal />}
       <UpdateModal />
       <UpdateToast />
+      <NotifyToast />
       <SshPromptDialog />
       {pendingCloseAction && (
         <ConfirmDialog

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -16,6 +16,8 @@ interface ComboboxProps {
   size?: "sm" | "md";
   /** Override the text size (trigger and options), e.g. "text-[13px]". */
   textClassName?: string;
+  /** Show trigger value and options in full instead of ellipsizing them. */
+  noTruncate?: boolean;
 }
 
 /**
@@ -34,11 +36,13 @@ export function Combobox({
   dropUp = false,
   size = "md",
   textClassName,
+  noTruncate = false,
 }: ComboboxProps) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
   const dense = size === "sm";
   const textClass = textClassName ?? (dense ? "text-xs" : "text-sm");
+  const clipClass = noTruncate ? "whitespace-nowrap" : "truncate";
   const fieldClass = `${dense ? "px-2 py-0.5" : "px-3 py-2"} ${textClass}`;
   const optionClass = `${dense ? "px-2 py-1" : "px-3 py-2"} ${textClass}`;
 
@@ -83,7 +87,7 @@ export function Combobox({
             onClick={() => setOpen((o) => !o)}
             className={`flex min-w-0 flex-1 items-center text-left ${dense ? "text-fg-muted" : "text-fg"} ${fieldClass}`}
           >
-            <span className="truncate">{value}</span>
+            <span className={clipClass}>{value}</span>
           </button>
         )}
         <button
@@ -103,9 +107,9 @@ export function Combobox({
       {open && (
         <ul
           data-combobox
-          className={`absolute left-0 z-50 max-h-60 w-max min-w-full max-w-[16rem] space-y-0.5 overflow-y-auto rounded-lg border border-border-strong bg-bg-elevated p-1 shadow-xl ${
-            dropUp ? "bottom-full mb-1.5" : "top-full mt-1.5"
-          }`}
+          className={`absolute left-0 z-50 max-h-60 w-max min-w-full space-y-0.5 overflow-y-auto rounded-lg border border-border-strong bg-bg-elevated p-1 shadow-xl ${
+            noTruncate ? "" : "max-w-[16rem]"
+          } ${dropUp ? "bottom-full mb-1.5" : "top-full mt-1.5"}`}
         >
           {list.map((opt) => {
             const active = opt === value;
@@ -121,7 +125,7 @@ export function Combobox({
                     active ? "bg-bg text-fg" : "text-fg-muted hover:bg-bg hover:text-fg"
                   }`}
                 >
-                  <span className="truncate">{opt}</span>
+                  <span className={clipClass}>{opt}</span>
                   {active && <Check size={14} className="shrink-0 text-accent" />}
                 </button>
               </li>

--- a/src/components/NotifyToast.test.tsx
+++ b/src/components/NotifyToast.test.tsx
@@ -1,5 +1,6 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@/i18n";
 import { NotifyToast } from "./NotifyToast";
 import { useNotifyStore } from "@/stores/notifyStore";
 
@@ -28,36 +29,82 @@ describe("NotifyToast", () => {
     expect(screen.getByRole("status")).toHaveTextContent("檔案總管已更新");
   });
 
-  it("auto-dismisses after a few seconds", () => {
+  it("fades in, stays, then auto-dismisses after the full 4s lifecycle", () => {
     render(<NotifyToast />);
     act(() => {
       useNotifyStore.getState().notify("done");
     });
 
-    act(() => {
-      vi.advanceTimersByTime(5000);
-    });
-
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
-  });
-
-  it("restarts the timer when the same message is posted again", () => {
-    render(<NotifyToast />);
-    act(() => {
-      useNotifyStore.getState().notify("done");
-    });
+    // Mid-lifecycle (fade-in done, still in the 3s stay): visible.
     act(() => {
       vi.advanceTimersByTime(2000);
     });
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    // Past enter (0.5s) + stay (3s) + exit (0.5s): gone.
+    act(() => {
+      vi.advanceTimersByTime(2200);
+    });
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("is transparent while entering and while leaving", () => {
+    render(<NotifyToast />);
+    act(() => {
+      useNotifyStore.getState().notify("done");
+    });
+
+    // Immediately after posting: mounted but still transparent (fade-in start).
+    expect(screen.getByRole("status")).toHaveClass("opacity-0");
+
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(screen.getByRole("status")).toHaveClass("opacity-100");
+
+    // After enter + stay, the fade-out phase turns it transparent again.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(screen.getByRole("status")).toHaveClass("opacity-0");
+  });
+
+  it("restarts the lifecycle when the same message is posted again", () => {
+    render(<NotifyToast />);
+    act(() => {
+      useNotifyStore.getState().notify("done");
+    });
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
 
     act(() => {
       useNotifyStore.getState().notify("done");
     });
     act(() => {
-      vi.advanceTimersByTime(2500);
+      vi.advanceTimersByTime(3000);
     });
 
-    // 2.5s after the second post: still visible (a fresh notice, fresh timer).
+    // 3s after the second post: still visible (fresh lifecycle).
     expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("closes early from the X button", () => {
+    render(<NotifyToast />);
+    act(() => {
+      useNotifyStore.getState().notify("done");
+    });
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    // The manual close plays the 0.5s fade-out, then unmounts.
+    expect(screen.getByRole("status")).toHaveClass("opacity-0");
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 });

--- a/src/components/NotifyToast.test.tsx
+++ b/src/components/NotifyToast.test.tsx
@@ -1,0 +1,63 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NotifyToast } from "./NotifyToast";
+import { useNotifyStore } from "@/stores/notifyStore";
+
+describe("NotifyToast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useNotifyStore.setState({ notice: null });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing until a notice is posted", () => {
+    render(<NotifyToast />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("shows the posted message", () => {
+    render(<NotifyToast />);
+
+    act(() => {
+      useNotifyStore.getState().notify("檔案總管已更新");
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("檔案總管已更新");
+  });
+
+  it("auto-dismisses after a few seconds", () => {
+    render(<NotifyToast />);
+    act(() => {
+      useNotifyStore.getState().notify("done");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("restarts the timer when the same message is posted again", () => {
+    render(<NotifyToast />);
+    act(() => {
+      useNotifyStore.getState().notify("done");
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    act(() => {
+      useNotifyStore.getState().notify("done");
+    });
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    // 2.5s after the second post: still visible (a fresh notice, fresh timer).
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+});

--- a/src/components/NotifyToast.tsx
+++ b/src/components/NotifyToast.tsx
@@ -1,36 +1,75 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { X } from "lucide-react";
 import { useNotifyStore } from "@/stores/notifyStore";
 
-const FADE_MS = 4000;
+const ENTER_MS = 500;
+const STAY_MS = 3000;
+const EXIT_MS = 500;
 
 /**
  * Transient top-center notice for app-wide feedback (e.g. "檔案總管已更新"
  * after a worktree switch). Post via useNotifyStore.getState().notify(text).
- * Auto-fades and never blocks input. Colors invert the app theme (bg-fg /
- * text-bg) so the toast stands out against whatever the theme background is.
+ * Fades in (0.5s), stays (3s), fades out (0.5s); the X closes it early with
+ * the same fade. Colors invert the app theme (bg-fg / text-bg) so the toast
+ * stands out against whatever the theme background is.
  */
 export function NotifyToast() {
+  const { t } = useTranslation();
   const notice = useNotifyStore((s) => s.notice);
   const clear = useNotifyStore((s) => s.clear);
+  const [faded, setFaded] = useState(false);
 
   useEffect(() => {
     if (!notice) {
+      setFaded(false);
       return;
     }
-    const timer = setTimeout(clear, FADE_MS);
-    return () => clearTimeout(timer);
+    setFaded(false);
+    // Flip on the next tick so the browser paints the opacity-0 frame first
+    // and the 0.5s opacity transition actually runs.
+    const enter = setTimeout(() => setFaded(true), 20);
+    const exit = setTimeout(() => setFaded(false), ENTER_MS + STAY_MS);
+    const remove = setTimeout(clear, ENTER_MS + STAY_MS + EXIT_MS);
+    return () => {
+      clearTimeout(enter);
+      clearTimeout(exit);
+      clearTimeout(remove);
+    };
   }, [notice, clear]);
 
   if (!notice) {
     return null;
   }
 
+  function dismiss() {
+    const dismissed = notice;
+    setFaded(false);
+    setTimeout(() => {
+      // A newer notice may have replaced this one during the fade — only
+      // clear if the store still holds the notice the user dismissed.
+      if (useNotifyStore.getState().notice === dismissed) {
+        clear();
+      }
+    }, EXIT_MS);
+  }
+
   return (
     <div
       role="status"
-      className="fixed left-1/2 top-12 z-[90] -translate-x-1/2 rounded-lg bg-fg px-4 py-2.5 text-xs font-medium text-bg shadow-2xl"
+      className={`fixed left-1/2 top-12 z-[90] flex -translate-x-1/2 items-center gap-2 rounded-lg bg-fg py-2.5 pl-4 pr-2.5 text-xs font-medium text-bg shadow-2xl transition-opacity duration-500 ${
+        faded ? "opacity-100" : "opacity-0"
+      }`}
     >
       {notice.text}
+      <button
+        type="button"
+        aria-label={t("actions.close")}
+        onClick={dismiss}
+        className="rounded p-0.5 text-bg/70 hover:bg-bg/10 hover:text-bg"
+      >
+        <X size={13} />
+      </button>
     </div>
   );
 }

--- a/src/components/NotifyToast.tsx
+++ b/src/components/NotifyToast.tsx
@@ -4,9 +4,10 @@ import { useNotifyStore } from "@/stores/notifyStore";
 const FADE_MS = 4000;
 
 /**
- * Transient bottom-right notice for app-wide feedback (e.g. "檔案總管已更新"
+ * Transient top-center notice for app-wide feedback (e.g. "檔案總管已更新"
  * after a worktree switch). Post via useNotifyStore.getState().notify(text).
- * Auto-fades and never blocks input, mirroring UpdateToast's placement.
+ * Auto-fades and never blocks input. Colors invert the app theme (bg-fg /
+ * text-bg) so the toast stands out against whatever the theme background is.
  */
 export function NotifyToast() {
   const notice = useNotifyStore((s) => s.notice);
@@ -27,7 +28,7 @@ export function NotifyToast() {
   return (
     <div
       role="status"
-      className="fixed bottom-10 right-4 z-[90] rounded-lg border border-border bg-bg-elevated px-3.5 py-2.5 text-xs text-fg shadow-2xl"
+      className="fixed left-1/2 top-12 z-[90] -translate-x-1/2 rounded-lg bg-fg px-4 py-2.5 text-xs font-medium text-bg shadow-2xl"
     >
       {notice.text}
     </div>

--- a/src/components/NotifyToast.tsx
+++ b/src/components/NotifyToast.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { useNotifyStore } from "@/stores/notifyStore";
+
+const FADE_MS = 4000;
+
+/**
+ * Transient bottom-right notice for app-wide feedback (e.g. "檔案總管已更新"
+ * after a worktree switch). Post via useNotifyStore.getState().notify(text).
+ * Auto-fades and never blocks input, mirroring UpdateToast's placement.
+ */
+export function NotifyToast() {
+  const notice = useNotifyStore((s) => s.notice);
+  const clear = useNotifyStore((s) => s.clear);
+
+  useEffect(() => {
+    if (!notice) {
+      return;
+    }
+    const timer = setTimeout(clear, FADE_MS);
+    return () => clearTimeout(timer);
+  }, [notice, clear]);
+
+  if (!notice) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      className="fixed bottom-10 right-4 z-[90] rounded-lg border border-border bg-bg-elevated px-3.5 py-2.5 text-xs text-fg shadow-2xl"
+    >
+      {notice.text}
+    </div>
+  );
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -97,7 +97,8 @@
     "search": "Search",
     "cancel": "Cancel",
     "save": "Save",
-    "confirm": "Confirm"
+    "confirm": "Confirm",
+    "close": "Close"
   },
   "paneCapacityAlert": "This tab can hold at most 8 panes — close one and try again",
   "placeholder": {

--- a/src/i18n/locales/en/gitGraph.json
+++ b/src/i18n/locales/en/gitGraph.json
@@ -24,7 +24,8 @@
     "more": "More",
     "commitOrder": "Commit order",
     "orderDate": "Date order",
-    "orderTopo": "Topological order"
+    "orderTopo": "Topological order",
+    "worktree": "Worktree"
   },
   "details": {
     "author": "Author",

--- a/src/i18n/locales/en/gitGraph.json
+++ b/src/i18n/locales/en/gitGraph.json
@@ -25,7 +25,8 @@
     "commitOrder": "Commit order",
     "orderDate": "Date order",
     "orderTopo": "Topological order",
-    "worktree": "Worktree"
+    "worktree": "Worktree",
+    "switchBranch": "Switch Branch"
   },
   "details": {
     "author": "Author",

--- a/src/i18n/locales/en/gitGraph.json
+++ b/src/i18n/locales/en/gitGraph.json
@@ -26,7 +26,8 @@
     "orderDate": "Date order",
     "orderTopo": "Topological order",
     "worktree": "Worktree",
-    "switchBranch": "Switch Branch"
+    "switchBranch": "Switch Branch",
+    "worktreeSwitched": "File explorer updated"
   },
   "details": {
     "author": "Author",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -97,7 +97,8 @@
     "search": "搜尋",
     "cancel": "取消",
     "save": "儲存",
-    "confirm": "確認"
+    "confirm": "確認",
+    "close": "關閉"
   },
   "paneCapacityAlert": "這個分頁最多只能開 8 個面板，請先關掉一個再試",
   "placeholder": {

--- a/src/i18n/locales/zh-Hant/gitGraph.json
+++ b/src/i18n/locales/zh-Hant/gitGraph.json
@@ -24,7 +24,8 @@
     "more": "更多",
     "commitOrder": "排序方式",
     "orderDate": "日期順序",
-    "orderTopo": "拓樸順序"
+    "orderTopo": "拓樸順序",
+    "worktree": "Worktree"
   },
   "details": {
     "author": "作者",

--- a/src/i18n/locales/zh-Hant/gitGraph.json
+++ b/src/i18n/locales/zh-Hant/gitGraph.json
@@ -25,7 +25,8 @@
     "commitOrder": "排序方式",
     "orderDate": "日期順序",
     "orderTopo": "拓樸順序",
-    "worktree": "Worktree"
+    "worktree": "Worktree",
+    "switchBranch": "切換分支"
   },
   "details": {
     "author": "作者",

--- a/src/i18n/locales/zh-Hant/gitGraph.json
+++ b/src/i18n/locales/zh-Hant/gitGraph.json
@@ -26,7 +26,8 @@
     "orderDate": "日期順序",
     "orderTopo": "拓樸順序",
     "worktree": "Worktree",
-    "switchBranch": "切換分支"
+    "switchBranch": "切換分支",
+    "worktreeSwitched": "檔案總管已更新"
   },
   "details": {
     "author": "作者",

--- a/src/modules/git-graph/GitGraphTabContent.test.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.test.tsx
@@ -15,9 +15,10 @@ vi.mock("./lib/gitGraphBridge", () => ({
   gitFetch: vi.fn(),
   gitCommitDetails: vi.fn().mockResolvedValue({ message: "", files: [] }),
   gitCommitFileDiff: vi.fn().mockResolvedValue(""),
+  gitWorktreeList: vi.fn().mockResolvedValue([]),
 }));
 
-import { gitGraphLog } from "./lib/gitGraphBridge";
+import { gitGraphLog, gitWorktreeList } from "./lib/gitGraphBridge";
 
 function commitList(hashes: string[], hasMore: boolean) {
   return {
@@ -36,6 +37,7 @@ function commitList(hashes: string[], hasMore: boolean) {
 describe("GitGraphTabContent pending commit selection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(gitWorktreeList).mockResolvedValue([]);
     usePendingGraphSelectionStore.setState({ hash: null });
     useWorkspaceStore.getState().setRoot("/repo");
   });
@@ -145,5 +147,38 @@ describe("GitGraphTabContent pending commit selection", () => {
 
     await waitFor(() => expect(screen.getAllByText("eee5555").length).toBeGreaterThan(0));
     expect(usePendingGraphSelectionStore.getState().hash).toBeNull();
+  });
+});
+
+describe("GitGraphTabContent worktree selector wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePendingGraphSelectionStore.setState({ hash: null });
+    useWorkspaceStore.getState().setRoot("/repo");
+  });
+
+  it("switches the workspace root when another worktree is picked", async () => {
+    vi.mocked(gitGraphLog).mockResolvedValue(commitList(["aaa1111"], false));
+    vi.mocked(gitWorktreeList).mockResolvedValue([
+      { path: "/repo", branch: "master" },
+      { path: "/repo-dev", branch: "feature" },
+    ]);
+
+    render(<GitGraphTabContent />);
+
+    fireEvent.click((await screen.findAllByLabelText("Worktree"))[0]);
+    fireEvent.click(screen.getByText("repo-dev (feature)"));
+
+    await waitFor(() => expect(useWorkspaceStore.getState().rootPath).toBe("/repo-dev"));
+  });
+
+  it("hides the selector when listing worktrees fails", async () => {
+    vi.mocked(gitGraphLog).mockResolvedValue(commitList(["aaa1111"], false));
+    vi.mocked(gitWorktreeList).mockRejectedValue(new Error("not a repo"));
+
+    render(<GitGraphTabContent />);
+    await screen.findByText("msg aaa1111");
+
+    expect(screen.queryByLabelText("Worktree")).not.toBeInTheDocument();
   });
 });

--- a/src/modules/git-graph/GitGraphTabContent.test.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.test.tsx
@@ -172,6 +172,24 @@ describe("GitGraphTabContent worktree selector wiring", () => {
     await waitFor(() => expect(useWorkspaceStore.getState().rootPath).toBe("/repo-dev"));
   });
 
+  it("refetches the worktree list whenever the graph reloads, so labels track checkouts", async () => {
+    vi.mocked(gitGraphLog).mockResolvedValue(commitList(["aaa1111"], false));
+    vi.mocked(gitWorktreeList).mockResolvedValue([
+      { path: "/repo", branch: "master" },
+      { path: "/repo-dev", branch: "feature" },
+    ]);
+
+    render(<GitGraphTabContent />);
+    await screen.findAllByLabelText("Worktree");
+    const callsBefore = vi.mocked(gitWorktreeList).mock.calls.length;
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() =>
+      expect(vi.mocked(gitWorktreeList).mock.calls.length).toBeGreaterThan(callsBefore),
+    );
+  });
+
   it("hides the selector when listing worktrees fails", async () => {
     vi.mocked(gitGraphLog).mockResolvedValue(commitList(["aaa1111"], false));
     vi.mocked(gitWorktreeList).mockRejectedValue(new Error("not a repo"));

--- a/src/modules/git-graph/GitGraphTabContent.test.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.test.tsx
@@ -4,6 +4,7 @@ import "@/i18n";
 import { GitGraphTabContent } from "./GitGraphTabContent";
 import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useNotifyStore } from "@/stores/notifyStore";
 
 vi.mock("@/modules/source-control/lib/gitBridge", () => ({
   gitResolveRepo: vi.fn().mockResolvedValue("/repo"),
@@ -170,6 +171,24 @@ describe("GitGraphTabContent worktree selector wiring", () => {
     fireEvent.click(screen.getByText("repo-dev (feature)"));
 
     await waitFor(() => expect(useWorkspaceStore.getState().rootPath).toBe("/repo-dev"));
+  });
+
+  it("posts a file-explorer-updated notice after switching worktree", async () => {
+    useNotifyStore.setState({ notice: null });
+    vi.mocked(gitGraphLog).mockResolvedValue(commitList(["aaa1111"], false));
+    vi.mocked(gitWorktreeList).mockResolvedValue([
+      { path: "/repo", branch: "master" },
+      { path: "/repo-dev", branch: "feature" },
+    ]);
+
+    render(<GitGraphTabContent />);
+
+    fireEvent.click((await screen.findAllByLabelText("Worktree"))[0]);
+    fireEvent.click(screen.getByText("repo-dev (feature)"));
+
+    await waitFor(() =>
+      expect(useNotifyStore.getState().notice?.text).toBe("File explorer updated"),
+    );
   });
 
   it("refetches the worktree list whenever the graph reloads, so labels track checkouts", async () => {

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -330,6 +330,30 @@ export function GitGraphTabContent() {
     }
   }, [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes, options.order]);
 
+  // Shared by the ref context menu and the toolbar's branch menu: prompt for a
+  // local name, then create the tracking branch.
+  const openCheckoutRemoteModal = useCallback(
+    (refName: string) => {
+      const { branch } = splitRemoteRef(refName);
+      setModal({
+        title: t("modal.checkoutRemote.title"),
+        confirmLabel: t("modal.checkoutRemote.confirm"),
+        fields: [
+          {
+            key: "name",
+            label: t("modal.branchName"),
+            placeholder: t("modal.branchPlaceholder"),
+            required: true,
+            defaultValue: branch,
+          },
+        ],
+        onConfirm: (values) =>
+          void runAction(() => gitBranchCheckoutTrack(repo!, values.name, refName)),
+      });
+    },
+    [t, runAction, repo],
+  );
+
   const toolbarLabels: GitGraphToolbarLabels = {
     branches: t("toolbar.branches"),
     showAll: t("toolbar.showAll"),
@@ -349,6 +373,7 @@ export function GitGraphTabContent() {
     orderDate: t("toolbar.orderDate"),
     orderTopo: t("toolbar.orderTopo"),
     worktree: t("toolbar.worktree"),
+    switchBranch: t("toolbar.switchBranch"),
   };
 
   const persistDetailsHeight = useCallback(() => {
@@ -475,24 +500,7 @@ export function GitGraphTabContent() {
         onMerge: () => void runAction(() => gitMerge(repo!, ref.name)),
         onDeleteBranch: () => void runAction(() => gitBranchDelete(repo!, ref.name, true)),
         onDeleteTag: () => void runAction(() => gitTagDelete(repo!, ref.name)),
-        onCheckoutRemote: () => {
-          const { branch } = splitRemoteRef(ref.name);
-          setModal({
-            title: t("modal.checkoutRemote.title"),
-            confirmLabel: t("modal.checkoutRemote.confirm"),
-            fields: [
-              {
-                key: "name",
-                label: t("modal.branchName"),
-                placeholder: t("modal.branchPlaceholder"),
-                required: true,
-                defaultValue: branch,
-              },
-            ],
-            onConfirm: (values) =>
-              void runAction(() => gitBranchCheckoutTrack(repo!, values.name, ref.name)),
-          });
-        },
+        onCheckoutRemote: () => openCheckoutRemoteModal(ref.name),
         onMergeRemote: () => void runAction(() => gitMerge(repo!, ref.name)),
         onPull: () => {
           const { remote, branch } = splitRemoteRef(ref.name);
@@ -561,6 +569,8 @@ export function GitGraphTabContent() {
           worktrees={worktrees}
           currentWorktreePath={repo}
           onSelectWorktree={handleSelectWorktree}
+          onCheckoutBranch={(name) => void runAction(() => gitBranchCheckout(repo!, name))}
+          onCheckoutRemoteBranch={openCheckoutRemoteModal}
           labels={toolbarLabels}
         />
       </div>

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -25,6 +25,8 @@ import {
   gitRevert,
   gitTagCreate,
   gitTagDelete,
+  gitWorktreeList,
+  type WorktreeItem,
 } from "./lib/gitGraphBridge";
 import { GitGraphToolbar, type GitGraphToolbarLabels } from "./GitGraphToolbar";
 import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore";
@@ -70,6 +72,7 @@ export function GitGraphTabContent() {
   const [resolved, setResolved] = useState(false);
   const [commits, setCommits] = useState<CommitNode[]>([]);
   const [branches, setBranches] = useState<Branch[]>([]);
+  const [worktrees, setWorktrees] = useState<WorktreeItem[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [limit, setLimit] = useState(PAGE_SIZE);
   const [selected, setSelected] = useState<CommitNode | null>(null);
@@ -155,6 +158,38 @@ export function GitGraphTabContent() {
       cancelled = true;
     };
   }, [rootPath]);
+
+  // The worktree set only changes on external `git worktree add/remove`, so
+  // fetch once per resolved repo; a failure (not a repo) just hides the
+  // selector, matching the toolbar's other optional data.
+  useEffect(() => {
+    if (!repo) {
+      setWorktrees([]);
+      return;
+    }
+    let cancelled = false;
+    gitWorktreeList(repo)
+      .then((list) => {
+        if (!cancelled) {
+          setWorktrees(list);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setWorktrees([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+
+  const handleSelectWorktree = useCallback((path: string) => {
+    // Switching worktree = switching the app's workspace root; the rootPath
+    // effect above re-resolves the repo and reloads everything, and the
+    // sidebar / file explorer follow the same store.
+    useWorkspaceStore.getState().setRoot(path);
+  }, []);
 
   // Initial load, and reload whenever a display option changes.
   useEffect(() => {
@@ -313,6 +348,7 @@ export function GitGraphTabContent() {
     commitOrder: t("toolbar.commitOrder"),
     orderDate: t("toolbar.orderDate"),
     orderTopo: t("toolbar.orderTopo"),
+    worktree: t("toolbar.worktree"),
   };
 
   const persistDetailsHeight = useCallback(() => {
@@ -522,6 +558,9 @@ export function GitGraphTabContent() {
           fetching={fetching}
           refreshing={busy}
           currentBranch={currentBranch}
+          worktrees={worktrees}
+          currentWorktreePath={repo}
+          onSelectWorktree={handleSelectWorktree}
           labels={toolbarLabels}
         />
       </div>

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -114,16 +114,22 @@ export function GitGraphTabContent() {
   const reload = useCallback(
     async (repoPath: string, nextLimit: number, opts: GraphOptions) => {
       try {
-        const [log, branchList] = await Promise.all([
+        const [log, branchList, worktreeList] = await Promise.all([
           gitGraphLog(repoPath, nextLimit, opts),
           gitBranches(repoPath),
+          // Refetched on every reload so the selector's branch labels track
+          // in-app checkouts and `git worktree add/remove` runs in the app's
+          // own terminal; a failure just hides the selector.
+          gitWorktreeList(repoPath).catch((): WorktreeItem[] => []),
         ]);
         setCommits(log.commits);
         setHasMore(log.hasMore);
         setBranches(branchList);
+        setWorktrees(worktreeList);
       } catch (err: unknown) {
         setCommits([]);
         setBranches([]);
+        setWorktrees([]);
         setHasMore(false);
         setError(getErrorMessage(err));
       }
@@ -159,31 +165,6 @@ export function GitGraphTabContent() {
     };
   }, [rootPath]);
 
-  // The worktree set only changes on external `git worktree add/remove`, so
-  // fetch once per resolved repo; a failure (not a repo) just hides the
-  // selector, matching the toolbar's other optional data.
-  useEffect(() => {
-    if (!repo) {
-      setWorktrees([]);
-      return;
-    }
-    let cancelled = false;
-    gitWorktreeList(repo)
-      .then((list) => {
-        if (!cancelled) {
-          setWorktrees(list);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setWorktrees([]);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [repo]);
-
   const handleSelectWorktree = useCallback((path: string) => {
     // Switching worktree = switching the app's workspace root; the rootPath
     // effect above re-resolves the repo and reloads everything, and the
@@ -194,6 +175,7 @@ export function GitGraphTabContent() {
   // Initial load, and reload whenever a display option changes.
   useEffect(() => {
     if (!repo) {
+      setWorktrees([]);
       return;
     }
     setLimit(PAGE_SIZE);

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -5,6 +5,7 @@ import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import { Resizer } from "@/components/Resizer";
 import { gitResolveRepo } from "@/modules/source-control/lib/gitBridge";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useNotifyStore } from "@/stores/notifyStore";
 import { GitGraph, type GitGraphLabels } from "./GitGraph";
 import { CommitInputModal, type InputField } from "./CommitInputModal";
 import { CommitDetailsPanel, type CommitDetailsLabels } from "./CommitDetailsPanel";
@@ -165,12 +166,17 @@ export function GitGraphTabContent() {
     };
   }, [rootPath]);
 
-  const handleSelectWorktree = useCallback((path: string) => {
-    // Switching worktree = switching the app's workspace root; the rootPath
-    // effect above re-resolves the repo and reloads everything, and the
-    // sidebar / file explorer follow the same store.
-    useWorkspaceStore.getState().setRoot(path);
-  }, []);
+  const handleSelectWorktree = useCallback(
+    (path: string) => {
+      // Switching worktree = switching the app's workspace root; the rootPath
+      // effect above re-resolves the repo and reloads everything, and the
+      // sidebar / file explorer follow the same store. The toast makes that
+      // side effect visible from inside the Git Graph tab.
+      useWorkspaceStore.getState().setRoot(path);
+      useNotifyStore.getState().notify(t("toolbar.worktreeSwitched"));
+    },
+    [t],
+  );
 
   // Initial load, and reload whenever a display option changes.
   useEffect(() => {

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -57,10 +57,12 @@ const labels: GitGraphToolbarLabels = {
   orderDate: "Date order",
   orderTopo: "Topological order",
   worktree: "Worktree",
+  switchBranch: "Switch Branch",
 };
 
 const branches: Branch[] = [
   { name: "master", isRemote: false } as Branch,
+  { name: "dev", isRemote: false } as Branch,
   { name: "origin/master", isRemote: true } as Branch,
 ];
 
@@ -88,6 +90,8 @@ function renderToolbar(overrides: Partial<Parameters<typeof GitGraphToolbar>[0]>
     worktrees: [],
     currentWorktreePath: null,
     onSelectWorktree: vi.fn(),
+    onCheckoutBranch: vi.fn(),
+    onCheckoutRemoteBranch: vi.fn(),
     labels,
     ...overrides,
   };
@@ -275,5 +279,58 @@ describe("GitGraphToolbar worktree selector", () => {
     });
 
     expect(screen.getAllByLabelText(labels.worktree)[0]).toHaveTextContent("/a/repo");
+  });
+});
+
+describe("GitGraphToolbar branch-switch menu", () => {
+  it("opens from the HEAD button and lists local branches with the current one checked", () => {
+    renderToolbar({ currentBranch: "master" });
+
+    fireEvent.click(screen.getByRole("button", { name: labels.switchBranch }));
+
+    const menu = screen.getByRole("menu");
+    expect(within(menu).getByText("master")).toBeInTheDocument();
+    expect(within(menu).getByText("dev")).toBeInTheDocument();
+    expect(within(menu).getByText("origin/master")).toBeInTheDocument();
+  });
+
+  it("clicking another local branch checks it out and closes the menu", () => {
+    const props = renderToolbar({ currentBranch: "master" });
+
+    fireEvent.click(screen.getByRole("button", { name: labels.switchBranch }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("dev"));
+
+    expect(props.onCheckoutBranch).toHaveBeenCalledWith("dev");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("clicking the current branch closes without checking out", () => {
+    const props = renderToolbar({ currentBranch: "master" });
+
+    fireEvent.click(screen.getByRole("button", { name: labels.switchBranch }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("master"));
+
+    expect(props.onCheckoutBranch).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("clicking a remote branch routes to the tracking flow", () => {
+    const props = renderToolbar({ currentBranch: "master" });
+
+    fireEvent.click(screen.getByRole("button", { name: labels.switchBranch }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("origin/master"));
+
+    expect(props.onCheckoutRemoteBranch).toHaveBeenCalledWith("origin/master");
+  });
+
+  it("compact mode reaches the same menu through the overflow HEAD row", () => {
+    const props = renderToolbar({ currentBranch: "master" });
+    setToolbarWidth(360);
+
+    fireEvent.click(screen.getByLabelText(labels.more));
+    fireEvent.click(screen.getByRole("button", { name: labels.switchBranch }));
+    fireEvent.click(within(screen.getByRole("menu")).getByText("dev"));
+
+    expect(props.onCheckoutBranch).toHaveBeenCalledWith("dev");
   });
 });

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -56,6 +56,7 @@ const labels: GitGraphToolbarLabels = {
   commitOrder: "Commit order",
   orderDate: "Date order",
   orderTopo: "Topological order",
+  worktree: "Worktree",
 };
 
 const branches: Branch[] = [
@@ -84,6 +85,9 @@ function renderToolbar(overrides: Partial<Parameters<typeof GitGraphToolbar>[0]>
     fetching: false,
     refreshing: false,
     currentBranch: "master",
+    worktrees: [],
+    currentWorktreePath: null,
+    onSelectWorktree: vi.fn(),
     labels,
     ...overrides,
   };
@@ -211,5 +215,65 @@ describe("GitGraphToolbar commit ordering", () => {
 
     fireEvent.click(screen.getByText(labels.orderTopo));
     expect(props.onChangeOrder).toHaveBeenCalledWith("topo");
+  });
+});
+
+describe("GitGraphToolbar worktree selector", () => {
+  const twoWorktrees = [
+    { path: "/repos/app", branch: "master" },
+    { path: "/repos/app-dev", branch: "feature" },
+  ];
+
+  it("is hidden when the repo has a single worktree", () => {
+    renderToolbar({
+      worktrees: [{ path: "/repos/app", branch: "master" }],
+      currentWorktreePath: "/repos/app",
+    });
+
+    expect(screen.queryByText(`${labels.worktree}:`)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(labels.worktree)).not.toBeInTheDocument();
+  });
+
+  it("shows the current worktree as the selected value when there are several", () => {
+    renderToolbar({ worktrees: twoWorktrees, currentWorktreePath: "/repos/app" });
+
+    expect(screen.getByText(`${labels.worktree}:`)).toBeInTheDocument();
+    expect(screen.getAllByLabelText(labels.worktree)[0]).toHaveTextContent("app (master)");
+  });
+
+  it("selecting another worktree reports its path", () => {
+    const props = renderToolbar({
+      worktrees: twoWorktrees,
+      currentWorktreePath: "/repos/app",
+    });
+
+    fireEvent.click(screen.getAllByLabelText(labels.worktree)[0]);
+    fireEvent.click(screen.getByText("app-dev (feature)"));
+
+    expect(props.onSelectWorktree).toHaveBeenCalledWith("/repos/app-dev");
+  });
+
+  it("re-picking the current worktree does not fire a switch", () => {
+    const props = renderToolbar({
+      worktrees: twoWorktrees,
+      currentWorktreePath: "/repos/app",
+    });
+
+    fireEvent.click(screen.getAllByLabelText(labels.worktree)[0]);
+    fireEvent.click(screen.getByRole("button", { name: /app \(master\)/ }));
+
+    expect(props.onSelectWorktree).not.toHaveBeenCalled();
+  });
+
+  it("falls back to full paths when two labels would collide", () => {
+    renderToolbar({
+      worktrees: [
+        { path: "/a/repo", branch: "main" },
+        { path: "/b/repo", branch: "main" },
+      ],
+      currentWorktreePath: "/a/repo",
+    });
+
+    expect(screen.getAllByLabelText(labels.worktree)[0]).toHaveTextContent("/a/repo");
   });
 });

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -269,6 +269,26 @@ describe("GitGraphToolbar worktree selector", () => {
     expect(props.onSelectWorktree).not.toHaveBeenCalled();
   });
 
+  it("matches the current worktree across mixed slash directions (Windows)", () => {
+    const props = renderToolbar({
+      worktrees: [
+        { path: "C:\\repos\\app", branch: "master" },
+        { path: "C:\\repos\\app-dev", branch: "feature" },
+      ],
+      // resolve_repo / system APIs may hand back forward slashes for the
+      // same directory git printed with backslashes.
+      currentWorktreePath: "C:/repos/app",
+    });
+
+    expect(screen.getAllByLabelText(labels.worktree)[0]).toHaveTextContent("app (master)");
+
+    // Re-picking the current worktree must be recognized as current — no
+    // redundant workspace switch.
+    fireEvent.click(screen.getAllByLabelText(labels.worktree)[0]);
+    fireEvent.click(screen.getByRole("button", { name: /app \(master\)/ }));
+    expect(props.onSelectWorktree).not.toHaveBeenCalled();
+  });
+
   it("falls back to full paths when two labels would collide", () => {
     renderToolbar({
       worktrees: [

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -286,7 +286,7 @@ describe("GitGraphToolbar branch-switch menu", () => {
   it("opens from the HEAD button and lists local branches with the current one checked", () => {
     renderToolbar({ currentBranch: "master" });
 
-    fireEvent.click(screen.getByRole("button", { name: labels.switchBranch }));
+    fireEvent.click(screen.getByRole("button", { name: /Switch Branch/ }));
 
     const menu = screen.getByRole("menu");
     expect(within(menu).getByText("master")).toBeInTheDocument();
@@ -297,7 +297,7 @@ describe("GitGraphToolbar branch-switch menu", () => {
   it("clicking another local branch checks it out and closes the menu", () => {
     const props = renderToolbar({ currentBranch: "master" });
 
-    fireEvent.click(screen.getByRole("button", { name: labels.switchBranch }));
+    fireEvent.click(screen.getByRole("button", { name: /Switch Branch/ }));
     fireEvent.click(within(screen.getByRole("menu")).getByText("dev"));
 
     expect(props.onCheckoutBranch).toHaveBeenCalledWith("dev");
@@ -307,7 +307,7 @@ describe("GitGraphToolbar branch-switch menu", () => {
   it("clicking the current branch closes without checking out", () => {
     const props = renderToolbar({ currentBranch: "master" });
 
-    fireEvent.click(screen.getByRole("button", { name: labels.switchBranch }));
+    fireEvent.click(screen.getByRole("button", { name: /Switch Branch/ }));
     fireEvent.click(within(screen.getByRole("menu")).getByText("master"));
 
     expect(props.onCheckoutBranch).not.toHaveBeenCalled();
@@ -317,7 +317,7 @@ describe("GitGraphToolbar branch-switch menu", () => {
   it("clicking a remote branch routes to the tracking flow", () => {
     const props = renderToolbar({ currentBranch: "master" });
 
-    fireEvent.click(screen.getByRole("button", { name: labels.switchBranch }));
+    fireEvent.click(screen.getByRole("button", { name: /Switch Branch/ }));
     fireEvent.click(within(screen.getByRole("menu")).getByText("origin/master"));
 
     expect(props.onCheckoutRemoteBranch).toHaveBeenCalledWith("origin/master");
@@ -328,9 +328,47 @@ describe("GitGraphToolbar branch-switch menu", () => {
     setToolbarWidth(360);
 
     fireEvent.click(screen.getByLabelText(labels.more));
-    fireEvent.click(screen.getByRole("button", { name: labels.switchBranch }));
+    fireEvent.click(screen.getByRole("button", { name: /Switch Branch/ }));
     fireEvent.click(within(screen.getByRole("menu")).getByText("dev"));
 
     expect(props.onCheckoutBranch).toHaveBeenCalledWith("dev");
+  });
+});
+
+describe("GitGraphToolbar branch-switch menu guards", () => {
+  it("announces the current branch in the HEAD button's accessible name", () => {
+    renderToolbar({ currentBranch: "master" });
+
+    expect(
+      screen.getByRole("button", { name: "Switch Branch (HEAD: master)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables the HEAD button while the branch list is empty", () => {
+    renderToolbar({ branches: [] });
+
+    expect(screen.getByRole("button", { name: /Switch Branch/ })).toBeDisabled();
+  });
+
+  it("disables a local branch that another worktree has checked out", () => {
+    const props = renderToolbar({
+      currentBranch: "master",
+      branches: [
+        { name: "master", isRemote: false } as Branch,
+        { name: "feature", isRemote: false } as Branch,
+      ],
+      worktrees: [
+        { path: "/repos/app", branch: "master" },
+        { path: "/repos/app-dev", branch: "feature" },
+      ],
+      currentWorktreePath: "/repos/app",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Switch Branch/ }));
+    const entry = within(screen.getByRole("menu")).getByText("feature").closest("button");
+    expect(entry).toBeDisabled();
+
+    fireEvent.click(within(screen.getByRole("menu")).getByText("feature"));
+    expect(props.onCheckoutBranch).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { Combobox } from "@/components/Combobox";
 import { Tooltip } from "@/components/Tooltip";
+import type { WorktreeItem } from "./lib/gitGraphBridge";
 import type { Branch, CommitOrder } from "./types";
 
 // Below this measured toolbar width the layout switches to compact: the action
@@ -17,6 +18,40 @@ import type { Branch, CommitOrder } from "./types";
 // row (branch label + combobox + remote checkbox + four icons + HEAD text) just
 // begins to crowd in a split panel.
 const COMPACT_WIDTH = 620;
+
+/** Last path segment; handles both / and \ separators (git on Windows may
+ * print either). */
+function worktreeBasename(path: string): string {
+  const segments = path.split(/[\\/]/).filter(Boolean);
+  return segments[segments.length - 1] ?? path;
+}
+
+interface WorktreeOption {
+  label: string;
+  path: string;
+}
+
+/** "basename (branch)" per worktree; colliding labels fall back to the full
+ * path so every Combobox option string stays unique (selection maps back by
+ * string value). */
+function buildWorktreeOptions(worktrees: WorktreeItem[]): WorktreeOption[] {
+  const base = worktrees.map((w) => ({
+    label: w.branch ? `${worktreeBasename(w.path)} (${w.branch})` : worktreeBasename(w.path),
+    path: w.path,
+  }));
+  const counts = new Map<string, number>();
+  for (const option of base) {
+    counts.set(option.label, (counts.get(option.label) ?? 0) + 1);
+  }
+  return base.map((option) =>
+    (counts.get(option.label) ?? 0) > 1 ? { ...option, label: option.path } : option,
+  );
+}
+
+/** Trailing-slash-insensitive path equality (resolve_repo trims, git doesn't). */
+function samePath(a: string, b: string): boolean {
+  return a.replace(/[\\/]+$/, "") === b.replace(/[\\/]+$/, "");
+}
 
 export interface GitGraphToolbarLabels {
   branches: string;
@@ -36,6 +71,7 @@ export interface GitGraphToolbarLabels {
   commitOrder: string;
   orderDate: string;
   orderTopo: string;
+  worktree: string;
 }
 
 interface GitGraphToolbarProps {
@@ -58,6 +94,9 @@ interface GitGraphToolbarProps {
   fetching: boolean;
   refreshing: boolean;
   currentBranch: string;
+  worktrees: WorktreeItem[];
+  currentWorktreePath: string | null;
+  onSelectWorktree: (path: string) => void;
   labels: GitGraphToolbarLabels;
 }
 
@@ -81,6 +120,9 @@ export function GitGraphToolbar({
   fetching,
   refreshing,
   currentBranch,
+  worktrees,
+  currentWorktreePath,
+  onSelectWorktree,
   labels,
 }: GitGraphToolbarProps) {
   const [optionsOpen, setOptionsOpen] = useState(false);
@@ -156,6 +198,14 @@ export function GitGraphToolbar({
   // combobox steps aside until search closes.
   const showBranchControls = !(isCompact && searchOpen);
 
+  const worktreeOptions = buildWorktreeOptions(worktrees);
+  const currentWorktree =
+    currentWorktreePath === null
+      ? undefined
+      : worktreeOptions.find((o) => samePath(o.path, currentWorktreePath));
+  // A single-worktree repo (the common case) hides the control entirely.
+  const showWorktreeControls = showBranchControls && worktreeOptions.length > 1;
+
   return (
     <div
       ref={rootRef}
@@ -172,6 +222,27 @@ export function GitGraphToolbar({
               onChange={(v) => onSelectBranch(v === labels.showAll ? null : v)}
               ariaLabel={labels.branches}
               className="w-48"
+            />
+          </div>
+        )}
+
+        {showWorktreeControls && (
+          <div className="flex min-w-0 items-center gap-1.5 text-xs text-fg-subtle">
+            <span className="shrink-0">{labels.worktree}:</span>
+            <Combobox
+              value={
+                currentWorktree?.label ??
+                (currentWorktreePath ? worktreeBasename(currentWorktreePath) : "")
+              }
+              options={worktreeOptions.map((o) => o.label)}
+              onChange={(label) => {
+                const picked = worktreeOptions.find((o) => o.label === label);
+                if (picked && (!currentWorktree || picked.path !== currentWorktree.path)) {
+                  onSelectWorktree(picked.path);
+                }
+              }}
+              ariaLabel={labels.worktree}
+              className="w-44"
             />
           </div>
         )}

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -72,6 +72,7 @@ export interface GitGraphToolbarLabels {
   orderDate: string;
   orderTopo: string;
   worktree: string;
+  switchBranch: string;
 }
 
 interface GitGraphToolbarProps {
@@ -97,6 +98,8 @@ interface GitGraphToolbarProps {
   worktrees: WorktreeItem[];
   currentWorktreePath: string | null;
   onSelectWorktree: (path: string) => void;
+  onCheckoutBranch: (name: string) => void;
+  onCheckoutRemoteBranch: (name: string) => void;
   labels: GitGraphToolbarLabels;
 }
 
@@ -123,11 +126,14 @@ export function GitGraphToolbar({
   worktrees,
   currentWorktreePath,
   onSelectWorktree,
+  onCheckoutBranch,
+  onCheckoutRemoteBranch,
   labels,
 }: GitGraphToolbarProps) {
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [overflowOpen, setOverflowOpen] = useState(false);
+  const [branchMenuOpen, setBranchMenuOpen] = useState(false);
 
   const rootRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState<number | null>(null);
@@ -324,9 +330,17 @@ export function GitGraphToolbar({
                   aria-hidden="true"
                 />
                 <div className="absolute right-0 z-30 mt-1 w-52 rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg">
-                  <div className="px-2 py-1.5 font-mono text-[11px] text-fg-subtle">
+                  <button
+                    type="button"
+                    aria-label={labels.switchBranch}
+                    onClick={() => {
+                      setOverflowOpen(false);
+                      setBranchMenuOpen(true);
+                    }}
+                    className="flex w-full items-center rounded px-2 py-1.5 text-left font-mono text-[11px] text-fg-subtle hover:bg-bg-inset hover:text-fg"
+                  >
                     {labels.head}: {currentBranch}
-                  </div>
+                  </button>
                   <ActionRow
                     icon={
                       <RefreshCw
@@ -365,6 +379,16 @@ export function GitGraphToolbar({
                   {orderSection}
                 </div>
               </>
+            )}
+            {branchMenuOpen && (
+              <BranchMenu
+                locals={locals}
+                remotes={remotes}
+                currentBranch={currentBranch}
+                onCheckoutBranch={onCheckoutBranch}
+                onCheckoutRemoteBranch={onCheckoutRemoteBranch}
+                onClose={() => setBranchMenuOpen(false)}
+              />
             )}
           </div>
         ) : (
@@ -421,9 +445,29 @@ export function GitGraphToolbar({
               </button>
             </Tooltip>
 
-            <span className="ml-1 whitespace-nowrap font-mono text-[11px] text-fg-subtle">
-              {labels.head}: {currentBranch}
-            </span>
+            <div className="relative">
+              <Tooltip label={labels.switchBranch}>
+                <button
+                  type="button"
+                  aria-label={labels.switchBranch}
+                  aria-expanded={branchMenuOpen}
+                  onClick={() => setBranchMenuOpen((v) => !v)}
+                  className="ml-1 whitespace-nowrap rounded px-1 py-0.5 font-mono text-[11px] text-fg-subtle hover:bg-bg-elevated hover:text-fg"
+                >
+                  {labels.head}: {currentBranch}
+                </button>
+              </Tooltip>
+              {branchMenuOpen && (
+                <BranchMenu
+                  locals={locals}
+                  remotes={remotes}
+                  currentBranch={currentBranch}
+                  onCheckoutBranch={onCheckoutBranch}
+                  onCheckoutRemoteBranch={onCheckoutRemoteBranch}
+                  onClose={() => setBranchMenuOpen(false)}
+                />
+              )}
+            </div>
           </>
         )}
       </div>
@@ -491,5 +535,72 @@ function ActionRow({ icon, label, onClick, disabled = false }: ActionRowProps) {
       <span className="text-fg-subtle">{icon}</span>
       <span>{label}</span>
     </button>
+  );
+}
+
+interface BranchMenuProps {
+  locals: Branch[];
+  remotes: Branch[];
+  currentBranch: string;
+  onCheckoutBranch: (name: string) => void;
+  onCheckoutRemoteBranch: (name: string) => void;
+  onClose: () => void;
+}
+
+/** The checkout popover behind the HEAD display. Locals check out directly;
+ * remotes route to the create-tracking-branch modal owned by the tab. */
+function BranchMenu({
+  locals,
+  remotes,
+  currentBranch,
+  onCheckoutBranch,
+  onCheckoutRemoteBranch,
+  onClose,
+}: BranchMenuProps) {
+  return (
+    <>
+      <div className="fixed inset-0 z-20" onClick={onClose} aria-hidden="true" />
+      <div
+        role="menu"
+        className="absolute right-0 z-30 mt-1 max-h-72 w-56 overflow-y-auto rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg"
+      >
+        {locals.map((b) => (
+          <button
+            key={b.name}
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              onClose();
+              if (b.name !== currentBranch) {
+                onCheckoutBranch(b.name);
+              }
+            }}
+            className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-xs text-fg-muted hover:bg-bg-inset hover:text-fg"
+          >
+            <span className="truncate font-mono">{b.name}</span>
+            {b.name === currentBranch && <Check className="h-3.5 w-3.5 shrink-0 text-accent" />}
+          </button>
+        ))}
+        {remotes.length > 0 && (
+          <>
+            <div className="my-1 border-t border-border" />
+            {remotes.map((b) => (
+              <button
+                key={b.name}
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  onClose();
+                  onCheckoutRemoteBranch(b.name);
+                }}
+                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-fg-muted hover:bg-bg-inset hover:text-fg"
+              >
+                <span className="truncate font-mono">{b.name}</span>
+              </button>
+            ))}
+          </>
+        )}
+      </div>
+    </>
   );
 }

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -42,9 +42,12 @@ function buildWorktreeOptions(worktrees: WorktreeItem[]): WorktreeOption[] {
   );
 }
 
-/** Trailing-slash-insensitive path equality (resolve_repo trims, git doesn't). */
+/** Separator- and trailing-slash-insensitive path equality: git prints
+ * forward slashes while Windows system paths may carry backslashes, and
+ * resolve_repo trims the trailing slash git keeps. */
 function samePath(a: string, b: string): boolean {
-  return a.replace(/[\\/]+$/, "") === b.replace(/[\\/]+$/, "");
+  const norm = (p: string) => p.replace(/\\/g, "/").replace(/\/+$/, "");
+  return norm(a) === norm(b);
 }
 
 export interface GitGraphToolbarLabels {
@@ -260,7 +263,7 @@ export function GitGraphToolbar({
               options={worktreeOptions.map((o) => o.label)}
               onChange={(label) => {
                 const picked = worktreeOptions.find((o) => o.label === label);
-                if (picked && (!currentWorktree || picked.path !== currentWorktree.path)) {
+                if (picked && (!currentWorktree || !samePath(picked.path, currentWorktree.path))) {
                   onSelectWorktree(picked.path);
                 }
               }}

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { Combobox } from "@/components/Combobox";
 import { Tooltip } from "@/components/Tooltip";
+import { basename } from "@/modules/explorer/lib/paths";
 import type { WorktreeItem } from "./lib/gitGraphBridge";
 import type { Branch, CommitOrder } from "./types";
 
@@ -18,13 +19,6 @@ import type { Branch, CommitOrder } from "./types";
 // row (branch label + combobox + remote checkbox + four icons + HEAD text) just
 // begins to crowd in a split panel.
 const COMPACT_WIDTH = 620;
-
-/** Last path segment; handles both / and \ separators (git on Windows may
- * print either). */
-function worktreeBasename(path: string): string {
-  const segments = path.split(/[\\/]/).filter(Boolean);
-  return segments[segments.length - 1] ?? path;
-}
 
 interface WorktreeOption {
   label: string;
@@ -36,7 +30,7 @@ interface WorktreeOption {
  * string value). */
 function buildWorktreeOptions(worktrees: WorktreeItem[]): WorktreeOption[] {
   const base = worktrees.map((w) => ({
-    label: w.branch ? `${worktreeBasename(w.path)} (${w.branch})` : worktreeBasename(w.path),
+    label: w.branch ? `${basename(w.path)} (${w.branch})` : basename(w.path),
     path: w.path,
   }));
   const counts = new Map<string, number>();
@@ -212,6 +206,28 @@ export function GitGraphToolbar({
   // A single-worktree repo (the common case) hides the control entirely.
   const showWorktreeControls = showBranchControls && worktreeOptions.length > 1;
 
+  // git refuses `git checkout <branch>` for a branch some other worktree has
+  // checked out — disable those menu entries and show where each one lives.
+  const branchesInOtherWorktrees = new Map<string, string>();
+  for (const w of worktrees) {
+    if (w.branch && (!currentWorktreePath || !samePath(w.path, currentWorktreePath))) {
+      branchesInOtherWorktrees.set(w.branch, basename(w.path));
+    }
+  }
+
+  const switchBranchLabel = `${labels.switchBranch} (${labels.head}: ${currentBranch})`;
+  const branchMenu = branchMenuOpen ? (
+    <BranchMenu
+      locals={locals}
+      remotes={remotes}
+      currentBranch={currentBranch}
+      branchesInOtherWorktrees={branchesInOtherWorktrees}
+      onCheckoutBranch={onCheckoutBranch}
+      onCheckoutRemoteBranch={onCheckoutRemoteBranch}
+      onClose={() => setBranchMenuOpen(false)}
+    />
+  ) : null;
+
   return (
     <div
       ref={rootRef}
@@ -238,7 +254,7 @@ export function GitGraphToolbar({
             <Combobox
               value={
                 currentWorktree?.label ??
-                (currentWorktreePath ? worktreeBasename(currentWorktreePath) : "")
+                (currentWorktreePath ? basename(currentWorktreePath) : "")
               }
               options={worktreeOptions.map((o) => o.label)}
               onChange={(label) => {
@@ -332,12 +348,13 @@ export function GitGraphToolbar({
                 <div className="absolute right-0 z-30 mt-1 w-52 rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg">
                   <button
                     type="button"
-                    aria-label={labels.switchBranch}
+                    aria-label={switchBranchLabel}
+                    disabled={branches.length === 0}
                     onClick={() => {
                       setOverflowOpen(false);
                       setBranchMenuOpen(true);
                     }}
-                    className="flex w-full items-center rounded px-2 py-1.5 text-left font-mono text-[11px] text-fg-subtle hover:bg-bg-inset hover:text-fg"
+                    className="flex w-full items-center rounded px-2 py-1.5 text-left font-mono text-[11px] text-fg-subtle hover:bg-bg-inset hover:text-fg disabled:opacity-50"
                   >
                     {labels.head}: {currentBranch}
                   </button>
@@ -380,16 +397,7 @@ export function GitGraphToolbar({
                 </div>
               </>
             )}
-            {branchMenuOpen && (
-              <BranchMenu
-                locals={locals}
-                remotes={remotes}
-                currentBranch={currentBranch}
-                onCheckoutBranch={onCheckoutBranch}
-                onCheckoutRemoteBranch={onCheckoutRemoteBranch}
-                onClose={() => setBranchMenuOpen(false)}
-              />
-            )}
+            {branchMenu}
           </div>
         ) : (
           <>
@@ -449,24 +457,16 @@ export function GitGraphToolbar({
               <Tooltip label={labels.switchBranch}>
                 <button
                   type="button"
-                  aria-label={labels.switchBranch}
+                  aria-label={switchBranchLabel}
                   aria-expanded={branchMenuOpen}
+                  disabled={branches.length === 0}
                   onClick={() => setBranchMenuOpen((v) => !v)}
-                  className="ml-1 whitespace-nowrap rounded px-1 py-0.5 font-mono text-[11px] text-fg-subtle hover:bg-bg-elevated hover:text-fg"
+                  className="ml-1 whitespace-nowrap rounded px-1 py-0.5 font-mono text-[11px] text-fg-subtle hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
                 >
                   {labels.head}: {currentBranch}
                 </button>
               </Tooltip>
-              {branchMenuOpen && (
-                <BranchMenu
-                  locals={locals}
-                  remotes={remotes}
-                  currentBranch={currentBranch}
-                  onCheckoutBranch={onCheckoutBranch}
-                  onCheckoutRemoteBranch={onCheckoutRemoteBranch}
-                  onClose={() => setBranchMenuOpen(false)}
-                />
-              )}
+              {branchMenu}
             </div>
           </>
         )}
@@ -542,6 +542,9 @@ interface BranchMenuProps {
   locals: Branch[];
   remotes: Branch[];
   currentBranch: string;
+  /** Branch name -> basename of the other worktree that has it checked out.
+   * git refuses to check these out here, so their entries are disabled. */
+  branchesInOtherWorktrees: Map<string, string>;
   onCheckoutBranch: (name: string) => void;
   onCheckoutRemoteBranch: (name: string) => void;
   onClose: () => void;
@@ -553,6 +556,7 @@ function BranchMenu({
   locals,
   remotes,
   currentBranch,
+  branchesInOtherWorktrees,
   onCheckoutBranch,
   onCheckoutRemoteBranch,
   onClose,
@@ -564,23 +568,33 @@ function BranchMenu({
         role="menu"
         className="absolute right-0 z-30 mt-1 max-h-72 w-56 overflow-y-auto rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg"
       >
-        {locals.map((b) => (
-          <button
-            key={b.name}
-            type="button"
-            role="menuitem"
-            onClick={() => {
-              onClose();
-              if (b.name !== currentBranch) {
-                onCheckoutBranch(b.name);
-              }
-            }}
-            className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-xs text-fg-muted hover:bg-bg-inset hover:text-fg"
-          >
-            <span className="truncate font-mono">{b.name}</span>
-            {b.name === currentBranch && <Check className="h-3.5 w-3.5 shrink-0 text-accent" />}
-          </button>
-        ))}
+        {locals.map((b) => {
+          const otherWorktree =
+            b.name === currentBranch ? undefined : branchesInOtherWorktrees.get(b.name);
+          return (
+            <button
+              key={b.name}
+              type="button"
+              role="menuitem"
+              disabled={otherWorktree !== undefined}
+              onClick={() => {
+                onClose();
+                if (b.name !== currentBranch) {
+                  onCheckoutBranch(b.name);
+                }
+              }}
+              className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left text-xs text-fg-muted hover:bg-bg-inset hover:text-fg disabled:opacity-50 disabled:hover:bg-transparent"
+            >
+              <span className="truncate font-mono">{b.name}</span>
+              {b.name === currentBranch && (
+                <Check className="h-3.5 w-3.5 shrink-0 text-accent" />
+              )}
+              {otherWorktree !== undefined && (
+                <span className="shrink-0 text-[10px] text-fg-subtle">{otherWorktree}</span>
+              )}
+            </button>
+          );
+        })}
         {remotes.length > 0 && (
           <>
             <div className="my-1 border-t border-border" />

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -243,7 +243,8 @@ export function GitGraphToolbar({
               options={branchOptions}
               onChange={(v) => onSelectBranch(v === labels.showAll ? null : v)}
               ariaLabel={labels.branches}
-              className="w-48"
+              textClassName="text-[13px]"
+              noTruncate
             />
           </div>
         )}
@@ -264,7 +265,8 @@ export function GitGraphToolbar({
                 }
               }}
               ariaLabel={labels.worktree}
-              className="w-44"
+              textClassName="text-[13px]"
+              noTruncate
             />
           </div>
         )}

--- a/src/modules/git-graph/lib/gitGraphBridge.ts
+++ b/src/modules/git-graph/lib/gitGraphBridge.ts
@@ -120,3 +120,15 @@ export function gitCommitFileDiff(
 ): Promise<string> {
   return invoke<string>("git_commit_file_diff", { repoPath, commit, file });
 }
+
+/** One worktree of the repository, from `git worktree list`. */
+export interface WorktreeItem {
+  path: string;
+  /** Checked-out branch, or null when the worktree is on a detached HEAD. */
+  branch: string | null;
+}
+
+/** List every worktree of the repository (main first, as git reports them). */
+export function gitWorktreeList(repo: string): Promise<WorktreeItem[]> {
+  return invoke<WorktreeItem[]>("git_worktree_list", { path: repo });
+}

--- a/src/stores/notifyStore.ts
+++ b/src/stores/notifyStore.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+
+interface Notice {
+  text: string;
+}
+
+interface NotifyState {
+  notice: Notice | null;
+  /** Post a transient app-wide notice (bottom-right toast, auto-dismisses). */
+  notify: (text: string) => void;
+  clear: () => void;
+}
+
+export const useNotifyStore = create<NotifyState>((set) => ({
+  notice: null,
+  // A fresh object per post so re-posting the same text still restarts the
+  // toast's dismiss timer (the effect keys on object identity, not the text).
+  notify: (text) => set({ notice: { text } }),
+  clear: () => set({ notice: null }),
+}));


### PR DESCRIPTION
> Stacked on #117 (feat/git-panel-batch2). Merge that first; GitHub will retarget this PR to master once the base branch is deleted.

## Summary
- **Worktree selector** (issue #94 item 4): a second labeled Combobox next to the Git Graph branch filter lists the repo's worktrees (new read-only `git_worktree_list` command parsing `git worktree list --porcelain`; bare and prunable entries skipped). Picking one switches the whole app's workspace root — sidebar, file explorer and graph all follow. Hidden for single-worktree repos. The list refetches with every graph reload so labels track in-app checkouts and terminal-run `git worktree add/remove`.
- **Branch-switch menu** (issue #94 item 5): the toolbar's "HEAD: branch" display becomes a button (and the compact-mode overflow HEAD row a trigger) opening a popover of local + remote branches. Locals check out via the existing `runAction` flow; remotes reuse the ref menu's create-tracking-branch modal (extracted into a shared `openCheckoutRemoteModal`). Branches checked out in another worktree are disabled with the holding worktree shown, since `git checkout` would refuse them. The branch filter dropdown remains a pure display filter.
- **Shared notify toast**: a new `notifyStore` + `NotifyToast` pair shows a top-center, theme-inverted, auto-fading notice (0.5s in / 3s stay / 0.5s out, manual X close); switching worktree posts "檔案總管已更新" so the cross-tab side effect is visible.
- Owner-requested polish: both toolbar dropdowns render 13px un-truncated text (`Combobox` gains a `noTruncate` option).
- Post-review hardening (high-effort multi-agent review, 7 confirmed findings fixed): prunable worktrees can't strand the workspace root on a deleted directory; empty-branch-list HEAD button disabled instead of opening an empty popover; HEAD button keeps the current branch in its accessible name; reused the explorer's cross-platform `basename`; deduplicated BranchMenu JSX.

Closes #94 (items 4–5, the final open items; items 1–3 shipped in #116/#117).

## Test plan
- [x] `pnpm test` — 1069 tests passing (Rust: 202 via `cargo test`)
- [x] `pnpm typecheck`
- [x] `/code-review` at high effort — 16 candidates, 7 confirmed findings all fixed, 5 refuted by verification
- [x] `/tauri-check` security review of the new command — PASS (read-only, fixed argv, no capability changes)
- [x] Manual verification in the bundled app (owner-tested): worktree switch both directions with toast, branch checkout roomy + compact, dirty-tree checkout error surfaced, disabled other-worktree branches, dropdown text sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)