### PR TITLE
fix: match file search against relative paths, skip heavy dirs in expand-all

### DIFF
--- a/src/modules/explorer/FileFinder.test.tsx
+++ b/src/modules/explorer/FileFinder.test.tsx
@@ -233,6 +233,26 @@ describe("FileFinder result rows", () => {
     expect(screen.getByText("src/modules")).toBeInTheDocument();
   });
 
+  it("does not match a query against the workspace root's own absolute path prefix", async () => {
+    // "Documents" (a segment of the root's absolute path, outside the
+    // project) already contains "d","o","c","s" in order followed by a "/" —
+    // matching against the raw absolute path would make "docs/" match every
+    // file in the workspace regardless of its actual relative path.
+    const { fsListFiles } = await import("./lib/fsBridge");
+    vi.mocked(fsListFiles).mockResolvedValueOnce([
+      "/Users/muki/Documents/project/src/App.tsx",
+      "/Users/muki/Documents/project/docs/guide.md",
+    ]);
+
+    render(<FileFinder root="/Users/muki/Documents/project" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("App.tsx"));
+
+    fireEvent.change(screen.getByLabelText("findFiles"), { target: { value: "docs/" } });
+
+    await waitFor(() => screen.getByText("guide.md"));
+    expect(screen.queryByText("App.tsx")).toBeNull();
+  });
+
   it("shows a loading state instead of 'no matches' while the file list is still loading", async () => {
     const { fsListFiles } = await import("./lib/fsBridge");
     let resolveList: (list: string[]) => void = () => {};

--- a/src/modules/explorer/FileFinder.tsx
+++ b/src/modules/explorer/FileFinder.tsx
@@ -74,10 +74,28 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   );
   const showRecent = query === "" && recentResults.length > 0;
 
-  const results = useMemo(
-    () => (showRecent ? recentResults : fuzzyRank(query, files).slice(0, 50)),
-    [query, files, showRecent, recentResults],
+  // Match against each file's path *relative to the workspace root*, not the
+  // raw absolute path `fsListFiles` returns. Matching the absolute path lets
+  // segments entirely outside the project (e.g. "Documents" in the user's
+  // home directory, which already contains "d","o","c","s" in order followed
+  // by a "/") satisfy a query like "docs/" for every single file in the
+  // workspace, regardless of where it actually lives relative to the root.
+  const relativeFiles = useMemo(
+    () => files.map((path) => ({ path, relative: relativePath(path, root) })),
+    [files, root],
   );
+
+  const results = useMemo(() => {
+    if (showRecent) {
+      return recentResults;
+    }
+    const rankedRelatives = fuzzyRank(
+      query,
+      relativeFiles.map((f) => f.relative),
+    ).slice(0, 50);
+    const byRelative = new Map(relativeFiles.map((f) => [f.relative, f.path]));
+    return rankedRelatives.map((relative) => byRelative.get(relative)!);
+  }, [query, relativeFiles, showRecent, recentResults]);
 
   // The result set changes on every keystroke; keep the highlighted row
   // pinned to the top match instead of an index that now points elsewhere.

--- a/src/modules/explorer/FileFinder.tsx
+++ b/src/modules/explorer/FileFinder.tsx
@@ -80,22 +80,24 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   // home directory, which already contains "d","o","c","s" in order followed
   // by a "/") satisfy a query like "docs/" for every single file in the
   // workspace, regardless of where it actually lives relative to the root.
-  const relativeFiles = useMemo(
-    () => files.map((path) => ({ path, relative: relativePath(path, root) })),
-    [files, root],
-  );
+  const { relativePaths, relativeToPath } = useMemo(() => {
+    const paths: string[] = [];
+    const toPath = new Map<string, string>();
+    for (const path of files) {
+      const relative = relativePath(path, root);
+      paths.push(relative);
+      toPath.set(relative, path);
+    }
+    return { relativePaths: paths, relativeToPath: toPath };
+  }, [files, root]);
 
   const results = useMemo(() => {
     if (showRecent) {
       return recentResults;
     }
-    const rankedRelatives = fuzzyRank(
-      query,
-      relativeFiles.map((f) => f.relative),
-    ).slice(0, 50);
-    const byRelative = new Map(relativeFiles.map((f) => [f.relative, f.path]));
-    return rankedRelatives.map((relative) => byRelative.get(relative)!);
-  }, [query, relativeFiles, showRecent, recentResults]);
+    const rankedRelatives = fuzzyRank(query, relativePaths).slice(0, 50);
+    return rankedRelatives.map((relative) => relativeToPath.get(relative)!);
+  }, [query, relativePaths, relativeToPath, showRecent, recentResults]);
 
   // The result set changes on every keystroke; keep the highlighted row
   // pinned to the top match instead of an index that now points elsewhere.

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -250,6 +250,47 @@ describe("FileTree expand-all", () => {
 
     expect(screen.queryByText("leaf.ts")).not.toBeInTheDocument();
   });
+
+  it("does not auto-cascade into a heavy/generated directory like node_modules", async () => {
+    // fs_read_dir has no gitignore awareness (unlike the search palette's
+    // fs_list_files), so an unconditional recursive cascade would expand
+    // node_modules' entire contents — tens of thousands of DOM nodes for a
+    // typical JS project — making the subsequent collapse-all pass visibly
+    // slow. Expand-all should skip auto-descending into well-known
+    // heavy/generated directories, the way other editors' "expand all" does.
+    const { fsReadDir } = await import("./lib/fsBridge");
+    vi.mocked(fsReadDir).mockImplementation(async (path: string) => {
+      if (path === "/p") {
+        return [
+          { name: "src", path: "/p/src", is_dir: true, size: 0 },
+          { name: "node_modules", path: "/p/node_modules", is_dir: true, size: 0 },
+        ];
+      }
+      if (path === "/p/src") {
+        return [{ name: "index.ts", path: "/p/src/index.ts", is_dir: false, size: 0 }];
+      }
+      if (path === "/p/node_modules") {
+        return [
+          { name: "some-pkg", path: "/p/node_modules/some-pkg", is_dir: true, size: 0 },
+        ];
+      }
+      return [];
+    });
+    const entries = [
+      { name: "src", path: "/p/src", is_dir: true, size: 0 },
+      { name: "node_modules", path: "/p/node_modules", is_dir: true, size: 0 },
+    ];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} expandSignal={1} />);
+
+    expect(await screen.findByText("index.ts")).toBeInTheDocument();
+    expect(fsReadDir).not.toHaveBeenCalledWith("/p/node_modules");
+    expect(screen.queryByText("some-pkg")).not.toBeInTheDocument();
+
+    // Manually clicking node_modules must still work — only the automatic
+    // cascade skips it, not the user's own explicit choice to look inside.
+    fireEvent.click(screen.getByText("node_modules"));
+    expect(await screen.findByText("some-pkg")).toBeInTheDocument();
+  });
 });
 
 describe("FileTree context menu: open in new tab", () => {

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -36,6 +36,30 @@ import { useChatStore } from "@/modules/ai/store/chatStore";
 
 type MenuPosition = { x: number; y: number };
 
+/**
+ * Directory names Expand All should not auto-descend into. `fs_read_dir`
+ * (unlike the search palette's gitignore-aware `fs_list_files`) has no
+ * ignore-file awareness, so an unconditional recursive cascade would mount a
+ * child TreeNode for every file inside e.g. `node_modules` — tens of
+ * thousands of DOM nodes for a typical JS project — which then makes the
+ * next collapse-all pass (a single synchronous unmount of all of them)
+ * visibly slow. Matches the common set of generated/dependency directories
+ * most editors also skip during a bulk "expand all". A manual click on one
+ * of these still opens it — only the automatic cascade skips it.
+ */
+const AUTO_EXPAND_EXCLUDED_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "target",
+  "dist",
+  "build",
+  ".next",
+  ".turbo",
+  ".venv",
+  "venv",
+  "__pycache__",
+]);
+
 /** Whether an inline name input is open, and which kind of entry it creates. */
 type Creating = { kind: "file" | "dir" } | null;
 
@@ -96,7 +120,7 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
   // (and immediately undo this) on every fresh mount, where `expanded`
   // starts out false by default.
   useEffect(() => {
-    if (expandSignal) {
+    if (expandSignal && !(entry.is_dir && AUTO_EXPAND_EXCLUDED_DIRS.has(entry.name))) {
       setIsExpandingAll(true);
       void expand();
     }


### PR DESCRIPTION
## Summary

Two bugs found while manually testing the just-merged search/explorer PRs (#133, #135) in a real local build.

**1. File search matched against the absolute path, not the relative path**

The global search palette (`FileFinder.tsx`) ranked/filtered queries against the raw absolute path `fsListFiles` returns. A path segment entirely outside the project — e.g. `Documents` in the user's home directory, which already contains `d`, `o`, `c`, `s` in order followed by a `/` — satisfies a query like `docs/` as a fuzzy subsequence match for *every single file* in the workspace, regardless of where it actually lives relative to the project root. The display code already relativized the path correctly; the matching code didn't. Now matches against each file's root-relative path instead.

**2. Expand All had no bound on recursion depth into generated/dependency directories**

`fs_read_dir` (the Rust command backing lazy tree loading) has no gitignore awareness, unlike the search palette's `fs_list_files` (which uses the `ignore` crate's gitignore-respecting walker). An unconditional recursive "Expand All" cascade into e.g. `node_modules` mounts a child `TreeNode` for every file inside it — tens of thousands of DOM nodes for a typical JS project. Expand happens incrementally (level by level, async), so it *feels* fast; the next Collapse All then has to synchronously unmount all of them in one commit, which is what actually reads as "collapse is slow" (not a hang — a genuinely large one-shot DOM teardown).

Expand All now skips auto-descending into a small set of well-known heavy/generated directories (`node_modules`, `.git`, `target`, `dist`, `build`, `.next`, `.turbo`, `venv`/`.venv`, `__pycache__`), matching how other editors' "expand all" already behaves. A manual click on one of these still opens it — only the automatic cascade skips it.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (147 files / 1133 tests)
- [x] New regression test: a query matching only the root's absolute-path prefix returns no results
- [x] New regression test: expand-all skips `node_modules` (no `fsReadDir` call, no children mounted) while a manual click on it still works