### PR TITLE
chore(release): v0.0.14

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -15,6 +15,10 @@
 
 ### fix
 
+### 感謝
+
+- 感謝 @j7-dev 貢獻 Windows 終端機工作目錄跟隨功能（#115）
+
 ## English
 
 ### feat
@@ -31,3 +35,7 @@
 - The tab close button (✕) now shows an "Unsaved changes" hint on hover when the tab has unsaved edits
 
 ### fix
+
+### Thanks
+
+- Thanks to @j7-dev for contributing the Windows terminal cwd-following feature (#115)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tempo-term",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-term"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-term"
-version = "0.0.13"
+version = "0.0.14"
 description = "TempoTerm - AI-powered terminal, editor and file explorer"
 authors = ["TempoTerm"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TempoTerm",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "identifier": "com.tempoterm.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
Version bump to 0.0.14 across package.json, tauri.conf.json, Cargo.toml and Cargo.lock, plus the 感謝/Thanks section in CHANGELOG-NEXT crediting @j7-dev for #115. Tagging and release artifacts follow after this merges (the v0.0.14 tag must point at a commit carrying the filled changelog).

## Test plan
- [x] Version fields consistent across all four files
- [x] CHANGELOG-NEXT complete: #114 #115 #116 #117 #118 entries + thanks section

🤖 Generated with [Claude Code](https://claude.com/claude-code)