### PR TITLE
chore: bump version to 0.0.15

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -4,6 +4,8 @@
 
 - 原始碼控制側欄的「近期提交」清單新增精簡版提交圖，用色點與連線標出提交順序、分支分岐、合併與目前 HEAD 位置
 - 檔案搜尋改成從頂部標題列開啟的全域搜尋面板（Cmd/Ctrl+P），不再侷限於檔案總管側欄；全寬顯示讓檔名與相對路徑不必再靠 tooltip 才看得完整，並新增「最近開啟的」清單
+- Git Graph 提交圖支援方向鍵導覽，並可用 Shift+點擊或方向鍵選取兩筆提交進入比較模式，直接看兩個版本間的差異
+- 筆記側邊欄新增變更筆記資料夾的按鈕，資料夾選錯或想換位置時可以重新指定，切換前會先跳確認，不會動到原本磁碟上的筆記
 
 ### fix
 
@@ -13,5 +15,7 @@
 
 - Added a compact commit graph beside the sidebar's Recent commits list, showing commit order, branch divergence, merges and the current HEAD position
 - Moved file search into a global search palette opened from the top header (Cmd/Ctrl+P) instead of the Explorer sidebar; the full-width layout shows filenames and relative paths in full without a tooltip, and adds a "Recently opened" list
+- Added arrow-key navigation to the Git Graph commit list, plus a two-commit compare mode (via Shift+click or arrow keys) to diff any two commits directly
+- Added a button to the notes sidebar for changing the notes folder after it's already been set; a confirmation dialog appears before switching, and existing notes stay untouched on disk
 
 ### fix

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tempo-term",
   "private": true,
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-term"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-term"
-version = "0.0.14"
+version = "0.0.15"
 description = "TempoTerm - AI-powered terminal, editor and file explorer"
 authors = ["TempoTerm"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TempoTerm",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "identifier": "com.tempoterm.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- Bump version to 0.0.15 across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`.
- Add the two unreleased features to `CHANGELOG-NEXT.md` (zh-Hant + English): Git Graph keyboard nav / compare mode (#138), notes folder change (#139).

Milestone v0.0.15 has all 14 issues closed, 0 open — ready to release.

## Test plan
- [x] Version strings match across all four files