### PR TITLE
fix(terminal): cap OSC 7 payload length before decoding

### DIFF
--- a/src/modules/terminal/lib/osc7.test.ts
+++ b/src/modules/terminal/lib/osc7.test.ts
@@ -75,4 +75,17 @@ describe("parseOsc7Cwd", () => {
   it("rejects unreasonably long paths since the value is persisted", () => {
     expect(parseOsc7Cwd(`file:///C:/${"a".repeat(5000)}`)).toBeNull();
   });
+
+  it("rejects an oversized payload", () => {
+    // A hostile or runaway program can emit a multi-megabyte OSC 7 sequence.
+    // The input cap short-circuits before decodeURIComponent and the regexes
+    // touch it; the percent-encoded form below would otherwise decode to a
+    // string the post-decode cap rejects anyway — this pins the early exit.
+    expect(parseOsc7Cwd(`file:///C:/${"%41".repeat(2_000_000)}`)).toBeNull();
+    // Worst-case legit encoding (CJK chars are 9 percent-encoded chars each)
+    // still fits comfortably under the cap for any realistic cwd.
+    expect(parseOsc7Cwd(`file:///C:/${"%E4%B8%AD".repeat(80)}`)).toBe(
+      `C:\\${"中".repeat(80)}`,
+    );
+  });
 });

--- a/src/modules/terminal/lib/osc7.ts
+++ b/src/modules/terminal/lib/osc7.ts
@@ -23,7 +23,13 @@
  * (`file://localhost/C:\Users\f o` — spaces, backslashes and `%` unencoded).
  */
 export function parseOsc7Cwd(payload: string): string | null {
-  if (!payload.startsWith("file://")) {
+  // Cap the raw input before any decoding or regex work: a hostile or runaway
+  // program can emit a multi-megabyte OSC 7 sequence, and while the post-decode
+  // length check below already rejects the result, there is no reason to spend
+  // decodeURIComponent + regex passes on it first. 8192 comfortably covers the
+  // worst legit case (a fully percent-encoded CJK path is 9 chars per
+  // character, so ~900 path characters — far beyond any practical cwd).
+  if (payload.length > 8192 || !payload.startsWith("file://")) {
     return null;
   }
   const rest = payload.slice("file://".length);


### PR DESCRIPTION
## Summary
Follow-up to #115 addressing the outstanding half of gemini-code-assist's security review comment there:
- Adds an 8192-char cap on the raw OSC 7 payload before decodeURIComponent/regex work, so a hostile or runaway multi-megabyte sequence is rejected up front instead of being decoded first. The post-decode 4096-char path cap already made the outcome safe; this removes the wasted work.
- The other half of the comment (filtering C1 controls and U+2028/U+2029 line separators) was already addressed in #115's merged revision.

## Test plan
- [x] New test: multi-megabyte percent-encoded payload rejected; worst-case legit CJK encoding (9 chars per character) still parses
- [x] pnpm test — 1084 tests passing
- [x] pnpm typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)