### PR TITLE
fix: improve file explorer search matching and keyboard navigation

### DIFF
--- a/src/modules/explorer/FileFinder.test.tsx
+++ b/src/modules/explorer/FileFinder.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { FileFinder } from "./FileFinder";
 import { useTabsStore } from "@/stores/tabsStore";
@@ -49,6 +49,10 @@ describe("FileFinder keyboard navigation", () => {
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("moves the active selection down with ArrowDown and opens it on Enter", async () => {
     render(<FileFinder root="/p" onClose={() => {}} />);
     await waitFor(() => screen.getByText("util.ts"));
@@ -90,6 +94,45 @@ describe("FileFinder keyboard navigation", () => {
     fireEvent.keyDown(input, { key: "Enter", isComposing: true });
 
     expect(useTabsStore.getState().tabs).toHaveLength(0);
+  });
+
+  it("does not steal the active selection when the list scrolls under a stationary cursor", async () => {
+    // A plain mouseenter fires when the row scrolls under an unmoving
+    // pointer (e.g. keyboard-driven scrolling), which would otherwise fight
+    // with ArrowDown/ArrowUp. Only an actual mouse move should reclaim
+    // selection from the keyboard.
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("util.ts"));
+
+    const input = screen.getByLabelText("findFiles");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.mouseEnter(screen.getByText("main.ts"));
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const tabs = useTabsStore.getState().tabs;
+    const pane = tabs[0].paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toMatchObject({
+      kind: "editor",
+      path: "/p/util.ts",
+    });
+  });
+
+  it("re-scrolls the active row into view when the result set changes even if the index stays the same", async () => {
+    // The active index resets to 0 on every keystroke, so a query change
+    // that keeps it at 0 must still re-scroll — otherwise a list the user
+    // had wheel-scrolled away from the top stays scrolled after filtering.
+    const scrollSpy = vi
+      .spyOn(HTMLElement.prototype, "scrollIntoView")
+      .mockImplementation(() => {});
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("util.ts"));
+    const callsAfterMount = scrollSpy.mock.calls.length;
+
+    const input = screen.getByLabelText("findFiles");
+    fireEvent.change(input, { target: { value: "u" } });
+    await waitFor(() => screen.getByText("util.ts"));
+
+    expect(scrollSpy.mock.calls.length).toBeGreaterThan(callsAfterMount);
   });
 });
 

--- a/src/modules/explorer/FileFinder.test.tsx
+++ b/src/modules/explorer/FileFinder.test.tsx
@@ -44,6 +44,55 @@ describe("FileFinder opening a file", () => {
   });
 });
 
+describe("FileFinder keyboard navigation", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("moves the active selection down with ArrowDown and opens it on Enter", async () => {
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("util.ts"));
+
+    const input = screen.getByLabelText("findFiles");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    const pane = tabs[0].paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toMatchObject({
+      kind: "editor",
+      path: "/p/util.ts",
+    });
+  });
+
+  it("wraps to the last result when ArrowUp is pressed at the top", async () => {
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("util.ts"));
+
+    const input = screen.getByLabelText("findFiles");
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const tabs = useTabsStore.getState().tabs;
+    const pane = tabs[0].paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toMatchObject({
+      kind: "editor",
+      path: "/p/util.ts",
+    });
+  });
+
+  it("ignores Enter while an IME composition is in progress", async () => {
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("main.ts"));
+
+    const input = screen.getByLabelText("findFiles");
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+
+    expect(useTabsStore.getState().tabs).toHaveLength(0);
+  });
+});
+
 describe("FileFinder at pane capacity", () => {
   beforeEach(() => {
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });

--- a/src/modules/explorer/FileFinder.tsx
+++ b/src/modules/explorer/FileFinder.tsx
@@ -49,7 +49,11 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
 
   useEffect(() => {
     activeResultRef.current?.scrollIntoView({ block: "nearest" });
-  }, [activeIndex]);
+    // A query change can leave activeIndex at the same value (still 0) while
+    // the list itself re-filters, e.g. after the user wheel-scrolled away
+    // from the top — results must stay in the dependency list so that case
+    // still re-scrolls back to the active row.
+  }, [activeIndex, results]);
 
   function open(path: string) {
     const result = openFromSidebar({ kind: "editor", path });
@@ -113,7 +117,10 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
                       ref={active ? activeResultRef : undefined}
                       type="button"
                       onClick={() => open(path)}
-                      onMouseEnter={() => setActiveIndex(index)}
+                      // mousemove, not mouseenter: keyboard-driven scrolling
+                      // can slide a row under a stationary cursor, and a plain
+                      // enter there would steal the selection from the keyboard.
+                      onMouseMove={() => setActiveIndex(index)}
                       aria-selected={active}
                       className={`block w-full truncate px-3 py-1.5 text-left text-sm ${
                         active ? "bg-bg text-fg" : "text-fg-muted hover:bg-bg hover:text-fg"

--- a/src/modules/explorer/FileFinder.tsx
+++ b/src/modules/explorer/FileFinder.tsx
@@ -5,6 +5,7 @@ import { fsListFiles } from "./lib/fsBridge";
 import { fuzzyRank } from "./lib/fuzzy";
 import { relativePath } from "./lib/paths";
 import { InfoDialog } from "@/components/InfoDialog";
+import { Tooltip } from "@/components/Tooltip";
 import { useTabsStore } from "@/stores/tabsStore";
 
 interface FileFinderProps {
@@ -18,7 +19,9 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   const [query, setQuery] = useState("");
   const [files, setFiles] = useState<string[]>([]);
   const [atCapacity, setAtCapacity] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const activeResultRef = useRef<HTMLButtonElement | null>(null);
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
 
   useEffect(() => {
@@ -38,6 +41,16 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
 
   const results = useMemo(() => fuzzyRank(query, files).slice(0, 50), [query, files]);
 
+  // The result set changes on every keystroke; keep the highlighted row
+  // pinned to the top match instead of an index that now points elsewhere.
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [results]);
+
+  useEffect(() => {
+    activeResultRef.current?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
   function open(path: string) {
     const result = openFromSidebar({ kind: "editor", path });
     if (result.status === "at-capacity") {
@@ -45,6 +58,25 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
       return;
     }
     onClose();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    // While an IME candidate window is open, Enter (and often the arrow keys)
+    // commit/navigate the candidate, not this list — let them through.
+    if (e.nativeEvent.isComposing || e.keyCode === 229) {
+      return;
+    }
+    if (e.key === "Escape") {
+      onClose();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => (results.length ? (i + 1) % results.length : 0));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => (results.length ? (i - 1 + results.length) % results.length : 0));
+    } else if (e.key === "Enter" && results[activeIndex]) {
+      open(results[activeIndex]);
+    }
   }
 
   return (
@@ -61,13 +93,7 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
             placeholder={t("findPlaceholder")}
             aria-label={t("findFiles")}
             onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") {
-                onClose();
-              } else if (e.key === "Enter" && results[0]) {
-                open(results[0]);
-              }
-            }}
+            onKeyDown={handleKeyDown}
             className="w-full bg-transparent text-sm text-fg outline-none placeholder:text-fg-subtle"
           />
         </div>
@@ -77,17 +103,28 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
               {t("noResults")}
             </li>
           ) : (
-            results.map((path) => (
-              <li key={path}>
-                <button
-                  type="button"
-                  onClick={() => open(path)}
-                  className="block w-full truncate px-3 py-1.5 text-left text-sm text-fg-muted hover:bg-bg hover:text-fg"
-                >
-                  {relativePath(path, root)}
-                </button>
-              </li>
-            ))
+            results.map((path, index) => {
+              const relative = relativePath(path, root);
+              const active = index === activeIndex;
+              return (
+                <li key={path}>
+                  <Tooltip label={relative} className="w-full">
+                    <button
+                      ref={active ? activeResultRef : undefined}
+                      type="button"
+                      onClick={() => open(path)}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      aria-selected={active}
+                      className={`block w-full truncate px-3 py-1.5 text-left text-sm ${
+                        active ? "bg-bg text-fg" : "text-fg-muted hover:bg-bg hover:text-fg"
+                      }`}
+                    >
+                      {relative}
+                    </button>
+                  </Tooltip>
+                </li>
+              );
+            })
           )}
         </ul>
       </div>

--- a/src/modules/explorer/lib/fuzzy.test.ts
+++ b/src/modules/explorer/lib/fuzzy.test.ts
@@ -30,6 +30,17 @@ describe("fuzzyMatch", () => {
     const scattered = fuzzyMatch("tab", "t-a-x-b.tsx");
     expect(contiguous.score).toBeGreaterThan(scattered.score);
   });
+
+  it("matches when a space-separated query has each word appear anywhere in the target", () => {
+    // The user is thinking "the FileTree file under explorer" and types
+    // words in path order; none of those words are literally adjacent, and
+    // there is no space character in the path itself.
+    expect(fuzzyMatch("file tree", "src/modules/explorer/FileTree.tsx").matched).toBe(true);
+  });
+
+  it("does not match a space-separated query when one word is missing from the target", () => {
+    expect(fuzzyMatch("file zzzzz", "src/modules/explorer/FileTree.tsx").matched).toBe(false);
+  });
 });
 
 describe("fuzzyRank", () => {
@@ -52,5 +63,10 @@ describe("fuzzyRank", () => {
   it("orders better matches first", () => {
     const ranked = fuzzyRank("view", files);
     expect(ranked[0]).toMatch(/View\.tsx$/);
+  });
+
+  it("finds a file via a multi-word query typed in path order", () => {
+    const ranked = fuzzyRank("terminal view", files);
+    expect(ranked).toEqual(["src/modules/terminal/TerminalView.tsx"]);
   });
 });

--- a/src/modules/explorer/lib/fuzzy.ts
+++ b/src/modules/explorer/lib/fuzzy.ts
@@ -20,18 +20,29 @@ const SEPARATORS = "/\\_-. ";
  * fail once the query had more than one word in it.
  */
 export function fuzzyMatch(query: string, target: string): FuzzyResult {
-  const words = query.trim().split(/\s+/).filter(Boolean);
+  return matchWords(parseQueryWords(query), target);
+}
+
+/**
+ * Lowercased, whitespace-split query words. `fuzzyRank` calls this once per
+ * keystroke and reuses the result across every candidate item, rather than
+ * re-parsing (and re-lowercasing) the same query once per item.
+ */
+function parseQueryWords(query: string): string[] {
+  return query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/** Matches a target against pre-parsed (already-lowercased) query words. */
+function matchWords(words: string[], target: string): FuzzyResult {
   if (words.length === 0) {
     return { matched: true, score: 0, indices: [] };
   }
 
-  // Lowercase the target once and reuse it across words, rather than
-  // redoing it per word for the same target.
   const t = target.toLowerCase();
   let score = 0;
   const indices = new Set<number>();
   for (const word of words) {
-    const result = matchWord(word, target, t);
+    const result = matchWord(word, t);
     if (!result.matched) {
       return { matched: false, score: 0, indices: [] };
     }
@@ -43,9 +54,8 @@ export function fuzzyMatch(query: string, target: string): FuzzyResult {
   return { matched: true, score, indices: [...indices].sort((a, b) => a - b) };
 }
 
-/** Matches a single word (no whitespace) as a subsequence of `t`, the already-lowercased `target`. */
-function matchWord(query: string, target: string, t: string): FuzzyResult {
-  const q = query.toLowerCase();
+/** Matches a single already-lowercased word as a subsequence of `t`, the already-lowercased target. */
+function matchWord(q: string, t: string): FuzzyResult {
   const indices: number[] = [];
   let qi = 0;
   let score = 0;
@@ -74,7 +84,7 @@ function matchWord(query: string, target: string, t: string): FuzzyResult {
   }
 
   // Slightly prefer shorter targets.
-  score -= Math.floor(target.length / 24);
+  score -= Math.floor(t.length / 24);
   return { matched: true, score, indices };
 }
 
@@ -86,8 +96,9 @@ export function fuzzyRank(query: string, items: string[]): string[] {
   if (query === "") {
     return [...items];
   }
+  const words = parseQueryWords(query);
   return items
-    .map((item) => ({ item, result: fuzzyMatch(query, item) }))
+    .map((item) => ({ item, result: matchWords(words, item) }))
     .filter((entry) => entry.result.matched)
     .sort(
       (a, b) =>

--- a/src/modules/explorer/lib/fuzzy.ts
+++ b/src/modules/explorer/lib/fuzzy.ts
@@ -12,13 +12,40 @@ export interface FuzzyResult {
 
 const SEPARATORS = "/\\_-. ";
 
+/**
+ * A query with multiple space-separated words requires each word to match
+ * somewhere in the target (in any order relative to each other) rather than
+ * being matched as one literal subsequence including the space character —
+ * paths never contain a literal space, so a single-pass match would always
+ * fail once the query had more than one word in it.
+ */
 export function fuzzyMatch(query: string, target: string): FuzzyResult {
-  if (query === "") {
+  const words = query.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) {
     return { matched: true, score: 0, indices: [] };
   }
 
-  const q = query.toLowerCase();
+  // Lowercase the target once and reuse it across words, rather than
+  // redoing it per word for the same target.
   const t = target.toLowerCase();
+  let score = 0;
+  const indices = new Set<number>();
+  for (const word of words) {
+    const result = matchWord(word, target, t);
+    if (!result.matched) {
+      return { matched: false, score: 0, indices: [] };
+    }
+    score += result.score;
+    for (const index of result.indices) {
+      indices.add(index);
+    }
+  }
+  return { matched: true, score, indices: [...indices].sort((a, b) => a - b) };
+}
+
+/** Matches a single word (no whitespace) as a subsequence of `t`, the already-lowercased `target`. */
+function matchWord(query: string, target: string, t: string): FuzzyResult {
+  const q = query.toLowerCase();
   const indices: number[] = [];
   let qi = 0;
   let score = 0;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -35,6 +35,10 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   } as never;
 }
 
+if (typeof HTMLElement.prototype.scrollIntoView === "undefined") {
+  HTMLElement.prototype.scrollIntoView = () => {};
+}
+
 if (typeof window.matchMedia === "undefined") {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
     matches: false,


### PR DESCRIPTION
## Summary

Fixes three usability problems in the file explorer's fuzzy finder reported in #125:

- **Search misses matches on multi-word queries.** `fuzzyMatch` treated the whole query as a single literal subsequence, so a query like `file tree` could never match `FileTree.tsx` — there's no space character in a file path for the query's space to match against. The matcher now splits the query into words and requires each word to match the target independently (AND semantics), which is how people actually type multi-word searches.
- **Long filenames were unreadable in the finder's results.** The file tree already truncates with a hover tooltip; the finder's result list truncated but had no tooltip. Each result row is now wrapped in the same `Tooltip` component used by the file tree, showing the full relative path on hover.
- **Up/Down did nothing, and Enter always opened the first result.** The finder now tracks an active index that Up/Down moves through the visible results (wrapping at both ends, auto-scrolling the active row into view), hovering a row also updates the active index, and Enter opens whichever row is highlighted instead of always the first one. Enter is ignored while an IME composition is in progress, so committing a candidate (e.g. selecting Chinese/Japanese/Korean characters) does not open a file.

### Scope note

The "Up/Down moves active selection" requirement is implemented for the file finder's search results, which is what the issue's "Expected" section describes ("Up/Down moves active selection through visible results"). The file tree itself is unaffected — it's a recursive, lazily-loaded, arbitrary-depth structure, and giving it full roving-tabindex keyboard navigation is a materially larger change than this issue calls for. The tree's existing truncation + hover tooltip already covers the narrow-sidebar readability problem for problem #2, so no changes were needed there.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (144 files / 1090 tests, including new coverage: multi-word fuzzy matching, ArrowDown/ArrowUp navigation with wraparound, Enter opening the active row, and IME-composition guard on Enter)
- [x] Self code review via the `code-review` skill; two minor issues found and fixed (ref-callback churn on every render simplified to a single active-row ref; a misleading test name)
- [ ] Manual check in the running app: open a folder, `Cmd/Ctrl+P` the finder, type a two-word query, use Up/Down + Enter to open a file, resize the sidebar narrow and hover a long filename

Closes #125