### PR TITLE
feat: move file search to a global header palette

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -3,6 +3,7 @@
 ### feat
 
 - 原始碼控制側欄的「近期提交」清單新增精簡版提交圖，用色點與連線標出提交順序、分支分岐、合併與目前 HEAD 位置
+- 檔案搜尋改成從頂部標題列開啟的全域搜尋面板（Cmd/Ctrl+P），不再侷限於檔案總管側欄；全寬顯示讓檔名與相對路徑不必再靠 tooltip 才看得完整，並新增「最近開啟的」清單
 
 ### fix
 
@@ -11,5 +12,6 @@
 ### feat
 
 - Added a compact commit graph beside the sidebar's Recent commits list, showing commit order, branch divergence, merges and the current HEAD position
+- Moved file search into a global search palette opened from the top header (Cmd/Ctrl+P) instead of the Explorer sidebar; the full-width layout shows filenames and relative paths in full without a tooltip, and adds a "Recently opened" list
 
 ### fix

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,6 +4,7 @@ import App from "./App";
 import "./i18n";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useUiStore } from "@/stores/uiStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { leaf, splitLeaf, type LayoutNode } from "@/modules/terminal/lib/terminalLayout";
 
@@ -34,6 +35,7 @@ describe("App shell", () => {
       sidebarView: "explorer",
       fileFinderOpen: false,
     });
+    useWorkspaceStore.setState({ rootPath: null });
     // Start every test with no tabs so the default render mounts no terminal
     // panes (which need a Tauri runtime jsdom doesn't provide).
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
@@ -191,5 +193,18 @@ describe("App shell", () => {
     expect(useUiStore.getState().sidebarView).toBe("explorer");
 
     input.remove();
+  });
+
+  it("clears a stale file-search flag left over from before a folder was opened", () => {
+    // Cmd/Ctrl+P pressed with no folder open (or a remote one) sets
+    // fileFinderOpen without anywhere to render it — if that flag survives
+    // until the user later opens a searchable folder, the palette would pop
+    // up unprompted. It must self-clear instead.
+    useWorkspaceStore.setState({ rootPath: null });
+    useUiStore.setState({ fileFinderOpen: true });
+
+    render(<App />);
+
+    expect(useUiStore.getState().fileFinderOpen).toBe(false);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import { pruneTerminalHistory } from "@/modules/terminal/lib/terminalHistory";
 import { findPaneContent, leafIds } from "@/modules/terminal/lib/terminalLayout";
 import { getPreviewControls } from "@/modules/preview/lib/previewControls";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { FileFinder } from "@/modules/explorer/FileFinder";
+import { canSearchRoot } from "@/modules/explorer/lib/fsBridge";
 import { applyTheme, getTheme } from "@/themes/themes";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -120,6 +122,9 @@ function App() {
   const uiZoom = useSettingsStore((s) => s.uiZoom);
   const sidebarVisible = useUiStore((s) => s.sidebarVisible);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
+  const fileFinderOpen = useUiStore((s) => s.fileFinderOpen);
+  const setFileFinderOpen = useUiStore((s) => s.setFileFinderOpen);
+  const rootPath = useWorkspaceStore((s) => s.rootPath);
   const [sidebarWidth, setSidebarWidth] = useState(260);
   const [pendingCloseAction, setPendingCloseAction] = useState<(() => void) | null>(null);
 
@@ -435,6 +440,9 @@ function App() {
 
       <StatusBar />
       {settingsOpen && <SettingsModal />}
+      {fileFinderOpen && canSearchRoot(rootPath) && (
+        <FileFinder root={rootPath} onClose={() => setFileFinderOpen(false)} />
+      )}
       <UpdateModal />
       <UpdateToast />
       <NotifyToast />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -128,6 +128,16 @@ function App() {
   const [sidebarWidth, setSidebarWidth] = useState(260);
   const [pendingCloseAction, setPendingCloseAction] = useState<(() => void) | null>(null);
 
+  // Cmd/Ctrl+P with no open folder (or a remote one) sets fileFinderOpen with
+  // nowhere to render it — left alone, that flag would survive until the user
+  // later opens a searchable folder and the palette would pop up unprompted.
+  // Clear it as soon as it stops having anywhere to render.
+  useEffect(() => {
+    if (fileFinderOpen && !canSearchRoot(rootPath)) {
+      setFileFinderOpen(false);
+    }
+  }, [fileFinderOpen, rootPath, setFileFinderOpen]);
+
   // Close the focused pane, or the whole tab when it holds a single pane. Shared
   // by the ⌘W key handler and the "Close Tab" menu item (both must behave the
   // same, and a dirty editor routes through the unsaved-changes confirmation).

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -8,6 +8,8 @@ import { leaf } from "@/modules/terminal/lib/terminalLayout";
 import { useEntryDragStore } from "@/modules/explorer/lib/dragEntry";
 import { useNoteDragStore } from "@/modules/notes/lib/noteDrag";
 import { useSshDragStore } from "@/modules/ssh/lib/sshDrag";
+import { useUiStore } from "@/stores/uiStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 beforeEach(() => {
   useTabsStore.setState({
@@ -32,6 +34,33 @@ afterEach(() => {
   useEntryDragStore.setState({ tabBarHover: null });
   useNoteDragStore.setState({ tabBarHover: null });
   useSshDragStore.setState({ tabBarHover: null });
+  useWorkspaceStore.setState({ rootPath: null });
+});
+
+describe("TabBar global file search trigger", () => {
+  it("opens the global file search when a local folder is open", () => {
+    useWorkspaceStore.setState({ rootPath: "/home/me/project" });
+    useUiStore.setState({ fileFinderOpen: false });
+    render(<TabBar />);
+
+    fireEvent.click(screen.getByLabelText("Find files"));
+
+    expect(useUiStore.getState().fileFinderOpen).toBe(true);
+  });
+
+  it("disables the trigger when no folder is open", () => {
+    useWorkspaceStore.setState({ rootPath: null });
+    render(<TabBar />);
+
+    expect(screen.getByLabelText("Find files")).toBeDisabled();
+  });
+
+  it("disables the trigger for a remote (SSH) root", () => {
+    useWorkspaceStore.setState({ rootPath: "ssh://c1/home/me" });
+    render(<TabBar />);
+
+    expect(screen.getByLabelText("Find files")).toBeDisabled();
+  });
 });
 
 describe("TabBar close button tooltip", () => {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -9,6 +9,7 @@ import {
   LayoutGrid,
   PanelLeft,
   Plus,
+  Search,
   SquareTerminal,
   X,
   type LucideIcon,
@@ -32,6 +33,7 @@ import { useTabsStore, type Tab } from "@/stores/tabsStore";
 import { Tooltip } from "@/components/Tooltip";
 import { useTabCloseRequest } from "./useTabCloseRequest";
 import { useUiStore } from "@/stores/uiStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { IS_MAC } from "@/lib/platform";
 import { SpaceDropdown } from "./SpaceDropdown";
 import { ContextMenu } from "./ContextMenu";
@@ -39,6 +41,7 @@ import { tabContextMenuItems } from "./tabContextMenuItems";
 import { useEntryDragStore } from "@/modules/explorer/lib/dragEntry";
 import { useNoteDragStore } from "@/modules/notes/lib/noteDrag";
 import { useSshDragStore } from "@/modules/ssh/lib/sshDrag";
+import { canSearchRoot } from "@/modules/explorer/lib/fsBridge";
 
 // Module-level so the reference stays stable across renders. Passing an inline
 // options object would make useSensor/useSensors return a new sensors array on
@@ -222,6 +225,9 @@ export function TabBar() {
   const openLauncherTab = useTabsStore((s) => s.openLauncherTab);
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
   const sidebarVisible = useUiStore((s) => s.sidebarVisible);
+  const openFileFinder = useUiStore((s) => s.openFileFinder);
+  const rootPath = useWorkspaceStore((s) => s.rootPath);
+  const canSearchFiles = canSearchRoot(rootPath);
   const reorderTab = useTabsStore((s) => s.reorderTab);
   const entryTabBarHover = useEntryDragStore((s) => s.tabBarHover);
   const noteTabBarHover = useNoteDragStore((s) => s.tabBarHover);
@@ -306,6 +312,17 @@ export function TabBar() {
         </div>
         <DragOverlay>{draggingTab ? <TabOverlay tab={draggingTab} /> : null}</DragOverlay>
       </DndContext>
+      <Tooltip label={t("explorer:findFiles")} side="bottom" className="shrink-0">
+        <button
+          type="button"
+          aria-label={t("explorer:findFiles")}
+          disabled={!canSearchFiles}
+          onClick={openFileFinder}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-fg-muted transition-colors hover:bg-bg-elevated hover:text-fg disabled:pointer-events-none disabled:opacity-40"
+        >
+          <Search size={15} />
+        </button>
+      </Tooltip>
     </header>
   );
 }

--- a/src/i18n/locales/en/explorer.json
+++ b/src/i18n/locales/en/explorer.json
@@ -7,6 +7,7 @@
   "expandAll": "Expand All",
   "collapseAll": "Collapse All",
   "findPlaceholder": "Type to fuzzy-find files",
+  "recentlyOpened": "Recently opened",
   "searchInFiles": "Search in files",
   "searchPlaceholder": "Search text in files",
   "noResults": "No matches",

--- a/src/i18n/locales/zh-Hant/explorer.json
+++ b/src/i18n/locales/zh-Hant/explorer.json
@@ -7,6 +7,7 @@
   "expandAll": "全部展開",
   "collapseAll": "全部收合",
   "findPlaceholder": "輸入以模糊搜尋檔案",
+  "recentlyOpened": "最近開啟的",
   "searchInFiles": "在檔案中搜尋",
   "searchPlaceholder": "搜尋檔案內的文字",
   "noResults": "沒有符合的結果",

--- a/src/modules/explorer/ExplorerView.test.tsx
+++ b/src/modules/explorer/ExplorerView.test.tsx
@@ -12,18 +12,24 @@ beforeEach(() => {
 });
 
 describe("ExplorerView remote root", () => {
-  it("hides the open-folder and find buttons and shows the remote path", () => {
+  it("hides the open-folder button and shows the remote path", () => {
     useWorkspaceStore.setState({ rootPath: "ssh://c1/home/me" });
     render(<ExplorerView />);
     expect(screen.queryByLabelText("Open folder")).toBeNull();
-    expect(screen.queryByLabelText("Find files")).toBeNull();
     expect(screen.getByText("/home/me")).toBeInTheDocument();
   });
 
-  it("keeps the buttons for a local root", () => {
+  it("keeps the open-folder button for a local root", () => {
     useWorkspaceStore.setState({ rootPath: "/home/me" });
     render(<ExplorerView />);
     expect(screen.getByLabelText("Open folder")).toBeInTheDocument();
-    expect(screen.getByLabelText("Find files")).toBeInTheDocument();
+  });
+
+  // The fuzzy file search moved to a global header trigger (Cmd/Ctrl+P) — see
+  // TabBar.test.tsx — so it is no longer embedded in this sidebar panel.
+  it("no longer renders a Find files button here", () => {
+    useWorkspaceStore.setState({ rootPath: "/home/me" });
+    render(<ExplorerView />);
+    expect(screen.queryByLabelText("Find files")).toBeNull();
   });
 });

--- a/src/modules/explorer/ExplorerView.tsx
+++ b/src/modules/explorer/ExplorerView.tsx
@@ -1,12 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { CopyMinus, CopyPlus, FolderOpen, Search } from "lucide-react";
+import { CopyMinus, CopyPlus, FolderOpen } from "lucide-react";
 import { FileTree } from "./FileTree";
-import { FileFinder } from "./FileFinder";
 import { Tooltip } from "@/components/Tooltip";
 import { fsReadDir, type DirEntry } from "./lib/fsBridge";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { useUiStore } from "@/stores/uiStore";
 import { pickFolder } from "@/lib/dialog";
 import { isRemoteUri, parseRemoteUri } from "@/modules/ssh/lib/remotePath";
 
@@ -14,8 +12,6 @@ export function ExplorerView() {
   const { t } = useTranslation("explorer");
   const rootPath = useWorkspaceStore((s) => s.rootPath);
   const setRoot = useWorkspaceStore((s) => s.setRoot);
-  const finderOpen = useUiStore((s) => s.fileFinderOpen);
-  const setFinderOpen = useUiStore((s) => s.setFileFinderOpen);
   const [entries, setEntries] = useState<DirEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [collapseSignal, setCollapseSignal] = useState(0);
@@ -60,28 +56,16 @@ export function ExplorerView() {
         </span>
         <div className="flex items-center gap-0.5">
           {!remote && (
-            <>
-              <Tooltip label={t("openFolder")}>
-                <button
-                  type="button"
-                  aria-label={t("openFolder")}
-                  onClick={() => void openFolder()}
-                  className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
-                >
-                  <FolderOpen size={15} />
-                </button>
-              </Tooltip>
-              <Tooltip label={t("findFiles")}>
-                <button
-                  type="button"
-                  aria-label={t("findFiles")}
-                  onClick={() => setFinderOpen(true)}
-                  className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
-                >
-                  <Search size={15} />
-                </button>
-              </Tooltip>
-            </>
+            <Tooltip label={t("openFolder")}>
+              <button
+                type="button"
+                aria-label={t("openFolder")}
+                onClick={() => void openFolder()}
+                className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+              >
+                <FolderOpen size={15} />
+              </button>
+            </Tooltip>
           )}
           {rootPath && (
             <>
@@ -132,10 +116,6 @@ export function ExplorerView() {
           />
         )}
       </div>
-
-      {finderOpen && rootPath && !remote && (
-        <FileFinder root={rootPath} onClose={() => setFinderOpen(false)} />
-      )}
     </div>
   );
 }

--- a/src/modules/explorer/FileFinder.test.tsx
+++ b/src/modules/explorer/FileFinder.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { FileFinder } from "./FileFinder";
 import { useTabsStore } from "@/stores/tabsStore";
+import { useRecentFilesStore } from "./lib/recentFiles";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -10,6 +11,12 @@ vi.mock("react-i18next", () => ({
 vi.mock("./lib/fsBridge", () => ({
   fsListFiles: vi.fn(() => Promise.resolve(["/p/main.ts", "/p/util.ts"])),
 }));
+
+// The recent-files store is a persisted singleton, so a path opened in one
+// test would otherwise leak into the next test's "empty query" list.
+beforeEach(() => {
+  useRecentFilesStore.setState({ paths: [] });
+});
 
 describe("FileFinder opening a file", () => {
   beforeEach(() => {
@@ -152,5 +159,77 @@ describe("FileFinder at pane capacity", () => {
     fireEvent.click(screen.getByText("main.ts"));
 
     expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
+  });
+
+  it("dismissing the InfoDialog does not also close the search palette underneath it", async () => {
+    const onClose = vi.fn();
+    useTabsStore.getState().openEditorTab("/0.ts");
+    for (let i = 1; i < 8; i++) {
+      useTabsStore.getState().openFromSidebar({ kind: "editor", path: `/${i}.ts` });
+    }
+    render(<FileFinder root="/p" onClose={onClose} />);
+    await waitFor(() => screen.getByText("main.ts"));
+
+    fireEvent.click(screen.getByText("main.ts"));
+    expect(screen.getByText("paneCapacityAlert")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("actions.confirm"));
+
+    expect(screen.queryByText("paneCapacityAlert")).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe("FileFinder recently opened files", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("records the opened path so it appears as a recent file next time", async () => {
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("main.ts"));
+
+    fireEvent.click(screen.getByText("main.ts"));
+
+    expect(useRecentFilesStore.getState().paths).toEqual(["/p/main.ts"]);
+  });
+
+  it("shows a recently-opened section before the default listing once a file has been opened", async () => {
+    useRecentFilesStore.setState({ paths: ["/p/util.ts"] });
+    render(<FileFinder root="/p" onClose={() => {}} />);
+
+    await waitFor(() => screen.getByText("recentlyOpened"));
+    expect(screen.getByText("util.ts")).toBeInTheDocument();
+  });
+
+  it("does not show a recently-opened header when nothing has been opened yet", async () => {
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("main.ts"));
+
+    expect(screen.queryByText("recentlyOpened")).toBeNull();
+  });
+
+  it("ignores a recent path that no longer exists in the workspace file list", async () => {
+    useRecentFilesStore.setState({ paths: ["/p/deleted.ts"] });
+    render(<FileFinder root="/p" onClose={() => {}} />);
+
+    await waitFor(() => screen.getByText("main.ts"));
+    expect(screen.queryByText("recentlyOpened")).toBeNull();
+  });
+});
+
+describe("FileFinder result rows", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("shows the containing folder next to a nested file's name", async () => {
+    const { fsListFiles } = await import("./lib/fsBridge");
+    vi.mocked(fsListFiles).mockResolvedValueOnce(["/p/src/modules/util.ts"]);
+
+    render(<FileFinder root="/p" onClose={() => {}} />);
+
+    await waitFor(() => screen.getByText("util.ts"));
+    expect(screen.getByText("src/modules")).toBeInTheDocument();
   });
 });

--- a/src/modules/explorer/FileFinder.test.tsx
+++ b/src/modules/explorer/FileFinder.test.tsx
@@ -232,4 +232,23 @@ describe("FileFinder result rows", () => {
     await waitFor(() => screen.getByText("util.ts"));
     expect(screen.getByText("src/modules")).toBeInTheDocument();
   });
+
+  it("shows a loading state instead of 'no matches' while the file list is still loading", async () => {
+    const { fsListFiles } = await import("./lib/fsBridge");
+    let resolveList: (list: string[]) => void = () => {};
+    vi.mocked(fsListFiles).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+
+    render(<FileFinder root="/p" onClose={() => {}} />);
+
+    expect(screen.getByText("loading")).toBeInTheDocument();
+    expect(screen.queryByText("noResults")).toBeNull();
+
+    resolveList(["/p/main.ts"]);
+    await waitFor(() => screen.getByText("main.ts"));
+    expect(screen.queryByText("loading")).toBeNull();
+  });
 });

--- a/src/modules/explorer/FileFinder.tsx
+++ b/src/modules/explorer/FileFinder.tsx
@@ -3,9 +3,11 @@ import { useTranslation } from "react-i18next";
 import { Search } from "lucide-react";
 import { fsListFiles } from "./lib/fsBridge";
 import { fuzzyRank } from "./lib/fuzzy";
-import { relativePath } from "./lib/paths";
+import { basename, relativeDirOf, relativePath } from "./lib/paths";
+import { useRecentFilesStore } from "./lib/recentFiles";
+import { FileIcon } from "./components/FileIcon";
 import { InfoDialog } from "@/components/InfoDialog";
-import { Tooltip } from "@/components/Tooltip";
+import { useOverlayGuard } from "@/lib/overlayGuard";
 import { useTabsStore } from "@/stores/tabsStore";
 
 interface FileFinderProps {
@@ -13,6 +15,13 @@ interface FileFinderProps {
   onClose: () => void;
 }
 
+/**
+ * Global fuzzy file search palette (Cmd/Ctrl+P), mounted at the app level so it
+ * opens over whatever the user is looking at rather than being scoped to the
+ * Explorer sidebar. Anchored near the top of the window and full-width (unlike
+ * the old sidebar-embedded version), so a matched file's full relative path is
+ * always visible without truncation or a hover tooltip.
+ */
 export function FileFinder({ root, onClose }: FileFinderProps) {
   const { t } = useTranslation("explorer");
   const { t: tCommon } = useTranslation("common");
@@ -23,6 +32,12 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const activeResultRef = useRef<HTMLButtonElement | null>(null);
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
+  const recentPaths = useRecentFilesStore((s) => s.paths);
+  const addRecent = useRecentFilesStore((s) => s.addRecent);
+
+  // A full-screen overlay, so hide the native preview webview (which floats
+  // above all DOM) for as long as this is mounted.
+  useOverlayGuard(true);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -39,7 +54,23 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
     };
   }, [root]);
 
-  const results = useMemo(() => fuzzyRank(query, files).slice(0, 50), [query, files]);
+  // A Set lookup keeps this O(files + recents) instead of O(files * recents) —
+  // `files` can hold up to 20,000 entries (see the fsListFiles call below).
+  const fileSet = useMemo(() => new Set(files), [files]);
+
+  // Recent picks still under this root, most-recently-opened first; a path
+  // that was deleted or belongs to a different workspace silently drops off
+  // since it no longer appears in `files`.
+  const recentResults = useMemo(
+    () => recentPaths.filter((path) => fileSet.has(path)),
+    [recentPaths, fileSet],
+  );
+  const showRecent = query === "" && recentResults.length > 0;
+
+  const results = useMemo(
+    () => (showRecent ? recentResults : fuzzyRank(query, files).slice(0, 50)),
+    [query, files, showRecent, recentResults],
+  );
 
   // The result set changes on every keystroke; keep the highlighted row
   // pinned to the top match instead of an index that now points elsewhere.
@@ -61,6 +92,7 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
       setAtCapacity(true);
       return;
     }
+    addRecent(path);
     onClose();
   }
 
@@ -84,13 +116,22 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   }
 
   return (
-    <div className="absolute inset-0 z-20 flex justify-center bg-black/40 pt-16">
-      <div
-        className="h-fit w-[90%] max-w-lg overflow-hidden rounded-lg border border-border-strong bg-bg-elevated shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
-          <Search size={15} className="text-fg-subtle" />
+    <div
+      className="fixed inset-0 z-[90] flex justify-center bg-black/40 pt-16"
+      // Clicking the dimmed area beside the panel dismisses it; clicks that
+      // originate inside the panel (or the at-capacity InfoDialog, which is a
+      // descendant of this wrapper too) bubble up here with a different
+      // target, so guard on currentTarget to leave those alone — otherwise
+      // dismissing the InfoDialog would also close this palette underneath it.
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div className="h-fit w-[70%] max-w-2xl overflow-hidden rounded-lg border border-border-strong bg-bg-elevated shadow-2xl">
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
+          <Search size={16} className="shrink-0 text-fg-subtle" />
           <input
             ref={inputRef}
             value={query}
@@ -101,18 +142,26 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
             className="w-full bg-transparent text-sm text-fg outline-none placeholder:text-fg-subtle"
           />
         </div>
-        <ul className="max-h-80 overflow-y-auto py-1">
+        <ul className="max-h-96 overflow-y-auto py-1">
           {results.length === 0 ? (
-            <li className="px-3 py-2 text-xs text-fg-subtle">
-              {t("noResults")}
-            </li>
+            <li className="px-3 py-2 text-xs text-fg-subtle">{t("noResults")}</li>
           ) : (
-            results.map((path, index) => {
-              const relative = relativePath(path, root);
-              const active = index === activeIndex;
-              return (
-                <li key={path}>
-                  <Tooltip label={relative} className="w-full">
+            <>
+              {showRecent && (
+                <li
+                  aria-hidden="true"
+                  className="px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-fg-subtle"
+                >
+                  {t("recentlyOpened")}
+                </li>
+              )}
+              {results.map((path, index) => {
+                const relative = relativePath(path, root);
+                const name = basename(path);
+                const dir = relativeDirOf(relative);
+                const active = index === activeIndex;
+                return (
+                  <li key={path}>
                     <button
                       ref={active ? activeResultRef : undefined}
                       type="button"
@@ -122,20 +171,29 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
                       // enter there would steal the selection from the keyboard.
                       onMouseMove={() => setActiveIndex(index)}
                       aria-selected={active}
-                      className={`block w-full truncate px-3 py-1.5 text-left text-sm ${
+                      className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm ${
                         active ? "bg-bg text-fg" : "text-fg-muted hover:bg-bg hover:text-fg"
                       }`}
                     >
-                      {relative}
+                      <FileIcon name={name} isDir={false} />
+                      <span className="min-w-0 flex-1 truncate">{name}</span>
+                      {dir && (
+                        // Capped (rather than plain shrink-0) so a deeply nested path
+                        // truncates itself instead of squeezing the filename above —
+                        // the filename staying fully readable is the point of this
+                        // redesign, so it must win the remaining space.
+                        <span className="max-w-[40%] shrink-0 truncate text-xs text-fg-subtle">
+                          {dir}
+                        </span>
+                      )}
                     </button>
-                  </Tooltip>
-                </li>
-              );
-            })
+                  </li>
+                );
+              })}
+            </>
           )}
         </ul>
       </div>
-      <div className="absolute inset-0 -z-10" onClick={onClose} />
 
       {atCapacity && (
         <InfoDialog

--- a/src/modules/explorer/FileFinder.tsx
+++ b/src/modules/explorer/FileFinder.tsx
@@ -27,6 +27,7 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   const { t: tCommon } = useTranslation("common");
   const [query, setQuery] = useState("");
   const [files, setFiles] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
   const [atCapacity, setAtCapacity] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -42,13 +43,19 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   useEffect(() => {
     inputRef.current?.focus();
     let cancelled = false;
+    setLoading(true);
     fsListFiles(root, 20000)
       .then((list) => {
         if (!cancelled) {
           setFiles(list);
         }
       })
-      .catch(() => setFiles([]));
+      .catch(() => setFiles([]))
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
     return () => {
       cancelled = true;
     };
@@ -129,7 +136,7 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
         }
       }}
     >
-      <div className="h-fit w-[70%] max-w-2xl overflow-hidden rounded-lg border border-border-strong bg-bg-elevated shadow-2xl">
+      <div className="h-fit w-[90%] max-w-2xl overflow-hidden rounded-lg border border-border-strong bg-bg-elevated shadow-2xl md:w-[70%]">
         <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
           <Search size={16} className="shrink-0 text-fg-subtle" />
           <input
@@ -143,7 +150,9 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
           />
         </div>
         <ul className="max-h-96 overflow-y-auto py-1">
-          {results.length === 0 ? (
+          {loading ? (
+            <li className="px-3 py-2 text-xs text-fg-subtle">{t("loading")}</li>
+          ) : results.length === 0 ? (
             <li className="px-3 py-2 text-xs text-fg-subtle">{t("noResults")}</li>
           ) : (
             <>
@@ -169,7 +178,13 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
                       // mousemove, not mouseenter: keyboard-driven scrolling
                       // can slide a row under a stationary cursor, and a plain
                       // enter there would steal the selection from the keyboard.
-                      onMouseMove={() => setActiveIndex(index)}
+                      // Guarded so merely wiggling the cursor over an already-
+                      // active row doesn't re-fire a state update per pixel.
+                      onMouseMove={() => {
+                        if (activeIndex !== index) {
+                          setActiveIndex(index);
+                        }
+                      }}
                       aria-selected={active}
                       className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm ${
                         active ? "bg-bg text-fg" : "text-fg-muted hover:bg-bg hover:text-fg"

--- a/src/modules/explorer/lib/fsBridge.test.ts
+++ b/src/modules/explorer/lib/fsBridge.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/modules/ssh/lib/sftp-bridge", () => ({
   sftpWriteFile: (...a: unknown[]) => sftpWriteFile(...a),
 }));
 
-import { fsReadDir, fsReadFile, fsWriteFile } from "./fsBridge";
+import { canSearchRoot, fsReadDir, fsReadFile, fsWriteFile } from "./fsBridge";
 
 beforeEach(() => {
   invoke.mockReset();
@@ -58,5 +58,19 @@ describe("fsBridge routing", () => {
     invoke.mockResolvedValue(undefined);
     await fsWriteFile("/a.txt", "x");
     expect(invoke).toHaveBeenCalledWith("fs_write_file", { path: "/a.txt", contents: "x" });
+  });
+});
+
+describe("canSearchRoot", () => {
+  it("allows a local root", () => {
+    expect(canSearchRoot("/home/me/project")).toBe(true);
+  });
+
+  it("rejects a remote (SFTP) root — fs_list_files only understands local paths", () => {
+    expect(canSearchRoot("ssh://c1/home/me")).toBe(false);
+  });
+
+  it("rejects no open folder", () => {
+    expect(canSearchRoot(null)).toBe(false);
   });
 });

--- a/src/modules/explorer/lib/fsBridge.ts
+++ b/src/modules/explorer/lib/fsBridge.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { buildRemoteUri, parseRemoteUri } from "@/modules/ssh/lib/remotePath";
+import { buildRemoteUri, isRemoteUri, parseRemoteUri } from "@/modules/ssh/lib/remotePath";
 import { sftpReadDir, sftpReadFile, sftpWriteFile } from "@/modules/ssh/lib/sftp-bridge";
 import { sftpSessionStore } from "@/modules/ssh/lib/sftpSessionStore";
 
@@ -50,6 +50,12 @@ export async function fsWriteFile(path: string, contents: string): Promise<void>
 
 export function fsListFiles(root: string, limit?: number): Promise<string[]> {
   return invoke<string[]>("fs_list_files", { root, limit });
+}
+
+/** Whether `root` is a local folder `fsListFiles` can search — it has no SFTP
+ *  support, so a remote root (or no open folder at all) is not searchable. */
+export function canSearchRoot(root: string | null): root is string {
+  return root !== null && !isRemoteUri(root);
 }
 
 export function fsGrep(

--- a/src/modules/explorer/lib/paths.test.ts
+++ b/src/modules/explorer/lib/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { basename, dirname, joinPath, relativePath } from "./paths";
+import { basename, dirname, joinPath, relativeDirOf, relativePath } from "./paths";
 
 describe("basename", () => {
   it("returns the final segment", () => {
@@ -69,5 +69,19 @@ describe("relativePath", () => {
   it("does not treat a sibling with a shared prefix as inside the root", () => {
     // "/root-extra" must not be seen as living under "/root".
     expect(relativePath("/root-extra/file.ts", "/root")).toBe("/root-extra/file.ts");
+  });
+});
+
+describe("relativeDirOf", () => {
+  it("returns the parent segment of a nested relative path", () => {
+    expect(relativeDirOf("src/modules/explorer/FileFinder.tsx")).toBe("src/modules/explorer");
+  });
+
+  it("returns an empty string for a file at the root (no directory component)", () => {
+    expect(relativeDirOf("main.ts")).toBe("");
+  });
+
+  it("handles Windows separators", () => {
+    expect(relativeDirOf("src\\modules\\file.ts")).toBe("src\\modules");
   });
 });

--- a/src/modules/explorer/lib/paths.ts
+++ b/src/modules/explorer/lib/paths.ts
@@ -41,6 +41,17 @@ export function joinPath(dir: string, child: string): string {
 }
 
 /**
+ * The parent segment of an already-relative path (as returned by
+ * `relativePath`), or "" when the entry has no directory component (it sits
+ * directly at the root). Used by the file search results list to show the
+ * folder a match lives in alongside its name.
+ */
+export function relativeDirOf(relative: string): string {
+  const name = basename(relative);
+  return relative.length > name.length ? relative.slice(0, relative.length - name.length - 1) : "";
+}
+
+/**
  * Express `path` relative to `root`. When `path` sits inside `root` the common
  * prefix (and the separator after it) is stripped; otherwise the original
  * absolute path is returned unchanged.

--- a/src/modules/explorer/lib/recentFiles.test.ts
+++ b/src/modules/explorer/lib/recentFiles.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { MAX_RECENT_FILES, useRecentFilesStore } from "./recentFiles";
+
+beforeEach(() => {
+  useRecentFilesStore.setState({ paths: [] });
+});
+
+describe("recentFiles store", () => {
+  it("adds a newly opened path to the front of the list", () => {
+    useRecentFilesStore.getState().addRecent("/p/a.ts");
+    useRecentFilesStore.getState().addRecent("/p/b.ts");
+
+    expect(useRecentFilesStore.getState().paths).toEqual(["/p/b.ts", "/p/a.ts"]);
+  });
+
+  it("moves a re-opened path back to the front instead of duplicating it", () => {
+    useRecentFilesStore.getState().addRecent("/p/a.ts");
+    useRecentFilesStore.getState().addRecent("/p/b.ts");
+    useRecentFilesStore.getState().addRecent("/p/a.ts");
+
+    expect(useRecentFilesStore.getState().paths).toEqual(["/p/a.ts", "/p/b.ts"]);
+  });
+
+  it("caps the list at MAX_RECENT_FILES, dropping the oldest entries", () => {
+    for (let i = 0; i < MAX_RECENT_FILES + 5; i++) {
+      useRecentFilesStore.getState().addRecent(`/p/${i}.ts`);
+    }
+
+    const { paths } = useRecentFilesStore.getState();
+    expect(paths).toHaveLength(MAX_RECENT_FILES);
+    // Most recent (last added) stays at the front; the oldest 5 fall off.
+    expect(paths[0]).toBe(`/p/${MAX_RECENT_FILES + 4}.ts`);
+    expect(paths).not.toContain("/p/0.ts");
+  });
+});

--- a/src/modules/explorer/lib/recentFiles.ts
+++ b/src/modules/explorer/lib/recentFiles.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { perWindowStorage } from "@/lib/window";
+
+/** How many recently-opened paths to remember, most-recent first. */
+export const MAX_RECENT_FILES = 20;
+
+const STORAGE_KEY = "tempoterm-recent-files";
+
+interface RecentFilesState {
+  /** Most-recently-opened paths first. Scoped across workspaces; callers
+   *  filter down to the active root's file list to display it. */
+  paths: string[];
+  /** Record a path as just opened, moving it to the front if already present. */
+  addRecent: (path: string) => void;
+}
+
+export const useRecentFilesStore = create<RecentFilesState>()(
+  persist(
+    (set) => ({
+      paths: [],
+      addRecent: (path) =>
+        set((state) => ({
+          paths: [path, ...state.paths.filter((p) => p !== path)].slice(0, MAX_RECENT_FILES),
+        })),
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => perWindowStorage()),
+    },
+  ),
+);

--- a/src/stores/uiStore.test.ts
+++ b/src/stores/uiStore.test.ts
@@ -13,6 +13,19 @@ describe("uiStore workspaces view", () => {
   });
 });
 
+describe("uiStore openFileFinder", () => {
+  it("opens the global file search without touching the sidebar", () => {
+    useUiStore.setState({ sidebarView: "notes", sidebarVisible: false, fileFinderOpen: false });
+
+    useUiStore.getState().openFileFinder();
+
+    const state = useUiStore.getState();
+    expect(state.fileFinderOpen).toBe(true);
+    expect(state.sidebarView).toBe("notes");
+    expect(state.sidebarVisible).toBe(false);
+  });
+});
+
 describe("uiStore overlay counter", () => {
   it("reports an overlay open while the count is positive", () => {
     expect(selectAnyOverlayOpen(useUiStore.getState())).toBe(false);

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -25,7 +25,9 @@ interface UiState {
   setFileFinderOpen: (open: boolean) => void;
   setPortsPanelOpen: (open: boolean) => void;
   togglePortsPanel: () => void;
-  /** Reveal the explorer and open the fuzzy file finder (Cmd/Ctrl+P). */
+  /** Open the global fuzzy file search palette (Cmd/Ctrl+P). Independent of
+   *  the sidebar — it renders as a top-anchored overlay regardless of which
+   *  sidebar panel (if any) is currently showing. */
   openFileFinder: () => void;
   pushOverlay: () => void;
   popOverlay: () => void;
@@ -50,8 +52,7 @@ export const useUiStore = create<UiState>((set) => ({
   setPortsPanelOpen: (portsPanelOpen) => set({ portsPanelOpen }),
   togglePortsPanel: () => set((state) => ({ portsPanelOpen: !state.portsPanelOpen })),
 
-  openFileFinder: () =>
-    set({ sidebarView: "explorer", sidebarVisible: true, fileFinderOpen: true }),
+  openFileFinder: () => set({ fileFinderOpen: true }),
 
   pushOverlay: () => set((state) => ({ overlayCount: state.overlayCount + 1 })),
   popOverlay: () => set((state) => ({ overlayCount: Math.max(0, state.overlayCount - 1) })),


### PR DESCRIPTION
## Summary

Redesigns file search per request: instead of a narrow sidebar-embedded finder, search now opens as a global, top-anchored palette triggered from the header (a search icon in the tab bar) or `Cmd/Ctrl+P` — same shortcut as before, now reused for a different, better UX.

- **Global, not sidebar-scoped**: `FileFinder` now mounts at the `App.tsx` level (alongside `SettingsModal`, `ConfirmDialog`, etc.) instead of nested inside `ExplorerView`. Previously `openFileFinder()` had to force `sidebarView: "explorer"` and `sidebarVisible: true` just so the finder had somewhere to render; that hack is gone. The palette now opens over whatever the user is looking at, regardless of which sidebar panel (or none) is showing.
- **Full-width layout**: the palette is a wide (`70%`, capped at `42rem`) panel near the top of the window instead of a narrow sidebar column. Each result row shows an icon, the filename, and its relative folder path — no more truncation + hover `Tooltip` needed for normal cases (a capped-width directory column still truncates gracefully for pathologically deep paths, per the original ask).
- **"Recently opened" section**: when the query is empty and at least one file has been opened through this palette, a "Recently opened" section shows those paths (MRU, capped at 20, persisted). Falls back to the previous unranked file listing when there's no recent history yet.
- **Existing behavior preserved**: multi-word AND fuzzy matching, Up/Down navigation with wraparound and auto-scroll, Enter-to-open, Escape-to-close, click-outside-to-close, and the IME composition guard on Enter are all unchanged from the prior implementation (`fuzzy.ts` untouched, its tests untouched).
- **Replaces, not coexists**: per the task's default, the old sidebar-embedded search button and finder in `ExplorerView` are removed — one search entry point.

## UX decisions (please confirm or push back)

1. **Trigger**: a search icon button added to the far right of the header/tab bar, plus the existing `Cmd/Ctrl+P` shortcut (no new shortcut needed — it was already bound to `openFileFinder`, just repointed at the new global behavior). The button is disabled when no local folder is open or the workspace root is remote (SSH/SFTP), since `fs_list_files` has no SFTP support.
2. **"Recently opened" scope**: it only tracks files opened *through this search palette*, not files opened by clicking in the file tree, from git diff views, etc. This is a deliberately narrow v1 (a small new persisted MRU store, not a rewrite of how file-opening works app-wide). If you'd like "recently opened" to reflect every way a file gets opened, that's a bigger, separate change — happy to follow up if wanted.
3. **Row layout**: filename is prioritized to always display in full where possible; the folder-path column is capped at 40% width and truncates first if a path is pathologically deep, so the filename never gets silently squeezed out.

## Other changes bundled in (small, related)

- Removed a duplicated "can this root be searched" check (was copy-pasted in `TabBar.tsx`'s trigger and `App.tsx`'s render gate) into a single `canSearchRoot()` helper in `fsBridge.ts`.
- Fixed a pre-existing latent bug: the at-capacity `InfoDialog` (shown when trying to open a 9th pane) could bubble a click through to the backdrop behind it and close the whole search palette — now guarded with a `target === currentTarget` check instead of relying on `stopPropagation`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 147 files / 1125 tests passing (new tests: recent-files store, `relativeDirOf` path helper, header trigger button, recently-opened section, InfoDialog-dismiss-doesn't-close-palette regression)
- [x] Manually verified in a running dev server: opens from the header button and `Cmd/Ctrl+P`, fuzzy filters, keyboard nav (arrows + wraparound + Enter), Escape closes, full filenames render without truncation in normal cases, "Recently opened" section appears after opening a file, light and dark theme both render correctly (component uses only existing semantic color tokens, no hardcoded colors)