### PR TITLE
fix: increase active tab contrast in light and dark themes

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -119,11 +119,11 @@ function TabItem({ id }: { id: string }) {
         e.preventDefault();
         setMenu({ x: e.clientX, y: e.clientY });
       }}
+      // Same active-chip recipe as WorkspacePanel's tab cards and the
+      // settings theme/language pickers: an accent border + accent-tinted
+      // fill reads clearly in every theme, unlike the old bg-elevated-only
+      // state whose contrast against bg-inset varies a lot theme to theme.
       className={`group flex h-7 cursor-pointer items-center gap-2 rounded-md border px-3 text-xs transition-colors ${
-        // Same active-chip recipe as WorkspacePanel's tab cards and the
-        // settings theme/language pickers: an accent border + accent-tinted
-        // fill reads clearly in every theme, unlike the old bg-elevated-only
-        // state whose contrast against bg-inset varies a lot theme to theme.
         active
           ? "border-accent bg-accent/10 text-fg"
           : "border-transparent text-fg-muted hover:bg-bg-elevated/60"

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -119,8 +119,14 @@ function TabItem({ id }: { id: string }) {
         e.preventDefault();
         setMenu({ x: e.clientX, y: e.clientY });
       }}
-      className={`group flex h-7 cursor-pointer items-center gap-2 rounded-md px-3 text-xs transition-colors ${
-        active ? "bg-bg-elevated text-fg" : "text-fg-muted hover:bg-bg-elevated/60"
+      className={`group flex h-7 cursor-pointer items-center gap-2 rounded-md border px-3 text-xs transition-colors ${
+        // Same active-chip recipe as WorkspacePanel's tab cards and the
+        // settings theme/language pickers: an accent border + accent-tinted
+        // fill reads clearly in every theme, unlike the old bg-elevated-only
+        // state whose contrast against bg-inset varies a lot theme to theme.
+        active
+          ? "border-accent bg-accent/10 text-fg"
+          : "border-transparent text-fg-muted hover:bg-bg-elevated/60"
       } ${isDragging ? "opacity-40" : ""}`}
     >
       <Icon size={13} className="shrink-0" />


### PR DESCRIPTION
## Summary

- The active tab was only distinguished from inactive tabs by a solid `bg-elevated` fill, which sits too close in lightness to the tab bar's own `bg-inset` background across most of the app's themes (a 6-20 lightness-unit delta, and literally identical in the default `vitesse-dark` and `vitesse-light` themes) — making it hard to tell which tab is active, as reported.
- Replaced that with an accent-colored border plus a 10%-opacity accent-tinted fill on the active tab, reusing the exact recipe `WorkspacePanel.tsx`'s tab cards already use for their active state. Inactive tabs keep a transparent border (no layout shift) and the existing muted-text/hover treatment.
- Since the `accent` token is deliberately tuned per-theme to read clearly against both `bg` and `fg`, this reads clearly in every one of the 9 built-in themes without needing separate light/dark-specific rules.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (144 files, 1084 tests)
- [x] Visually verified in the running app (`pnpm dev` + headless Chromium) with 2 tabs open, switching the active tab back and forth, in both the default dark theme (Vitesse Dark Soft) and the default light theme (Vitesse Light) — the active tab is now clearly marked by an accent border + tinted fill in both
- [x] Self code-review of the diff: checked Tailwind class validity, verified no code depends on the active tab having an opaque background, confirmed the new pattern matches existing conventions, and computed WCAG contrast for the active tab's text across all 9 themes (worst case 3.69:1 in Solarized Light, matching that theme's own pre-existing baseline contrast, not a regression)

Closes #127