### PR TITLE
feat: add compact commit graph to sidebar commit list

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -2,10 +2,14 @@
 
 ### feat
 
+- 原始碼控制側欄的「近期提交」清單新增精簡版提交圖，用色點與連線標出提交順序、分支分岐、合併與目前 HEAD 位置
+
 ### fix
 
 ## English
 
 ### feat
+
+- Added a compact commit graph beside the sidebar's Recent commits list, showing commit order, branch divergence, merges and the current HEAD position
 
 ### fix

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -25,6 +25,9 @@ pub struct CommitInfo {
     pub summary: String,
     pub author: String,
     pub timestamp: i64,
+    /// Parent commit hashes, abbreviated to match `id`. Lets the frontend lay
+    /// out a compact commit graph without a second round-trip.
+    pub parents: Vec<String>,
 }
 
 /// A ref decoration attached to a commit in the graph view. `kind` is one of
@@ -395,26 +398,58 @@ pub fn commit(repo_path: &str, message: &str) -> Result<String, String> {
     Ok(oid.to_string())
 }
 
-pub fn log(repo_path: &str, limit: usize) -> Result<Vec<CommitInfo>, String> {
-    let repo = Repository::open(repo_path).map_err(|e| e.message().to_string())?;
-    let mut revwalk = repo.revwalk().map_err(|e| e.message().to_string())?;
-    if revwalk.push_head().is_err() {
-        return Ok(Vec::new());
+/// Parses one `git log --pretty=format:%h|%p|%an|%ct|%s` line. Pure function,
+/// mirrors `parse_graph_commit`'s style. `%p` is empty (not absent) for a
+/// root commit, which `split_whitespace` already collapses to an empty Vec.
+fn parse_commit_info(line: &str) -> Option<CommitInfo> {
+    if line.trim().is_empty() {
+        return None;
     }
+    let parts: Vec<&str> = line.split('|').collect();
+    let timestamp: i64 = parts.get(3).unwrap_or(&"").trim().parse().unwrap_or(0);
+    Some(CommitInfo {
+        id: parts.first().unwrap_or(&"").trim().to_string(),
+        parents: parts
+            .get(1)
+            .unwrap_or(&"")
+            .split_whitespace()
+            .map(String::from)
+            .collect(),
+        author: parts.get(2).unwrap_or(&"").trim().to_string(),
+        timestamp,
+        // The summary may itself contain "|", so re-join the tail.
+        summary: parts
+            .get(4..)
+            .map(|rest| rest.join("|"))
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+    })
+}
 
-    let mut commits = Vec::new();
-    for oid in revwalk.take(limit) {
-        let oid = oid.map_err(|e| e.message().to_string())?;
-        let commit = repo.find_commit(oid).map_err(|e| e.message().to_string())?;
-        let id = oid.to_string();
-        commits.push(CommitInfo {
-            id: id.chars().take(7).collect(),
-            summary: commit.summary().unwrap_or_default().to_string(),
-            author: commit.author().name().unwrap_or_default().to_string(),
-            timestamp: commit.time().seconds(),
-        });
-    }
-    Ok(commits)
+pub fn log(repo_path: &str, limit: usize) -> Result<Vec<CommitInfo>, String> {
+    let limit = limit.max(1);
+    let max_count = format!("--max-count={limit}");
+    // Shell out to the system `git` binary (same approach as `graph_log`
+    // below) instead of a libgit2 revwalk: `--max-count` keeps this genuinely
+    // bounded by `limit` regardless of total repo history. A libgit2 revwalk
+    // with an explicit sort mode (needed for correct child-before-parent
+    // ordering) forces an eager traversal of the *entire* reachable history
+    // before it can yield the first result, which made this O(repo size)
+    // instead of O(limit) on large repos.
+    let stdout = run_git(
+        repo_path,
+        &[
+            "log",
+            "--date-order",
+            "--pretty=format:%h|%p|%an|%ct|%s",
+            &max_count,
+        ],
+    )
+    // An empty/unborn repo makes `git log` exit non-zero; treat that as no history.
+    .unwrap_or_default();
+
+    Ok(stdout.lines().filter_map(parse_commit_info).collect())
 }
 
 #[tauri::command]
@@ -1354,6 +1389,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_commit_info_splits_fields_and_keeps_pipes_in_summary() {
+        let commit = parse_commit_info("abc123|p1 p2|Ada|1700000000|fix: a|b").unwrap();
+        assert_eq!(commit.id, "abc123");
+        assert_eq!(commit.parents, vec!["p1".to_string(), "p2".to_string()]);
+        assert_eq!(commit.author, "Ada");
+        assert_eq!(commit.timestamp, 1700000000);
+        // The summary retained its embedded pipe.
+        assert_eq!(commit.summary, "fix: a|b");
+    }
+
+    #[test]
+    fn parse_commit_info_handles_a_root_commit_with_no_parents() {
+        let commit = parse_commit_info("abc123||Ada|1700000000|root").unwrap();
+        assert!(commit.parents.is_empty());
+    }
+
+    #[test]
+    fn parse_commit_info_rejects_blank_lines() {
+        assert!(parse_commit_info("   ").is_none());
+        assert!(parse_commit_info("").is_none());
+    }
+
+    #[test]
     fn graph_log_and_branches_on_a_real_repo() {
         let dir = temp_repo_dir("graph");
         let path = dir.to_string_lossy().to_string();
@@ -1552,6 +1610,36 @@ mod tests {
         let history = log(&path, 10).unwrap();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].summary, "first commit");
+        // A root commit has no parents.
+        assert!(history[0].parents.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn log_includes_parent_hashes_for_graph_layout() {
+        let dir = temp_repo_dir("log-parents");
+        let path = dir.to_string_lossy().to_string();
+        run_git(&path, &["init", "-b", "main"]).unwrap();
+        run_git(&path, &["config", "user.email", "t@t.dev"]).unwrap();
+        run_git(&path, &["config", "user.name", "Tester"]).unwrap();
+        std::fs::write(dir.join("a.txt"), "one").unwrap();
+        run_git(&path, &["add", "."]).unwrap();
+        run_git(&path, &["commit", "-m", "first"]).unwrap();
+        let first_id = run_git(&path, &["rev-parse", "--short", "HEAD"])
+            .unwrap()
+            .trim()
+            .to_string();
+        std::fs::write(dir.join("a.txt"), "two").unwrap();
+        run_git(&path, &["add", "."]).unwrap();
+        run_git(&path, &["commit", "-m", "second"]).unwrap();
+
+        let history = log(&path, 10).unwrap();
+        assert_eq!(history.len(), 2);
+        // Newest first: the second commit's parent is the first commit.
+        assert_eq!(history[0].summary, "second");
+        assert_eq!(history[0].parents, vec![first_id]);
+        assert!(history[1].parents.is_empty());
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -398,32 +398,31 @@ pub fn commit(repo_path: &str, message: &str) -> Result<String, String> {
     Ok(oid.to_string())
 }
 
-/// Parses one `git log --pretty=format:%h|%p|%an|%ct|%s` line. Pure function,
-/// mirrors `parse_graph_commit`'s style. `%p` is empty (not absent) for a
-/// root commit, which `split_whitespace` already collapses to an empty Vec.
+/// Parses one `git log --pretty=format:%h%x1f%p%x1f%an%x1f%ct%x1f%s` line.
+/// `%x1f` (ASCII unit separator) is the field delimiter rather than a
+/// printable character like "|": author names and commit summaries are free
+/// text that could in principle contain any printable character, and a
+/// delimiter byte that never appears in normal text means no field can ever
+/// be mistaken for another, regardless of its position in the line.
+/// `splitn(5, ..)` bounds the split to the 5 known fields, so a delimiter-like
+/// byte inside the final field (the summary) is naturally preserved without
+/// an extra rejoin. `%p` is empty (not absent) for a root commit, which
+/// `split_whitespace` already collapses to an empty Vec.
 fn parse_commit_info(line: &str) -> Option<CommitInfo> {
     if line.trim().is_empty() {
         return None;
     }
-    let parts: Vec<&str> = line.split('|').collect();
-    let timestamp: i64 = parts.get(3).unwrap_or(&"").trim().parse().unwrap_or(0);
+    let parts: Vec<&str> = line.splitn(5, '\x1f').collect();
+    if parts.len() < 5 {
+        return None;
+    }
+    let timestamp: i64 = parts[3].trim().parse().unwrap_or(0);
     Some(CommitInfo {
-        id: parts.first().unwrap_or(&"").trim().to_string(),
-        parents: parts
-            .get(1)
-            .unwrap_or(&"")
-            .split_whitespace()
-            .map(String::from)
-            .collect(),
-        author: parts.get(2).unwrap_or(&"").trim().to_string(),
+        id: parts[0].trim().to_string(),
+        parents: parts[1].split_whitespace().map(String::from).collect(),
+        author: parts[2].trim().to_string(),
         timestamp,
-        // The summary may itself contain "|", so re-join the tail.
-        summary: parts
-            .get(4..)
-            .map(|rest| rest.join("|"))
-            .unwrap_or_default()
-            .trim()
-            .to_string(),
+        summary: parts[4].trim().to_string(),
     })
 }
 
@@ -442,7 +441,7 @@ pub fn log(repo_path: &str, limit: usize) -> Result<Vec<CommitInfo>, String> {
         &[
             "log",
             "--date-order",
-            "--pretty=format:%h|%p|%an|%ct|%s",
+            "--pretty=format:%h%x1f%p%x1f%an%x1f%ct%x1f%s",
             &max_count,
         ],
     )
@@ -1390,18 +1389,31 @@ mod tests {
 
     #[test]
     fn parse_commit_info_splits_fields_and_keeps_pipes_in_summary() {
-        let commit = parse_commit_info("abc123|p1 p2|Ada|1700000000|fix: a|b").unwrap();
+        let commit =
+            parse_commit_info("abc123\x1fp1 p2\x1fAda\x1f1700000000\x1ffix: a|b").unwrap();
         assert_eq!(commit.id, "abc123");
         assert_eq!(commit.parents, vec!["p1".to_string(), "p2".to_string()]);
         assert_eq!(commit.author, "Ada");
         assert_eq!(commit.timestamp, 1700000000);
-        // The summary retained its embedded pipe.
+        // The summary keeps a literal pipe intact; "|" is not the delimiter.
         assert_eq!(commit.summary, "fix: a|b");
     }
 
     #[test]
+    fn parse_commit_info_keeps_a_pipe_embedded_in_the_author_name() {
+        // A printable delimiter like "|" would misalign every field after
+        // the author if the author name itself contained one. %x1f (ASCII
+        // unit separator) can't appear in a real git author name, so a
+        // literal "|" there is now just ordinary text, not a field boundary.
+        let commit = parse_commit_info("abc123\x1fp1\x1fA|B\x1f1700000000\x1fmsg").unwrap();
+        assert_eq!(commit.author, "A|B");
+        assert_eq!(commit.timestamp, 1700000000);
+        assert_eq!(commit.summary, "msg");
+    }
+
+    #[test]
     fn parse_commit_info_handles_a_root_commit_with_no_parents() {
-        let commit = parse_commit_info("abc123||Ada|1700000000|root").unwrap();
+        let commit = parse_commit_info("abc123\x1f\x1fAda\x1f1700000000\x1froot").unwrap();
         assert!(commit.parents.is_empty());
     }
 
@@ -1409,6 +1421,11 @@ mod tests {
     fn parse_commit_info_rejects_blank_lines() {
         assert!(parse_commit_info("   ").is_none());
         assert!(parse_commit_info("").is_none());
+    }
+
+    #[test]
+    fn parse_commit_info_rejects_a_truncated_line() {
+        assert!(parse_commit_info("abc123\x1fp1\x1fAda").is_none());
     }
 
     #[test]

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -8,6 +8,7 @@ import {
   edgePath,
 } from "./lib/graphLayout";
 import { isCurrentCommit } from "./lib/currentCommit";
+import { BRANCH_COLORS } from "./lib/branchColors";
 
 export interface GitGraphLabels {
   emptyTitle: string;
@@ -26,23 +27,6 @@ interface GitGraphProps {
   onLoadMore?: () => void;
   labels: GitGraphLabels;
 }
-
-// Branch colours cycle per branch line (see CommitLayout.colorIndex), not per
-// lane index, so concurrent lanes never share a colour. This is a fixed rainbow
-// (red→violet), deliberately NOT theme tokens: branch colours are identifiers,
-// not UI surfaces, so they stay constant across themes — and the theme's colour
-// scales aren't remapped per theme anyway, so a token palette would wash out on
-// the light themes. Hues are mid-lightness so each reads on both dark (#222) and
-// light (#fff) backgrounds, and evenly spaced so adjacent lanes stay distinct.
-const BRANCH_COLORS = [
-  "#e0555f", // red
-  "#e3712f", // orange (shifted redder to separate from yellow)
-  "#e8c139", // yellow (brighter gold so it never reads like orange)
-  "#46a758", // green
-  "#3b8ee0", // blue
-  "#6366d6", // indigo
-  "#a857c4", // violet
-];
 
 // Decoration chip styles per ref kind, built from semantic tokens.
 const REF_CHIP_STYLES: Record<string, string> = {

--- a/src/modules/git-graph/lib/branchColors.ts
+++ b/src/modules/git-graph/lib/branchColors.ts
@@ -1,0 +1,19 @@
+// Branch colours cycle per branch line (see CommitLayout.colorIndex), not per
+// lane index, so concurrent lanes never share a colour. This is a fixed rainbow
+// (red→violet), deliberately NOT theme tokens: branch colours are identifiers,
+// not UI surfaces, so they stay constant across themes — and the theme's colour
+// scales aren't remapped per theme anyway, so a token palette would wash out on
+// the light themes. Hues are mid-lightness so each reads on both dark (#222) and
+// light (#fff) backgrounds, and evenly spaced so adjacent lanes stay distinct.
+//
+// Shared by the full Git Graph tab and the sidebar's compact history graph so
+// the same branch reads as the same colour in both places.
+export const BRANCH_COLORS = [
+  "#e0555f", // red
+  "#e3712f", // orange (shifted redder to separate from yellow)
+  "#e8c139", // yellow (brighter gold so it never reads like orange)
+  "#46a758", // green
+  "#3b8ee0", // blue
+  "#6366d6", // indigo
+  "#a857c4", // violet
+];

--- a/src/modules/git-graph/lib/graphLayout.ts
+++ b/src/modules/git-graph/lib/graphLayout.ts
@@ -1,4 +1,13 @@
-import type { CommitNode } from "../types";
+/**
+ * Minimal shape the layout algorithm needs: an id and its parent ids. A full
+ * `CommitNode` satisfies this structurally, but callers that only have a
+ * flat commit list (e.g. the sidebar's compact history graph) don't need to
+ * fabricate the rest of `CommitNode`'s fields to reuse this algorithm.
+ */
+export interface GraphLayoutCommit {
+  hash: string;
+  parents: string[];
+}
 
 /** Geometry used to turn lane/row indices into SVG coordinates. */
 export interface GraphGeometry {
@@ -64,7 +73,7 @@ export function laneX(lane: number, geometry: GraphGeometry): number {
  * Pure (no DOM, no React) so it can be unit tested in isolation.
  */
 export function computeGraphLayout(
-  commits: readonly CommitNode[],
+  commits: readonly GraphLayoutCommit[],
   geometry: GraphGeometry = DEFAULT_GEOMETRY,
 ): GraphLayout {
   const layouts: Record<string, CommitLayout> = {};

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -96,7 +96,7 @@ describe("SourceControlView row interactions", () => {
 
   it("history row right-click offers copy hash", async () => {
     vi.mocked(gitBridge.gitLog).mockResolvedValue([
-      { id: "abc1234", summary: "feat: x", author: "a", timestamp: 1 },
+      { id: "abc1234", summary: "feat: x", author: "a", timestamp: 1, parents: [] },
     ]);
     render(<SourceControlView />);
     fireEvent.contextMenu(await screen.findByText("feat: x"));
@@ -313,7 +313,7 @@ describe("SourceControlView commit jump", () => {
     vi.mocked(gitBridge.gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitBridge.gitStatus).mockResolvedValue({ branch: "main", staged: [], unstaged: [] });
     vi.mocked(gitBridge.gitLog).mockResolvedValue([
-      { id: "abc1234", summary: "feat: x", author: "a", timestamp: 1 },
+      { id: "abc1234", summary: "feat: x", author: "a", timestamp: 1, parents: [] },
     ]);
     useWorkspaceStore.getState().setRoot("/repo");
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
@@ -336,5 +336,60 @@ describe("SourceControlView commit jump", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "View in Git Graph" }));
 
     expect(usePendingGraphSelectionStore.getState().hash).toBe("abc1234");
+  });
+});
+
+describe("SourceControlView commit graph", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(gitBridge.gitResolveRepo).mockResolvedValue("/repo");
+    vi.mocked(gitBridge.gitStatus).mockResolvedValue({ branch: "main", staged: [], unstaged: [] });
+    useWorkspaceStore.getState().setRoot("/repo");
+  });
+
+  it("draws one graph dot per history commit, marking the newest as HEAD", async () => {
+    vi.mocked(gitBridge.gitLog).mockResolvedValue([
+      { id: "c3", summary: "third", author: "a", timestamp: 3, parents: ["c2"] },
+      { id: "c2", summary: "second", author: "a", timestamp: 2, parents: ["c1"] },
+      { id: "c1", summary: "first", author: "a", timestamp: 1, parents: [] },
+    ]);
+
+    const { container } = render(<SourceControlView />);
+    await screen.findByText("third");
+
+    const dots = container.querySelectorAll("svg.history-graph circle");
+    expect(dots).toHaveLength(3);
+    // The first commit returned by git log is always HEAD; it gets a larger
+    // dot filled with the accent colour instead of a branch-lane colour.
+    expect(dots[0].getAttribute("fill")).toBe("var(--color-accent)");
+    expect(Number(dots[0].getAttribute("r"))).toBeGreaterThan(
+      Number(dots[1].getAttribute("r")),
+    );
+  });
+
+  it("draws a connector for each parent link in a linear history", async () => {
+    vi.mocked(gitBridge.gitLog).mockResolvedValue([
+      { id: "c2", summary: "second", author: "a", timestamp: 2, parents: ["c1"] },
+      { id: "c1", summary: "first", author: "a", timestamp: 1, parents: [] },
+    ]);
+
+    const { container } = render(<SourceControlView />);
+    await screen.findByText("second");
+
+    expect(container.querySelectorAll("svg.history-graph path")).toHaveLength(1);
+  });
+
+  it("opens a second lane for a merge commit", async () => {
+    vi.mocked(gitBridge.gitLog).mockResolvedValue([
+      { id: "m", summary: "merge", author: "a", timestamp: 3, parents: ["c1", "c2"] },
+      { id: "c2", summary: "side", author: "a", timestamp: 2, parents: ["c1"] },
+      { id: "c1", summary: "first", author: "a", timestamp: 1, parents: [] },
+    ]);
+
+    const { container } = render(<SourceControlView />);
+    await screen.findByText("merge");
+
+    // Three parent links total: m→c1, m→c2 (the merge's two parents), c2→c1.
+    expect(container.querySelectorAll("svg.history-graph path")).toHaveLength(3);
   });
 });

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ChevronDown,
@@ -43,11 +43,14 @@ import { Tooltip } from "@/components/Tooltip";
 import { buildFileTree, collectDescendantFiles, type TreeNode } from "@/lib/fileTree";
 import { useCollapsedPaths } from "@/lib/useCollapsedPaths";
 import { usePendingGraphSelectionStore } from "@/modules/git-graph/lib/pendingGraphSelectionStore";
+import { edgePath } from "@/modules/git-graph/lib/graphLayout";
+import { BRANCH_COLORS } from "@/modules/git-graph/lib/branchColors";
 import { generateCommitMessage } from "./lib/aiCommit";
 import { withMinDuration } from "@/lib/withMinDuration";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { useChatStore } from "@/modules/ai/store/chatStore";
+import { computeHistoryGraphLayout, HISTORY_GRAPH_GEOMETRY } from "./lib/commitGraph";
 
 type ViewMode = "flat" | "folder";
 
@@ -229,10 +232,11 @@ function HistoryRow({ commit }: { commit: CommitInfo }) {
         e.preventDefault();
         setMenu({ x: e.clientX, y: e.clientY });
       }}
-      className="cursor-pointer py-1 text-xs hover:bg-bg-elevated/60"
+      style={{ height: `${HISTORY_GRAPH_GEOMETRY.rowHeight}px` }}
+      className="flex cursor-pointer items-center gap-2 text-xs hover:bg-bg-elevated/60"
     >
-      <span className="font-mono text-fg-subtle">{commit.id}</span>
-      <span className="ml-2 text-fg-muted">{commit.summary}</span>
+      <span className="shrink-0 font-mono text-fg-subtle">{commit.id}</span>
+      <span className="min-w-0 flex-1 truncate text-fg-muted">{commit.summary}</span>
       {menu && (
         <ContextMenu
           x={menu.x}
@@ -264,6 +268,55 @@ function HistoryRow({ commit }: { commit: CommitInfo }) {
         />
       )}
     </li>
+  );
+}
+
+/**
+ * Compact SVG rail drawn beside the history list: one dot per commit and a
+ * connector per parent link, laid out with `HISTORY_GRAPH_GEOMETRY` so each
+ * row lines up with its `HistoryRow` counterpart. Kept intentionally narrow
+ * (see HISTORY_GRAPH_GEOMETRY) — this is a compact indicator of order,
+ * divergence and merges, not the full interactive Git Graph tab.
+ */
+function HistoryGraphColumn({ commits }: { commits: CommitInfo[] }) {
+  const { layouts, edges } = useMemo(() => computeHistoryGraphLayout(commits), [commits]);
+  const width =
+    HISTORY_GRAPH_GEOMETRY.paddingLeft +
+    HISTORY_GRAPH_GEOMETRY.maxLane * HISTORY_GRAPH_GEOMETRY.laneWidth +
+    18;
+  const height = commits.length * HISTORY_GRAPH_GEOMETRY.rowHeight;
+
+  return (
+    <svg width={width} height={height} className="history-graph shrink-0" aria-hidden="true">
+      {edges.map((edge, idx) => (
+        <path
+          key={`edge-${idx}`}
+          d={edgePath(edge, HISTORY_GRAPH_GEOMETRY.rowHeight)}
+          fill="none"
+          stroke={BRANCH_COLORS[edge.colorIndex % BRANCH_COLORS.length]}
+          strokeWidth={1.5}
+          className="opacity-80"
+        />
+      ))}
+      {commits.map((commit, index) => {
+        const layout = layouts[commit.id];
+        if (!layout) {
+          return null;
+        }
+        // The history list is always rooted at HEAD (git log walks from
+        // HEAD), so the first row is always the current commit.
+        const isHead = index === 0;
+        return (
+          <circle
+            key={commit.id}
+            cx={layout.x}
+            cy={layout.y}
+            r={isHead ? 3.5 : 2.5}
+            fill={isHead ? "var(--color-accent)" : BRANCH_COLORS[layout.colorIndex % BRANCH_COLORS.length]}
+          />
+        );
+      })}
+    </svg>
   );
 }
 
@@ -760,11 +813,14 @@ export function SourceControlView() {
             <h3 className="px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-fg-subtle">
               {t("history")}
             </h3>
-            <ul className="px-3">
-              {history.map((commit) => (
-                <HistoryRow key={commit.id} commit={commit} />
-              ))}
-            </ul>
+            <div className="flex gap-1 px-3">
+              <HistoryGraphColumn commits={history} />
+              <ul className="min-w-0 flex-1">
+                {history.map((commit) => (
+                  <HistoryRow key={commit.id} commit={commit} />
+                ))}
+              </ul>
+            </div>
           </section>
         )}
       </div>

--- a/src/modules/source-control/lib/commitGraph.test.ts
+++ b/src/modules/source-control/lib/commitGraph.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { computeHistoryGraphLayout, HISTORY_GRAPH_GEOMETRY } from "./commitGraph";
+import type { CommitInfo } from "./gitBridge";
+
+function commit(id: string, parents: string[]): CommitInfo {
+  return { id, parents, summary: id, author: "Test", timestamp: 0 };
+}
+
+describe("computeHistoryGraphLayout", () => {
+  it("keeps a linear history in a single lane", () => {
+    const commits = [commit("c", ["b"]), commit("b", ["a"]), commit("a", [])];
+    const { layouts } = computeHistoryGraphLayout(commits);
+
+    expect(layouts.c.lane).toBe(0);
+    expect(layouts.b.lane).toBe(0);
+    expect(layouts.a.lane).toBe(0);
+  });
+
+  it("opens a second lane for a merge commit's extra parent", () => {
+    const commits = [commit("m", ["a", "b"]), commit("b", ["a"]), commit("a", [])];
+    const { layouts } = computeHistoryGraphLayout(commits);
+
+    expect(layouts.m.lane).toBe(0);
+    expect(layouts.b.lane).toBe(1);
+  });
+
+  it("positions rows using the compact geometry, not the full graph tab's", () => {
+    const commits = [commit("b", ["a"]), commit("a", [])];
+    const { layouts } = computeHistoryGraphLayout(commits);
+
+    expect(layouts.b.y).toBe(HISTORY_GRAPH_GEOMETRY.paddingTop);
+    expect(layouts.a.y).toBe(HISTORY_GRAPH_GEOMETRY.paddingTop + HISTORY_GRAPH_GEOMETRY.rowHeight);
+  });
+
+  it("produces one edge per parent link", () => {
+    const commits = [commit("c", ["b"]), commit("b", ["a"]), commit("a", [])];
+    const { edges } = computeHistoryGraphLayout(commits);
+
+    expect(edges).toHaveLength(2);
+  });
+
+  it("ignores a parent hash that falls outside the loaded page", () => {
+    const commits = [commit("only", ["missing-parent"])];
+    const { edges } = computeHistoryGraphLayout(commits);
+
+    expect(edges).toHaveLength(0);
+  });
+});

--- a/src/modules/source-control/lib/commitGraph.ts
+++ b/src/modules/source-control/lib/commitGraph.ts
@@ -1,0 +1,29 @@
+import {
+  computeGraphLayout,
+  type GraphGeometry,
+  type GraphLayout,
+  type GraphLayoutCommit,
+} from "@/modules/git-graph/lib/graphLayout";
+import type { CommitInfo } from "./gitBridge";
+
+/**
+ * Compact geometry for the sidebar's inline history graph — a fraction of the
+ * full Git Graph tab's lane width and row height so the panel never feels
+ * wide or heavy (issue #126 explicitly scopes this out of a full graph view).
+ */
+export const HISTORY_GRAPH_GEOMETRY: GraphGeometry = {
+  laneWidth: 10,
+  rowHeight: 24,
+  paddingLeft: 4,
+  paddingTop: 12,
+  maxLane: 2,
+};
+
+/** Adapts the sidebar's flat commit list into the shared graph-layout algorithm. */
+export function computeHistoryGraphLayout(commits: readonly CommitInfo[]): GraphLayout {
+  const nodes: GraphLayoutCommit[] = commits.map((commit) => ({
+    hash: commit.id,
+    parents: commit.parents,
+  }));
+  return computeGraphLayout(nodes, HISTORY_GRAPH_GEOMETRY);
+}

--- a/src/modules/source-control/lib/gitBridge.ts
+++ b/src/modules/source-control/lib/gitBridge.ts
@@ -17,6 +17,8 @@ export interface CommitInfo {
   summary: string;
   author: string;
   timestamp: number;
+  /** Parent commit hashes, abbreviated to match `id`; used to lay out the sidebar's commit graph. */
+  parents: string[];
 }
 
 export function gitResolveRepo(path: string): Promise<string | null> {


### PR DESCRIPTION
## Summary

Adds a lightweight branch/merge graph column beside the sidebar commit list, similar in spirit to VS Code's source control history graph — compact, not a full Git Graph replacement. Reuses the layout logic already established by the full Git Graph tab (`src/modules/git-graph/lib/graphLayout.ts`), generalized so the sidebar can consume it too via `src/modules/source-control/lib/commitGraph.ts`.

`git_log` now also returns parent commit hashes and shells out to the system `git` binary (bounded by `--max-count`) instead of using git2's revwalk. An earlier version of this change used `revwalk.set_sorting(TOPOLOGICAL | TIME)` to get correct ordering, but that forces libgit2 to eagerly traverse the entire reachable history before yielding anything, making `.take(limit)` no longer bound the cost (~115ms at 40k commits). Shelling out to `git log --max-count=N` mirrors the existing `graph_log` pattern in the same file and keeps the cost bounded by `limit`, not repo size.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (frontend)
- [x] `cargo check` / relevant Rust tests
- [x] Tauri security review (PASS, 0 CRITICAL/HIGH, 1 LOW informational)
- [x] Tauri performance review (PASS, 0 CRITICAL/HIGH, 1 LOW informational, confirms the `git_log` fix bounds cost)
- [ ] Manual visual check of the graph column in the sidebar (light + dark themes)

Closes #126