### PR TITLE
feat: add keyboard nav and compare mode to Git Graph (#100)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-git-graph-keyboard-nav.md
+++ b/docs/superpowers/plans/2026-07-04-git-graph-keyboard-nav.md
@@ -1,0 +1,1618 @@
+# Git Graph Keyboard Navigation and Compare Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Up/Down and Shift+Up/Down keyboard navigation to the Git Graph commit list, plus Shift+click to diff two arbitrary commits, per issue #100 and the approved design at `docs/superpowers/specs/2026-07-04-git-graph-keyboard-nav-design.md`.
+
+**Architecture:** Two new pure Rust commands generalize the existing "commit vs. its first parent" diff endpoints to "diff between two arbitrary commits". Two new pure TypeScript functions expose the existing lane-layout algorithm's first-parent/lane-continuation relationships for keyboard traversal. Commit selection becomes a `GraphSelection` union (`single` | `compare`) threaded through `GitGraph` → `GitGraphTabContent` → `CommitDetailsPanel`.
+
+**Tech Stack:** React + TypeScript (Vitest + React Testing Library), Rust (Tauri commands, `#[cfg(test)]` unit tests against real temp git repos).
+
+## Global Constraints
+
+- Shift+Down always follows the commit's first parent (`parents[0]`); there is never a "pick which branch" UI, even at a merge commit.
+- Plain Up/Down clamp at the list's top/bottom — no wraparound.
+- Compare mode exits back to single-select on a plain click (no Shift) on any commit, or on any arrow-key press (plain or Shift).
+- The AI "explain this diff" tab is not shown while in compare mode.
+- `pnpm vitest run <file>` (the `test` script) does not type-check the whole project — it transpiles each test file independently, so a task can turn its own test file green even while a sibling file it calls into still has the *old* prop shape. Only `pnpm typecheck` (`tsc --noEmit`) checks the whole project at once. Because Tasks 3-5 change a prop contract shared across three files, the whole-project `pnpm typecheck` is expected to fail until Task 5 lands — verify each of Tasks 3-5 by running only that task's own test file, and treat `pnpm typecheck` as the final gate in Task 6, not a per-task gate.
+
+---
+
+### Task 1: Backend — diff between two arbitrary commits
+
+**Files:**
+- Modify: `src-tauri/src/modules/git/mod.rs` (add `commit_range_files`, `commit_range_file_diff`, their `#[tauri::command]` wrappers, and tests)
+- Modify: `src-tauri/src/lib.rs` (register the two new commands)
+
+**Interfaces:**
+- Consumes: `CommitFileChange { status: String, path: String }` (already defined at `mod.rs:75`), `run_git(repo_path: &str, args: &[&str]) -> Result<String, String>` (`mod.rs:499`), `ensure_not_flag(value: &str) -> Result<(), String>` (`mod.rs:527`), `parse_name_status_line(line: &str) -> Option<CommitFileChange>` (`mod.rs:697`).
+- Produces: `pub fn commit_range_files(repo_path: &str, from: &str, to: &str) -> Result<Vec<CommitFileChange>, String>`, `pub fn commit_range_file_diff(repo_path: &str, from: &str, to: &str, file: &str) -> Result<String, String>`, Tauri commands `git_commit_range_files` and `git_commit_range_file_diff` (used by Task 5's frontend bridge).
+
+- [ ] **Step 1: Write the failing test**
+
+Open `src-tauri/src/modules/git/mod.rs` and find the `mod tests` block (starts at line 1163). Add this test right after the `flag_like_arguments_are_rejected_before_running_git` test (which ends around line 1524):
+
+```rust
+    #[test]
+    fn commit_range_files_and_diff_between_arbitrary_commits() {
+        let dir = temp_repo_dir("range-diff");
+        let path = dir.to_string_lossy().to_string();
+        run_git(&path, &["init", "-b", "main"]).unwrap();
+        run_git(&path, &["config", "user.email", "t@t.dev"]).unwrap();
+        run_git(&path, &["config", "user.name", "Tester"]).unwrap();
+
+        std::fs::write(dir.join("a.txt"), "line1\n").unwrap();
+        run_git(&path, &["add", "a.txt"]).unwrap();
+        run_git(&path, &["commit", "-m", "first"]).unwrap();
+        let first = run_git(&path, &["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+        std::fs::write(dir.join("a.txt"), "line1\nline2\n").unwrap();
+        run_git(&path, &["commit", "-am", "second"]).unwrap();
+
+        std::fs::write(dir.join("b.txt"), "new file\n").unwrap();
+        run_git(&path, &["add", "b.txt"]).unwrap();
+        run_git(&path, &["commit", "-am", "third"]).unwrap();
+        let third = run_git(&path, &["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+        // first..third skips the middle commit entirely — proves this isn't
+        // limited to adjacent parent-child pairs like commit_details is.
+        let files = commit_range_files(&path, &first, &third).unwrap();
+        let mut paths: Vec<_> = files.iter().map(|f| f.path.as_str()).collect();
+        paths.sort();
+        assert_eq!(paths, vec!["a.txt", "b.txt"]);
+        assert!(files.iter().any(|f| f.path == "a.txt" && f.status == "M"));
+        assert!(files.iter().any(|f| f.path == "b.txt" && f.status == "A"));
+
+        let diff = commit_range_file_diff(&path, &first, &third, "a.txt").unwrap();
+        assert!(diff.contains("+line2"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+```
+
+Also extend the existing `flag_like_arguments_are_rejected_before_running_git` test (around line 1505-1524) by adding these two lines right before its closing `}`:
+
+```rust
+        assert!(commit_range_files("/no/such/repo", "-x", "HEAD").is_err());
+        assert!(commit_range_file_diff("/no/such/repo", "HEAD", "-x", "a.txt").is_err());
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd src-tauri && cargo test commit_range`
+Expected: compile error — `commit_range_files` and `commit_range_file_diff` are not defined.
+
+- [ ] **Step 3: Implement the two pure functions**
+
+In `src-tauri/src/modules/git/mod.rs`, find `commit_file_diff` (ends at line 1022, right before the blank line and `#[tauri::command]` at line 1024). Insert these two new functions between the end of `commit_file_diff` and the `#[tauri::command]` line:
+
+```rust
+/// 兩個任意 commit 之間變更的檔案清單(`git diff --name-status from to`)。
+/// 不像 commit_details 限定「對第一個 parent」，from/to 可以是歷史上任意兩點。
+pub fn commit_range_files(
+    repo_path: &str,
+    from: &str,
+    to: &str,
+) -> Result<Vec<CommitFileChange>, String> {
+    let from = from.trim();
+    let to = to.trim();
+    if from.is_empty() || to.is_empty() {
+        return Err("commit hash is required".to_string());
+    }
+    ensure_not_flag(from)?;
+    ensure_not_flag(to)?;
+
+    let name_status = run_git(repo_path, &["diff", "--name-status", from, to])?;
+    let files = name_status
+        .lines()
+        .filter_map(parse_name_status_line)
+        .collect();
+    Ok(files)
+}
+
+/// 兩個任意 commit 之間、單一檔案的 diff(`git diff from to -- file`)。
+pub fn commit_range_file_diff(
+    repo_path: &str,
+    from: &str,
+    to: &str,
+    file: &str,
+) -> Result<String, String> {
+    let from = from.trim();
+    let to = to.trim();
+    if from.is_empty() || to.is_empty() {
+        return Err("commit hash is required".to_string());
+    }
+    ensure_not_flag(from)?;
+    ensure_not_flag(to)?;
+
+    run_git(repo_path, &["diff", from, to, "--", file])
+}
+```
+
+Then find `git_commit_file_diff` (the `#[tauri::command]` wrapper, ends around line 1160, right before `#[cfg(test)]` at line 1162). Insert these two wrappers between the end of `git_commit_file_diff` and `#[cfg(test)]`:
+
+```rust
+#[tauri::command]
+pub fn git_commit_range_files(
+    repo_path: String,
+    from: String,
+    to: String,
+) -> Result<Vec<CommitFileChange>, String> {
+    commit_range_files(&repo_path, &from, &to)
+}
+
+#[tauri::command]
+pub fn git_commit_range_file_diff(
+    repo_path: String,
+    from: String,
+    to: String,
+    file: String,
+) -> Result<String, String> {
+    commit_range_file_diff(&repo_path, &from, &to, &file)
+}
+```
+
+- [ ] **Step 4: Register the two new commands in `lib.rs`**
+
+In `src-tauri/src/lib.rs`, find the `use modules::git::{...}` block (starts at line 22). Change:
+
+```rust
+use modules::git::{
+    git_branch_checkout, git_branch_checkout_track, git_branch_create_at, git_branch_delete,
+    git_branches, git_cherry_pick, git_commit, git_commit_details, git_commit_file_diff, git_diff,
+    git_fetch, git_file_at_rev, git_graph_log, git_log, git_merge, git_pull, git_push,
+    git_push_delete, git_rebase, git_reset, git_resolve_repo, git_restore_file, git_revert,
+    git_stage, git_status, git_tag_create, git_tag_delete, git_unstage, git_worktree_info,
+    git_worktree_list,
+};
+```
+
+to:
+
+```rust
+use modules::git::{
+    git_branch_checkout, git_branch_checkout_track, git_branch_create_at, git_branch_delete,
+    git_branches, git_cherry_pick, git_commit, git_commit_details, git_commit_file_diff,
+    git_commit_range_file_diff, git_commit_range_files, git_diff, git_fetch, git_file_at_rev,
+    git_graph_log, git_log, git_merge, git_pull, git_push, git_push_delete, git_rebase, git_reset,
+    git_resolve_repo, git_restore_file, git_revert, git_stage, git_status, git_tag_create,
+    git_tag_delete, git_unstage, git_worktree_info, git_worktree_list,
+};
+```
+
+Then find the `generate_handler!` list entries (around lines 196-197):
+
+```rust
+            git_commit_details,
+            git_commit_file_diff,
+```
+
+Change to:
+
+```rust
+            git_commit_details,
+            git_commit_file_diff,
+            git_commit_range_files,
+            git_commit_range_file_diff,
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd src-tauri && cargo test commit_range`
+Expected: PASS (2 tests: `commit_range_files_and_diff_between_arbitrary_commits` and the extended `flag_like_arguments_are_rejected_before_running_git`)
+
+Run: `cd src-tauri && cargo test flag_like_arguments`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/modules/git/mod.rs src-tauri/src/lib.rs
+git commit -m "feat: add backend commands to diff two arbitrary commits"
+```
+
+---
+
+### Task 2: Frontend — first-parent and lane-continuation lookups
+
+**Files:**
+- Modify: `src/modules/git-graph/lib/graphLayout.ts`
+- Test: `src/modules/git-graph/lib/graphLayout.test.ts`
+
+**Interfaces:**
+- Consumes: `GraphLayoutCommit { hash: string; parents: string[] }`, `GraphEdge { cx, cy, px, py, lane, childIndex, parentIndex, colorIndex }`, `computeGraphLayout` (all already in `graphLayout.ts`).
+- Produces: `firstParentRowIndex(commits: readonly GraphLayoutCommit[], index: number): number | null`, `laneContinuationRowIndex(edges: readonly GraphEdge[], index: number): number | null` (both consumed by Task 3's `GitGraph.tsx`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `src/modules/git-graph/lib/graphLayout.test.ts`. Add these imports to the existing `import { ... } from "./graphLayout";` at the top:
+
+```ts
+import {
+  computeGraphLayout,
+  DEFAULT_GEOMETRY,
+  edgePath,
+  firstParentRowIndex,
+  laneContinuationRowIndex,
+  laneX,
+  type GraphEdge,
+} from "./graphLayout";
+```
+
+Then append these two new `describe` blocks at the end of the file:
+
+```ts
+describe("firstParentRowIndex", () => {
+  it("finds the row of the first parent in a simple chain", () => {
+    const commits = [commit("c", ["b"]), commit("b", ["a"]), commit("a", [])];
+    expect(firstParentRowIndex(commits, 0)).toBe(1);
+    expect(firstParentRowIndex(commits, 1)).toBe(2);
+  });
+
+  it("returns null for a root commit with no parents", () => {
+    const commits = [commit("a", [])];
+    expect(firstParentRowIndex(commits, 0)).toBeNull();
+  });
+
+  it("returns null when the first parent is not loaded in the page", () => {
+    const commits = [commit("only", ["missing-parent"])];
+    expect(firstParentRowIndex(commits, 0)).toBeNull();
+  });
+
+  it("always follows the first parent from a merge commit, not the merged-in branch", () => {
+    const commits = [commit("m", ["a", "b"]), commit("b", ["a"]), commit("a", [])];
+    expect(firstParentRowIndex(commits, 0)).toBe(2); // "a" (index 2), not "b" (index 1)
+  });
+
+  it("resolves a short-hash parent reference by prefix", () => {
+    const commits = [commit("abcdef1", ["abc"]), commit("abc", [])];
+    expect(firstParentRowIndex(commits, 0)).toBe(1);
+  });
+});
+
+describe("laneContinuationRowIndex", () => {
+  it("finds the child that continues the same lane going up", () => {
+    const commits = [commit("c", ["b"]), commit("b", ["a"]), commit("a", [])];
+    const { edges } = computeGraphLayout(commits);
+    expect(laneContinuationRowIndex(edges, 1)).toBe(0); // b's continuation is c
+    expect(laneContinuationRowIndex(edges, 2)).toBe(1); // a's continuation is b
+  });
+
+  it("returns null for the newest commit on a lane", () => {
+    const commits = [commit("c", ["b"]), commit("b", ["a"]), commit("a", [])];
+    const { edges } = computeGraphLayout(commits);
+    expect(laneContinuationRowIndex(edges, 0)).toBeNull();
+  });
+
+  it("skips the merge-in bend and finds the straight-line child at a fork", () => {
+    // m merges a and b; from a's perspective going up, the straight
+    // continuation is m (same lane), not the b->a bend.
+    const commits = [commit("m", ["a", "b"]), commit("b", ["a"]), commit("a", [])];
+    const { edges } = computeGraphLayout(commits);
+    expect(laneContinuationRowIndex(edges, 2)).toBe(0); // a -> m, straight
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm vitest run src/modules/git-graph/lib/graphLayout.test.ts`
+Expected: FAIL — `firstParentRowIndex` and `laneContinuationRowIndex` are not exported from `./graphLayout`.
+
+- [ ] **Step 3: Implement the two functions**
+
+In `src/modules/git-graph/lib/graphLayout.ts`, add these two functions after `computeGraphLayout` (after its closing `}` at line 177, before `edgePath` at line 180):
+
+```ts
+/**
+ * Row index of `commits[index]`'s first parent within the same array. Null
+ * if the commit has no parent, or its first parent isn't loaded in `commits`
+ * yet (the caller should page in more history and retry).
+ */
+export function firstParentRowIndex(
+  commits: readonly GraphLayoutCommit[],
+  index: number,
+): number | null {
+  const parentHash = commits[index]?.parents[0];
+  if (!parentHash) {
+    return null;
+  }
+  const found = commits.findIndex(
+    (c) =>
+      c.hash === parentHash || c.hash.startsWith(parentHash) || parentHash.startsWith(c.hash),
+  );
+  return found === -1 ? null : found;
+}
+
+/**
+ * Row index of the one commit whose first-parent edge continues
+ * `commits[index]`'s exact lane going up (newer) — the straight line in the
+ * graph, not a merge-in bend. Null if `commits[index]` is the newest commit
+ * on its lane.
+ */
+export function laneContinuationRowIndex(
+  edges: readonly GraphEdge[],
+  index: number,
+): number | null {
+  const edge = edges.find((e) => e.parentIndex === index && e.cx === e.px);
+  return edge ? edge.childIndex : null;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm vitest run src/modules/git-graph/lib/graphLayout.test.ts`
+Expected: PASS (all tests in the file, including the pre-existing ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modules/git-graph/lib/graphLayout.ts src/modules/git-graph/lib/graphLayout.test.ts
+git commit -m "feat: add first-parent and lane-continuation lookups to graph layout"
+```
+
+---
+
+### Task 3: `GraphSelection` type and `GitGraph.tsx` keyboard + shift-click
+
+**Files:**
+- Modify: `src/modules/git-graph/types.ts`
+- Modify: `src/modules/git-graph/GitGraph.tsx`
+- Test: `src/modules/git-graph/GitGraph.test.tsx` (full rewrite)
+
+**Interfaces:**
+- Consumes: `firstParentRowIndex`, `laneContinuationRowIndex` (Task 2), `usePendingGraphSelectionStore` (existing, `lib/pendingGraphSelectionStore.ts`).
+- Produces: `GraphSelection` type (`{ mode: "single"; commit: CommitNode } | { mode: "compare"; from: CommitNode; to: CommitNode }`, in `types.ts`, consumed by Tasks 4-5). `GitGraph`'s new prop contract: `selection: GraphSelection | null` (was `selectedCommit: CommitNode | null`), `onSelectCommit: (commit: CommitNode, options: { shiftKey: boolean }) => void` (was `(commit: CommitNode) => void`) — consumed by Task 4.
+
+**Note:** After this task, `GitGraphTabContent.tsx` (unmodified until Task 4) will fail `pnpm typecheck` because it still passes the old `selectedCommit`/`onSelectCommit` prop shape. This is expected — verify this task with `pnpm vitest run src/modules/git-graph/GitGraph.test.tsx` only.
+
+- [ ] **Step 1: Add the `GraphSelection` type**
+
+In `src/modules/git-graph/types.ts`, add this after the `CommitNode` interface (after its closing `}` at line 16, before `GraphLog` at line 19):
+
+```ts
+/**
+ * What the Git Graph commit list currently has selected: one commit, or two
+ * commits being compared. `from`/`to` are ordered older/newer by list
+ * position, not by click order.
+ */
+export type GraphSelection =
+  | { mode: "single"; commit: CommitNode }
+  | { mode: "compare"; from: CommitNode; to: CommitNode };
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Replace the entire contents of `src/modules/git-graph/GitGraph.test.tsx` with:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GitGraph } from "./GitGraph";
+import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore";
+import type { CommitNode } from "./types";
+
+const LABELS = {
+  emptyTitle: "No commits",
+  emptyHint: "",
+  loadMore: "Load more",
+  refHint: "{{name}}",
+} as never;
+
+function commit(hash: string, parents: string[], message = hash): CommitNode {
+  return { hash, parents, author: "a", date: "today", message, refs: [] };
+}
+
+function container(text: string): HTMLElement {
+  return screen.getByText(text).closest("div.flex-1.overflow-auto") as HTMLElement;
+}
+
+describe("GitGraph row click area", () => {
+  const COMMIT = commit("abc1234", [], "feat: x");
+
+  it("selects the commit when clicking the row, including the lane gutter area", () => {
+    const onSelect = vi.fn();
+    render(
+      <GitGraph commits={[COMMIT]} selection={null} onSelectCommit={onSelect} labels={LABELS} />,
+    );
+
+    const row = screen.getByText("feat: x").closest("div[class*='absolute']");
+    expect(row).not.toBeNull();
+    // The row must span from the container's left edge so clicks beside the
+    // node dot (in the lane gutter) still open the commit detail.
+    expect(row!.className).toContain("left-0");
+    fireEvent.click(row!);
+    expect(onSelect).toHaveBeenCalledWith(COMMIT, { shiftKey: false });
+  });
+
+  it("passes shiftKey through to onSelectCommit for compare mode", () => {
+    const onSelect = vi.fn();
+    render(
+      <GitGraph commits={[COMMIT]} selection={null} onSelectCommit={onSelect} labels={LABELS} />,
+    );
+
+    const row = screen.getByText("feat: x").closest("div[class*='absolute']");
+    fireEvent.click(row!, { shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith(COMMIT, { shiftKey: true });
+  });
+});
+
+describe("GitGraph keyboard navigation", () => {
+  const commits = [
+    commit("c", ["b"], "msg c"),
+    commit("b", ["a"], "msg b"),
+    commit("a", [], "msg a"),
+  ];
+
+  function renderGraph(selected: CommitNode, onSelect = vi.fn()) {
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: selected }}
+        onSelectCommit={onSelect}
+        labels={LABELS}
+      />,
+    );
+    return onSelect;
+  }
+
+  it("ArrowDown moves to the adjacent row below", () => {
+    const onSelect = renderGraph(commits[0]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown" });
+    expect(onSelect).toHaveBeenCalledWith(commits[1], { shiftKey: false });
+  });
+
+  it("ArrowUp moves to the adjacent row above", () => {
+    const onSelect = renderGraph(commits[1]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp" });
+    expect(onSelect).toHaveBeenCalledWith(commits[0], { shiftKey: false });
+  });
+
+  it("clamps at the bottom without wrapping", () => {
+    const onSelect = renderGraph(commits[2]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("clamps at the top without wrapping", () => {
+    const onSelect = renderGraph(commits[0]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Shift+ArrowDown follows the first-parent chain", () => {
+    const onSelect = renderGraph(commits[0]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown", shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith(commits[1], { shiftKey: false });
+  });
+
+  it("Shift+ArrowUp no-ops on the newest commit of a lane", () => {
+    const onSelect = renderGraph(commits[0]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp", shiftKey: true });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Shift+ArrowUp follows the lane continuation", () => {
+    const onSelect = renderGraph(commits[1]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp", shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith(commits[0], { shiftKey: false });
+  });
+
+  it("Shift+ArrowDown no-ops at a root commit", () => {
+    const onSelect = renderGraph(commits[2]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown", shiftKey: true });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Shift+ArrowDown requests pagination when the parent is not loaded", () => {
+    usePendingGraphSelectionStore.setState({ hash: null });
+    const rootless = [commit("only", ["missing-parent"], "msg only")];
+    render(
+      <GitGraph
+        commits={rootless}
+        selection={{ mode: "single", commit: rootless[0] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+    fireEvent.keyDown(container("msg only"), { key: "ArrowDown", shiftKey: true });
+    expect(usePendingGraphSelectionStore.getState().hash).toBe("missing-parent");
+  });
+});
+
+describe("GitGraph compare-mode highlighting", () => {
+  it("marks both endpoints as selected", () => {
+    const commits = [commit("c", ["b"], "msg c"), commit("b", ["a"], "msg b")];
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "compare", from: commits[1], to: commits[0] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+    const rowC = screen.getByText("msg c").closest("div[class*='absolute']");
+    const rowB = screen.getByText("msg b").closest("div[class*='absolute']");
+    expect(rowC!.className).toContain("border-border-strong");
+    expect(rowB!.className).toContain("border-border-strong");
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm vitest run src/modules/git-graph/GitGraph.test.tsx`
+Expected: FAIL — `GitGraph` doesn't accept a `selection` prop yet, and `onSelectCommit` is called with only one argument.
+
+- [ ] **Step 4: Update `GitGraph.tsx`'s imports and props**
+
+In `src/modules/git-graph/GitGraph.tsx`, change the import block (lines 1-11) from:
+
+```tsx
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, Clock, GitBranch, Tag, User } from "lucide-react";
+import { Tooltip } from "@/components/Tooltip";
+import type { CommitNode, CommitRef } from "./types";
+import {
+  computeGraphLayout,
+  DEFAULT_GEOMETRY,
+  edgePath,
+} from "./lib/graphLayout";
+import { isCurrentCommit } from "./lib/currentCommit";
+import { BRANCH_COLORS } from "./lib/branchColors";
+```
+
+to:
+
+```tsx
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, Clock, GitBranch, Tag, User } from "lucide-react";
+import { Tooltip } from "@/components/Tooltip";
+import type { CommitNode, CommitRef, GraphSelection } from "./types";
+import {
+  computeGraphLayout,
+  DEFAULT_GEOMETRY,
+  edgePath,
+  firstParentRowIndex,
+  laneContinuationRowIndex,
+} from "./lib/graphLayout";
+import { isCurrentCommit } from "./lib/currentCommit";
+import { BRANCH_COLORS } from "./lib/branchColors";
+import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore";
+```
+
+Change the props interface (lines 20-29) from:
+
+```tsx
+interface GitGraphProps {
+  commits: CommitNode[];
+  selectedCommit: CommitNode | null;
+  onSelectCommit: (commit: CommitNode) => void;
+  onCommitContextMenu?: (commit: CommitNode, x: number, y: number) => void;
+  onRefContextMenu?: (ref: CommitRef, x: number, y: number) => void;
+  hasMore?: boolean;
+  onLoadMore?: () => void;
+  labels: GitGraphLabels;
+}
+```
+
+to:
+
+```tsx
+interface GitGraphProps {
+  commits: CommitNode[];
+  selection: GraphSelection | null;
+  onSelectCommit: (commit: CommitNode, options: { shiftKey: boolean }) => void;
+  onCommitContextMenu?: (commit: CommitNode, x: number, y: number) => void;
+  onRefContextMenu?: (ref: CommitRef, x: number, y: number) => void;
+  hasMore?: boolean;
+  onLoadMore?: () => void;
+  labels: GitGraphLabels;
+}
+```
+
+Change the component's destructured parameters (lines 45-54) from:
+
+```tsx
+export function GitGraph({
+  commits,
+  selectedCommit,
+  onSelectCommit,
+  onCommitContextMenu,
+  onRefContextMenu,
+  hasMore = false,
+  onLoadMore,
+  labels,
+}: GitGraphProps) {
+```
+
+to:
+
+```tsx
+export function GitGraph({
+  commits,
+  selection,
+  onSelectCommit,
+  onCommitContextMenu,
+  onRefContextMenu,
+  hasMore = false,
+  onLoadMore,
+  labels,
+}: GitGraphProps) {
+```
+
+- [ ] **Step 5: Add the click/keyboard handlers**
+
+Still in `GitGraph.tsx`, right after `const { layouts, edges } = useMemo(() => computeGraphLayout(commits), [commits]);` (line 75), add:
+
+```tsx
+
+  const activeHash =
+    selection?.mode === "single"
+      ? selection.commit.hash
+      : selection?.mode === "compare"
+        ? selection.to.hash
+        : null;
+
+  const isSelectedHash = (hash: string) =>
+    selection?.mode === "compare"
+      ? hash === selection.from.hash || hash === selection.to.hash
+      : hash === activeHash;
+
+  function selectFromClick(commit: CommitNode, event: { shiftKey: boolean }) {
+    scrollRef.current?.focus();
+    onSelectCommit(commit, { shiftKey: event.shiftKey });
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (commits.length === 0 || !activeHash) {
+      return;
+    }
+    const currentIndex = commits.findIndex((c) => c.hash === activeHash);
+    if (currentIndex === -1) {
+      return;
+    }
+    if (event.key === "ArrowDown" && !event.shiftKey) {
+      event.preventDefault();
+      const targetIndex = Math.min(currentIndex + 1, commits.length - 1);
+      if (targetIndex !== currentIndex) {
+        onSelectCommit(commits[targetIndex], { shiftKey: false });
+      }
+    } else if (event.key === "ArrowUp" && !event.shiftKey) {
+      event.preventDefault();
+      const targetIndex = Math.max(currentIndex - 1, 0);
+      if (targetIndex !== currentIndex) {
+        onSelectCommit(commits[targetIndex], { shiftKey: false });
+      }
+    } else if (event.key === "ArrowDown" && event.shiftKey) {
+      event.preventDefault();
+      const parentHash = commits[currentIndex].parents[0];
+      if (!parentHash) {
+        return;
+      }
+      const targetIndex = firstParentRowIndex(commits, currentIndex);
+      if (targetIndex !== null) {
+        onSelectCommit(commits[targetIndex], { shiftKey: false });
+      } else {
+        usePendingGraphSelectionStore.getState().request(parentHash);
+      }
+    } else if (event.key === "ArrowUp" && event.shiftKey) {
+      event.preventDefault();
+      const targetIndex = laneContinuationRowIndex(edges, currentIndex);
+      if (targetIndex !== null) {
+        onSelectCommit(commits[targetIndex], { shiftKey: false });
+      }
+    }
+  }
+```
+
+- [ ] **Step 6: Wire the handlers into the render**
+
+Still in `GitGraph.tsx`, change the scroll container's opening tag (lines 100-107) from:
+
+```tsx
+      <div
+        ref={scrollRef}
+        className="flex-1 overflow-auto"
+        onScroll={(event) => {
+          const target = event.currentTarget;
+          setViewport({ scrollTop: target.scrollTop, height: target.clientHeight });
+        }}
+      >
+```
+
+to:
+
+```tsx
+      <div
+        ref={scrollRef}
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className="flex-1 overflow-auto outline-none"
+        onScroll={(event) => {
+          const target = event.currentTarget;
+          setViewport({ scrollTop: target.scrollTop, height: target.clientHeight });
+        }}
+      >
+```
+
+Change the SVG node button (lines 148, 154) from:
+
+```tsx
+              const isSelected = selectedCommit?.hash === commit.hash;
+```
+
+(this appears twice, once for the node at line 148 and once for the row at line 191 — replace **both** occurrences with:)
+
+```tsx
+              const isSelected = isSelectedHash(commit.hash);
+```
+
+Change the node button's `onClick` (line 154) from:
+
+```tsx
+                    onClick={() => onSelectCommit(commit)}
+```
+
+to:
+
+```tsx
+                    onClick={(e) => selectFromClick(commit, e)}
+```
+
+Change the row `<div>`'s `onClick` (line 207) from:
+
+```tsx
+                  onClick={() => onSelectCommit(commit)}
+```
+
+to:
+
+```tsx
+                  onClick={(e) => selectFromClick(commit, e)}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `pnpm vitest run src/modules/git-graph/GitGraph.test.tsx`
+Expected: PASS (all tests)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/modules/git-graph/types.ts src/modules/git-graph/GitGraph.tsx src/modules/git-graph/GitGraph.test.tsx
+git commit -m "feat: add keyboard navigation and shift-click selection to GitGraph"
+```
+
+---
+
+### Task 4: `GitGraphTabContent.tsx` — compare-mode selection state
+
+**Files:**
+- Modify: `src/modules/git-graph/GitGraphTabContent.tsx`
+
+**Interfaces:**
+- Consumes: `GraphSelection` type, `GitGraph`'s new `selection`/`onSelectCommit` contract (Task 3).
+- Produces: nothing new consumed by other tasks directly, but this task changes `CommitDetailsPanel`'s call site to pass `selection={selection}` instead of `commit={selected}` — Task 5 must land for the whole project to typecheck again (see Global Constraints note).
+
+**Note:** No dedicated test file changes are required — the existing `GitGraphTabContent.test.tsx` asserts on rendered DOM text (e.g. the commit hash appearing once details are shown), which stays identical in single-select mode. This task is verified by confirming those existing assertions still pass, plus a manual compare-mode check in Task 6's end-to-end pass (`CommitDetailsPanel` doesn't yet render compare mode until Task 5, so an automated compare-mode test belongs there).
+
+- [ ] **Step 1: Run the existing test file to confirm the starting baseline**
+
+Run: `pnpm vitest run src/modules/git-graph/GitGraphTabContent.test.tsx`
+Expected: PASS (this establishes the baseline before this task's changes — these tests must still pass after Step 2 below)
+
+- [ ] **Step 2: Replace the `selected` state with `selection`, and add `handleSelectCommit`**
+
+In `src/modules/git-graph/GitGraphTabContent.tsx`, change the type import (line 38) from:
+
+```tsx
+import type { Branch, CommitNode, CommitRef, CommitOrder, GraphOptions } from "./types";
+```
+
+to:
+
+```tsx
+import type { Branch, CommitNode, CommitRef, CommitOrder, GraphOptions, GraphSelection } from "./types";
+```
+
+Change the state declaration (line 79) from:
+
+```tsx
+  const [selected, setSelected] = useState<CommitNode | null>(null);
+```
+
+to:
+
+```tsx
+  const [selection, setSelection] = useState<GraphSelection | null>(null);
+```
+
+Add a new `handleSelectCommit` callback right after the `loadMore` callback (after its closing `}, [...]);` around line 235, before the `// Consume a pending "select this commit" request...` comment at line 237):
+
+```tsx
+
+  // Plain click/arrow-nav selects one commit. Shift+click while a commit is
+  // already selected (single or as the "to" side of an existing compare)
+  // pairs it with the new one, ordered older ("from") to newer ("to") by
+  // position in `commits` — the list is already newest-first, so no extra
+  // git call is needed to know which side is which.
+  const handleSelectCommit = useCallback(
+    (commit: CommitNode, { shiftKey }: { shiftKey: boolean }) => {
+      if (!shiftKey) {
+        setSelection({ mode: "single", commit });
+        return;
+      }
+      setSelection((prev) => {
+        const anchor =
+          prev?.mode === "single" ? prev.commit : prev?.mode === "compare" ? prev.to : null;
+        if (!anchor || anchor.hash === commit.hash) {
+          return { mode: "single", commit };
+        }
+        const anchorIndex = commits.findIndex((c) => c.hash === anchor.hash);
+        const commitIndex = commits.findIndex((c) => c.hash === commit.hash);
+        const [from, to] = anchorIndex > commitIndex ? [anchor, commit] : [commit, anchor];
+        return { mode: "compare", from, to };
+      });
+    },
+    [commits],
+  );
+```
+
+- [ ] **Step 3: Update the pending-selection effect**
+
+In the same file, find the pending-hash effect (around lines 262-270):
+
+```tsx
+    const visibleMatch = visibleCommits.find((c) => hashMatches(c.hash));
+    if (visibleMatch) {
+      setSelected(visibleMatch);
+      usePendingGraphSelectionStore.getState().consume();
+      pendingSelectionAttempts.current = 0;
+      return;
+    }
+```
+
+Change `setSelected(visibleMatch);` to:
+
+```tsx
+      setSelection({ mode: "single", commit: visibleMatch });
+```
+
+- [ ] **Step 4: Update the `GitGraph` and `CommitDetailsPanel` render**
+
+Find the render block (around lines 583-614):
+
+```tsx
+          <GitGraph
+            commits={visibleCommits}
+            selectedCommit={selected}
+            onSelectCommit={setSelected}
+            onCommitContextMenu={(commit, x, y) =>
+              setMenu({ type: "commit", commit, x, y })
+            }
+            onRefContextMenu={(ref, x, y) => setMenu({ type: "ref", ref, x, y })}
+            hasMore={hasMore}
+            onLoadMore={loadMore}
+            labels={labels}
+          />
+        </div>
+        {selected && repo && (
+          <>
+            <Resizer
+              orientation="horizontal"
+              onResize={(delta) =>
+                setDetailsHeight((h) => Math.min(700, Math.max(120, h - delta)))
+              }
+              onResizeEnd={persistDetailsHeight}
+            />
+            <div style={{ height: `${detailsHeight}px` }} className="shrink-0">
+              <CommitDetailsPanel
+                repo={repo}
+                commit={selected}
+                onClose={() => setSelected(null)}
+                labels={detailsLabels}
+              />
+            </div>
+          </>
+        )}
+```
+
+Change to:
+
+```tsx
+          <GitGraph
+            commits={visibleCommits}
+            selection={selection}
+            onSelectCommit={handleSelectCommit}
+            onCommitContextMenu={(commit, x, y) =>
+              setMenu({ type: "commit", commit, x, y })
+            }
+            onRefContextMenu={(ref, x, y) => setMenu({ type: "ref", ref, x, y })}
+            hasMore={hasMore}
+            onLoadMore={loadMore}
+            labels={labels}
+          />
+        </div>
+        {selection && repo && (
+          <>
+            <Resizer
+              orientation="horizontal"
+              onResize={(delta) =>
+                setDetailsHeight((h) => Math.min(700, Math.max(120, h - delta)))
+              }
+              onResizeEnd={persistDetailsHeight}
+            />
+            <div style={{ height: `${detailsHeight}px` }} className="shrink-0">
+              <CommitDetailsPanel
+                repo={repo}
+                selection={selection}
+                onClose={() => setSelection(null)}
+                labels={detailsLabels}
+              />
+            </div>
+          </>
+        )}
+```
+
+- [ ] **Step 5: Run the existing tests**
+
+Run: `pnpm vitest run src/modules/git-graph/GitGraphTabContent.test.tsx`
+Expected: PASS (same tests as Step 1's baseline — `selected`/`selection` is an internal rename, so the DOM output they assert on is unchanged). Note: `pnpm typecheck` will still fail at this point because `CommitDetailsPanel` hasn't been updated to accept `selection` yet — that's expected until Task 5.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/modules/git-graph/GitGraphTabContent.tsx
+git commit -m "feat: track compare-mode selection state in GitGraphTabContent"
+```
+
+---
+
+### Task 5: Bridge functions + `CommitDetailsPanel.tsx` compare mode
+
+**Files:**
+- Modify: `src/modules/git-graph/lib/gitGraphBridge.ts`
+- Modify: `src/modules/git-graph/CommitDetailsPanel.tsx`
+- Test: `src/modules/git-graph/CommitDetailsPanel.test.tsx`
+- Test: `src/modules/git-graph/GitGraphTabContent.test.tsx` (adds the end-to-end compare-mode flow; Task 4 already established the pending-selection baseline in this same file)
+
+**Interfaces:**
+- Consumes: `git_commit_range_files`/`git_commit_range_file_diff` Tauri commands (Task 1), `GraphSelection` type (Task 3), `selection` prop now passed by `GitGraphTabContent` (Task 4).
+- Produces: `gitCommitRangeFiles(repoPath, from, to): Promise<CommitFileChange[]>`, `gitCommitRangeFileDiff(repoPath, from, to, file): Promise<string>`. `CommitDetailsPanel`'s new prop contract: `selection: GraphSelection` (was `commit: CommitNode`) — this is the last piece of the shared prop-shape change, so `pnpm typecheck` becomes green again after this task.
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `src/modules/git-graph/CommitDetailsPanel.test.tsx`. Change the import and mock at the top from:
+
+```tsx
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@/i18n";
+import { CommitDetailsPanel } from "./CommitDetailsPanel";
+import { gitCommitDetails, gitCommitFileDiff } from "./lib/gitGraphBridge";
+import type { CommitNode } from "./types";
+
+vi.mock("./lib/gitGraphBridge", () => ({
+  gitCommitDetails: vi.fn(),
+  gitCommitFileDiff: vi.fn().mockResolvedValue(""),
+}));
+```
+
+to:
+
+```tsx
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@/i18n";
+import { CommitDetailsPanel } from "./CommitDetailsPanel";
+import {
+  gitCommitDetails,
+  gitCommitFileDiff,
+  gitCommitRangeFiles,
+  gitCommitRangeFileDiff,
+} from "./lib/gitGraphBridge";
+import type { CommitNode } from "./types";
+
+vi.mock("./lib/gitGraphBridge", () => ({
+  gitCommitDetails: vi.fn(),
+  gitCommitFileDiff: vi.fn().mockResolvedValue(""),
+  gitCommitRangeFiles: vi.fn(),
+  gitCommitRangeFileDiff: vi.fn().mockResolvedValue(""),
+}));
+```
+
+Change all three existing `render(<CommitDetailsPanel repo="/repo" commit={COMMIT} onClose={() => {}} labels={LABELS} />)` calls (lines 52, 67, 82) to:
+
+```tsx
+    render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "single", commit: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
+```
+
+Then append this new `describe` block at the end of the file:
+
+```tsx
+
+describe("CommitDetailsPanel compare mode", () => {
+  const OTHER: CommitNode = {
+    hash: "def5678",
+    parents: [],
+    author: "b",
+    date: "yesterday",
+    message: "fix: y",
+    refs: [],
+  };
+
+  it("shows both hashes in the header and fetches the range diff", async () => {
+    vi.mocked(gitCommitRangeFiles).mockResolvedValue([{ status: "M", path: "a.ts" }]);
+    render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "compare", from: OTHER, to: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
+
+    expect(await screen.findByText("def5678 .. abc1234")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(gitCommitRangeFileDiff).toHaveBeenCalledWith("/repo", "def5678", "abc1234", "a.ts"),
+    );
+  });
+
+  it("hides the AI tab in compare mode", async () => {
+    vi.mocked(gitCommitRangeFiles).mockResolvedValue([{ status: "M", path: "a.ts" }]);
+    render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "compare", from: OTHER, to: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
+    await screen.findByText("a.ts");
+    expect(screen.queryByRole("button", { name: "AI Explain" })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm vitest run src/modules/git-graph/CommitDetailsPanel.test.tsx`
+Expected: FAIL — `CommitDetailsPanel` doesn't accept a `selection` prop, and `gitCommitRangeFiles`/`gitCommitRangeFileDiff` aren't exported from the bridge.
+
+- [ ] **Step 3: Add the bridge functions**
+
+In `src/modules/git-graph/lib/gitGraphBridge.ts`, change the type import (line 2) from:
+
+```ts
+import type { Branch, CommitDetails, GraphLog, GraphOptions } from "../types";
+```
+
+to:
+
+```ts
+import type { Branch, CommitDetails, CommitFileChange, GraphLog, GraphOptions } from "../types";
+```
+
+Then add these two functions right after `gitCommitFileDiff` (after its closing `}` around line 122, before the `WorktreeItem` interface):
+
+```ts
+
+/** Read the file list changed between two arbitrary commits (name-status). */
+export function gitCommitRangeFiles(
+  repoPath: string,
+  from: string,
+  to: string,
+): Promise<CommitFileChange[]> {
+  return invoke<CommitFileChange[]>("git_commit_range_files", { repoPath, from, to });
+}
+
+/** Read a single file's diff between two arbitrary commits. */
+export function gitCommitRangeFileDiff(
+  repoPath: string,
+  from: string,
+  to: string,
+  file: string,
+): Promise<string> {
+  return invoke<string>("git_commit_range_file_diff", { repoPath, from, to, file });
+}
+```
+
+- [ ] **Step 4: Update `CommitDetailsPanel.tsx`'s imports and props**
+
+In `src/modules/git-graph/CommitDetailsPanel.tsx`, change the bridge import (line 9) from:
+
+```tsx
+import { gitCommitDetails, gitCommitFileDiff } from "./lib/gitGraphBridge";
+```
+
+to:
+
+```tsx
+import {
+  gitCommitDetails,
+  gitCommitFileDiff,
+  gitCommitRangeFiles,
+  gitCommitRangeFileDiff,
+} from "./lib/gitGraphBridge";
+```
+
+Change the type import (line 14) from:
+
+```tsx
+import type { CommitDetails, CommitFileChange, CommitNode, DiffLine } from "./types";
+```
+
+to:
+
+```tsx
+import type { CommitDetails, CommitFileChange, DiffLine, GraphSelection } from "./types";
+```
+
+Change the props interface (lines 38-43) from:
+
+```tsx
+interface CommitDetailsPanelProps {
+  repo: string;
+  commit: CommitNode;
+  onClose: () => void;
+  labels: CommitDetailsLabels;
+}
+```
+
+to:
+
+```tsx
+interface CommitDetailsPanelProps {
+  repo: string;
+  selection: GraphSelection;
+  onClose: () => void;
+  labels: CommitDetailsLabels;
+}
+```
+
+- [ ] **Step 5: Update the component body**
+
+Change the component signature (line 152) from:
+
+```tsx
+export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDetailsPanelProps) {
+```
+
+to:
+
+```tsx
+export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitDetailsPanelProps) {
+```
+
+Right after the destructured props (before `const [details, setDetails] = useState...` at line 153), add:
+
+```tsx
+  const isCompare = selection.mode === "compare";
+  // Non-null only in single mode; used for the author/date/message block and
+  // the AI-explain tab, both of which only make sense for one commit. Safe to
+  // assert `!` where used below because both are unreachable while isCompare
+  // is true (the AI tab button that would flip `tab` to "ai" isn't rendered).
+  const singleCommit = selection.mode === "single" ? selection.commit : null;
+  const rangeKey =
+    selection.mode === "single" ? selection.commit.hash : `${selection.from.hash}..${selection.to.hash}`;
+  const headerHash =
+    selection.mode === "single" ? selection.commit.hash : `${selection.from.hash} .. ${selection.to.hash}`;
+```
+
+Change the data-fetch effect (lines 185-208) from:
+
+```tsx
+  // Load message + changed files when the commit changes; auto-open first file.
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    setDetails(null);
+    setSelectedFile(null);
+    setDiffLines([]);
+    resetCollapsedFolders();
+    gitCommitDetails(repo, commit.hash)
+      .then((d) => {
+        if (cancelled) {
+          return;
+        }
+        setDetails(d);
+        setSelectedFile(d.files[0]?.path ?? null);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setError(getErrorMessage(e));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, commit.hash, resetCollapsedFolders]);
+```
+
+to:
+
+```tsx
+  // Load message + changed files when the selection changes; auto-open first
+  // file. Compare mode has no single message, so `details.message` stays "".
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    setDetails(null);
+    setSelectedFile(null);
+    setDiffLines([]);
+    resetCollapsedFolders();
+    const request =
+      selection.mode === "single"
+        ? gitCommitDetails(repo, selection.commit.hash)
+        : gitCommitRangeFiles(repo, selection.from.hash, selection.to.hash).then((files) => ({
+            message: "",
+            files,
+          }));
+    request
+      .then((d) => {
+        if (cancelled) {
+          return;
+        }
+        setDetails(d);
+        setSelectedFile(d.files[0]?.path ?? null);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setError(getErrorMessage(e));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, selection, resetCollapsedFolders]);
+```
+
+Change the diff-fetch effect (lines 212-236) from:
+
+```tsx
+  // Lazily load the selected file's diff (both parsed lines and raw text), and
+  // reset to the Diff tab when the file changes.
+  useEffect(() => {
+    setTab("diff");
+    if (!selectedFile) {
+      setDiffLines([]);
+      setDiffText("");
+      return;
+    }
+    let cancelled = false;
+    gitCommitFileDiff(repo, commit.hash, selectedFile)
+      .then((diff) => {
+        if (!cancelled) {
+          setDiffText(diff);
+          setDiffLines(parseDiffLines(diff));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDiffText("");
+          setDiffLines([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, commit.hash, selectedFile]);
+```
+
+to:
+
+```tsx
+  // Lazily load the selected file's diff (both parsed lines and raw text), and
+  // reset to the Diff tab when the file changes.
+  useEffect(() => {
+    setTab("diff");
+    if (!selectedFile) {
+      setDiffLines([]);
+      setDiffText("");
+      return;
+    }
+    let cancelled = false;
+    const request =
+      selection.mode === "single"
+        ? gitCommitFileDiff(repo, selection.commit.hash, selectedFile)
+        : gitCommitRangeFileDiff(repo, selection.from.hash, selection.to.hash, selectedFile);
+    request
+      .then((diff) => {
+        if (!cancelled) {
+          setDiffText(diff);
+          setDiffLines(parseDiffLines(diff));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDiffText("");
+          setDiffLines([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, selection, selectedFile]);
+```
+
+Change the `useVirtualRows` call (lines 244-250) from:
+
+```tsx
+  const filesWindow = useVirtualRows(
+    files.length,
+    FILE_ROW_HEIGHT,
+    FILE_OVERSCAN,
+    commit.hash,
+    { listRef: fileListRef },
+  );
+```
+
+to:
+
+```tsx
+  const filesWindow = useVirtualRows(
+    files.length,
+    FILE_ROW_HEIGHT,
+    FILE_OVERSCAN,
+    rangeKey,
+    { listRef: fileListRef },
+  );
+```
+
+Change the header (lines 256-258) from:
+
+```tsx
+        <span className="select-all font-mono text-xs font-semibold text-accent">
+          {commit.hash}
+        </span>
+```
+
+to:
+
+```tsx
+        <span className="select-all font-mono text-xs font-semibold text-accent">
+          {headerHash}
+        </span>
+```
+
+Change the metadata block (lines 281-293) from:
+
+```tsx
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 font-mono text-[13px] text-fg-subtle">
+            <span>
+              {labels.author}: {commit.author}
+            </span>
+            <span>
+              {labels.date}: {commit.date}
+            </span>
+          </div>
+          {details && (
+            <pre className="mt-2 whitespace-pre-wrap font-sans text-[13px] text-fg">
+              {details.message}
+            </pre>
+          )}
+```
+
+to:
+
+```tsx
+          {singleCommit && (
+            <>
+              <div className="flex flex-wrap gap-x-4 gap-y-0.5 font-mono text-[13px] text-fg-subtle">
+                <span>
+                  {labels.author}: {singleCommit.author}
+                </span>
+                <span>
+                  {labels.date}: {singleCommit.date}
+                </span>
+              </div>
+              {details && (
+                <pre className="mt-2 whitespace-pre-wrap font-sans text-[13px] text-fg">
+                  {details.message}
+                </pre>
+              )}
+            </>
+          )}
+```
+
+Change the AI tab button (lines 379-389) from:
+
+```tsx
+                <button
+                  type="button"
+                  onClick={() => setTab("ai")}
+                  className={`rounded px-2 py-0.5 text-[13px] ${
+                    tab === "ai"
+                      ? "bg-bg-elevated text-fg"
+                      : "text-fg-subtle hover:text-fg"
+                  }`}
+                >
+                  {labels.aiTab}
+                </button>
+```
+
+to:
+
+```tsx
+                {!isCompare && (
+                  <button
+                    type="button"
+                    onClick={() => setTab("ai")}
+                    className={`rounded px-2 py-0.5 text-[13px] ${
+                      tab === "ai"
+                        ? "bg-bg-elevated text-fg"
+                        : "text-fg-subtle hover:text-fg"
+                    }`}
+                  >
+                    {labels.aiTab}
+                  </button>
+                )}
+```
+
+Change the `DiffExplain` usage (around line 395-410) from:
+
+```tsx
+                  <DiffExplain
+                    key={`${commit.hash}|${selectedFile}`}
+                    commitHash={commit.hash}
+                    file={selectedFile}
+```
+
+to:
+
+```tsx
+                  <DiffExplain
+                    key={`${singleCommit!.hash}|${selectedFile}`}
+                    commitHash={singleCommit!.hash}
+                    file={selectedFile}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pnpm vitest run src/modules/git-graph/CommitDetailsPanel.test.tsx`
+Expected: PASS (all tests, including the three pre-existing ones updated in Step 1)
+
+- [ ] **Step 7: Add an end-to-end compare-mode test through `GitGraphTabContent`**
+
+This is the first point where the full click → shift-click → compare UI → plain-click-collapses flow can be exercised through real components (Task 4 added the state logic, but `CommitDetailsPanel` couldn't render compare mode until this task). Open `src/modules/git-graph/GitGraphTabContent.test.tsx` and update the bridge mock (lines 13-20) from:
+
+```tsx
+vi.mock("./lib/gitGraphBridge", () => ({
+  gitGraphLog: vi.fn(),
+  gitBranches: vi.fn().mockResolvedValue([]),
+  gitFetch: vi.fn(),
+  gitCommitDetails: vi.fn().mockResolvedValue({ message: "", files: [] }),
+  gitCommitFileDiff: vi.fn().mockResolvedValue(""),
+  gitWorktreeList: vi.fn().mockResolvedValue([]),
+}));
+
+import { gitGraphLog, gitWorktreeList } from "./lib/gitGraphBridge";
+```
+
+to:
+
+```tsx
+vi.mock("./lib/gitGraphBridge", () => ({
+  gitGraphLog: vi.fn(),
+  gitBranches: vi.fn().mockResolvedValue([]),
+  gitFetch: vi.fn(),
+  gitCommitDetails: vi.fn().mockResolvedValue({ message: "", files: [] }),
+  gitCommitFileDiff: vi.fn().mockResolvedValue(""),
+  gitCommitRangeFiles: vi.fn().mockResolvedValue([]),
+  gitCommitRangeFileDiff: vi.fn().mockResolvedValue(""),
+  gitWorktreeList: vi.fn().mockResolvedValue([]),
+}));
+
+import { gitGraphLog, gitWorktreeList } from "./lib/gitGraphBridge";
+```
+
+Then append this new `describe` block at the end of the file:
+
+```tsx
+
+describe("GitGraphTabContent compare mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(gitWorktreeList).mockResolvedValue([]);
+    usePendingGraphSelectionStore.setState({ hash: null });
+    useWorkspaceStore.getState().setRoot("/repo");
+  });
+
+  it("shift-clicking a second commit shows the compare header, and a plain click collapses back", async () => {
+    vi.mocked(gitGraphLog).mockImplementation(async () =>
+      commitList(["aaa1111", "bbb2222"], false),
+    );
+
+    render(<GitGraphTabContent />);
+    await waitFor(() => screen.getByText("msg aaa1111"));
+
+    const rowA = screen.getByText("msg aaa1111").closest("div[class*='absolute']")!;
+    const rowB = screen.getByText("msg bbb2222").closest("div[class*='absolute']")!;
+
+    fireEvent.click(rowA);
+    fireEvent.click(rowB, { shiftKey: true });
+
+    // aaa1111 is the newer commit (index 0), bbb2222 the older one (index 1):
+    // from (older) .. to (newer).
+    await waitFor(() => expect(screen.getByText("bbb2222 .. aaa1111")).toBeInTheDocument());
+
+    fireEvent.click(rowA);
+
+    await waitFor(() => expect(screen.getAllByText("aaa1111").length).toBeGreaterThan(0));
+    expect(screen.queryByText("bbb2222 .. aaa1111")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `pnpm vitest run src/modules/git-graph/GitGraphTabContent.test.tsx`
+Expected: PASS (all tests, including the new compare-mode test and every pre-existing pending-selection test from Task 4's baseline)
+
+- [ ] **Step 9: Run the full frontend test suite and typecheck**
+
+Run: `pnpm vitest run`
+Expected: PASS (every test file)
+
+Run: `pnpm typecheck`
+Expected: PASS — this is the first point since Task 3 where the whole project type-checks cleanly again.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/modules/git-graph/lib/gitGraphBridge.ts src/modules/git-graph/CommitDetailsPanel.tsx src/modules/git-graph/CommitDetailsPanel.test.tsx src/modules/git-graph/GitGraphTabContent.test.tsx
+git commit -m "feat: add two-commit compare mode to CommitDetailsPanel"
+```
+
+---
+
+### Task 6: Final verification
+
+**Files:** none (verification only; fix forward in the relevant file from Tasks 1-5 if something surfaces here)
+
+- [ ] **Step 1: Run the full frontend suite**
+
+Run: `pnpm vitest run`
+Expected: PASS, 0 failures
+
+- [ ] **Step 2: Run the full frontend typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS, 0 errors
+
+- [ ] **Step 3: Run the full Rust test suite**
+
+Run: `cd src-tauri && cargo test`
+Expected: PASS, 0 failures
+
+- [ ] **Step 4: Build and manually verify in the running app**
+
+Build a local test copy per this project's documented local-build command:
+
+```bash
+export TAURI_SIGNING_PRIVATE_KEY="$(cat ~/.tauri/tempo-term.key)" TAURI_SIGNING_PRIVATE_KEY_PASSWORD="" \
+  && pnpm tauri build
+```
+
+Open the built app (`src-tauri/target/release/bundle/macos/TempoTerm.app`) against a real git repo with at least one merge commit in its history (this repo itself works), open the Git Graph tab, and manually verify:
+
+1. Click a commit row — it gets selected and the details panel opens.
+2. Press `ArrowDown` / `ArrowUp` repeatedly — selection moves one row at a time, stops (doesn't wrap) at the top and bottom of the loaded list.
+3. Select a merge commit, press `Shift+ArrowDown` — selection jumps to the merge's first parent (the mainline side), not the merged-in branch.
+4. From that first-parent commit, press `Shift+ArrowUp` — selection jumps back to the merge commit.
+5. Select a commit's feature-branch history, press `Shift+ArrowDown` repeatedly toward the bottom of the loaded list — more history pages in automatically and selection keeps moving (no dead stop mid-branch).
+6. Click one commit, then Shift+click a different one — the details panel switches to showing `hash1 .. hash2` with a combined changed-files list and diff, and the "AI Explain" tab is gone.
+7. Click any commit without Shift — compare mode ends, back to single-commit details.
+8. While in compare mode, press a plain arrow key — compare mode ends and selection moves normally from where the arrow key would put it.
+
+- [ ] **Step 5: Report results**
+
+If all manual checks in Step 4 pass, the feature is complete — no further commit needed for this task (it's verification-only). If any check fails, identify which of Tasks 1-5 owns the affected file, fix it there with its own updated test, and re-run Steps 1-4 of this task.

--- a/docs/superpowers/specs/2026-07-04-git-graph-keyboard-nav-design.md
+++ b/docs/superpowers/specs/2026-07-04-git-graph-keyboard-nav-design.md
@@ -1,0 +1,129 @@
+# Git Graph: Keyboard Commit Navigation + Two-Commit Compare Design (issue #100)
+
+Status: approved in conversation on 2026-07-04 (owner: mukiwu)
+Scope source: issue #100, all three items in one PR. Related but out of scope: #94 (closed, background context only).
+
+## Goal
+
+Add keyboard navigation to the Git Graph commit list — plain Up/Down between adjacent rows, and Shift+Up/Down that follows the commit's branch line (first-parent chain) instead of the raw row order — plus Shift+click to diff two arbitrary commits against each other.
+
+## Decisions already made by the owner
+
+- **One PR, not phased.** The three items are tightly related (all live in the same keyboard-interaction surface); splitting would leave intermediate states nobody wants shipped alone.
+- **Shift+Up/Down semantics = first-parent chain**, confirmed against a diagram of a merge (main branch M merging in a feature branch via D→C→B): Shift+Down from a merge commit always goes to `parents[0]` (main line), never a branch-picker. Shift+Up from a commit finds the one child that continues its exact lane (the straight line in the graph), not a child that merged it in as a side branch. Verified against `computeGraphLayout`'s lane-assignment invariant (below) — this is exact, not a heuristic, in every case except an extremely rare simultaneous-fork tie-break that we're not special-casing.
+- **No wraparound at list boundaries** for plain Up/Down (commit history is chronological, not a short filtered list like `FileFinder`'s Cmd+P palette — cycling top-to-bottom isn't intuitive here).
+- **Keyboard nav activates per-row on click**, roving-tabindex style like `LauncherPanel`, independent of the toolbar search input's own focus.
+- **Compare mode reuses `CommitDetailsPanel`** (header shows two hashes instead of one) rather than a new tab/panel.
+- **Exiting compare mode is implicit**: click any commit without Shift → back to single-select. No dedicated "leave compare" control.
+- **Any arrow key press while in compare mode exits it** and falls back to single-select navigation, to avoid designing arrow-key semantics on top of a two-commit state.
+- **AI "explain this diff" tab is hidden in compare mode** — out of scope, avoids complicating the per-commit AI explain flow.
+
+## Current state (verified in code)
+
+- `GitGraphTabContent.tsx:68` (`GitGraphTabContent`) owns `selected: CommitNode | null` (line 79, plain `useState`, no store) and passes `selectedCommit`/`onSelectCommit` to `GitGraph` (lines 585-586); the details panel mounts at lines 596-614 when `selected && repo`.
+- `GitGraph.tsx:45` (`GitGraph`) renders SVG lane lines plus one `<div>` row per commit; both the SVG node button (line 154) and the row `<div>`'s `onClick` (line 207) call `onSelectCommit(commit)` — the whole row is already clickable (from #94 item 1). No `onKeyDown`, `tabIndex`, or focus handling exists anywhere in this module today.
+- `graphLayout.ts:75` (`computeGraphLayout`) assigns each commit a `lane` (`CommitLayout.lane`, line 34) by an invariant that matters directly for Shift+Up/Down: when a commit is processed, `activeLanes[lane] = commit.parents[0]` (line 116) — **the commit's own lane is always inherited by its first parent**. Extra (merge-in) parents claim a fresh lane (line 117-119, `claimLane()`). `edges` (line 146-174) records every parent link with `cx`/`px` (child/parent x-coordinates); an edge is visually straight iff `cx === px`, which holds exactly when `child.lane === parent.lane` — i.e., exactly the first-parent, same-lane relationship. This means: (a) "Shift+Down" = look up `parents[0]` directly; (b) "Shift+Up" = find the one edge with `parentIndex === current index && cx === px`, take its `childIndex`. No such lookup exists yet — it needs two new pure functions.
+- `GitGraphTabContent.tsx:243-297` already implements "keep paging until a target hash appears, then select it": `usePendingGraphSelectionStore` (`lib/pendingGraphSelectionStore.ts`, whole file) carries a hash from elsewhere in the app (sidebar history) into this effect, which retries `loadMore()` (defined at line 228) up to 5 times as `commits` grows, then calls `setSelected` once the hash is found. **This is directly reusable** for Shift+Up/Down's pagination-boundary case (owner decision: auto-load-more) — no new paging logic needed, just `usePendingGraphSelectionStore.getState().request(targetHash)` from the keyboard handler when the target isn't in the currently loaded `commits`.
+- `types.ts:9-16` `CommitNode { hash, parents, author, date, message, refs }`; `types.ts:48-51` `CommitFileChange { status, path }`; `types.ts:54-57` `CommitDetails { message, files: CommitFileChange[] }` — the compare-mode file list reuses `CommitFileChange`, not a new type.
+- `CommitDetailsPanel.tsx:152` (`CommitDetailsPanel`) fetches `gitCommitDetails`/`gitCommitFileDiff` keyed on `commit.hash` (effects at lines 185-236), renders a resizable two-column layout: left = metadata + changed-files list (flat/tree toggle, `filesViewMode` line 159), right = Diff/AI tabs (`DiffView` / `DiffExplain`). This entire right column and the flat/tree file list are reusable as-is for compare mode; only the data-fetching effect and the header (lines 255-269, currently `commit.hash` + close button) change.
+- Backend `commit_file_diff` (`src-tauri/src/modules/git/mod.rs:1010-1022`) runs `git diff <commit>^1 <commit> -- <file>`; `commit_details` (lines 979-1008) runs `git diff --name-status <commit>^1 <commit>` for the file list. Both are hardcoded to "commit vs. its first parent" — no existing backend command diffs two arbitrary commits. The generalization is mechanical: replace `<commit>^1 <commit>` with `<from> <to>`.
+- Keyboard-handling pattern to mirror: `FileFinder.tsx:126-143` (`handleKeyDown`) — `ArrowUp`/`ArrowDown` adjust an index, `e.preventDefault()`, guards IME composition; active row auto-scrolls via a ref + effect (`FileFinder.tsx:104-114`, `scrollIntoView({ block: "nearest" })`). Focus pattern to mirror: `LauncherPanel.tsx:280-284` (`<div ref={rootRef} tabIndex={-1} onKeyDown={onKeyDown}>`) plus an effect (lines 255-259) calling `rootRef.current?.focus()`.
+- Rust test convention: `src-tauri/src/modules/git/mod.rs:1163` `mod tests`, e.g. `worktree_info_reports_branch_for_a_plain_repo` (line 1167) — builds a real temp git repo via `temp_repo_dir(name)` + `run_git(path, &[...])`, asserts, then `std::fs::remove_dir_all`. New backend tests follow this exactly.
+
+## Components
+
+### 1. `graphLayout.ts`: two new pure helpers
+
+```ts
+/** Row index of `commits[index]`'s first parent, or null if it has none or
+ *  isn't in the currently loaded `commits` (caller pages in more history). */
+export function firstParentRowIndex(
+  commits: readonly GraphLayoutCommit[],
+  index: number,
+): number | null;
+
+/** Row index of the one commit that continues `commits[index]`'s exact lane
+ *  going up (newer) — the straight-line child, not a merge-in child. Null if
+ *  `commits[index]` is the newest commit on its lane. */
+export function laneContinuationRowIndex(
+  edges: readonly GraphEdge[],
+  index: number,
+): number | null;
+```
+
+`firstParentRowIndex` reads `commits[index].parents[0]` and finds its row by hash (reuse `resolveParent`'s prefix-matching rule since short/long hash mixes are already a real case in this codebase). `laneContinuationRowIndex` scans `layout.edges` for the one entry with `parentIndex === index && cx === px`.
+
+Unit tests in `graphLayout.test.ts` alongside the existing lane-assignment tests: a straight chain, a merge (Shift+Down from the merge commit lands on the first parent, not the merged-in one), and a branch tip (Shift+Up from the newest commit on a lane returns null).
+
+### 2. `GitGraph.tsx`: keyboard handling
+
+- The row list's scroll container (`scrollRef`, line 100) gains `tabIndex={-1}` and `onKeyDown`.
+- `onSelectCommit` already exists as the single source of truth for "commit becomes selected" (used by both click handlers today); the keyboard handler computes a target row and calls the same callback plus `.focus()`s the container on click so keyboard nav "activates" per the owner's decision.
+- Plain `ArrowUp`/`ArrowDown`: move to the adjacent row in `commits` (index ± 1), clamped at the array bounds (no wraparound).
+- `Shift+ArrowDown`: `firstParentRowIndex(commits, selectedIndex)`. If it resolves inside the loaded `commits`, select that row directly. If it's null because the parent isn't loaded yet, call `usePendingGraphSelectionStore.getState().request(parentHash)` — the existing effect in `GitGraphTabContent` (lines 243-297) takes it from there (pages in more history, selects once found). If the commit has no parent at all (root commit), no-op.
+- `Shift+ArrowUp`: `laneContinuationRowIndex(edges, selectedIndex)` (the `edges` already destructured from `computeGraphLayout(commits)` at `GitGraph.tsx:75`). Null means this is the newest commit on its lane — no-op (this direction never needs pagination since "newer" is always already loaded).
+- All four handlers call `e.preventDefault()` and scroll the resulting row into view (reuse the `scrollIntoView({ block: "nearest" })` pattern from `FileFinder.tsx`).
+- Any of the four handlers, when a compare-mode selection is active (see below), first collapses back to single-select on the row the navigation lands on.
+
+### 3. `GitGraphTabContent.tsx`: compare-mode state
+
+- Selection state becomes a small discriminated union instead of the plain `CommitNode | null`:
+  ```ts
+  type GraphSelection =
+    | { mode: "single"; commit: CommitNode }
+    | { mode: "compare"; from: CommitNode; to: CommitNode }
+    | null;
+  ```
+  (`from` is always the chronologically older of the two, `to` the newer — decided by comparing their indices in `commits`, since the list is already ordered newest-first; no extra git call needed.)
+- `GitGraph`'s row click handler: plain click → `{ mode: "single", commit }`. Shift+click while a selection already exists → `{ mode: "compare", from, to }` using the existing selected commit as the other endpoint. Shift+click with nothing currently selected behaves like a plain click (standard shift-click convention — you need an anchor first).
+- The details panel branches on `selection.mode`: `mode: "single"` renders `CommitDetailsPanel` unchanged; `mode: "compare"` renders it in the new compare mode (next section).
+
+### 4. `CommitDetailsPanel.tsx`: compare mode
+
+- Props grow to accept either a single `commit` or a `{ from, to }` pair (a union prop, mirroring the store's `GraphSelection`) so this stays one component rather than a fork.
+- Header (currently just `commit.hash` + close, lines 255-269): compare mode shows `{from.hash} .. {to.hash}`.
+- The data-fetch effect (lines 185-208, currently `gitCommitDetails(repo, commit.hash)`) branches: single mode unchanged; compare mode calls the new `gitCommitRangeFiles(repo, from.hash, to.hash)` for the file list, and skips the message paragraph (a range has no single commit message — the metadata row above the file list is simply omitted in compare mode).
+- The per-file diff effect (lines 212-236, currently `gitCommitFileDiff`) branches to `gitCommitRangeFileDiff(repo, from.hash, to.hash, selectedFile)` in compare mode. `DiffView` and the flat/tree file list are unchanged — both already operate on `CommitFileChange[]` / `DiffLine[]`, agnostic to how the diff was produced.
+- The AI tab button (lines 379-389) is not rendered in compare mode (owner decision).
+
+### 5. Backend: two new commands mirroring the existing per-commit ones
+
+In `src-tauri/src/modules/git/mod.rs`, next to `commit_details`/`commit_file_diff`:
+
+```rust
+pub fn commit_range_files(repo_path: &str, from: &str, to: &str) -> Result<Vec<ChangedFile>, String>;
+// `git diff --name-status <from> <to>` — same parsing as commit_details's file-list half.
+// command wrapper: git_commit_range_files(repo_path, from, to)
+
+pub fn commit_range_file_diff(repo_path: &str, from: &str, to: &str, file: &str) -> Result<String, String>;
+// `git diff <from> <to> -- <file>` — same shape as commit_file_diff, no ^1 / root-commit fallback needed
+// since both endpoints are always real, already-loaded commits.
+// command wrapper: git_commit_range_file_diff(repo_path, from, to, file)
+```
+
+`ChangedFile` reuses whatever struct `commit_details` already serializes to the frontend's `CommitFileChange` (same `{status, path}` shape) — no new backend type.
+
+### 6. Frontend bridge
+
+`lib/gitGraphBridge.ts` gets `gitCommitRangeFiles(repo, from, to)` and `gitCommitRangeFileDiff(repo, from, to, file)`, following the exact `invoke(...)` wrapper shape already used by `gitCommitDetails`/`gitCommitFileDiff` (lines 116-122 for the latter).
+
+## Error handling
+
+- `firstParentRowIndex`/`laneContinuationRowIndex` return `null` for "nothing to move to" — callers no-op rather than throwing; this covers root commits, lane tips, and (rare) unresolvable hashes the same way.
+- Shift+Down pagination retry reuses `usePendingGraphSelectionStore`'s existing 5-attempt budget (`GitGraphTabContent.tsx:283`) and silent give-up — if the parent truly can't be found (shallow clone, corrupted history), navigation just stays put after 5 failed page-ins, same as the existing "jump from sidebar" feature degrades today.
+- `git_commit_range_files`/`git_commit_range_file_diff` failures (e.g. one hash no longer resolves) surface through the same `error` state and `role="alert"` banner `CommitDetailsPanel` already renders (line 271) for the single-commit path.
+
+## Testing
+
+- `graphLayout.test.ts`: unit tests for `firstParentRowIndex` and `laneContinuationRowIndex` — straight chain, merge commit, branch tip, and a not-yet-loaded parent (hash absent from the array).
+- `GitGraph.test.tsx`: `fireEvent.keyDown(container, { key: "ArrowDown" })` / `"ArrowUp"` move selection between adjacent rows and clamp at the ends (pattern from `FileFinder.test.tsx`); `fireEvent.keyDown(container, { key: "ArrowDown", shiftKey: true })` selects the first-parent row directly when loaded, and calls `usePendingGraphSelectionStore.getState().request` when not; `fireEvent.click(row, { shiftKey: true })` after an initial plain click produces a compare selection; a bare click afterward collapses back to single-select.
+- `CommitDetailsPanel.test.tsx`: compare-mode props render the two-hash header, call `gitCommitRangeFiles`/`gitCommitRangeFileDiff` instead of the single-commit bridge functions, and hide the AI tab.
+- Rust `mod.rs` tests: `commit_range_files` and `commit_range_file_diff` against a temp repo with at least two branches and a merge (reuse the `temp_repo_dir` + `run_git` helpers already used by the worktree tests at line 1167 onward) — verifying `git diff --name-status`/`git diff -- file` between two arbitrary hashes, not just parent-child pairs.
+
+## Out of scope (explicitly)
+
+- Any "pick which branch to follow" UI at a merge/fork commit — Shift+Down is always first-parent, unconditionally.
+- Wraparound navigation.
+- A dedicated "exit compare mode" button.
+- AI diff explanation for a two-commit compare.
+- Handling the rare simultaneous-fork tie-break case in `laneContinuationRowIndex` where two children could both claim the same parent's lane — accepted as a known, exceedingly unlikely edge case per the approved design.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,11 +21,11 @@ use modules::clipboard::{
 };
 use modules::git::{
     git_branch_checkout, git_branch_checkout_track, git_branch_create_at, git_branch_delete,
-    git_branches, git_cherry_pick, git_commit, git_commit_details, git_commit_file_diff, git_diff,
-    git_fetch, git_file_at_rev, git_graph_log, git_log, git_merge, git_pull, git_push,
-    git_push_delete, git_rebase, git_reset, git_resolve_repo, git_restore_file, git_revert,
-    git_stage, git_status, git_tag_create, git_tag_delete, git_unstage, git_worktree_info,
-    git_worktree_list,
+    git_branches, git_cherry_pick, git_commit, git_commit_details, git_commit_file_diff,
+    git_commit_range_file_diff, git_commit_range_files, git_diff, git_fetch, git_file_at_rev,
+    git_graph_log, git_log, git_merge, git_pull, git_push, git_push_delete, git_rebase, git_reset,
+    git_resolve_repo, git_restore_file, git_revert, git_stage, git_status, git_tag_create,
+    git_tag_delete, git_unstage, git_worktree_info, git_worktree_list,
 };
 use modules::pr::{gh_available, pr_via_api, pr_via_gh};
 use modules::preview::{
@@ -195,6 +195,8 @@ pub fn run() {
             git_push_delete,
             git_commit_details,
             git_commit_file_diff,
+            git_commit_range_files,
+            git_commit_range_file_diff,
             secrets_set_key,
             secrets_delete_key,
             secrets_has_key,

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -1021,6 +1021,47 @@ pub fn commit_file_diff(repo_path: &str, commit: &str, file: &str) -> Result<Str
     Ok(diff)
 }
 
+/// 兩個任意 commit 之間變更的檔案清單(`git diff --name-status from to`)。
+/// 不像 commit_details 限定「對第一個 parent」，from/to 可以是歷史上任意兩點。
+pub fn commit_range_files(
+    repo_path: &str,
+    from: &str,
+    to: &str,
+) -> Result<Vec<CommitFileChange>, String> {
+    let from = from.trim();
+    let to = to.trim();
+    if from.is_empty() || to.is_empty() {
+        return Err("commit hash is required".to_string());
+    }
+    ensure_not_flag(from)?;
+    ensure_not_flag(to)?;
+
+    let name_status = run_git(repo_path, &["diff", "--name-status", from, to])?;
+    let files = name_status
+        .lines()
+        .filter_map(parse_name_status_line)
+        .collect();
+    Ok(files)
+}
+
+/// 兩個任意 commit 之間、單一檔案的 diff(`git diff from to -- file`)。
+pub fn commit_range_file_diff(
+    repo_path: &str,
+    from: &str,
+    to: &str,
+    file: &str,
+) -> Result<String, String> {
+    let from = from.trim();
+    let to = to.trim();
+    if from.is_empty() || to.is_empty() {
+        return Err("commit hash is required".to_string());
+    }
+    ensure_not_flag(from)?;
+    ensure_not_flag(to)?;
+
+    run_git(repo_path, &["diff", from, to, "--", file])
+}
+
 #[tauri::command]
 pub fn git_log(repo_path: String, limit: Option<usize>) -> Result<Vec<CommitInfo>, String> {
     log(&repo_path, limit.unwrap_or(50))
@@ -1157,6 +1198,25 @@ pub fn git_commit_file_diff(
     file: String,
 ) -> Result<String, String> {
     commit_file_diff(&repo_path, &commit, &file)
+}
+
+#[tauri::command]
+pub fn git_commit_range_files(
+    repo_path: String,
+    from: String,
+    to: String,
+) -> Result<Vec<CommitFileChange>, String> {
+    commit_range_files(&repo_path, &from, &to)
+}
+
+#[tauri::command]
+pub fn git_commit_range_file_diff(
+    repo_path: String,
+    from: String,
+    to: String,
+    file: String,
+) -> Result<String, String> {
+    commit_range_file_diff(&repo_path, &from, &to, &file)
 }
 
 #[cfg(test)]
@@ -1521,6 +1581,45 @@ mod tests {
         assert!(ensure_not_flag("a1b2c3d").is_ok());
         assert!(ensure_not_flag("-x").is_err());
         assert!(ensure_not_flag("--upload-pack=evil").is_err());
+
+        assert!(commit_range_files("/no/such/repo", "-x", "HEAD").is_err());
+        assert!(commit_range_file_diff("/no/such/repo", "HEAD", "-x", "a.txt").is_err());
+    }
+
+    #[test]
+    fn commit_range_files_and_diff_between_arbitrary_commits() {
+        let dir = temp_repo_dir("range-diff");
+        let path = dir.to_string_lossy().to_string();
+        run_git(&path, &["init", "-b", "main"]).unwrap();
+        run_git(&path, &["config", "user.email", "t@t.dev"]).unwrap();
+        run_git(&path, &["config", "user.name", "Tester"]).unwrap();
+
+        std::fs::write(dir.join("a.txt"), "line1\n").unwrap();
+        run_git(&path, &["add", "a.txt"]).unwrap();
+        run_git(&path, &["commit", "-m", "first"]).unwrap();
+        let first = run_git(&path, &["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+        std::fs::write(dir.join("a.txt"), "line1\nline2\n").unwrap();
+        run_git(&path, &["commit", "-am", "second"]).unwrap();
+
+        std::fs::write(dir.join("b.txt"), "new file\n").unwrap();
+        run_git(&path, &["add", "b.txt"]).unwrap();
+        run_git(&path, &["commit", "-am", "third"]).unwrap();
+        let third = run_git(&path, &["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+        // first..third skips the middle commit entirely — proves this isn't
+        // limited to adjacent parent-child pairs like commit_details is.
+        let files = commit_range_files(&path, &first, &third).unwrap();
+        let mut paths: Vec<_> = files.iter().map(|f| f.path.as_str()).collect();
+        paths.sort();
+        assert_eq!(paths, vec!["a.txt", "b.txt"]);
+        assert!(files.iter().any(|f| f.path == "a.txt" && f.status == "M"));
+        assert!(files.iter().any(|f| f.path == "b.txt" && f.status == "A"));
+
+        let diff = commit_range_file_diff(&path, &first, &third, "a.txt").unwrap();
+        assert!(diff.contains("+line2"));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -1582,8 +1582,10 @@ mod tests {
         assert!(ensure_not_flag("-x").is_err());
         assert!(ensure_not_flag("--upload-pack=evil").is_err());
 
-        assert!(commit_range_files("/no/such/repo", "-x", "HEAD").is_err());
-        assert!(commit_range_file_diff("/no/such/repo", "HEAD", "-x", "a.txt").is_err());
+        let err = commit_range_files("/no/such/repo", "-x", "HEAD").unwrap_err();
+        assert!(err.to_lowercase().contains("flag"), "got: {err}");
+        let err = commit_range_file_diff("/no/such/repo", "HEAD", "-x", "a.txt").unwrap_err();
+        assert!(err.to_lowercase().contains("flag"), "got: {err}");
     }
 
     #[test]

--- a/src/i18n/locales/en/gitGraph.json
+++ b/src/i18n/locales/en/gitGraph.json
@@ -37,6 +37,7 @@
     "noDiff": "No diff to display",
     "noFileSelected": "Select a file to see its diff",
     "close": "Close",
+    "compareBadge": "Comparing",
     "diffTab": "Diff",
     "aiTab": "AI Explain",
     "aiGenerate": "Explain this diff",

--- a/src/i18n/locales/zh-Hant/gitGraph.json
+++ b/src/i18n/locales/zh-Hant/gitGraph.json
@@ -37,6 +37,7 @@
     "noDiff": "沒有可顯示的差異",
     "noFileSelected": "選一個檔案看差異",
     "close": "關閉",
+    "compareBadge": "比較模式",
     "diffTab": "Diff",
     "aiTab": "AI 解釋",
     "aiGenerate": "產生 AI 解釋",

--- a/src/modules/git-graph/CommitDetailsPanel.test.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.test.tsx
@@ -160,4 +160,36 @@ describe("CommitDetailsPanel compare mode", () => {
     await screen.findByText("a.ts");
     expect(screen.queryByRole("button", { name: "AI Explain" })).not.toBeInTheDocument();
   });
+
+  it("does not crash when the selection flips to compare mode while the AI tab is active", async () => {
+    vi.mocked(gitCommitDetails).mockResolvedValue({
+      message: "feat: x",
+      files: [{ status: "M", path: "a.ts" }],
+    });
+    vi.mocked(gitCommitRangeFiles).mockResolvedValue([{ status: "M", path: "a.ts" }]);
+
+    const { rerender } = render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "single", commit: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
+    await screen.findByText("a.ts");
+    fireEvent.click(screen.getByRole("button", { name: "AI Explain" }));
+    await screen.findByText("Empty");
+
+    rerender(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "compare", from: OTHER, to: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
+
+    expect(await screen.findByText("No diff")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "AI Explain" })).not.toBeInTheDocument();
+  });
 });

--- a/src/modules/git-graph/CommitDetailsPanel.test.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.test.tsx
@@ -2,12 +2,19 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@/i18n";
 import { CommitDetailsPanel } from "./CommitDetailsPanel";
-import { gitCommitDetails, gitCommitFileDiff } from "./lib/gitGraphBridge";
+import {
+  gitCommitDetails,
+  gitCommitFileDiff,
+  gitCommitRangeFiles,
+  gitCommitRangeFileDiff,
+} from "./lib/gitGraphBridge";
 import type { CommitNode } from "./types";
 
 vi.mock("./lib/gitGraphBridge", () => ({
   gitCommitDetails: vi.fn(),
   gitCommitFileDiff: vi.fn().mockResolvedValue(""),
+  gitCommitRangeFiles: vi.fn(),
+  gitCommitRangeFileDiff: vi.fn().mockResolvedValue(""),
 }));
 
 const LABELS = {
@@ -49,7 +56,14 @@ describe("CommitDetailsPanel changed-files tree", () => {
         { status: "M", path: "dist/bbb/y.ts" },
       ],
     });
-    render(<CommitDetailsPanel repo="/repo" commit={COMMIT} onClose={() => {}} labels={LABELS} />);
+    render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "single", commit: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
     await screen.findByText("dist/aaa/x.ts");
 
     fireEvent.click(screen.getByRole("button", { name: "Group by folder" }));
@@ -64,7 +78,14 @@ describe("CommitDetailsPanel changed-files tree", () => {
       message: "feat: x",
       files: [{ status: "M", path: "dist/aaa/x.ts" }],
     });
-    render(<CommitDetailsPanel repo="/repo" commit={COMMIT} onClose={() => {}} labels={LABELS} />);
+    render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "single", commit: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
     await screen.findByText("dist/aaa/x.ts");
     fireEvent.click(screen.getByRole("button", { name: "Group by folder" }));
     await screen.findByText("dist");
@@ -79,7 +100,14 @@ describe("CommitDetailsPanel changed-files tree", () => {
       message: "feat: x",
       files: [{ status: "M", path: "dist/aaa/x.ts" }],
     });
-    render(<CommitDetailsPanel repo="/repo" commit={COMMIT} onClose={() => {}} labels={LABELS} />);
+    render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "single", commit: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
     await screen.findByText("dist/aaa/x.ts");
     fireEvent.click(screen.getByRole("button", { name: "Group by folder" }));
     await screen.findByText("x.ts");
@@ -89,5 +117,47 @@ describe("CommitDetailsPanel changed-files tree", () => {
     await waitFor(() =>
       expect(gitCommitFileDiff).toHaveBeenCalledWith("/repo", "abc1234", "dist/aaa/x.ts"),
     );
+  });
+});
+
+describe("CommitDetailsPanel compare mode", () => {
+  const OTHER: CommitNode = {
+    hash: "def5678",
+    parents: [],
+    author: "b",
+    date: "yesterday",
+    message: "fix: y",
+    refs: [],
+  };
+
+  it("shows both hashes in the header and fetches the range diff", async () => {
+    vi.mocked(gitCommitRangeFiles).mockResolvedValue([{ status: "M", path: "a.ts" }]);
+    render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "compare", from: OTHER, to: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
+
+    expect(await screen.findByText("def5678 .. abc1234")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(gitCommitRangeFileDiff).toHaveBeenCalledWith("/repo", "def5678", "abc1234", "a.ts"),
+    );
+  });
+
+  it("hides the AI tab in compare mode", async () => {
+    vi.mocked(gitCommitRangeFiles).mockResolvedValue([{ status: "M", path: "a.ts" }]);
+    render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "compare", from: OTHER, to: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
+    await screen.findByText("a.ts");
+    expect(screen.queryByRole("button", { name: "AI Explain" })).not.toBeInTheDocument();
   });
 });

--- a/src/modules/git-graph/CommitDetailsPanel.test.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.test.tsx
@@ -25,6 +25,7 @@ const LABELS = {
   noDiff: "No diff",
   noFileSelected: "Select a file",
   close: "Close",
+  compareBadge: "Comparing",
   diffTab: "Diff",
   aiTab: "AI Explain",
   aiGenerate: "Explain",
@@ -142,9 +143,24 @@ describe("CommitDetailsPanel compare mode", () => {
     );
 
     expect(await screen.findByText("def5678 .. abc1234")).toBeInTheDocument();
+    expect(screen.getByText("Comparing")).toBeInTheDocument();
     await waitFor(() =>
       expect(gitCommitRangeFileDiff).toHaveBeenCalledWith("/repo", "def5678", "abc1234", "a.ts"),
     );
+  });
+
+  it("does not show the compare badge in single-commit mode", async () => {
+    vi.mocked(gitCommitDetails).mockResolvedValue({ message: "feat: x", files: [] });
+    render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "single", commit: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />,
+    );
+    await screen.findByText("abc1234");
+    expect(screen.queryByText("Comparing")).not.toBeInTheDocument();
   });
 
   it("hides the AI tab in compare mode", async () => {

--- a/src/modules/git-graph/CommitDetailsPanel.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.tsx
@@ -6,12 +6,17 @@ import { Tooltip } from "@/components/Tooltip";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 import { buildFileTree, type TreeNode } from "@/lib/fileTree";
 import { useCollapsedPaths } from "@/lib/useCollapsedPaths";
-import { gitCommitDetails, gitCommitFileDiff } from "./lib/gitGraphBridge";
+import {
+  gitCommitDetails,
+  gitCommitFileDiff,
+  gitCommitRangeFiles,
+  gitCommitRangeFileDiff,
+} from "./lib/gitGraphBridge";
 import { parseDiffLines } from "./lib/parseDiff";
 import { useVirtualRows } from "./lib/useVirtualRows";
 import { DiffView } from "./DiffView";
 import { DiffExplain } from "./DiffExplain";
-import type { CommitDetails, CommitFileChange, CommitNode, DiffLine } from "./types";
+import type { CommitDetails, CommitFileChange, DiffLine, GraphSelection } from "./types";
 
 export interface CommitDetailsLabels {
   author: string;
@@ -37,7 +42,7 @@ export interface CommitDetailsLabels {
 
 interface CommitDetailsPanelProps {
   repo: string;
-  commit: CommitNode;
+  selection: GraphSelection;
   onClose: () => void;
   labels: CommitDetailsLabels;
 }
@@ -149,7 +154,17 @@ function DetailsTreeRows({
   );
 }
 
-export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDetailsPanelProps) {
+export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitDetailsPanelProps) {
+  const isCompare = selection.mode === "compare";
+  // Non-null only in single mode; used for the author/date/message block and
+  // the AI-explain tab, both of which only make sense for one commit. Safe to
+  // assert `!` where used below because both are unreachable while isCompare
+  // is true (the AI tab button that would flip `tab` to "ai" isn't rendered).
+  const singleCommit = selection.mode === "single" ? selection.commit : null;
+  const rangeKey =
+    selection.mode === "single" ? selection.commit.hash : `${selection.from.hash}..${selection.to.hash}`;
+  const headerHash =
+    selection.mode === "single" ? selection.commit.hash : `${selection.from.hash} .. ${selection.to.hash}`;
   const [details, setDetails] = useState<CommitDetails | null>(null);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [diffLines, setDiffLines] = useState<DiffLine[]>([]);
@@ -181,7 +196,8 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
     );
   }, []);
 
-  // Load message + changed files when the commit changes; auto-open first file.
+  // Load message + changed files when the selection changes; auto-open first
+  // file. Compare mode has no single message, so `details.message` stays "".
   useEffect(() => {
     let cancelled = false;
     setError(null);
@@ -189,7 +205,14 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
     setSelectedFile(null);
     setDiffLines([]);
     resetCollapsedFolders();
-    gitCommitDetails(repo, commit.hash)
+    const request =
+      selection.mode === "single"
+        ? gitCommitDetails(repo, selection.commit.hash)
+        : gitCommitRangeFiles(repo, selection.from.hash, selection.to.hash).then((files) => ({
+            message: "",
+            files,
+          }));
+    request
       .then((d) => {
         if (cancelled) {
           return;
@@ -205,7 +228,7 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
     return () => {
       cancelled = true;
     };
-  }, [repo, commit.hash, resetCollapsedFolders]);
+  }, [repo, selection, resetCollapsedFolders]);
 
   // Lazily load the selected file's diff (both parsed lines and raw text), and
   // reset to the Diff tab when the file changes.
@@ -217,7 +240,11 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
       return;
     }
     let cancelled = false;
-    gitCommitFileDiff(repo, commit.hash, selectedFile)
+    const request =
+      selection.mode === "single"
+        ? gitCommitFileDiff(repo, selection.commit.hash, selectedFile)
+        : gitCommitRangeFileDiff(repo, selection.from.hash, selection.to.hash, selectedFile);
+    request
       .then((diff) => {
         if (!cancelled) {
           setDiffText(diff);
@@ -233,7 +260,7 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
     return () => {
       cancelled = true;
     };
-  }, [repo, commit.hash, selectedFile]);
+  }, [repo, selection, selectedFile]);
 
   // Window the changed-files list inside the left column's single scroll
   // container: the metadata/message header scrolls with it, so the list is
@@ -245,7 +272,7 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
     files.length,
     FILE_ROW_HEIGHT,
     FILE_OVERSCAN,
-    commit.hash,
+    rangeKey,
     { listRef: fileListRef },
   );
   const visibleFiles = files.slice(filesWindow.start, filesWindow.end);
@@ -254,7 +281,7 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
     <div className="flex h-full flex-col overflow-hidden bg-bg">
       <div className="flex items-center justify-between border-b border-border bg-bg-inset px-3 py-1.5">
         <span className="select-all font-mono text-xs font-semibold text-accent">
-          {commit.hash}
+          {headerHash}
         </span>
         <Tooltip label={labels.close}>
           <button
@@ -278,18 +305,22 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
           style={{ width: `${leftWidth}px` }}
           className="relative shrink-0 overflow-auto px-3 py-2"
         >
-          <div className="flex flex-wrap gap-x-4 gap-y-0.5 font-mono text-[13px] text-fg-subtle">
-            <span>
-              {labels.author}: {commit.author}
-            </span>
-            <span>
-              {labels.date}: {commit.date}
-            </span>
-          </div>
-          {details && (
-            <pre className="mt-2 whitespace-pre-wrap font-sans text-[13px] text-fg">
-              {details.message}
-            </pre>
+          {singleCommit && (
+            <>
+              <div className="flex flex-wrap gap-x-4 gap-y-0.5 font-mono text-[13px] text-fg-subtle">
+                <span>
+                  {labels.author}: {singleCommit.author}
+                </span>
+                <span>
+                  {labels.date}: {singleCommit.date}
+                </span>
+              </div>
+              {details && (
+                <pre className="mt-2 whitespace-pre-wrap font-sans text-[13px] text-fg">
+                  {details.message}
+                </pre>
+              )}
+            </>
           )}
           <div className="mt-2 flex items-center justify-between text-[13px] font-medium text-fg-subtle">
             <span>
@@ -376,25 +407,27 @@ export function CommitDetailsPanel({ repo, commit, onClose, labels }: CommitDeta
                 >
                   {labels.diffTab}
                 </button>
-                <button
-                  type="button"
-                  onClick={() => setTab("ai")}
-                  className={`rounded px-2 py-0.5 text-[13px] ${
-                    tab === "ai"
-                      ? "bg-bg-elevated text-fg"
-                      : "text-fg-subtle hover:text-fg"
-                  }`}
-                >
-                  {labels.aiTab}
-                </button>
+                {!isCompare && (
+                  <button
+                    type="button"
+                    onClick={() => setTab("ai")}
+                    className={`rounded px-2 py-0.5 text-[13px] ${
+                      tab === "ai"
+                        ? "bg-bg-elevated text-fg"
+                        : "text-fg-subtle hover:text-fg"
+                    }`}
+                  >
+                    {labels.aiTab}
+                  </button>
+                )}
               </div>
               <div className="min-h-0 flex-1">
                 {tab === "diff" ? (
                   <DiffView lines={diffLines} emptyLabel={labels.noDiff} />
                 ) : (
                   <DiffExplain
-                    key={`${commit.hash}|${selectedFile}`}
-                    commitHash={commit.hash}
+                    key={`${singleCommit!.hash}|${selectedFile}`}
+                    commitHash={singleCommit!.hash}
                     file={selectedFile}
                     diffText={diffText}
                     providerId={providerId}

--- a/src/modules/git-graph/CommitDetailsPanel.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.tsx
@@ -429,8 +429,8 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
                   <DiffView lines={diffLines} emptyLabel={labels.noDiff} />
                 ) : (
                   <DiffExplain
-                    key={`${singleCommit!.hash}|${selectedFile}`}
-                    commitHash={singleCommit!.hash}
+                    key={`${singleCommit?.hash ?? ""}|${selectedFile}`}
+                    commitHash={singleCommit?.hash ?? ""}
                     file={selectedFile}
                     diffText={diffText}
                     providerId={providerId}

--- a/src/modules/git-graph/CommitDetailsPanel.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.tsx
@@ -157,9 +157,7 @@ function DetailsTreeRows({
 export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitDetailsPanelProps) {
   const isCompare = selection.mode === "compare";
   // Non-null only in single mode; used for the author/date/message block and
-  // the AI-explain tab, both of which only make sense for one commit. Safe to
-  // assert `!` where used below because both are unreachable while isCompare
-  // is true (the AI tab button that would flip `tab` to "ai" isn't rendered).
+  // the AI-explain tab, both of which only make sense for one commit.
   const singleCommit = selection.mode === "single" ? selection.commit : null;
   const rangeKey =
     selection.mode === "single" ? selection.commit.hash : `${selection.from.hash}..${selection.to.hash}`;
@@ -171,6 +169,11 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
   const [error, setError] = useState<string | null>(null);
   const [diffText, setDiffText] = useState("");
   const [tab, setTab] = useState<"diff" | "ai">("diff");
+  // `tab` is state, so it can still read "ai" on the render where `selection`
+  // just flipped to compare mode (the effect that resets it to "diff" hasn't
+  // run yet). Fall back to "diff" here so the content below never tries to
+  // render the AI tab (and dereference `singleCommit`) while isCompare.
+  const activeTab = isCompare ? "diff" : tab;
   const [filesViewMode, setFilesViewMode] = useState<FilesViewMode>("flat");
   const {
     collapsed: collapsedFolders,
@@ -422,7 +425,7 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
                 )}
               </div>
               <div className="min-h-0 flex-1">
-                {tab === "diff" ? (
+                {activeTab === "diff" ? (
                   <DiffView lines={diffLines} emptyLabel={labels.noDiff} />
                 ) : (
                   <DiffExplain

--- a/src/modules/git-graph/CommitDetailsPanel.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.tsx
@@ -26,6 +26,8 @@ export interface CommitDetailsLabels {
   noDiff: string;
   noFileSelected: string;
   close: string;
+  /** Badge shown next to the header hashes while comparing two commits. */
+  compareBadge: string;
   diffTab: string;
   aiTab: string;
   aiGenerate: string;
@@ -283,9 +285,16 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
   return (
     <div className="flex h-full flex-col overflow-hidden bg-bg">
       <div className="flex items-center justify-between border-b border-border bg-bg-inset px-3 py-1.5">
-        <span className="select-all font-mono text-xs font-semibold text-accent">
-          {headerHash}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="select-all font-mono text-xs font-semibold text-accent">
+            {headerHash}
+          </span>
+          {isCompare && (
+            <span className="rounded border border-accent/40 bg-accent/15 px-1.5 py-0.5 text-[11px] font-medium text-accent">
+              {labels.compareBadge}
+            </span>
+          )}
+        </div>
         <Tooltip label={labels.close}>
           <button
             type="button"

--- a/src/modules/git-graph/GitGraph.test.tsx
+++ b/src/modules/git-graph/GitGraph.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { GitGraph } from "./GitGraph";
 import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore";
@@ -46,6 +46,21 @@ describe("GitGraph row click area", () => {
     const row = screen.getByText("feat: x").closest("div[class*='absolute']");
     fireEvent.click(row!, { shiftKey: true });
     expect(onSelect).toHaveBeenCalledWith(COMMIT, { shiftKey: true });
+  });
+
+  it("blocks the browser's native text-selection drag on a shift-mousedown, but not a plain one", () => {
+    render(
+      <GitGraph commits={[COMMIT]} selection={null} onSelectCommit={vi.fn()} labels={LABELS} />,
+    );
+    const row = screen.getByText("feat: x").closest("div[class*='absolute']")!;
+
+    const shiftMouseDown = createEvent.mouseDown(row, { shiftKey: true });
+    fireEvent(row, shiftMouseDown);
+    expect(shiftMouseDown.defaultPrevented).toBe(true);
+
+    const plainMouseDown = createEvent.mouseDown(row, { shiftKey: false });
+    fireEvent(row, plainMouseDown);
+    expect(plainMouseDown.defaultPrevented).toBe(false);
   });
 });
 

--- a/src/modules/git-graph/GitGraph.test.tsx
+++ b/src/modules/git-graph/GitGraph.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { GitGraph } from "./GitGraph";
+import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore";
 import type { CommitNode } from "./types";
 
 const LABELS = {
@@ -10,25 +11,21 @@ const LABELS = {
   refHint: "{{name}}",
 } as never;
 
-const COMMIT: CommitNode = {
-  hash: "abc1234",
-  parents: [],
-  author: "a",
-  date: "today",
-  message: "feat: x",
-  refs: [],
-};
+function commit(hash: string, parents: string[], message = hash): CommitNode {
+  return { hash, parents, author: "a", date: "today", message, refs: [] };
+}
+
+function container(text: string): HTMLElement {
+  return screen.getByText(text).closest("div.flex-1.overflow-auto") as HTMLElement;
+}
 
 describe("GitGraph row click area", () => {
+  const COMMIT = commit("abc1234", [], "feat: x");
+
   it("selects the commit when clicking the row, including the lane gutter area", () => {
     const onSelect = vi.fn();
     render(
-      <GitGraph
-        commits={[COMMIT]}
-        selectedCommit={null}
-        onSelectCommit={onSelect}
-        labels={LABELS}
-      />,
+      <GitGraph commits={[COMMIT]} selection={null} onSelectCommit={onSelect} labels={LABELS} />,
     );
 
     const row = screen.getByText("feat: x").closest("div[class*='absolute']");
@@ -37,6 +34,118 @@ describe("GitGraph row click area", () => {
     // node dot (in the lane gutter) still open the commit detail.
     expect(row!.className).toContain("left-0");
     fireEvent.click(row!);
-    expect(onSelect).toHaveBeenCalledWith(COMMIT);
+    expect(onSelect).toHaveBeenCalledWith(COMMIT, { shiftKey: false });
+  });
+
+  it("passes shiftKey through to onSelectCommit for compare mode", () => {
+    const onSelect = vi.fn();
+    render(
+      <GitGraph commits={[COMMIT]} selection={null} onSelectCommit={onSelect} labels={LABELS} />,
+    );
+
+    const row = screen.getByText("feat: x").closest("div[class*='absolute']");
+    fireEvent.click(row!, { shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith(COMMIT, { shiftKey: true });
+  });
+});
+
+describe("GitGraph keyboard navigation", () => {
+  const commits = [
+    commit("c", ["b"], "msg c"),
+    commit("b", ["a"], "msg b"),
+    commit("a", [], "msg a"),
+  ];
+
+  function renderGraph(selected: CommitNode, onSelect = vi.fn()) {
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: selected }}
+        onSelectCommit={onSelect}
+        labels={LABELS}
+      />,
+    );
+    return onSelect;
+  }
+
+  it("ArrowDown moves to the adjacent row below", () => {
+    const onSelect = renderGraph(commits[0]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown" });
+    expect(onSelect).toHaveBeenCalledWith(commits[1], { shiftKey: false });
+  });
+
+  it("ArrowUp moves to the adjacent row above", () => {
+    const onSelect = renderGraph(commits[1]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp" });
+    expect(onSelect).toHaveBeenCalledWith(commits[0], { shiftKey: false });
+  });
+
+  it("clamps at the bottom without wrapping", () => {
+    const onSelect = renderGraph(commits[2]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("clamps at the top without wrapping", () => {
+    const onSelect = renderGraph(commits[0]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Shift+ArrowDown follows the first-parent chain", () => {
+    const onSelect = renderGraph(commits[0]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown", shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith(commits[1], { shiftKey: false });
+  });
+
+  it("Shift+ArrowUp no-ops on the newest commit of a lane", () => {
+    const onSelect = renderGraph(commits[0]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp", shiftKey: true });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Shift+ArrowUp follows the lane continuation", () => {
+    const onSelect = renderGraph(commits[1]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp", shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith(commits[0], { shiftKey: false });
+  });
+
+  it("Shift+ArrowDown no-ops at a root commit", () => {
+    const onSelect = renderGraph(commits[2]);
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown", shiftKey: true });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Shift+ArrowDown requests pagination when the parent is not loaded", () => {
+    usePendingGraphSelectionStore.setState({ hash: null });
+    const rootless = [commit("only", ["missing-parent"], "msg only")];
+    render(
+      <GitGraph
+        commits={rootless}
+        selection={{ mode: "single", commit: rootless[0] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+    fireEvent.keyDown(container("msg only"), { key: "ArrowDown", shiftKey: true });
+    expect(usePendingGraphSelectionStore.getState().hash).toBe("missing-parent");
+  });
+});
+
+describe("GitGraph compare-mode highlighting", () => {
+  it("marks both endpoints as selected", () => {
+    const commits = [commit("c", ["b"], "msg c"), commit("b", ["a"], "msg b")];
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "compare", from: commits[1], to: commits[0] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+    const rowC = screen.getByText("msg c").closest("div[class*='absolute']");
+    const rowB = screen.getByText("msg b").closest("div[class*='absolute']");
+    expect(rowC!.className).toContain("border-border-strong");
+    expect(rowB!.className).toContain("border-border-strong");
   });
 });

--- a/src/modules/git-graph/GitGraph.test.tsx
+++ b/src/modules/git-graph/GitGraph.test.tsx
@@ -190,6 +190,35 @@ describe("GitGraph auto-scroll", () => {
 
     expect(scrollContainer.scrollTop).toBe(0);
   });
+
+  it("does not re-scroll when layouts change but the active commit stays the same (e.g. pagination)", () => {
+    const { rerender } = render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: commits[0] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+    const scrollContainer = document.querySelector("div.flex-1.overflow-auto") as HTMLElement;
+    Object.defineProperty(scrollContainer, "clientHeight", { value: 200, configurable: true });
+    // The user manually scrolled away from the active row to browse history.
+    scrollContainer.scrollTop = 500;
+
+    // More history pages in: `commits` gets a new array identity (and thus a
+    // new `layouts` object from useMemo), but the selection is unchanged.
+    const morePages = [...commits, commit("z", [], "msg z")];
+    rerender(
+      <GitGraph
+        commits={morePages}
+        selection={{ mode: "single", commit: commits[0] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+
+    expect(scrollContainer.scrollTop).toBe(500);
+  });
 });
 
 describe("GitGraph compare-mode highlighting", () => {

--- a/src/modules/git-graph/GitGraph.test.tsx
+++ b/src/modules/git-graph/GitGraph.test.tsx
@@ -132,6 +132,70 @@ describe("GitGraph keyboard navigation", () => {
   });
 });
 
+describe("GitGraph compare-mode exit at boundaries", () => {
+  const commits = [
+    commit("c", ["b"], "msg c"),
+    commit("b", ["a"], "msg b"),
+    commit("a", [], "msg a"),
+  ];
+
+  it("plain ArrowDown at the bottom still collapses out of compare mode", () => {
+    const onSelect = vi.fn();
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "compare", from: commits[0], to: commits[2] }}
+        onSelectCommit={onSelect}
+        labels={LABELS}
+      />,
+    );
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown" });
+    expect(onSelect).toHaveBeenCalledWith(commits[2], { shiftKey: false });
+  });
+
+  it("plain ArrowUp at the top still collapses out of compare mode", () => {
+    const onSelect = vi.fn();
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "compare", from: commits[2], to: commits[0] }}
+        onSelectCommit={onSelect}
+        labels={LABELS}
+      />,
+    );
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp" });
+    expect(onSelect).toHaveBeenCalledWith(commits[0], { shiftKey: false });
+  });
+
+  it("Shift+ArrowDown at a root commit still collapses out of compare mode", () => {
+    const onSelect = vi.fn();
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "compare", from: commits[0], to: commits[2] }}
+        onSelectCommit={onSelect}
+        labels={LABELS}
+      />,
+    );
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown", shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith(commits[2], { shiftKey: false });
+  });
+
+  it("Shift+ArrowUp on the newest commit of a lane still collapses out of compare mode", () => {
+    const onSelect = vi.fn();
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "compare", from: commits[2], to: commits[0] }}
+        onSelectCommit={onSelect}
+        labels={LABELS}
+      />,
+    );
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp", shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith(commits[0], { shiftKey: false });
+  });
+});
+
 describe("GitGraph auto-scroll", () => {
   const commits = [
     commit("c", ["b"], "msg c"),

--- a/src/modules/git-graph/GitGraph.test.tsx
+++ b/src/modules/git-graph/GitGraph.test.tsx
@@ -132,6 +132,66 @@ describe("GitGraph keyboard navigation", () => {
   });
 });
 
+describe("GitGraph auto-scroll", () => {
+  const commits = [
+    commit("c", ["b"], "msg c"),
+    commit("b", ["a"], "msg b"),
+    commit("a", [], "msg a"),
+  ];
+
+  it("scrolls down so the newly active row's bottom edge is visible", () => {
+    const { rerender } = render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: commits[0] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+    const scrollContainer = container("msg c");
+    Object.defineProperty(scrollContainer, "clientHeight", { value: 40, configurable: true });
+    scrollContainer.scrollTop = 0;
+
+    rerender(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: commits[2] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+
+    // commits[2] ("a") is row index 2: y = 20 + 2*36 = 92, half-height 18 =>
+    // bottom edge at 110, below the 40px-tall visible window starting at 0.
+    expect(scrollContainer.scrollTop).toBe(70);
+  });
+
+  it("does not scroll when the newly active row is already fully visible", () => {
+    const { rerender } = render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: commits[0] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+    const scrollContainer = container("msg c");
+    Object.defineProperty(scrollContainer, "clientHeight", { value: 200, configurable: true });
+    scrollContainer.scrollTop = 0;
+
+    rerender(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: commits[1] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+
+    expect(scrollContainer.scrollTop).toBe(0);
+  });
+});
+
 describe("GitGraph compare-mode highlighting", () => {
   it("marks both endpoints as selected", () => {
     const commits = [commit("c", ["b"], "msg c"), commit("b", ["a"], "msg b")];

--- a/src/modules/git-graph/GitGraph.test.tsx
+++ b/src/modules/git-graph/GitGraph.test.tsx
@@ -219,6 +219,52 @@ describe("GitGraph auto-scroll", () => {
 
     expect(scrollContainer.scrollTop).toBe(500);
   });
+
+  it("still scrolls once the active commit's layout becomes available after a hash change with no layout yet", () => {
+    const missing = commit("x", [], "msg x");
+    const { rerender } = render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: commits[0] }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+    const scrollContainer = document.querySelector("div.flex-1.overflow-auto") as HTMLElement;
+    Object.defineProperty(scrollContainer, "clientHeight", { value: 40, configurable: true });
+    scrollContainer.scrollTop = 0;
+
+    // Selection points at a commit whose layout doesn't exist yet (e.g. its
+    // page is still loading) — the effect must bail without "consuming"
+    // this hash change.
+    rerender(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: missing }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+    expect(scrollContainer.scrollTop).toBe(0);
+
+    // The commit's page finishes loading: it's now in commits/layouts, and
+    // the selection is unchanged. The scroll must still happen here, not be
+    // silently skipped because the earlier render already "used up" the
+    // hash change.
+    const loaded = [...commits, missing];
+    rerender(
+      <GitGraph
+        commits={loaded}
+        selection={{ mode: "single", commit: missing }}
+        onSelectCommit={vi.fn()}
+        labels={LABELS}
+      />,
+    );
+
+    // "x" is row index 3: y = 20 + 3*36 = 128, bottom edge 146, beyond the
+    // 40px-tall window starting at 0 => scrollTop becomes 146 - 40 = 106.
+    expect(scrollContainer.scrollTop).toBe(106);
+  });
 });
 
 describe("GitGraph compare-mode highlighting", () => {

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -137,10 +137,20 @@ export function GitGraph({
 
   // Keep the active commit in view when keyboard navigation moves it off
   // the visible edge of the (virtualized, manually-scrolled) container.
+  // Gated on activeHash actually changing (not just `layouts`, which gets a
+  // new reference every time more history pages in) so browsing further
+  // down the list doesn't keep snapping back to the still-selected row.
+  const prevActiveHashRef = useRef<string | null>(null);
   useEffect(() => {
     if (!activeHash || !scrollRef.current) {
+      prevActiveHashRef.current = activeHash;
       return;
     }
+    if (activeHash === prevActiveHashRef.current) {
+      return;
+    }
+    prevActiveHashRef.current = activeHash;
+
     const layout = layouts[activeHash];
     if (!layout) {
       return;

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -94,6 +94,17 @@ export function GitGraph({
     onSelectCommit(commit, { shiftKey: event.shiftKey });
   }
 
+  // Without this, holding Shift while clicking asks the browser to extend a
+  // native text selection from the last click point across every row in
+  // between (the hash spans are selectable text) instead of firing a plain
+  // click on this row — the compare pair never gets set, and it visibly
+  // highlights text the user never meant to select.
+  function preventShiftClickTextSelection(event: React.MouseEvent) {
+    if (event.shiftKey) {
+      event.preventDefault();
+    }
+  }
+
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
     if (commits.length === 0 || !activeHash) {
       return;
@@ -260,6 +271,7 @@ export function GitGraph({
                 <Tooltip key={commit.hash} label={commit.hash}>
                   <button
                     type="button"
+                    onMouseDown={preventShiftClickTextSelection}
                     onClick={(e) => selectFromClick(commit, e)}
                     onContextMenu={(e) => {
                       e.preventDefault();
@@ -313,6 +325,7 @@ export function GitGraph({
               return (
                 <div
                   key={commit.hash}
+                  onMouseDown={preventShiftClickTextSelection}
                   onClick={(e) => selectFromClick(commit, e)}
                   onContextMenu={(e) => {
                     e.preventDefault();

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Check, Clock, GitBranch, Tag, User } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
-import type { CommitNode, CommitRef } from "./types";
+import type { CommitNode, CommitRef, GraphSelection } from "./types";
 import {
   computeGraphLayout,
   DEFAULT_GEOMETRY,
   edgePath,
+  firstParentRowIndex,
+  laneContinuationRowIndex,
 } from "./lib/graphLayout";
 import { isCurrentCommit } from "./lib/currentCommit";
 import { BRANCH_COLORS } from "./lib/branchColors";
+import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore";
 
 export interface GitGraphLabels {
   emptyTitle: string;
@@ -19,8 +22,8 @@ export interface GitGraphLabels {
 
 interface GitGraphProps {
   commits: CommitNode[];
-  selectedCommit: CommitNode | null;
-  onSelectCommit: (commit: CommitNode) => void;
+  selection: GraphSelection | null;
+  onSelectCommit: (commit: CommitNode, options: { shiftKey: boolean }) => void;
   onCommitContextMenu?: (commit: CommitNode, x: number, y: number) => void;
   onRefContextMenu?: (ref: CommitRef, x: number, y: number) => void;
   hasMore?: boolean;
@@ -44,7 +47,7 @@ const PADDING_TOP = DEFAULT_GEOMETRY.paddingTop;
 
 export function GitGraph({
   commits,
-  selectedCommit,
+  selection,
   onSelectCommit,
   onCommitContextMenu,
   onRefContextMenu,
@@ -74,6 +77,64 @@ export function GitGraph({
 
   const { layouts, edges } = useMemo(() => computeGraphLayout(commits), [commits]);
 
+  const activeHash =
+    selection?.mode === "single"
+      ? selection.commit.hash
+      : selection?.mode === "compare"
+        ? selection.to.hash
+        : null;
+
+  const isSelectedHash = (hash: string) =>
+    selection?.mode === "compare"
+      ? hash === selection.from.hash || hash === selection.to.hash
+      : hash === activeHash;
+
+  function selectFromClick(commit: CommitNode, event: { shiftKey: boolean }) {
+    scrollRef.current?.focus();
+    onSelectCommit(commit, { shiftKey: event.shiftKey });
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (commits.length === 0 || !activeHash) {
+      return;
+    }
+    const currentIndex = commits.findIndex((c) => c.hash === activeHash);
+    if (currentIndex === -1) {
+      return;
+    }
+    if (event.key === "ArrowDown" && !event.shiftKey) {
+      event.preventDefault();
+      const targetIndex = Math.min(currentIndex + 1, commits.length - 1);
+      if (targetIndex !== currentIndex) {
+        onSelectCommit(commits[targetIndex], { shiftKey: false });
+      }
+    } else if (event.key === "ArrowUp" && !event.shiftKey) {
+      event.preventDefault();
+      const targetIndex = Math.max(currentIndex - 1, 0);
+      if (targetIndex !== currentIndex) {
+        onSelectCommit(commits[targetIndex], { shiftKey: false });
+      }
+    } else if (event.key === "ArrowDown" && event.shiftKey) {
+      event.preventDefault();
+      const parentHash = commits[currentIndex].parents[0];
+      if (!parentHash) {
+        return;
+      }
+      const targetIndex = firstParentRowIndex(commits, currentIndex);
+      if (targetIndex !== null) {
+        onSelectCommit(commits[targetIndex], { shiftKey: false });
+      } else {
+        usePendingGraphSelectionStore.getState().request(parentHash);
+      }
+    } else if (event.key === "ArrowUp" && event.shiftKey) {
+      event.preventDefault();
+      const targetIndex = laneContinuationRowIndex(edges, currentIndex);
+      if (targetIndex !== null) {
+        onSelectCommit(commits[targetIndex], { shiftKey: false });
+      }
+    }
+  }
+
   const svgHeight = commits.length * ROW_HEIGHT + PADDING_TOP * 2 - 20;
   const visibleStart = Math.max(
     0,
@@ -99,7 +160,9 @@ export function GitGraph({
     <div className="flex h-full flex-col overflow-hidden rounded-lg border border-border bg-bg">
       <div
         ref={scrollRef}
-        className="flex-1 overflow-auto"
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className="flex-1 overflow-auto outline-none"
         onScroll={(event) => {
           const target = event.currentTarget;
           setViewport({ scrollTop: target.scrollTop, height: target.clientHeight });
@@ -145,13 +208,13 @@ export function GitGraph({
                 return null;
               }
               const color = BRANCH_COLORS[layout.colorIndex % BRANCH_COLORS.length];
-              const isSelected = selectedCommit?.hash === commit.hash;
+              const isSelected = isSelectedHash(commit.hash);
               const isCurrent = isCurrentCommit(commit);
               return (
                 <Tooltip key={commit.hash} label={commit.hash}>
                   <button
                     type="button"
-                    onClick={() => onSelectCommit(commit)}
+                    onClick={(e) => selectFromClick(commit, e)}
                     onContextMenu={(e) => {
                       e.preventDefault();
                       onCommitContextMenu?.(commit, e.clientX, e.clientY);
@@ -188,7 +251,7 @@ export function GitGraph({
               if (!layout) {
                 return null;
               }
-              const isSelected = selectedCommit?.hash === commit.hash;
+              const isSelected = isSelectedHash(commit.hash);
               const isCurrent = isCurrentCommit(commit);
               // The HEAD commit is marked at its graph node (filled accent + glow);
               // its row stays calm and only brightens to full foreground, so the
@@ -204,7 +267,7 @@ export function GitGraph({
               return (
                 <div
                   key={commit.hash}
-                  onClick={() => onSelectCommit(commit)}
+                  onClick={(e) => selectFromClick(commit, e)}
                   onContextMenu={(e) => {
                     e.preventDefault();
                     onCommitContextMenu?.(commit, e.clientX, e.clientY);

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -102,22 +102,29 @@ export function GitGraph({
     if (currentIndex === -1) {
       return;
     }
+    // Any arrow key exits compare mode, even one that can't actually move
+    // the selection (a boundary clamp or a dead-end lane) — it still
+    // collapses onto the current commit as a single selection.
+    const isComparing = selection?.mode === "compare";
     if (event.key === "ArrowDown" && !event.shiftKey) {
       event.preventDefault();
       const targetIndex = Math.min(currentIndex + 1, commits.length - 1);
-      if (targetIndex !== currentIndex) {
+      if (targetIndex !== currentIndex || isComparing) {
         onSelectCommit(commits[targetIndex], { shiftKey: false });
       }
     } else if (event.key === "ArrowUp" && !event.shiftKey) {
       event.preventDefault();
       const targetIndex = Math.max(currentIndex - 1, 0);
-      if (targetIndex !== currentIndex) {
+      if (targetIndex !== currentIndex || isComparing) {
         onSelectCommit(commits[targetIndex], { shiftKey: false });
       }
     } else if (event.key === "ArrowDown" && event.shiftKey) {
       event.preventDefault();
       const parentHash = commits[currentIndex].parents[0];
       if (!parentHash) {
+        if (isComparing) {
+          onSelectCommit(commits[currentIndex], { shiftKey: false });
+        }
         return;
       }
       const targetIndex = firstParentRowIndex(commits, currentIndex);
@@ -131,6 +138,8 @@ export function GitGraph({
       const targetIndex = laneContinuationRowIndex(edges, currentIndex);
       if (targetIndex !== null) {
         onSelectCommit(commits[targetIndex], { shiftKey: false });
+      } else if (isComparing) {
+        onSelectCommit(commits[currentIndex], { shiftKey: false });
       }
     }
   }

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -149,12 +149,17 @@ export function GitGraph({
     if (activeHash === prevActiveHashRef.current) {
       return;
     }
-    prevActiveHashRef.current = activeHash;
 
     const layout = layouts[activeHash];
     if (!layout) {
+      // Layout for this hash isn't ready yet (e.g. its page is still
+      // loading) — leave prevActiveHashRef alone so a later render, once
+      // the layout does exist, still recognizes this as an unhandled
+      // hash change instead of skipping it.
       return;
     }
+    prevActiveHashRef.current = activeHash;
+
     const container = scrollRef.current;
     const rowTop = layout.y - ROW_HEIGHT / 2;
     const rowBottom = layout.y + ROW_HEIGHT / 2;

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -135,6 +135,28 @@ export function GitGraph({
     }
   }
 
+  // Keep the active commit in view when keyboard navigation moves it off
+  // the visible edge of the (virtualized, manually-scrolled) container.
+  useEffect(() => {
+    if (!activeHash || !scrollRef.current) {
+      return;
+    }
+    const layout = layouts[activeHash];
+    if (!layout) {
+      return;
+    }
+    const container = scrollRef.current;
+    const rowTop = layout.y - ROW_HEIGHT / 2;
+    const rowBottom = layout.y + ROW_HEIGHT / 2;
+    const { scrollTop, clientHeight } = container;
+
+    if (rowTop < scrollTop) {
+      container.scrollTop = rowTop;
+    } else if (rowBottom > scrollTop + clientHeight) {
+      container.scrollTop = rowBottom - clientHeight;
+    }
+  }, [activeHash, layouts]);
+
   const svgHeight = commits.length * ROW_HEIGHT + PADDING_TOP * 2 - 20;
   const visibleStart = Math.max(
     0,

--- a/src/modules/git-graph/GitGraphTabContent.test.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.test.tsx
@@ -16,6 +16,8 @@ vi.mock("./lib/gitGraphBridge", () => ({
   gitFetch: vi.fn(),
   gitCommitDetails: vi.fn().mockResolvedValue({ message: "", files: [] }),
   gitCommitFileDiff: vi.fn().mockResolvedValue(""),
+  gitCommitRangeFiles: vi.fn().mockResolvedValue([]),
+  gitCommitRangeFileDiff: vi.fn().mockResolvedValue(""),
   gitWorktreeList: vi.fn().mockResolvedValue([]),
 }));
 
@@ -254,5 +256,38 @@ describe("GitGraphTabContent worktree selector wiring", () => {
     await screen.findByText("msg aaa1111");
 
     expect(screen.queryByLabelText("Worktree")).not.toBeInTheDocument();
+  });
+});
+
+describe("GitGraphTabContent compare mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(gitWorktreeList).mockResolvedValue([]);
+    usePendingGraphSelectionStore.setState({ hash: null });
+    useWorkspaceStore.getState().setRoot("/repo");
+  });
+
+  it("shift-clicking a second commit shows the compare header, and a plain click collapses back", async () => {
+    vi.mocked(gitGraphLog).mockImplementation(async () =>
+      commitList(["aaa1111", "bbb2222"], false),
+    );
+
+    render(<GitGraphTabContent />);
+    await waitFor(() => screen.getByText("msg aaa1111"));
+
+    const rowA = screen.getByText("msg aaa1111").closest("div[class*='absolute']")!;
+    const rowB = screen.getByText("msg bbb2222").closest("div[class*='absolute']")!;
+
+    fireEvent.click(rowA);
+    fireEvent.click(rowB, { shiftKey: true });
+
+    // aaa1111 is the newer commit (index 0), bbb2222 the older one (index 1):
+    // from (older) .. to (newer).
+    await waitFor(() => expect(screen.getByText("bbb2222 .. aaa1111")).toBeInTheDocument());
+
+    fireEvent.click(rowA);
+
+    await waitFor(() => expect(screen.getAllByText("aaa1111").length).toBeGreaterThan(0));
+    expect(screen.queryByText("bbb2222 .. aaa1111")).not.toBeInTheDocument();
   });
 });

--- a/src/modules/git-graph/GitGraphTabContent.test.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.test.tsx
@@ -311,4 +311,31 @@ describe("GitGraphTabContent compare mode", () => {
     // no second fetch) is even scheduled — safe to assert synchronously.
     expect(gitCommitDetails).toHaveBeenCalledTimes(1);
   });
+
+  it("falls back to a single selection when the shift-click anchor is no longer in a freshly reloaded commit list", async () => {
+    vi.mocked(gitGraphLog)
+      .mockResolvedValueOnce(commitList(["aaa1111", "bbb2222"], false))
+      .mockResolvedValueOnce(commitList(["ccc3333", "bbb2222"], false));
+
+    render(<GitGraphTabContent />);
+    await waitFor(() => screen.getByText("msg aaa1111"));
+
+    const rowA = screen.getByText("msg aaa1111").closest("div[class*='absolute']")!;
+    fireEvent.click(rowA);
+
+    // Simulate the repo changing underneath the stale selection (e.g. a
+    // branch switch): the reload drops aaa1111 out of the list entirely.
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => screen.getByText("msg ccc3333"));
+    expect(screen.queryByText("msg aaa1111")).not.toBeInTheDocument();
+
+    const rowB = screen.getByText("msg bbb2222").closest("div[class*='absolute']")!;
+    fireEvent.click(rowB, { shiftKey: true });
+
+    // The stale anchor's index can't be found (-1), so this must collapse to
+    // a plain single selection on bbb2222 instead of an arbitrarily-ordered
+    // compare pair.
+    await waitFor(() => expect(screen.getAllByText("bbb2222").length).toBeGreaterThan(0));
+    expect(screen.queryByText(/ \.\. /)).not.toBeInTheDocument();
+  });
 });

--- a/src/modules/git-graph/GitGraphTabContent.test.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.test.tsx
@@ -21,7 +21,7 @@ vi.mock("./lib/gitGraphBridge", () => ({
   gitWorktreeList: vi.fn().mockResolvedValue([]),
 }));
 
-import { gitGraphLog, gitWorktreeList } from "./lib/gitGraphBridge";
+import { gitCommitDetails, gitGraphLog, gitWorktreeList } from "./lib/gitGraphBridge";
 
 function commitList(hashes: string[], hasMore: boolean) {
   return {
@@ -289,5 +289,26 @@ describe("GitGraphTabContent compare mode", () => {
 
     await waitFor(() => expect(screen.getAllByText("aaa1111").length).toBeGreaterThan(0));
     expect(screen.queryByText("bbb2222 .. aaa1111")).not.toBeInTheDocument();
+  });
+
+  it("does not refetch commit details when clicking the already-selected commit again", async () => {
+    vi.mocked(gitGraphLog).mockImplementation(async () =>
+      commitList(["aaa1111", "bbb2222"], false),
+    );
+
+    render(<GitGraphTabContent />);
+    await waitFor(() => screen.getByText("msg aaa1111"));
+
+    const rowA = screen.getByText("msg aaa1111").closest("div[class*='absolute']")!;
+
+    fireEvent.click(rowA);
+    await waitFor(() => expect(gitCommitDetails).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(rowA);
+
+    // React bails out of re-rendering when a functional setState update
+    // returns the previous state by reference, so no new effect run (and
+    // no second fetch) is even scheduled — safe to assert synchronously.
+    expect(gitCommitDetails).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -631,7 +631,6 @@ export function GitGraphTabContent() {
             <div style={{ height: `${detailsHeight}px` }} className="shrink-0">
               <CommitDetailsPanel
                 repo={repo}
-                commit={selection.mode === "single" ? selection.commit : selection.to}
                 selection={selection}
                 onClose={() => setSelection(null)}
                 labels={detailsLabels}

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -261,6 +261,16 @@ export function GitGraphTabContent() {
         }
         const anchorIndex = commits.findIndex((c) => c.hash === anchor.hash);
         const commitIndex = commits.findIndex((c) => c.hash === commit.hash);
+        if (anchorIndex === -1 || commitIndex === -1) {
+          // The anchor (or, in principle, the clicked commit) is no longer in
+          // the loaded list — e.g. the branch/repo changed underneath a
+          // stale selection. Ordering would be meaningless, so drop back to
+          // a plain single selection instead of guessing.
+          if (prev?.mode === "single" && prev.commit.hash === commit.hash) {
+            return prev;
+          }
+          return { mode: "single", commit };
+        }
         const [from, to] = anchorIndex > commitIndex ? [anchor, commit] : [commit, anchor];
         if (prev?.mode === "compare" && prev.from.hash === from.hash && prev.to.hash === to.hash) {
           return prev;

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -242,18 +242,29 @@ export function GitGraphTabContent() {
   const handleSelectCommit = useCallback(
     (commit: CommitNode, { shiftKey }: { shiftKey: boolean }) => {
       if (!shiftKey) {
-        setSelection({ mode: "single", commit });
+        setSelection((prev) => {
+          if (prev?.mode === "single" && prev.commit.hash === commit.hash) {
+            return prev;
+          }
+          return { mode: "single", commit };
+        });
         return;
       }
       setSelection((prev) => {
         const anchor =
           prev?.mode === "single" ? prev.commit : prev?.mode === "compare" ? prev.to : null;
         if (!anchor || anchor.hash === commit.hash) {
+          if (prev?.mode === "single" && prev.commit.hash === commit.hash) {
+            return prev;
+          }
           return { mode: "single", commit };
         }
         const anchorIndex = commits.findIndex((c) => c.hash === anchor.hash);
         const commitIndex = commits.findIndex((c) => c.hash === commit.hash);
         const [from, to] = anchorIndex > commitIndex ? [anchor, commit] : [commit, anchor];
+        if (prev?.mode === "compare" && prev.from.hash === from.hash && prev.to.hash === to.hash) {
+          return prev;
+        }
         return { mode: "compare", from, to };
       });
     },

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -448,6 +448,7 @@ export function GitGraphTabContent() {
     noDiff: t("details.noDiff"),
     noFileSelected: t("details.noFileSelected"),
     close: t("details.close"),
+    compareBadge: t("details.compareBadge"),
     diffTab: t("details.diffTab"),
     aiTab: t("details.aiTab"),
     aiGenerate: t("details.aiGenerate"),

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -35,7 +35,7 @@ import { filterCommits } from "./lib/filterCommits";
 import { buildCommitMenu, buildRefMenu } from "./lib/contextMenuItems";
 import { splitRemoteRef } from "./lib/remoteRef";
 import { withMinDuration } from "@/lib/withMinDuration";
-import type { Branch, CommitNode, CommitRef, CommitOrder, GraphOptions } from "./types";
+import type { Branch, CommitNode, CommitRef, CommitOrder, GraphOptions, GraphSelection } from "./types";
 
 const PAGE_SIZE = 200;
 // Local git reloads finish almost instantly; keep the busy spinner up at least
@@ -76,7 +76,7 @@ export function GitGraphTabContent() {
   const [worktrees, setWorktrees] = useState<WorktreeItem[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [limit, setLimit] = useState(PAGE_SIZE);
-  const [selected, setSelected] = useState<CommitNode | null>(null);
+  const [selection, setSelection] = useState<GraphSelection | null>(null);
   const [detailsHeight, setDetailsHeight] = useState<number>(() => {
     const v = Number(localStorage.getItem("tempoterm-gitgraph-details-height"));
     return Number.isFinite(v) && v > 0 ? v : 280;
@@ -234,6 +234,32 @@ export function GitGraphTabContent() {
     void reload(repo, next, options);
   }, [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes, options.order]);
 
+  // Plain click/arrow-nav selects one commit. Shift+click while a commit is
+  // already selected (single or as the "to" side of an existing compare)
+  // pairs it with the new one, ordered older ("from") to newer ("to") by
+  // position in `commits` — the list is already newest-first, so no extra
+  // git call is needed to know which side is which.
+  const handleSelectCommit = useCallback(
+    (commit: CommitNode, { shiftKey }: { shiftKey: boolean }) => {
+      if (!shiftKey) {
+        setSelection({ mode: "single", commit });
+        return;
+      }
+      setSelection((prev) => {
+        const anchor =
+          prev?.mode === "single" ? prev.commit : prev?.mode === "compare" ? prev.to : null;
+        if (!anchor || anchor.hash === commit.hash) {
+          return { mode: "single", commit };
+        }
+        const anchorIndex = commits.findIndex((c) => c.hash === anchor.hash);
+        const commitIndex = commits.findIndex((c) => c.hash === commit.hash);
+        const [from, to] = anchorIndex > commitIndex ? [anchor, commit] : [commit, anchor];
+        return { mode: "compare", from, to };
+      });
+    },
+    [commits],
+  );
+
   // Consume a pending "select this commit" request from the sidebar's history
   // list. Subscribes to the store's hash (not a one-shot getState() read) so
   // this fires for every new request, including one that arrives while the
@@ -263,7 +289,7 @@ export function GitGraphTabContent() {
       commitHash.startsWith(pendingHash) || pendingHash.startsWith(commitHash);
     const visibleMatch = visibleCommits.find((c) => hashMatches(c.hash));
     if (visibleMatch) {
-      setSelected(visibleMatch);
+      setSelection({ mode: "single", commit: visibleMatch });
       usePendingGraphSelectionStore.getState().consume();
       pendingSelectionAttempts.current = 0;
       return;
@@ -582,8 +608,8 @@ export function GitGraphTabContent() {
         <div className="min-h-0 flex-1">
           <GitGraph
             commits={visibleCommits}
-            selectedCommit={selected}
-            onSelectCommit={setSelected}
+            selection={selection}
+            onSelectCommit={handleSelectCommit}
             onCommitContextMenu={(commit, x, y) =>
               setMenu({ type: "commit", commit, x, y })
             }
@@ -593,7 +619,7 @@ export function GitGraphTabContent() {
             labels={labels}
           />
         </div>
-        {selected && repo && (
+        {selection && repo && (
           <>
             <Resizer
               orientation="horizontal"
@@ -605,8 +631,9 @@ export function GitGraphTabContent() {
             <div style={{ height: `${detailsHeight}px` }} className="shrink-0">
               <CommitDetailsPanel
                 repo={repo}
-                commit={selected}
-                onClose={() => setSelected(null)}
+                commit={selection.mode === "single" ? selection.commit : selection.to}
+                selection={selection}
+                onClose={() => setSelection(null)}
                 labels={detailsLabels}
               />
             </div>

--- a/src/modules/git-graph/lib/gitGraphBridge.ts
+++ b/src/modules/git-graph/lib/gitGraphBridge.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { Branch, CommitDetails, GraphLog, GraphOptions } from "../types";
+import type { Branch, CommitDetails, CommitFileChange, GraphLog, GraphOptions } from "../types";
 
 /** Read the commit DAG for the graph view, filtered by display options. */
 export function gitGraphLog(
@@ -119,6 +119,25 @@ export function gitCommitFileDiff(
   file: string,
 ): Promise<string> {
   return invoke<string>("git_commit_file_diff", { repoPath, commit, file });
+}
+
+/** Read the file list changed between two arbitrary commits (name-status). */
+export function gitCommitRangeFiles(
+  repoPath: string,
+  from: string,
+  to: string,
+): Promise<CommitFileChange[]> {
+  return invoke<CommitFileChange[]>("git_commit_range_files", { repoPath, from, to });
+}
+
+/** Read a single file's diff between two arbitrary commits. */
+export function gitCommitRangeFileDiff(
+  repoPath: string,
+  from: string,
+  to: string,
+  file: string,
+): Promise<string> {
+  return invoke<string>("git_commit_range_file_diff", { repoPath, from, to, file });
 }
 
 /** One worktree of the repository, from `git worktree list`. */

--- a/src/modules/git-graph/lib/graphLayout.test.ts
+++ b/src/modules/git-graph/lib/graphLayout.test.ts
@@ -3,6 +3,8 @@ import {
   computeGraphLayout,
   DEFAULT_GEOMETRY,
   edgePath,
+  firstParentRowIndex,
+  laneContinuationRowIndex,
   laneX,
   type GraphEdge,
 } from "./graphLayout";
@@ -169,5 +171,56 @@ describe("edgePath", () => {
     const path = edgePath(edge, 36);
     expect(path.startsWith("M 20 20 C")).toBe(true);
     expect(path).toContain("L 34 92");
+  });
+});
+
+describe("firstParentRowIndex", () => {
+  it("finds the row of the first parent in a simple chain", () => {
+    const commits = [commit("c", ["b"]), commit("b", ["a"]), commit("a", [])];
+    expect(firstParentRowIndex(commits, 0)).toBe(1);
+    expect(firstParentRowIndex(commits, 1)).toBe(2);
+  });
+
+  it("returns null for a root commit with no parents", () => {
+    const commits = [commit("a", [])];
+    expect(firstParentRowIndex(commits, 0)).toBeNull();
+  });
+
+  it("returns null when the first parent is not loaded in the page", () => {
+    const commits = [commit("only", ["missing-parent"])];
+    expect(firstParentRowIndex(commits, 0)).toBeNull();
+  });
+
+  it("always follows the first parent from a merge commit, not the merged-in branch", () => {
+    const commits = [commit("m", ["a", "b"]), commit("b", ["a"]), commit("a", [])];
+    expect(firstParentRowIndex(commits, 0)).toBe(2); // "a" (index 2), not "b" (index 1)
+  });
+
+  it("resolves a short-hash parent reference by prefix", () => {
+    const commits = [commit("abcdef1", ["abc"]), commit("abc", [])];
+    expect(firstParentRowIndex(commits, 0)).toBe(1);
+  });
+});
+
+describe("laneContinuationRowIndex", () => {
+  it("finds the child that continues the same lane going up", () => {
+    const commits = [commit("c", ["b"]), commit("b", ["a"]), commit("a", [])];
+    const { edges } = computeGraphLayout(commits);
+    expect(laneContinuationRowIndex(edges, 1)).toBe(0); // b's continuation is c
+    expect(laneContinuationRowIndex(edges, 2)).toBe(1); // a's continuation is b
+  });
+
+  it("returns null for the newest commit on a lane", () => {
+    const commits = [commit("c", ["b"]), commit("b", ["a"]), commit("a", [])];
+    const { edges } = computeGraphLayout(commits);
+    expect(laneContinuationRowIndex(edges, 0)).toBeNull();
+  });
+
+  it("skips the merge-in bend and finds the straight-line child at a fork", () => {
+    // m merges a and b; from a's perspective going up, the straight
+    // continuation is m (same lane), not the b->a bend.
+    const commits = [commit("m", ["a", "b"]), commit("b", ["a"]), commit("a", [])];
+    const { edges } = computeGraphLayout(commits);
+    expect(laneContinuationRowIndex(edges, 2)).toBe(0); // a -> m, straight
   });
 });

--- a/src/modules/git-graph/lib/graphLayout.ts
+++ b/src/modules/git-graph/lib/graphLayout.ts
@@ -176,6 +176,45 @@ export function computeGraphLayout(
   return { layouts, edges };
 }
 
+/**
+ * Row index of `commits[index]`'s first parent within the same array. Null
+ * if the commit has no parent, or its first parent isn't loaded in `commits`
+ * yet (the caller should page in more history and retry).
+ */
+export function firstParentRowIndex(
+  commits: readonly GraphLayoutCommit[],
+  index: number,
+): number | null {
+  const parentHash = commits[index]?.parents[0];
+  if (!parentHash) {
+    return null;
+  }
+  // Try exact match first.
+  let found = commits.findIndex((c) => c.hash === parentHash);
+  if (found !== -1) {
+    return found;
+  }
+  // Fall back to prefix matching.
+  found = commits.findIndex(
+    (c) => c.hash.startsWith(parentHash) || parentHash.startsWith(c.hash),
+  );
+  return found === -1 ? null : found;
+}
+
+/**
+ * Row index of the one commit whose first-parent edge continues
+ * `commits[index]`'s exact lane going up (newer) — the straight line in the
+ * graph, not a merge-in bend. Null if `commits[index]` is the newest commit
+ * on its lane.
+ */
+export function laneContinuationRowIndex(
+  edges: readonly GraphEdge[],
+  index: number,
+): number | null {
+  const edge = edges.find((e) => e.parentIndex === index && e.cx === e.px);
+  return edge ? edge.childIndex : null;
+}
+
 /** SVG path data for one edge: a straight track, or a bend into the parent lane. */
 export function edgePath(edge: GraphEdge, rowHeight: number): string {
   const { cx, cy, px, py } = edge;

--- a/src/modules/git-graph/types.ts
+++ b/src/modules/git-graph/types.ts
@@ -15,6 +15,15 @@ export interface CommitNode {
   refs: CommitRef[];
 }
 
+/**
+ * What the Git Graph commit list currently has selected: one commit, or two
+ * commits being compared. `from`/`to` are ordered older/newer by list
+ * position, not by click order.
+ */
+export type GraphSelection =
+  | { mode: "single"; commit: CommitNode }
+  | { mode: "compare"; from: CommitNode; to: CommitNode };
+
 /** A page of graph commits plus whether more history exists past `commits`. */
 export interface GraphLog {
   commits: CommitNode[];


### PR DESCRIPTION
## Summary
- Add Up/Down keyboard navigation between adjacent Git Graph commit rows, clamped at the list boundaries (no wraparound)
- Add Shift+Up/Down navigation that follows a commit's branch line (first-parent chain), auto-paging in more history when the target isn't loaded yet
- Add Shift+click to diff two arbitrary commits against each other in the details panel, with a two-hash header and the AI-explain tab hidden while comparing
- Add two backend commands (`git_commit_range_files`, `git_commit_range_file_diff`) generalizing the existing "commit vs. its first parent" diff to any two commits

Design: `docs/superpowers/specs/2026-07-04-git-graph-keyboard-nav-design.md`
Plan: `docs/superpowers/plans/2026-07-04-git-graph-keyboard-nav.md`

Closes #100

## Test plan
- [x] `pnpm vitest run` — 1156 tests passing
- [x] `pnpm typecheck` — clean
- [x] `cargo test` (src-tauri) — 213 tests passing
- [x] Local build launches without crashing
- [ ] Manual click-through in a real repo with a merge commit (arrow keys, Shift+arrow at a merge, Shift+click compare, exit compare) — recommended before release, not yet done interactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)