### PR TITLE
fix: keep xterm viewport transparent so terminal padding matches the theme

### DIFF
--- a/src/modules/terminal/lib/terminalPadding.test.ts
+++ b/src/modules/terminal/lib/terminalPadding.test.ts
@@ -7,4 +7,22 @@ describe("applyTerminalPadding", () => {
     applyTerminalPadding(el, 24);
     expect(el.style.padding).toBe("24px");
   });
+
+  it("makes the xterm viewport transparent so it doesn't paint over the padding gutter", () => {
+    // xterm.js's own .xterm-viewport child is absolutely positioned with
+    // inset: 0, which resolves against the *padding* edge of this element,
+    // so it always covers the full box regardless of the padding we set
+    // above. Its default background (xterm.css's static #000 fallback) is
+    // never themed, so left alone it paints a black ring over the padding
+    // gutter in every theme. See terminalPadding.ts for the full write-up.
+    const el = document.createElement("div");
+    const viewport = document.createElement("div");
+    viewport.className = "xterm-viewport";
+    viewport.style.backgroundColor = "rgb(0, 0, 0)";
+    el.appendChild(viewport);
+
+    applyTerminalPadding(el, 24);
+
+    expect(viewport.style.backgroundColor).toBe("transparent");
+  });
 });

--- a/src/modules/terminal/lib/terminalPadding.ts
+++ b/src/modules/terminal/lib/terminalPadding.ts
@@ -7,4 +7,27 @@
  */
 export function applyTerminalPadding(element: HTMLElement, paddingPx: number): void {
   element.style.padding = `${paddingPx}px`;
+  neutralizeViewportBackground(element);
+}
+
+/**
+ * xterm.js's own `.xterm-viewport` child is absolutely positioned with
+ * `inset: 0` (see @xterm/xterm's css/xterm.css), which CSS resolves against
+ * the *padding* edge of its positioned ancestor (this element), not the
+ * content edge. So the viewport always covers this element's full box,
+ * completely ignoring the padding set above. Its own background-color is
+ * xterm.css's static `#000` fallback and is never themed — xterm.js only
+ * themes the `.xterm-scrollable-element` div nested inside it, which (being
+ * in normal flow) does respect the padding. Left alone, that paints a
+ * `paddingPx`-wide black ring over the padding gutter in every app theme,
+ * dark or light. Making the viewport transparent lets the wrapping
+ * container's own themed background (set in TerminalView) show through
+ * instead, so the gutter reads as intended breathing room, not a
+ * mismatched black frame.
+ */
+function neutralizeViewportBackground(element: HTMLElement): void {
+  const viewport = element.querySelector<HTMLElement>(".xterm-viewport");
+  if (viewport) {
+    viewport.style.backgroundColor = "transparent";
+  }
 }


### PR DESCRIPTION
## Summary

- Fixes a visual regression from #130 where the terminal pane's padding gutter renders as a solid black rectangle instead of matching the theme background, in both light and dark themes.
- Root cause: #130 moved `padding` from the wrapping container onto `term.element` (the `.xterm` div) so `@xterm/addon-fit` would account for it. xterm.js's own `.xterm-viewport` child is absolutely positioned with `inset: 0`, which CSS resolves against the *padding* edge of its positioned ancestor (`.xterm`), not the content edge — so the viewport always covers `.xterm`'s full box, completely ignoring the padding. The viewport's own background is xterm.css's static `#000` fallback and is never themed (xterm.js only themes the `.xterm-scrollable-element` div nested inside it, which — being in normal flow — does respect the padding). The result: a `padding`-px-wide **black ring** painted over the padding gutter in every app theme, dark or light, with only the correctly-inset text/cursor layer showing the right color — which is what read as "one large black rectangle with content squeezed into a corner."
- Fix: make `.xterm-viewport`'s background transparent whenever `applyTerminalPadding` runs, so the wrapping container's own themed background (already set correctly in `TerminalView`) shows through the gutter instead of xterm's hardcoded black fallback. This is a small, low-risk change scoped to the same helper #130 introduced; the padding/fit math itself was already correct.

## Root cause detail

Verified via a live xterm.js instance (real `createTerminal` + `applyTerminalPadding` code, inspected through devtools):

Before fix (10px padding, dark theme, container bg `rgb(34,34,34)`):
- `.xterm` (term.element): 912×785, padding 10px, background transparent
- `.xterm-viewport`: 912×785 (same box as `.xterm`, ignoring its own padding), background **`rgb(0, 0, 0)`**
- `.xterm-scrollable-element` (actual themed content layer): 892×765, correctly inset by 10px, background `rgb(34,34,34)`

Because `.xterm-viewport` paints before `.xterm-scrollable-element` in the same stacking context, its solid black fills the entire padding gutter.

After fix:
- `.xterm-viewport` background: **`rgba(0, 0, 0, 0)`** (transparent) — the container's themed background now shows through the gutter, matching `.xterm-scrollable-element` visually.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (146 files / 1106 tests pass)
- [x] New unit test in `terminalPadding.test.ts` covering the viewport-transparency behavior (RED → GREEN via TDD)
- [x] Manually verified against a live xterm.js instance in both `vitesse-dark` and `vitesse-light` themes, at padding values from 10px to 35px — padding gutter now shows the correct themed background with no black ring, terminal content fills the pane normally with an evenly-inset gutter