### PR TITLE
feat: add expand all action to file explorer

### DIFF
--- a/src/i18n/locales/en/explorer.json
+++ b/src/i18n/locales/en/explorer.json
@@ -4,6 +4,7 @@
   "rootPlaceholder": "Folder path",
   "go": "Go",
   "findFiles": "Find files",
+  "expandAll": "Expand All",
   "collapseAll": "Collapse All",
   "findPlaceholder": "Type to fuzzy-find files",
   "searchInFiles": "Search in files",

--- a/src/i18n/locales/zh-Hant/explorer.json
+++ b/src/i18n/locales/zh-Hant/explorer.json
@@ -4,6 +4,7 @@
   "rootPlaceholder": "資料夾路徑",
   "go": "前往",
   "findFiles": "尋找檔案",
+  "expandAll": "全部展開",
   "collapseAll": "全部收合",
   "findPlaceholder": "輸入以模糊搜尋檔案",
   "searchInFiles": "在檔案中搜尋",

--- a/src/modules/explorer/ExplorerView.tsx
+++ b/src/modules/explorer/ExplorerView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { CopyMinus, FolderOpen, Search } from "lucide-react";
+import { CopyMinus, CopyPlus, FolderOpen, Search } from "lucide-react";
 import { FileTree } from "./FileTree";
 import { FileFinder } from "./FileFinder";
 import { Tooltip } from "@/components/Tooltip";
@@ -19,6 +19,7 @@ export function ExplorerView() {
   const [entries, setEntries] = useState<DirEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [collapseSignal, setCollapseSignal] = useState(0);
+  const [expandSignal, setExpandSignal] = useState(0);
 
   // A remote (SFTP) root hides local-only controls and shows the remote path
   // rather than the raw ssh:// uri.
@@ -83,16 +84,28 @@ export function ExplorerView() {
             </>
           )}
           {rootPath && (
-            <Tooltip label={t("collapseAll")}>
-              <button
-                type="button"
-                aria-label={t("collapseAll")}
-                onClick={() => setCollapseSignal((v) => v + 1)}
-                className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
-              >
-                <CopyMinus size={15} />
-              </button>
-            </Tooltip>
+            <>
+              <Tooltip label={t("expandAll")}>
+                <button
+                  type="button"
+                  aria-label={t("expandAll")}
+                  onClick={() => setExpandSignal((v) => v + 1)}
+                  className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+                >
+                  <CopyPlus size={15} />
+                </button>
+              </Tooltip>
+              <Tooltip label={t("collapseAll")}>
+                <button
+                  type="button"
+                  aria-label={t("collapseAll")}
+                  onClick={() => setCollapseSignal((v) => v + 1)}
+                  className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+                >
+                  <CopyMinus size={15} />
+                </button>
+              </Tooltip>
+            </>
           )}
         </div>
       </div>
@@ -111,7 +124,12 @@ export function ExplorerView() {
         ) : entries.length === 0 ? (
           <p className="px-3 py-2 text-xs text-fg-subtle">{t("empty")}</p>
         ) : (
-          <FileTree entries={entries} onReloadRoot={loadEntries} collapseSignal={collapseSignal} />
+          <FileTree
+            entries={entries}
+            onReloadRoot={loadEntries}
+            collapseSignal={collapseSignal}
+            expandSignal={expandSignal}
+          />
         )}
       </div>
 

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -166,6 +166,52 @@ describe("FileTree expand-all", () => {
 
     expect(fsReadDir).not.toHaveBeenCalledWith("/p/dir/child.ts");
   });
+
+  it("does not re-cascade into a folder's unloaded descendants on a later manual expand", async () => {
+    const { fsReadDir } = await import("./lib/fsBridge");
+    vi.mocked(fsReadDir).mockImplementation(async (path: string) => {
+      if (path === "/p/dir") {
+        return [{ name: "subdir", path: "/p/dir/subdir", is_dir: true, size: 0 }];
+      }
+      if (path === "/p/dir/subdir") {
+        return [{ name: "inner", path: "/p/dir/subdir/inner", is_dir: true, size: 0 }];
+      }
+      if (path === "/p/dir/subdir/inner") {
+        return [
+          { name: "leaf.ts", path: "/p/dir/subdir/inner/leaf.ts", is_dir: false, size: 0 },
+        ];
+      }
+      return [];
+    });
+    const entries = [{ name: "dir", path: "/p/dir", is_dir: true, size: 0 }];
+    const { rerender } = render(
+      <FileTree entries={entries} onReloadRoot={() => {}} expandSignal={0} />,
+    );
+
+    // Expand-all cascades all the way down to leaf.ts once.
+    rerender(
+      <FileTree entries={entries} onReloadRoot={() => {}} expandSignal={1} />,
+    );
+    expect(await screen.findByText("leaf.ts")).toBeInTheDocument();
+
+    // Manually collapse, then re-expand "subdir". The expandSignal prop is
+    // still the same nonzero value it was during expand-all (it never
+    // resets), so this must not auto-cascade into "inner" again.
+    fireEvent.click(screen.getByText("subdir"));
+    expect(screen.queryByText("inner")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("subdir"));
+    expect(await screen.findByText("inner")).toBeInTheDocument();
+
+    // "inner" not yet being in the DOM proves nothing on its own: if it were
+    // wrongly auto-expanding, that would happen asynchronously (its own
+    // effect awaits fsReadDir). Give that a chance to settle before
+    // asserting it never happened.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(screen.queryByText("leaf.ts")).not.toBeInTheDocument();
+  });
 });
 
 describe("FileTree context menu: open in new tab", () => {

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -107,6 +107,67 @@ describe("FileTree collapse-all", () => {
   });
 });
 
+describe("FileTree expand-all", () => {
+  it("expands a collapsed folder and loads its children when expandSignal increments", async () => {
+    const { fsReadDir } = await import("./lib/fsBridge");
+    vi.mocked(fsReadDir).mockResolvedValue([
+      { name: "child.ts", path: "/p/dir/child.ts", is_dir: false, size: 0 },
+    ]);
+    const entries = [{ name: "dir", path: "/p/dir", is_dir: true, size: 0 }];
+    const { rerender } = render(
+      <FileTree entries={entries} onReloadRoot={() => {}} expandSignal={0} />,
+    );
+
+    expect(screen.queryByText("child.ts")).not.toBeInTheDocument();
+
+    rerender(
+      <FileTree entries={entries} onReloadRoot={() => {}} expandSignal={1} />,
+    );
+    expect(await screen.findByText("child.ts")).toBeInTheDocument();
+  });
+
+  it("recursively expands nested folders that have not been lazily loaded yet", async () => {
+    const { fsReadDir } = await import("./lib/fsBridge");
+    vi.mocked(fsReadDir).mockImplementation(async (path: string) => {
+      if (path === "/p/dir") {
+        return [{ name: "subdir", path: "/p/dir/subdir", is_dir: true, size: 0 }];
+      }
+      if (path === "/p/dir/subdir") {
+        return [{ name: "leaf.ts", path: "/p/dir/subdir/leaf.ts", is_dir: false, size: 0 }];
+      }
+      return [];
+    });
+    const entries = [{ name: "dir", path: "/p/dir", is_dir: true, size: 0 }];
+    const { rerender } = render(
+      <FileTree entries={entries} onReloadRoot={() => {}} expandSignal={0} />,
+    );
+
+    rerender(
+      <FileTree entries={entries} onReloadRoot={() => {}} expandSignal={1} />,
+    );
+
+    expect(await screen.findByText("leaf.ts")).toBeInTheDocument();
+  });
+
+  it("does not fsReadDir a file entry's own path when expand-all fires", async () => {
+    const { fsReadDir } = await import("./lib/fsBridge");
+    vi.mocked(fsReadDir).mockResolvedValue([
+      { name: "child.ts", path: "/p/dir/child.ts", is_dir: false, size: 0 },
+    ]);
+    const entries = [{ name: "dir", path: "/p/dir", is_dir: true, size: 0 }];
+    const { rerender } = render(
+      <FileTree entries={entries} onReloadRoot={() => {}} expandSignal={0} />,
+    );
+
+    rerender(
+      <FileTree entries={entries} onReloadRoot={() => {}} expandSignal={1} />,
+    );
+    await screen.findByText("child.ts");
+
+    expect(fsReadDir).not.toHaveBeenCalledWith("/p/dir/child.ts");
+  });
+});
+
 describe("FileTree context menu: open in new tab", () => {
   beforeEach(() => {
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -46,9 +46,11 @@ interface TreeNodeProps {
   onReloadParent: () => void;
   /** Increments when the header's collapse-all button fires; folds this node. */
   collapseSignal?: number;
+  /** Increments when the header's expand-all button fires; unfolds this node. */
+  expandSignal?: number;
 }
 
-function TreeNode({ entry, depth, onReloadParent, collapseSignal }: TreeNodeProps) {
+function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }: TreeNodeProps) {
   const { t } = useTranslation("explorer");
   const { t: tCommon } = useTranslation("common");
   const [expanded, setExpanded] = useState(false);
@@ -67,6 +69,17 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal }: TreeNodeProp
       setExpanded(false);
     }
   }, [collapseSignal]);
+
+  // Mirrors the collapse-all effect above. Runs on mount too, which is what
+  // makes it cascade into lazily-loaded children: expanding a node here
+  // mounts its child TreeNodes with the same (already-nonzero) expandSignal,
+  // so each of them expands itself in turn as soon as it appears. (expand()
+  // itself is a no-op for files, so no is_dir check is needed here.)
+  useEffect(() => {
+    if (expandSignal) {
+      void expand();
+    }
+  }, [expandSignal]);
 
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const openInNewTab = useTabsStore((s) => s.openInNewTab);
@@ -94,6 +107,9 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal }: TreeNodeProp
   }, [entry.path]);
 
   async function expand() {
+    if (!entry.is_dir) {
+      return;
+    }
     if (children === null) {
       await reloadChildren();
     }
@@ -331,6 +347,7 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal }: TreeNodeProp
               depth={depth + 1}
               onReloadParent={reloadChildren}
               collapseSignal={collapseSignal}
+              expandSignal={expandSignal}
             />
           ))}
         </ul>
@@ -407,9 +424,11 @@ interface FileTreeProps {
   onReloadRoot: () => void;
   /** Increments when the header's collapse-all button fires; folds every folder. */
   collapseSignal?: number;
+  /** Increments when the header's expand-all button fires; unfolds every folder. */
+  expandSignal?: number;
 }
 
-export function FileTree({ entries, onReloadRoot, collapseSignal }: FileTreeProps) {
+export function FileTree({ entries, onReloadRoot, collapseSignal, expandSignal }: FileTreeProps) {
   return (
     <ul className="select-none">
       {entries.map((entry) => (
@@ -419,6 +438,7 @@ export function FileTree({ entries, onReloadRoot, collapseSignal }: FileTreeProp
           depth={0}
           onReloadParent={onReloadRoot}
           collapseSignal={collapseSignal}
+          expandSignal={expandSignal}
         />
       ))}
     </ul>

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -61,12 +61,18 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
   // JS hover: CSS :hover is suppressed inside a draggable subtree (WebKit), so
   // track hover manually to highlight just this row.
   const [hovered, setHovered] = useState(false);
+  // Whether this node is currently expanded *because* of an expand-all
+  // cascade (as opposed to a manual click). expandSignal itself never
+  // resets, so this is what lets a later manual re-expand stay local
+  // instead of re-cascading into this node's children.
+  const [isExpandingAll, setIsExpandingAll] = useState(false);
 
   // Skip the initial value (0 / undefined) so a future restore-on-mount of
   // expanded state wouldn't be immediately collapsed.
   useEffect(() => {
     if (collapseSignal) {
       setExpanded(false);
+      setIsExpandingAll(false);
     }
   }, [collapseSignal]);
 
@@ -74,9 +80,15 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
   // makes it cascade into lazily-loaded children: expanding a node here
   // mounts its child TreeNodes with the same (already-nonzero) expandSignal,
   // so each of them expands itself in turn as soon as it appears. (expand()
-  // itself is a no-op for files, so no is_dir check is needed here.)
+  // itself is a no-op for files, so no is_dir check is needed here.) Only
+  // this effect ever sets isExpandingAll true; it's reset explicitly at
+  // every place a collapse happens (above, and in toggle() below) rather
+  // than via an effect on `expanded` itself, since that would also fire
+  // (and immediately undo this) on every fresh mount, where `expanded`
+  // starts out false by default.
   useEffect(() => {
     if (expandSignal) {
+      setIsExpandingAll(true);
       void expand();
     }
   }, [expandSignal]);
@@ -126,6 +138,7 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
     }
     if (expanded) {
       setExpanded(false);
+      setIsExpandingAll(false);
       return;
     }
     await expand();
@@ -347,7 +360,7 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
               depth={depth + 1}
               onReloadParent={reloadChildren}
               collapseSignal={collapseSignal}
-              expandSignal={expandSignal}
+              expandSignal={isExpandingAll ? expandSignal : undefined}
             />
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- Add an "Expand All" action to the file explorer toolbar, next to the existing "Collapse All" action, with matching placement and icon treatment (`CopyPlus` mirroring `CopyMinus`).
- Expanding is driven by an `expandSignal` counter that mirrors the existing `collapseSignal` pattern. Each `TreeNode` reacts to the signal by expanding itself and lazily loading its children if they haven't been fetched yet.
- Because the effect also runs on mount, newly-rendered child nodes (revealed once their parent expands) pick up the same signal and expand themselves in turn, so the whole tree unfolds recursively even for folders that were never opened before (not just already-loaded ones).

Closes #124

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (144 files / 1087 tests, including 3 new tests covering: expanding a lazily-unloaded top-level folder, recursively expanding nested folders that haven't been loaded yet, and a regression test that `fsReadDir` is never called with a file's own path)
- [ ] Manual check: open a folder in the explorer, collapse a few directories, click "Expand All", confirm every directory (including nested/never-opened ones) expands