### PR TITLE
fix: stop collapse-all hang and merge expand/collapse into a toggle

### DIFF
--- a/src/modules/explorer/ExplorerView.test.tsx
+++ b/src/modules/explorer/ExplorerView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/i18n";
 
@@ -25,5 +25,26 @@ describe("ExplorerView remote root", () => {
     render(<ExplorerView />);
     expect(screen.getByLabelText("Open folder")).toBeInTheDocument();
     expect(screen.getByLabelText("Find files")).toBeInTheDocument();
+  });
+});
+
+describe("ExplorerView expand/collapse toggle", () => {
+  it("shows a single toggle button that flips between Expand All and Collapse All on click", () => {
+    useWorkspaceStore.setState({ rootPath: "/home/me" });
+    render(<ExplorerView />);
+
+    // Merged into one button: no separate Expand All / Collapse All pair.
+    expect(screen.queryAllByLabelText("Expand All")).toHaveLength(1);
+    expect(screen.queryAllByLabelText("Collapse All")).toHaveLength(0);
+
+    fireEvent.click(screen.getByLabelText("Expand All"));
+
+    expect(screen.getByLabelText("Collapse All")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Expand All")).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Collapse All"));
+
+    expect(screen.getByLabelText("Expand All")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Collapse All")).toBeNull();
   });
 });

--- a/src/modules/explorer/ExplorerView.test.tsx
+++ b/src/modules/explorer/ExplorerView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/i18n";
 
@@ -46,5 +46,40 @@ describe("ExplorerView expand/collapse toggle", () => {
 
     expect(screen.getByLabelText("Expand All")).toBeInTheDocument();
     expect(screen.queryByLabelText("Collapse All")).toBeNull();
+  });
+
+  it("does not auto-expand a newly opened root that inherits a stale expandSignal", async () => {
+    const { fsReadDir } = await import("./lib/fsBridge");
+    vi.mocked(fsReadDir).mockImplementation(async (path: string) => {
+      if (path === "/root-a") {
+        return [{ name: "a-dir", path: "/root-a/a-dir", is_dir: true, size: 0 }];
+      }
+      if (path === "/root-b") {
+        return [{ name: "b-dir", path: "/root-b/b-dir", is_dir: true, size: 0 }];
+      }
+      if (path === "/root-b/b-dir") {
+        return [{ name: "leaf.ts", path: "/root-b/b-dir/leaf.ts", is_dir: false, size: 0 }];
+      }
+      return [];
+    });
+
+    useWorkspaceStore.setState({ rootPath: "/root-a" });
+    render(<ExplorerView />);
+    await screen.findByText("a-dir");
+
+    // Expand-all on root A leaves expandSignal at a nonzero value.
+    fireEvent.click(screen.getByLabelText("Expand All"));
+
+    // Switch to a brand new root (e.g. the user opens a different folder).
+    await act(async () => {
+      useWorkspaceStore.setState({ rootPath: "/root-b" });
+    });
+    await screen.findByText("b-dir");
+
+    // "b-dir" must render collapsed: it never received an explicit Expand
+    // All click of its own, so it shouldn't auto-cascade just because root
+    // A's expandSignal was already nonzero when it mounted.
+    await waitFor(() => new Promise((resolve) => setTimeout(resolve, 0)));
+    expect(screen.queryByText("leaf.ts")).not.toBeInTheDocument();
   });
 });

--- a/src/modules/explorer/ExplorerView.tsx
+++ b/src/modules/explorer/ExplorerView.tsx
@@ -58,8 +58,16 @@ export function ExplorerView() {
   }, [loadEntries]);
 
   // A newly opened (or switched-to) root always renders fully collapsed.
+  // ExplorerView doesn't remount when the workspace root changes (rootPath
+  // just comes from the store), so collapseSignal/expandSignal must be reset
+  // here too: otherwise a leftover nonzero expandSignal from the previous
+  // root would hit the new root's freshly mounted TreeNodes on mount
+  // (effects always run on mount, regardless of the dependency array) and
+  // silently cascade-expand it.
   useEffect(() => {
     setTreeExpanded(false);
+    setCollapseSignal(0);
+    setExpandSignal(0);
   }, [rootPath]);
 
   function toggleExpandCollapseAll() {

--- a/src/modules/explorer/ExplorerView.tsx
+++ b/src/modules/explorer/ExplorerView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { CopyMinus, CopyPlus, FolderOpen, Search } from "lucide-react";
+import { ChevronsDownUp, ChevronsUpDown, FolderOpen, Search } from "lucide-react";
 import { FileTree } from "./FileTree";
 import { FileFinder } from "./FileFinder";
 import { Tooltip } from "@/components/Tooltip";
@@ -20,6 +20,11 @@ export function ExplorerView() {
   const [loading, setLoading] = useState(false);
   const [collapseSignal, setCollapseSignal] = useState(0);
   const [expandSignal, setExpandSignal] = useState(0);
+  // Tracks which action the merged expand/collapse toggle button performs
+  // next. A fresh root always starts fully collapsed, so this resets to
+  // false whenever the root changes rather than trying to inspect every
+  // node's live expanded state.
+  const [treeExpanded, setTreeExpanded] = useState(false);
 
   // A remote (SFTP) root hides local-only controls and shows the remote path
   // rather than the raw ssh:// uri.
@@ -51,6 +56,20 @@ export function ExplorerView() {
   useEffect(() => {
     loadEntries();
   }, [loadEntries]);
+
+  // A newly opened (or switched-to) root always renders fully collapsed.
+  useEffect(() => {
+    setTreeExpanded(false);
+  }, [rootPath]);
+
+  function toggleExpandCollapseAll() {
+    if (treeExpanded) {
+      setCollapseSignal((v) => v + 1);
+    } else {
+      setExpandSignal((v) => v + 1);
+    }
+    setTreeExpanded((v) => !v);
+  }
 
   return (
     <div className="relative flex h-full flex-col bg-bg-inset">
@@ -84,28 +103,16 @@ export function ExplorerView() {
             </>
           )}
           {rootPath && (
-            <>
-              <Tooltip label={t("expandAll")}>
-                <button
-                  type="button"
-                  aria-label={t("expandAll")}
-                  onClick={() => setExpandSignal((v) => v + 1)}
-                  className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
-                >
-                  <CopyPlus size={15} />
-                </button>
-              </Tooltip>
-              <Tooltip label={t("collapseAll")}>
-                <button
-                  type="button"
-                  aria-label={t("collapseAll")}
-                  onClick={() => setCollapseSignal((v) => v + 1)}
-                  className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
-                >
-                  <CopyMinus size={15} />
-                </button>
-              </Tooltip>
-            </>
+            <Tooltip label={treeExpanded ? t("collapseAll") : t("expandAll")}>
+              <button
+                type="button"
+                aria-label={treeExpanded ? t("collapseAll") : t("expandAll")}
+                onClick={toggleExpandCollapseAll}
+                className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+              >
+                {treeExpanded ? <ChevronsDownUp size={15} /> : <ChevronsUpDown size={15} />}
+              </button>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
-import { fireEvent, screen } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
 import { FileTree } from "./FileTree";
 import { useTabsStore } from "@/stores/tabsStore";
 
@@ -103,6 +103,44 @@ describe("FileTree collapse-all", () => {
     rerender(
       <FileTree entries={entries} onReloadRoot={() => {}} collapseSignal={1} />,
     );
+    expect(screen.queryByText("child.ts")).not.toBeInTheDocument();
+  });
+
+  it("does not re-expand a folder whose expand-all fetch is still in flight when collapse-all fires", async () => {
+    const { fsReadDir } = await import("./lib/fsBridge");
+    let resolveFetch!: (entries: { name: string; path: string; is_dir: boolean; size: number }[]) => void;
+    const pending = new Promise<{ name: string; path: string; is_dir: boolean; size: number }[]>(
+      (resolve) => {
+        resolveFetch = resolve;
+      },
+    );
+    vi.mocked(fsReadDir).mockReturnValue(pending);
+
+    const entries = [{ name: "dir", path: "/p/dir", is_dir: true, size: 0 }];
+    const { rerender } = render(
+      <FileTree entries={entries} onReloadRoot={() => {}} collapseSignal={0} expandSignal={0} />,
+    );
+
+    // Expand-all fires, kicking off a fetch for "dir" that we hold pending
+    // (mirroring a real, slower Tauri IPC round trip).
+    rerender(
+      <FileTree entries={entries} onReloadRoot={() => {}} collapseSignal={0} expandSignal={1} />,
+    );
+
+    // Collapse-all fires before that fetch resolves.
+    rerender(
+      <FileTree entries={entries} onReloadRoot={() => {}} collapseSignal={1} expandSignal={1} />,
+    );
+
+    // The stale fetch lands after the collapse.
+    await act(async () => {
+      resolveFetch([{ name: "child.ts", path: "/p/dir/child.ts", is_dir: false, size: 0 }]);
+      await pending;
+    });
+
+    // The user already asked to collapse everything; a fetch that was in
+    // flight at that moment shouldn't silently re-open the folder once it
+    // lands.
     expect(screen.queryByText("child.ts")).not.toBeInTheDocument();
   });
 });

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ChevronDown,
@@ -66,11 +66,20 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
   // resets, so this is what lets a later manual re-expand stay local
   // instead of re-cascading into this node's children.
   const [isExpandingAll, setIsExpandingAll] = useState(false);
+  // Bumped every time this node is told to collapse (collapse-all or a
+  // manual toggle-close). expand() is async (it may await a real fsReadDir
+  // IPC round trip), so a fetch kicked off just before a collapse can land
+  // after it; expand() checks this token to tell whether that happened and,
+  // if so, drops its own result instead of silently re-opening the folder
+  // the user just asked to close. This matters most right after Expand All,
+  // which can leave many such fetches in flight at once.
+  const collapseTokenRef = useRef(0);
 
   // Skip the initial value (0 / undefined) so a future restore-on-mount of
   // expanded state wouldn't be immediately collapsed.
   useEffect(() => {
     if (collapseSignal) {
+      collapseTokenRef.current += 1;
       setExpanded(false);
       setIsExpandingAll(false);
     }
@@ -122,8 +131,14 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
     if (!entry.is_dir) {
       return;
     }
+    const token = collapseTokenRef.current;
     if (children === null) {
       await reloadChildren();
+    }
+    if (collapseTokenRef.current !== token) {
+      // Collapsed (collapse-all or a manual toggle) while this fetch was in
+      // flight; respect that instead of re-opening behind the user's back.
+      return;
     }
     setExpanded(true);
   }
@@ -137,6 +152,7 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
       return;
     }
     if (expanded) {
+      collapseTokenRef.current += 1;
       setExpanded(false);
       setIsExpandingAll(false);
       return;


### PR DESCRIPTION
## Summary

- **Bug fix**: Collapse All appeared to hang / do nothing right after Expand All on a tree with several folders. Root cause: `expand()` in `FileTree.tsx` is async (it awaits a real `fsReadDir` IPC round trip), and Expand All's recursive cascade can leave many of these fetches in flight at once. If Collapse All fired while one was still pending, that fetch's completion ran unconditionally afterward and called `setExpanded(true)`, silently re-opening the folder the user had just asked to close. With several folders racing this way at once, the tree visibly flickered back open shortly after the click — which read as "no response" plus a stutter. Fixed by tracking a per-node token that's bumped on every collapse (collapse-all or a manual toggle-close); `expand()` captures the token before its async gap and bails instead of re-opening if it changed while awaiting.
- **UX change**: Merged the separate "Expand All" / "Collapse All" toolbar buttons into a single toggle. The icon/tooltip reflects the action the next click performs (chevrons pointing apart → expand, pointing together → collapse), same toolbar placement.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (146 files / 1107 tests passing)
- [x] Added a regression test in `FileTree.test.tsx` that reproduces the race with a manually-controlled `fsReadDir` promise (RED before the fix, GREEN after)
- [x] Added a test in `ExplorerView.test.tsx` covering the merged toggle button's label/behavior
- [x] Manually verified in a running dev build: toggle expands/collapses correctly with no hang, in both light and dark theme