### PR TITLE
feat(ssh): remote file write-ops and remote cd tracking

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,7 +44,8 @@ use modules::ssh::{
     ssh_write, SshState,
 };
 use modules::sftp::{
-    sftp_close, sftp_home, sftp_read_dir, sftp_read_file, sftp_start, sftp_write_file, SftpState,
+    sftp_close, sftp_create_dir, sftp_create_file, sftp_delete, sftp_home, sftp_read_dir,
+    sftp_read_file, sftp_rename, sftp_start, sftp_write_file, SftpState,
 };
 use modules::terminal_history::{
     terminal_history_clear, terminal_history_delete, terminal_history_load,
@@ -238,6 +239,10 @@ pub fn run() {
             sftp_read_dir,
             sftp_read_file,
             sftp_write_file,
+            sftp_create_file,
+            sftp_create_dir,
+            sftp_delete,
+            sftp_rename,
             sftp_close,
             ssh_secret_set,
             ssh_secret_delete,

--- a/src-tauri/src/modules/sftp/mod.rs
+++ b/src-tauri/src/modules/sftp/mod.rs
@@ -52,6 +52,44 @@ pub async fn sftp_write_file(
 }
 
 #[tauri::command]
+pub async fn sftp_create_file(
+    state: State<'_, SftpState>,
+    id: u32,
+    path: String,
+) -> Result<(), String> {
+    session::create_file_cmd(&state, id, path).await
+}
+
+#[tauri::command]
+pub async fn sftp_create_dir(
+    state: State<'_, SftpState>,
+    id: u32,
+    path: String,
+) -> Result<(), String> {
+    session::create_dir_cmd(&state, id, path).await
+}
+
+#[tauri::command]
+pub async fn sftp_delete(
+    state: State<'_, SftpState>,
+    id: u32,
+    path: String,
+    is_dir: bool,
+) -> Result<(), String> {
+    session::delete_cmd(&state, id, path, is_dir).await
+}
+
+#[tauri::command]
+pub async fn sftp_rename(
+    state: State<'_, SftpState>,
+    id: u32,
+    from: String,
+    to: String,
+) -> Result<(), String> {
+    session::rename_cmd(&state, id, from, to).await
+}
+
+#[tauri::command]
 pub fn sftp_close(state: State<'_, SftpState>, id: u32) {
     session::close(&state, id)
 }

--- a/src-tauri/src/modules/sftp/session.rs
+++ b/src-tauri/src/modules/sftp/session.rs
@@ -43,6 +43,24 @@ pub enum SftpControl {
         contents: String,
         reply: oneshot::Sender<Result<(), String>>,
     },
+    CreateFile {
+        path: String,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    CreateDir {
+        path: String,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    Delete {
+        path: String,
+        is_dir: bool,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    Rename {
+        from: String,
+        to: String,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
     Close,
 }
 
@@ -189,6 +207,22 @@ async fn run(
             } => {
                 let _ = reply.send(write_file(&sftp, &path, &contents).await);
             }
+            SftpControl::CreateFile { path, reply } => {
+                let _ = reply.send(create_file(&sftp, &path).await);
+            }
+            SftpControl::CreateDir { path, reply } => {
+                let _ = reply.send(
+                    sftp.create_dir(path).await.map_err(|e| e.to_string()),
+                );
+            }
+            SftpControl::Delete { path, is_dir, reply } => {
+                let _ = reply.send(delete(&sftp, &path, is_dir).await);
+            }
+            SftpControl::Rename { from, to, reply } => {
+                let _ = reply.send(
+                    sftp.rename(from, to).await.map_err(|e| e.to_string()),
+                );
+            }
             SftpControl::Close => break,
         }
     }
@@ -209,6 +243,12 @@ async fn fail(mut rx: mpsc::UnboundedReceiver<SftpControl>, reason: String) {
                 let _ = reply.send(Err(reason.clone()));
             }
             SftpControl::WriteFile { reply, .. } => {
+                let _ = reply.send(Err(reason.clone()));
+            }
+            SftpControl::CreateFile { reply, .. }
+            | SftpControl::CreateDir { reply, .. }
+            | SftpControl::Delete { reply, .. }
+            | SftpControl::Rename { reply, .. } => {
                 let _ = reply.send(Err(reason.clone()));
             }
             SftpControl::Close => break,
@@ -269,6 +309,31 @@ async fn write_file(sftp: &SftpSession, path: &str, contents: &str) -> Result<()
     Ok(())
 }
 
+/// Create an empty file, failing when it already exists — the same contract as
+/// the local `fs/ops.rs::create_file`, via SFTP's EXCLUDE open flag.
+async fn create_file(sftp: &SftpSession, path: &str) -> Result<(), String> {
+    use russh_sftp::protocol::OpenFlags;
+    use tokio::io::AsyncWriteExt;
+    let mut file = sftp
+        .open_with_flags(
+            path.to_string(),
+            OpenFlags::CREATE | OpenFlags::WRITE | OpenFlags::EXCLUDE,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    file.shutdown().await.map_err(|e| e.to_string())
+}
+
+/// SFTP splits delete into two calls by entry kind; the caller passes the kind
+/// it already knows from the DirEntry it is deleting.
+async fn delete(sftp: &SftpSession, path: &str, is_dir: bool) -> Result<(), String> {
+    if is_dir {
+        sftp.remove_dir(path.to_string()).await.map_err(|e| e.to_string())
+    } else {
+        sftp.remove_file(path.to_string()).await.map_err(|e| e.to_string())
+    }
+}
+
 fn send(state: &State<'_, SftpState>, id: u32, msg: SftpControl) -> Result<(), String> {
     let sessions = state.sessions.lock().unwrap();
     let handle = sessions
@@ -322,6 +387,48 @@ pub async fn write_file_cmd(
             reply: tx,
         },
     )?;
+    rx.await.map_err(|_| "sftp session closed".to_string())?
+}
+
+pub async fn create_file_cmd(
+    state: &State<'_, SftpState>,
+    id: u32,
+    path: String,
+) -> Result<(), String> {
+    let (tx, rx) = oneshot::channel();
+    send(state, id, SftpControl::CreateFile { path, reply: tx })?;
+    rx.await.map_err(|_| "sftp session closed".to_string())?
+}
+
+pub async fn create_dir_cmd(
+    state: &State<'_, SftpState>,
+    id: u32,
+    path: String,
+) -> Result<(), String> {
+    let (tx, rx) = oneshot::channel();
+    send(state, id, SftpControl::CreateDir { path, reply: tx })?;
+    rx.await.map_err(|_| "sftp session closed".to_string())?
+}
+
+pub async fn delete_cmd(
+    state: &State<'_, SftpState>,
+    id: u32,
+    path: String,
+    is_dir: bool,
+) -> Result<(), String> {
+    let (tx, rx) = oneshot::channel();
+    send(state, id, SftpControl::Delete { path, is_dir, reply: tx })?;
+    rx.await.map_err(|_| "sftp session closed".to_string())?
+}
+
+pub async fn rename_cmd(
+    state: &State<'_, SftpState>,
+    id: u32,
+    from: String,
+    to: String,
+) -> Result<(), String> {
+    let (tx, rx) = oneshot::channel();
+    send(state, id, SftpControl::Rename { from, to, reply: tx })?;
     rx.await.map_err(|_| "sftp session closed".to_string())?
 }
 

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -198,6 +198,12 @@
       "destHost": "Destination host",
       "destPort": "Destination port",
       "enabled": "Enabled"
+    },
+    "osc7": {
+      "toggle": "Follow remote cd (shell setup)",
+      "explanation": "To let the file explorer follow cd on the remote host, the remote shell must announce its working directory (OSC 7). Paste this into the remote shell's rc file:",
+      "copy": "Copy snippet",
+      "copied": "Copied"
     }
   },
   "workspace": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -101,6 +101,11 @@
     "close": "Close"
   },
   "paneCapacityAlert": "This tab can hold at most 8 panes — close one and try again",
+  "osc7Hint": {
+    "title": "Follow remote cd",
+    "message": "This SSH session hasn't reported its working directory, so the file explorer can't follow cd on the remote host. Edit this connection to copy a one-line shell setup snippet that enables it.",
+    "confirm": "Got it"
+  },
   "placeholder": {
     "comingSoon": "Coming soon",
     "terminalArea": "Terminal sessions will appear here",

--- a/src/i18n/locales/en/explorer.json
+++ b/src/i18n/locales/en/explorer.json
@@ -4,6 +4,7 @@
   "rootPlaceholder": "Folder path",
   "go": "Go",
   "findFiles": "Find files",
+  "refresh": "Refresh",
   "expandAll": "Expand All",
   "collapseAll": "Collapse All",
   "findPlaceholder": "Type to fuzzy-find files",

--- a/src/i18n/locales/en/explorer.json
+++ b/src/i18n/locales/en/explorer.json
@@ -26,6 +26,7 @@
     "copyRelativePath": "Copy Relative Path",
     "attachToAgent": "Attach to Agent",
     "rename": "Rename",
-    "delete": "Delete"
+    "delete": "Delete",
+    "deleteRemoteConfirm": "Permanently delete \"{{name}}\" from the remote host? There is no trash over SFTP — this cannot be undone."
   }
 }

--- a/src/i18n/locales/en/explorer.json
+++ b/src/i18n/locales/en/explorer.json
@@ -25,6 +25,7 @@
     "copyPath": "Copy Path",
     "copyRelativePath": "Copy Relative Path",
     "attachToAgent": "Attach to Agent",
+    "rename": "Rename",
     "delete": "Delete"
   }
 }

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -198,6 +198,12 @@
       "destHost": "目標主機",
       "destPort": "目標埠號",
       "enabled": "啟用"
+    },
+    "osc7": {
+      "toggle": "跟隨遠端 cd（shell 設定）",
+      "explanation": "要讓檔案總管跟隨遠端主機上的 cd，遠端 shell 必須回報工作目錄（OSC 7）。把這段貼進遠端 shell 的 rc 檔：",
+      "copy": "複製片段",
+      "copied": "已複製"
     }
   },
   "workspace": {

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -101,6 +101,11 @@
     "close": "關閉"
   },
   "paneCapacityAlert": "這個分頁最多只能開 8 個面板，請先關掉一個再試",
+  "osc7Hint": {
+    "title": "跟隨遠端 cd",
+    "message": "這個 SSH 連線尚未回報工作目錄，檔案總管無法跟隨遠端的 cd。編輯這個連線可複製一段 shell 設定片段來啟用。",
+    "confirm": "知道了"
+  },
   "placeholder": {
     "comingSoon": "即將推出",
     "terminalArea": "終端機工作階段會顯示在這裡",

--- a/src/i18n/locales/zh-Hant/explorer.json
+++ b/src/i18n/locales/zh-Hant/explorer.json
@@ -26,6 +26,7 @@
     "copyRelativePath": "複製相對路徑",
     "attachToAgent": "附加到 AI 助手",
     "rename": "重新命名",
-    "delete": "刪除"
+    "delete": "刪除",
+    "deleteRemoteConfirm": "確定要從遠端主機永久刪除「{{name}}」嗎？SFTP 沒有垃圾桶，刪了救不回來。"
   }
 }

--- a/src/i18n/locales/zh-Hant/explorer.json
+++ b/src/i18n/locales/zh-Hant/explorer.json
@@ -25,6 +25,7 @@
     "copyPath": "複製路徑",
     "copyRelativePath": "複製相對路徑",
     "attachToAgent": "附加到 AI 助手",
+    "rename": "重新命名",
     "delete": "刪除"
   }
 }

--- a/src/i18n/locales/zh-Hant/explorer.json
+++ b/src/i18n/locales/zh-Hant/explorer.json
@@ -4,6 +4,7 @@
   "rootPlaceholder": "資料夾路徑",
   "go": "前往",
   "findFiles": "尋找檔案",
+  "refresh": "重新整理",
   "expandAll": "全部展開",
   "collapseAll": "全部收合",
   "findPlaceholder": "輸入以模糊搜尋檔案",

--- a/src/modules/explorer/ExplorerView.test.tsx
+++ b/src/modules/explorer/ExplorerView.test.tsx
@@ -89,3 +89,47 @@ describe("ExplorerView expand/collapse toggle", () => {
     expect(screen.queryByText("leaf.ts")).not.toBeInTheDocument();
   });
 });
+
+describe("ExplorerView refresh", () => {
+  it("re-fetches the root listing when the refresh button is clicked", async () => {
+    const { fsReadDir } = await import("./lib/fsBridge");
+    vi.mocked(fsReadDir).mockReset().mockResolvedValue([]);
+
+    useWorkspaceStore.setState({ rootPath: "/home/me" });
+    render(<ExplorerView />);
+
+    await waitFor(() => expect(vi.mocked(fsReadDir)).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByLabelText("Refresh"));
+
+    await waitFor(() => expect(vi.mocked(fsReadDir)).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(fsReadDir)).toHaveBeenLastCalledWith("/home/me");
+  });
+
+  it("discards cached expanded children on refresh, rendering the tree collapsed again", async () => {
+    const { fsReadDir } = await import("./lib/fsBridge");
+    vi.mocked(fsReadDir).mockImplementation(async (path: string) => {
+      if (path === "/home/me") {
+        return [{ name: "a-dir", path: "/home/me/a-dir", is_dir: true, size: 0 }];
+      }
+      if (path === "/home/me/a-dir") {
+        return [{ name: "leaf.ts", path: "/home/me/a-dir/leaf.ts", is_dir: false, size: 0 }];
+      }
+      return [];
+    });
+
+    useWorkspaceStore.setState({ rootPath: "/home/me" });
+    render(<ExplorerView />);
+    await screen.findByText("a-dir");
+
+    // Expand everything so "a-dir" caches its child listing.
+    fireEvent.click(screen.getByLabelText("Expand All"));
+    await screen.findByText("leaf.ts");
+
+    fireEvent.click(screen.getByLabelText("Refresh"));
+
+    // A fresh tree renders fully collapsed again: the cached child is gone.
+    await screen.findByText("a-dir");
+    expect(screen.queryByText("leaf.ts")).not.toBeInTheDocument();
+  });
+});

--- a/src/modules/explorer/ExplorerView.tsx
+++ b/src/modules/explorer/ExplorerView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronsDownUp, ChevronsUpDown, FolderOpen } from "lucide-react";
+import { ChevronsDownUp, ChevronsUpDown, FolderOpen, RotateCw } from "lucide-react";
 import { FileTree } from "./FileTree";
 import { Tooltip } from "@/components/Tooltip";
 import { fsReadDir, type DirEntry } from "./lib/fsBridge";
@@ -21,6 +21,12 @@ export function ExplorerView() {
   // false whenever the root changes rather than trying to inspect every
   // node's live expanded state.
   const [treeExpanded, setTreeExpanded] = useState(false);
+  // Bumped on manual refresh; used as <FileTree>'s key so a refresh remounts
+  // the whole tree instead of just re-fetching the root. TreeNode caches its
+  // own `children` state once expanded, so a bare loadEntries() call would
+  // leave stale subfolders in place — remounting is the only way to discard
+  // that cache and guarantee a truly fresh listing.
+  const [refreshTick, setRefreshTick] = useState(0);
 
   // A remote (SFTP) root hides local-only controls and shows the remote path
   // rather than the raw ssh:// uri.
@@ -75,6 +81,16 @@ export function ExplorerView() {
     setTreeExpanded((v) => !v);
   }
 
+  // Mirrors the root-change reset above: a refresh must render as if a brand
+  // new root had just been opened, fully collapsed with no cached children.
+  function refresh() {
+    setTreeExpanded(false);
+    setCollapseSignal(0);
+    setExpandSignal(0);
+    setRefreshTick((v) => v + 1);
+    loadEntries();
+  }
+
   return (
     <div className="relative flex h-full flex-col bg-bg-inset">
       <div className="flex h-9 shrink-0 items-center justify-between border-b border-border px-3">
@@ -91,6 +107,18 @@ export function ExplorerView() {
                 className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
               >
                 <FolderOpen size={15} />
+              </button>
+            </Tooltip>
+          )}
+          {rootPath && (
+            <Tooltip label={t("refresh")}>
+              <button
+                type="button"
+                aria-label={t("refresh")}
+                onClick={refresh}
+                className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+              >
+                <RotateCw size={15} />
               </button>
             </Tooltip>
           )}
@@ -124,6 +152,7 @@ export function ExplorerView() {
           <p className="px-3 py-2 text-xs text-fg-subtle">{t("empty")}</p>
         ) : (
           <FileTree
+            key={refreshTick}
             entries={entries}
             onReloadRoot={loadEntries}
             collapseSignal={collapseSignal}

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -351,4 +351,89 @@ describe("FileTree rename", () => {
     await Promise.resolve();
     expect(fsRename).not.toHaveBeenCalled();
   });
+
+  it("ignores an IME composition-commit Enter (keyCode 229) but still confirms on a plain Enter", async () => {
+    const { fsRename } = await import("./lib/fsBridge");
+    vi.mocked(fsRename).mockResolvedValue(undefined);
+    const entries = [{ name: "old.ts", path: "/p/old.ts", is_dir: false, size: 0 }];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.contextMenu(screen.getByText("old.ts"));
+    fireEvent.click(screen.getByText("menu.rename"));
+    const input = screen.getByDisplayValue("old.ts");
+
+    fireEvent.change(input, { target: { value: "new.ts" } });
+    // Simulates an IME candidate-commit Enter: must not confirm the rename.
+    fireEvent.keyDown(input, { key: "Enter", keyCode: 229 });
+
+    expect(fsRename).not.toHaveBeenCalled();
+    expect(screen.getByDisplayValue("new.ts")).toBeInTheDocument();
+
+    // A genuine Enter afterwards still confirms normally.
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await vi.waitFor(() =>
+      expect(fsRename).toHaveBeenCalledWith("/p/old.ts", "/p/new.ts"),
+    );
+  });
+});
+
+describe("FileTree delete", () => {
+  beforeEach(async () => {
+    const { fsDelete } = await import("./lib/fsBridge");
+    vi.mocked(fsDelete).mockClear();
+  });
+
+  it("gates a remote delete behind a confirm dialog and only calls fsDelete on confirm", async () => {
+    const { fsDelete } = await import("./lib/fsBridge");
+    vi.mocked(fsDelete).mockResolvedValue(undefined);
+    const entries = [
+      { name: "x.txt", path: "ssh://c1/home/me/x.txt", is_dir: false, size: 0 },
+    ];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.contextMenu(screen.getByText("x.txt"));
+    fireEvent.click(screen.getByText("menu.delete"));
+
+    expect(fsDelete).not.toHaveBeenCalled();
+    expect(screen.getByText("menu.deleteRemoteConfirm")).toBeInTheDocument();
+
+    // The dialog's title also reads "menu.delete", so disambiguate by role
+    // to click its confirm button specifically.
+    fireEvent.click(screen.getByRole("button", { name: "menu.delete" }));
+
+    await vi.waitFor(() =>
+      expect(fsDelete).toHaveBeenCalledWith("ssh://c1/home/me/x.txt", false),
+    );
+  });
+
+  it("cancels a remote delete without ever calling fsDelete", async () => {
+    const { fsDelete } = await import("./lib/fsBridge");
+    const entries = [
+      { name: "x.txt", path: "ssh://c1/home/me/x.txt", is_dir: false, size: 0 },
+    ];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.contextMenu(screen.getByText("x.txt"));
+    fireEvent.click(screen.getByText("menu.delete"));
+    fireEvent.click(screen.getByText("actions.cancel"));
+
+    expect(screen.queryByText("menu.deleteRemoteConfirm")).not.toBeInTheDocument();
+    expect(fsDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes a local entry immediately, with no confirm dialog", async () => {
+    const { fsDelete } = await import("./lib/fsBridge");
+    vi.mocked(fsDelete).mockResolvedValue(undefined);
+    const entries = [{ name: "local.txt", path: "/p/local.txt", is_dir: false, size: 0 }];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.contextMenu(screen.getByText("local.txt"));
+    fireEvent.click(screen.getByText("menu.delete"));
+
+    await vi.waitFor(() =>
+      expect(fsDelete).toHaveBeenCalledWith("/p/local.txt", false),
+    );
+    expect(screen.queryByText("menu.deleteRemoteConfirm")).not.toBeInTheDocument();
+  });
 });

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -13,6 +13,7 @@ vi.mock("./lib/fsBridge", () => ({
   fsCreateDir: vi.fn(),
   fsCreateFile: vi.fn(),
   fsDelete: vi.fn(),
+  fsRename: vi.fn(),
   fsReveal: vi.fn(),
 }));
 
@@ -307,5 +308,47 @@ describe("FileTree context menu: open in new tab", () => {
     fireEvent.click(screen.getByText("menu.openInNewTab"));
 
     expect(useTabsStore.getState().tabs).toHaveLength(2);
+  });
+});
+
+describe("FileTree rename", () => {
+  // fsRename is a shared mock across both tests below; vitest does not clear
+  // call history between tests in the same file (no clearMocks/restoreMocks
+  // configured), so without this reset the second test would see the first
+  // test's call and fail its `not.toHaveBeenCalled()` assertion.
+  beforeEach(async () => {
+    const { fsRename } = await import("./lib/fsBridge");
+    vi.mocked(fsRename).mockClear();
+  });
+
+  it("renames an entry in place and reloads the parent", async () => {
+    const { fsRename } = await import("./lib/fsBridge");
+    vi.mocked(fsRename).mockResolvedValue(undefined);
+    const onReloadRoot = vi.fn();
+    const entries = [{ name: "old.ts", path: "/p/old.ts", is_dir: false, size: 0 }];
+    render(<FileTree entries={entries} onReloadRoot={onReloadRoot} />);
+
+    fireEvent.contextMenu(screen.getByText("old.ts"));
+    fireEvent.click(screen.getByText("menu.rename"));
+    const input = screen.getByDisplayValue("old.ts");
+    fireEvent.change(input, { target: { value: "new.ts" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await vi.waitFor(() => expect(fsRename).toHaveBeenCalledWith("/p/old.ts", "/p/new.ts"));
+    expect(onReloadRoot).toHaveBeenCalled();
+  });
+
+  it("does nothing when the name is unchanged", async () => {
+    const { fsRename } = await import("./lib/fsBridge");
+    const entries = [{ name: "same.ts", path: "/p/same.ts", is_dir: false, size: 0 }];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.contextMenu(screen.getByText("same.ts"));
+    fireEvent.click(screen.getByText("menu.rename"));
+    const input = screen.getByDisplayValue("same.ts");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await Promise.resolve();
+    expect(fsRename).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -226,7 +226,7 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
 
   async function handleDelete() {
     try {
-      await fsDelete(entry.path);
+      await fsDelete(entry.path, entry.is_dir);
     } catch {
       return;
     }

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -27,7 +27,9 @@ import {
 } from "./lib/fsBridge";
 import { dirname, joinPath, relativePath } from "./lib/paths";
 import { beginEntryDrag, consumeDragClick } from "./lib/dragEntry";
+import { isRemoteUri } from "@/modules/ssh/lib/remotePath";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { InfoDialog } from "@/components/InfoDialog";
 import { Tooltip } from "@/components/Tooltip";
 import { useTabsStore } from "@/stores/tabsStore";
@@ -85,6 +87,7 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
   const [creating, setCreating] = useState<Creating>(null);
   const [renaming, setRenaming] = useState(false);
   const [atCapacity, setAtCapacity] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
   // JS hover: CSS :hover is suppressed inside a draggable subtree (WebKit), so
   // track hover manually to highlight just this row.
   const [hovered, setHovered] = useState(false);
@@ -350,7 +353,16 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
       icon: Trash2,
       group: 4,
       danger: true,
-      onSelect: () => void handleDelete(),
+      // Local deletes go to the OS trash and are recoverable, so they fire
+      // immediately as before. Remote (SFTP) deletes are permanent, so gate
+      // them behind a confirm dialog first.
+      onSelect: () => {
+        if (isRemoteUri(entry.path)) {
+          setConfirmingDelete(true);
+        } else {
+          void handleDelete();
+        }
+      },
     },
   ];
 
@@ -460,6 +472,20 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
           onConfirm={() => setAtCapacity(false)}
         />
       )}
+
+      {confirmingDelete && (
+        <ConfirmDialog
+          title={t("menu.delete")}
+          message={t("menu.deleteRemoteConfirm", { name: entry.name })}
+          confirmLabel={t("menu.delete")}
+          cancelLabel={tCommon("actions.cancel")}
+          onConfirm={() => {
+            setConfirmingDelete(false);
+            void handleDelete();
+          }}
+          onCancel={() => setConfirmingDelete(false)}
+        />
+      )}
     </li>
   );
 }
@@ -496,6 +522,11 @@ function NewEntryInput({ kind, depth, initialValue, onConfirm, onCancel }: NewEn
         aria-label={kind === "file" ? t("menu.newFile") : t("menu.newFolder")}
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={(event) => {
+          // Ignore the Enter that commits an IME candidate (CJK input), so it
+          // doesn't also confirm/cancel this entry mid-composition.
+          if (event.nativeEvent.isComposing || event.keyCode === 229) {
+            return;
+          }
           if (event.key === "Enter") {
             event.preventDefault();
             onConfirm(value);

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -10,6 +10,7 @@ import {
   FolderOpen,
   FolderPlus,
   MessageSquarePlus,
+  Pencil,
   SquarePlus,
   TerminalSquare,
   Trash2,
@@ -20,6 +21,7 @@ import {
   fsCreateFile,
   fsDelete,
   fsReadDir,
+  fsRename,
   fsReveal,
   type DirEntry,
 } from "./lib/fsBridge";
@@ -81,6 +83,7 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
   const [children, setChildren] = useState<DirEntry[] | null>(null);
   const [menu, setMenu] = useState<MenuPosition | null>(null);
   const [creating, setCreating] = useState<Creating>(null);
+  const [renaming, setRenaming] = useState(false);
   const [atCapacity, setAtCapacity] = useState(false);
   // JS hover: CSS :hover is suppressed inside a draggable subtree (WebKit), so
   // track hover manually to highlight just this row.
@@ -233,6 +236,21 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
     onReloadParent();
   }
 
+  async function confirmRename(name: string) {
+    const trimmed = name.trim();
+    setRenaming(false);
+    if (!trimmed || trimmed === entry.name) {
+      return;
+    }
+    const to = joinPath(dirname(entry.path), trimmed);
+    try {
+      await fsRename(entry.path, to);
+    } catch {
+      return;
+    }
+    onReloadParent();
+  }
+
   function copyToClipboard(text: string) {
     void navigator.clipboard.writeText(text);
   }
@@ -320,6 +338,13 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
       onSelect: attachToAgent,
     },
     {
+      id: "rename",
+      label: t("menu.rename"),
+      icon: Pencil,
+      group: 4,
+      onSelect: () => setRenaming(true),
+    },
+    {
       id: "delete",
       label: t("menu.delete"),
       icon: Trash2,
@@ -334,53 +359,55 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
       {/* Pointer-based drag (not HTML5) so Tauri's native drag interception
           doesn't break hover/drop coordinates; the row swallows the click that
           trails a completed drag so it doesn't also open/expand the entry. */}
-      <div
-        onPointerDown={(event) =>
-          beginEntryDrag(
-            { path: entry.path, name: entry.name, isDir: entry.is_dir },
-            event,
-          )
-        }
-      >
-        <Tooltip label={entry.name} className="w-full">
-          <button
-            type="button"
-            onClick={() => {
-              if (consumeDragClick()) {
-                return;
-              }
-              void toggle();
-            }}
-            onContextMenu={(event) => {
-              event.preventDefault();
-              setMenu({ x: event.clientX, y: event.clientY });
-            }}
-            onMouseEnter={() => setHovered(true)}
-            onMouseLeave={() => setHovered(false)}
-            style={{ paddingLeft: depth * 12 + 8 }}
-            className={`flex w-full items-center gap-1.5 py-1 pr-2 text-left text-[13px] transition-colors ${
-              isActive
-                ? "bg-accent/15 text-fg"
-                : hovered
-                  ? "bg-fg/10 text-fg"
-                  : "text-fg-muted"
-            }`}
-          >
-            {entry.is_dir ? (
-              <>
-                {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                <FileIcon name={entry.name} isDir open={expanded} size={16} />
-              </>
-            ) : (
-              <>
-                <span className="w-[14px]" />
-                <FileIcon name={entry.name} isDir={false} size={16} />
-              </>
-            )}
-            <span className="truncate">{entry.name}</span>
-          </button>
-        </Tooltip>
-      </div>
+      {!renaming && (
+        <div
+          onPointerDown={(event) =>
+            beginEntryDrag(
+              { path: entry.path, name: entry.name, isDir: entry.is_dir },
+              event,
+            )
+          }
+        >
+          <Tooltip label={entry.name} className="w-full">
+            <button
+              type="button"
+              onClick={() => {
+                if (consumeDragClick()) {
+                  return;
+                }
+                void toggle();
+              }}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                setMenu({ x: event.clientX, y: event.clientY });
+              }}
+              onMouseEnter={() => setHovered(true)}
+              onMouseLeave={() => setHovered(false)}
+              style={{ paddingLeft: depth * 12 + 8 }}
+              className={`flex w-full items-center gap-1.5 py-1 pr-2 text-left text-[13px] transition-colors ${
+                isActive
+                  ? "bg-accent/15 text-fg"
+                  : hovered
+                    ? "bg-fg/10 text-fg"
+                    : "text-fg-muted"
+              }`}
+            >
+              {entry.is_dir ? (
+                <>
+                  {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                  <FileIcon name={entry.name} isDir open={expanded} size={16} />
+                </>
+              ) : (
+                <>
+                  <span className="w-[14px]" />
+                  <FileIcon name={entry.name} isDir={false} size={16} />
+                </>
+              )}
+              <span className="truncate">{entry.name}</span>
+            </button>
+          </Tooltip>
+        </div>
+      )}
 
       {creating && (
         <NewEntryInput
@@ -388,6 +415,16 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
           depth={depth + 1}
           onConfirm={confirmCreate}
           onCancel={() => setCreating(null)}
+        />
+      )}
+
+      {renaming && (
+        <NewEntryInput
+          kind={entry.is_dir ? "dir" : "file"}
+          depth={depth}
+          initialValue={entry.name}
+          onConfirm={(name) => void confirmRename(name)}
+          onCancel={() => setRenaming(false)}
         />
       )}
 
@@ -430,14 +467,16 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
 interface NewEntryInputProps {
   kind: "file" | "dir";
   depth: number;
+  /** Pre-filled text (rename); empty for a new entry. */
+  initialValue?: string;
   onConfirm: (name: string) => void;
   onCancel: () => void;
 }
 
 /** An inline row that prompts for a new file or folder name, in place in the tree. */
-function NewEntryInput({ kind, depth, onConfirm, onCancel }: NewEntryInputProps) {
+function NewEntryInput({ kind, depth, initialValue, onConfirm, onCancel }: NewEntryInputProps) {
   const { t } = useTranslation("explorer");
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(initialValue ?? "");
 
   return (
     <div

--- a/src/modules/explorer/lib/fsBridge.test.ts
+++ b/src/modules/explorer/lib/fsBridge.test.ts
@@ -133,4 +133,11 @@ describe("fsBridge write-op routing", () => {
     await expect(fsRename("ssh://c1/a.txt", "ssh://c2/a.txt")).rejects.toThrow();
     expect(sftpRename).not.toHaveBeenCalled();
   });
+
+  it("rejects a rename that mixes local and remote paths", async () => {
+    await expect(fsRename("/p/a.txt", "ssh://c1/a.txt")).rejects.toThrow();
+    await expect(fsRename("ssh://c1/a.txt", "/p/a.txt")).rejects.toThrow();
+    expect(sftpRename).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+  });
 });

--- a/src/modules/explorer/lib/fsBridge.test.ts
+++ b/src/modules/explorer/lib/fsBridge.test.ts
@@ -11,13 +11,21 @@ vi.mock("@/modules/ssh/lib/sftpSessionStore", () => ({
 const sftpReadDir = vi.fn();
 const sftpReadFile = vi.fn();
 const sftpWriteFile = vi.fn();
+const sftpCreateFile = vi.fn();
+const sftpCreateDir = vi.fn();
+const sftpDelete = vi.fn();
+const sftpRename = vi.fn();
 vi.mock("@/modules/ssh/lib/sftp-bridge", () => ({
   sftpReadDir: (...a: unknown[]) => sftpReadDir(...a),
   sftpReadFile: (...a: unknown[]) => sftpReadFile(...a),
   sftpWriteFile: (...a: unknown[]) => sftpWriteFile(...a),
+  sftpCreateFile: (...a: unknown[]) => sftpCreateFile(...a),
+  sftpCreateDir: (...a: unknown[]) => sftpCreateDir(...a),
+  sftpDelete: (...a: unknown[]) => sftpDelete(...a),
+  sftpRename: (...a: unknown[]) => sftpRename(...a),
 }));
 
-import { canSearchRoot, fsReadDir, fsReadFile, fsWriteFile } from "./fsBridge";
+import { canSearchRoot, fsCreateDir, fsCreateFile, fsDelete, fsReadDir, fsReadFile, fsRename, fsWriteFile } from "./fsBridge";
 
 beforeEach(() => {
   invoke.mockReset();
@@ -25,6 +33,10 @@ beforeEach(() => {
   sftpReadDir.mockReset();
   sftpReadFile.mockReset();
   sftpWriteFile.mockReset();
+  sftpCreateFile.mockReset();
+  sftpCreateDir.mockReset();
+  sftpDelete.mockReset();
+  sftpRename.mockReset();
 });
 
 describe("fsBridge routing", () => {
@@ -72,5 +84,53 @@ describe("canSearchRoot", () => {
 
   it("rejects no open folder", () => {
     expect(canSearchRoot(null)).toBe(false);
+  });
+});
+
+describe("fsBridge write-op routing", () => {
+  it("creates local entries through fs_create_file / fs_create_dir", async () => {
+    invoke.mockResolvedValue(undefined);
+    await fsCreateFile("/p/x.txt");
+    expect(invoke).toHaveBeenCalledWith("fs_create_file", { path: "/p/x.txt" });
+    await fsCreateDir("/p/dir");
+    expect(invoke).toHaveBeenCalledWith("fs_create_dir", { path: "/p/dir" });
+  });
+
+  it("creates remote entries over sftp", async () => {
+    ensure.mockResolvedValue(7);
+    await fsCreateFile("ssh://c1/home/me/x.txt");
+    expect(sftpCreateFile).toHaveBeenCalledWith(7, "/home/me/x.txt");
+    await fsCreateDir("ssh://c1/home/me/dir");
+    expect(sftpCreateDir).toHaveBeenCalledWith(7, "/home/me/dir");
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("deletes locally through fs_delete, ignoring isDir", async () => {
+    invoke.mockResolvedValue(undefined);
+    await fsDelete("/p/dir", true);
+    expect(invoke).toHaveBeenCalledWith("fs_delete", { path: "/p/dir" });
+  });
+
+  it("deletes remotely over sftp, passing the entry kind through", async () => {
+    ensure.mockResolvedValue(7);
+    await fsDelete("ssh://c1/home/me/dir", true);
+    expect(sftpDelete).toHaveBeenCalledWith(7, "/home/me/dir", true);
+  });
+
+  it("renames locally through fs_rename", async () => {
+    invoke.mockResolvedValue(undefined);
+    await fsRename("/p/a.txt", "/p/b.txt");
+    expect(invoke).toHaveBeenCalledWith("fs_rename", { from: "/p/a.txt", to: "/p/b.txt" });
+  });
+
+  it("renames remotely over sftp with both paths unwrapped", async () => {
+    ensure.mockResolvedValue(7);
+    await fsRename("ssh://c1/a/old.txt", "ssh://c1/a/new.txt");
+    expect(sftpRename).toHaveBeenCalledWith(7, "/a/old.txt", "/a/new.txt");
+  });
+
+  it("rejects a rename that crosses hosts", async () => {
+    await expect(fsRename("ssh://c1/a.txt", "ssh://c2/a.txt")).rejects.toThrow();
+    expect(sftpRename).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/explorer/lib/fsBridge.ts
+++ b/src/modules/explorer/lib/fsBridge.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { buildRemoteUri, isRemoteUri, parseRemoteUri } from "@/modules/ssh/lib/remotePath";
-import { sftpReadDir, sftpReadFile, sftpWriteFile } from "@/modules/ssh/lib/sftp-bridge";
+import { sftpReadDir, sftpReadFile, sftpWriteFile, sftpCreateFile, sftpCreateDir, sftpDelete, sftpRename } from "@/modules/ssh/lib/sftp-bridge";
 import { sftpSessionStore } from "@/modules/ssh/lib/sftpSessionStore";
 
 export interface DirEntry {
@@ -66,19 +66,46 @@ export function fsGrep(
   return invoke<GrepMatch[]>("fs_grep", { root, query, limit });
 }
 
-export function fsCreateFile(path: string): Promise<void> {
+export async function fsCreateFile(path: string): Promise<void> {
+  const remote = parseRemoteUri(path);
+  if (remote) {
+    const id = await sftpSessionStore.getState().ensure(remote.connectionId);
+    return sftpCreateFile(id, remote.path);
+  }
   return invoke("fs_create_file", { path });
 }
 
-export function fsCreateDir(path: string): Promise<void> {
+export async function fsCreateDir(path: string): Promise<void> {
+  const remote = parseRemoteUri(path);
+  if (remote) {
+    const id = await sftpSessionStore.getState().ensure(remote.connectionId);
+    return sftpCreateDir(id, remote.path);
+  }
   return invoke("fs_create_dir", { path });
 }
 
-export function fsDelete(path: string): Promise<void> {
+/** `isDir` is only consulted on the remote branch — SFTP deletes files and
+ *  directories with different calls, and the caller already knows the kind
+ *  from the DirEntry it is deleting. The local `fs_delete` infers it itself. */
+export async function fsDelete(path: string, isDir: boolean): Promise<void> {
+  const remote = parseRemoteUri(path);
+  if (remote) {
+    const id = await sftpSessionStore.getState().ensure(remote.connectionId);
+    return sftpDelete(id, remote.path, isDir);
+  }
   return invoke("fs_delete", { path });
 }
 
-export function fsRename(from: string, to: string): Promise<void> {
+export async function fsRename(from: string, to: string): Promise<void> {
+  const remote = parseRemoteUri(from);
+  if (remote) {
+    const toRemote = parseRemoteUri(to);
+    if (!toRemote || toRemote.connectionId !== remote.connectionId) {
+      throw new Error("cannot rename across hosts");
+    }
+    const id = await sftpSessionStore.getState().ensure(remote.connectionId);
+    return sftpRename(id, remote.path, toRemote.path);
+  }
   return invoke("fs_rename", { from, to });
 }
 

--- a/src/modules/explorer/lib/fsBridge.ts
+++ b/src/modules/explorer/lib/fsBridge.ts
@@ -97,14 +97,14 @@ export async function fsDelete(path: string, isDir: boolean): Promise<void> {
 }
 
 export async function fsRename(from: string, to: string): Promise<void> {
-  const remote = parseRemoteUri(from);
-  if (remote) {
-    const toRemote = parseRemoteUri(to);
-    if (!toRemote || toRemote.connectionId !== remote.connectionId) {
+  const fromRemote = parseRemoteUri(from);
+  const toRemote = parseRemoteUri(to);
+  if (fromRemote || toRemote) {
+    if (!fromRemote || !toRemote || fromRemote.connectionId !== toRemote.connectionId) {
       throw new Error("cannot rename across hosts");
     }
-    const id = await sftpSessionStore.getState().ensure(remote.connectionId);
-    return sftpRename(id, remote.path, toRemote.path);
+    const id = await sftpSessionStore.getState().ensure(fromRemote.connectionId);
+    return sftpRename(id, fromRemote.path, toRemote.path);
   }
   return invoke("fs_rename", { from, to });
 }

--- a/src/modules/ssh/ConnectionForm.test.tsx
+++ b/src/modules/ssh/ConnectionForm.test.tsx
@@ -338,4 +338,23 @@ describe("ConnectionForm", () => {
     // The row should be pre-filled with the saved destHost
     expect(screen.getByDisplayValue("internal.server")).toBeInTheDocument();
   });
+
+  // ──────────────────────────────────────────────
+  // OSC 7 setup section
+  // ──────────────────────────────────────────────
+
+  describe("OSC 7 setup section", () => {
+    it("reveals the snippet on toggle and copies it", async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      render(<ConnectionForm onClose={() => {}} />);
+      fireEvent.click(screen.getByText(/follow remote cd/i));
+      expect(screen.getByText(/PROMPT_COMMAND/)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /copy snippet/i }));
+      await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+      expect(writeText.mock.calls[0][0]).toContain("add-zsh-hook precmd");
+    });
+  });
 });

--- a/src/modules/ssh/ConnectionForm.tsx
+++ b/src/modules/ssh/ConnectionForm.tsx
@@ -8,6 +8,7 @@ import { useTabsStore } from "@/stores/tabsStore";
 import type { SshAuthMethod } from "@/modules/ssh/lib/parseSshCommand";
 import { pickFile } from "@/lib/dialog";
 import { useOverlayGuard } from "@/lib/overlayGuard";
+import { OSC7_SNIPPET } from "./lib/osc7Snippet";
 
 interface ConnectionFormProps {
   /** When provided, the form is in edit mode pre-filled from this connection. */
@@ -121,6 +122,8 @@ export function ConnectionForm({ connection, onClose }: ConnectionFormProps) {
   const [pasteIgnored, setPasteIgnored] = useState<string[]>([]);
   const [pasteWarnings, setPasteWarnings] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
+  const [showOsc7, setShowOsc7] = useState(false);
+  const [osc7Copied, setOsc7Copied] = useState(false);
 
   const isEdit = !!connection;
 
@@ -516,6 +519,41 @@ export function ConnectionForm({ connection, onClose }: ConnectionFormProps) {
                     </div>
                   </div>
                 ))}
+              </div>
+            )}
+          </div>
+
+          <div className="border-t border-border" />
+
+          {/* OSC 7 / follow remote cd */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowOsc7((v) => !v)}
+              className="text-xs font-medium text-fg-muted hover:text-fg"
+            >
+              {showOsc7 ? "▾" : "▸"} {t("connectionForm.osc7.toggle")}
+            </button>
+            {showOsc7 && (
+              <div className="mt-2 space-y-2">
+                <p className="text-xs text-fg-subtle">
+                  {t("connectionForm.osc7.explanation")}
+                </p>
+                <pre className="overflow-x-auto rounded border border-border bg-bg-inset p-2 text-[11px] leading-relaxed text-fg-muted font-mono">
+                  {OSC7_SNIPPET}
+                </pre>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void navigator.clipboard.writeText(OSC7_SNIPPET);
+                    setOsc7Copied(true);
+                  }}
+                  className="rounded border border-border px-2 py-1 text-xs text-fg-muted hover:bg-bg-inset hover:text-fg"
+                >
+                  {osc7Copied
+                    ? t("connectionForm.osc7.copied")
+                    : t("connectionForm.osc7.copy")}
+                </button>
               </div>
             )}
           </div>

--- a/src/modules/ssh/lib/osc7Snippet.ts
+++ b/src/modules/ssh/lib/osc7Snippet.ts
@@ -1,0 +1,14 @@
+/**
+ * Copy-pasteable shell setup that makes a remote shell announce its working
+ * directory with OSC 7 at every prompt, which lets the file explorer follow
+ * `cd` on the remote host (see parseOsc7RemotePath in terminal/lib/osc7.ts).
+ */
+export const OSC7_SNIPPET = `# bash — add to ~/.bashrc
+__osc7_report() { printf '\\033]7;file://%s%s\\033\\\\' "$HOSTNAME" "$PWD"; }
+PROMPT_COMMAND="__osc7_report\${PROMPT_COMMAND:+; \$PROMPT_COMMAND}"
+
+# zsh — add to ~/.zshrc
+autoload -Uz add-zsh-hook
+__osc7_report() { printf '\\033]7;file://%s%s\\033\\\\' "$HOST" "$PWD"; }
+add-zsh-hook precmd __osc7_report
+`;

--- a/src/modules/ssh/lib/remoteCwdStore.test.ts
+++ b/src/modules/ssh/lib/remoteCwdStore.test.ts
@@ -1,0 +1,15 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { remoteCwdStore } from "./remoteCwdStore";
+
+beforeEach(() => {
+  remoteCwdStore.setState({ cwds: {} });
+});
+
+describe("remoteCwdStore", () => {
+  it("records the latest reported cwd per connection", () => {
+    remoteCwdStore.getState().report("c1", "/home/me");
+    remoteCwdStore.getState().report("c1", "/home/me/proj");
+    remoteCwdStore.getState().report("c2", "/srv");
+    expect(remoteCwdStore.getState().cwds).toEqual({ c1: "/home/me/proj", c2: "/srv" });
+  });
+});

--- a/src/modules/ssh/lib/remoteCwdStore.ts
+++ b/src/modules/ssh/lib/remoteCwdStore.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+/**
+ * Last OSC 7-reported working directory per SSH connection. Written by the
+ * terminal's OSC 7 handler on every report (active pane or not); read by
+ * useRemoteExplorerRoot (prefer the shell's cwd over the SFTP home) and by the
+ * OSC 7 fallback hint (a present entry means the remote shell emits OSC 7).
+ */
+interface RemoteCwdState {
+  cwds: Record<string, string>;
+  report: (connectionId: string, path: string) => void;
+}
+
+export const remoteCwdStore = create<RemoteCwdState>()((set) => ({
+  cwds: {},
+  report: (connectionId, path) =>
+    set((s) => ({ cwds: { ...s.cwds, [connectionId]: path } })),
+}));

--- a/src/modules/ssh/lib/sftp-bridge.test.ts
+++ b/src/modules/ssh/lib/sftp-bridge.test.ts
@@ -3,7 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const invoke = vi.fn();
 vi.mock("@tauri-apps/api/core", () => ({ invoke: (...a: unknown[]) => invoke(...a) }));
 
-import { sftpReadDir, sftpStart, sftpWriteFile } from "./sftp-bridge";
+import {
+  sftpCreateDir,
+  sftpCreateFile,
+  sftpDelete,
+  sftpReadDir,
+  sftpRename,
+  sftpStart,
+  sftpWriteFile,
+} from "./sftp-bridge";
 
 beforeEach(() => invoke.mockReset());
 
@@ -38,5 +46,24 @@ describe("sftp-bridge", () => {
       path: "/a.txt",
       contents: "hi",
     });
+  });
+});
+
+describe("sftp write ops", () => {
+  it("invokes sftp_create_file / sftp_create_dir with id and path", async () => {
+    await sftpCreateFile(7, "/home/me/x.txt");
+    expect(invoke).toHaveBeenCalledWith("sftp_create_file", { id: 7, path: "/home/me/x.txt" });
+    await sftpCreateDir(7, "/home/me/dir");
+    expect(invoke).toHaveBeenCalledWith("sftp_create_dir", { id: 7, path: "/home/me/dir" });
+  });
+
+  it("invokes sftp_delete with the entry kind", async () => {
+    await sftpDelete(7, "/home/me/dir", true);
+    expect(invoke).toHaveBeenCalledWith("sftp_delete", { id: 7, path: "/home/me/dir", isDir: true });
+  });
+
+  it("invokes sftp_rename with both paths", async () => {
+    await sftpRename(7, "/a/old.txt", "/a/new.txt");
+    expect(invoke).toHaveBeenCalledWith("sftp_rename", { id: 7, from: "/a/old.txt", to: "/a/new.txt" });
   });
 });

--- a/src/modules/ssh/lib/sftp-bridge.ts
+++ b/src/modules/ssh/lib/sftp-bridge.ts
@@ -33,3 +33,19 @@ export function sftpWriteFile(id: number, path: string, contents: string): Promi
 export function sftpClose(id: number): Promise<void> {
   return invoke("sftp_close", { id });
 }
+
+export function sftpCreateFile(id: number, path: string): Promise<void> {
+  return invoke("sftp_create_file", { id, path });
+}
+
+export function sftpCreateDir(id: number, path: string): Promise<void> {
+  return invoke("sftp_create_dir", { id, path });
+}
+
+export function sftpDelete(id: number, path: string, isDir: boolean): Promise<void> {
+  return invoke("sftp_delete", { id, path, isDir });
+}
+
+export function sftpRename(id: number, from: string, to: string): Promise<void> {
+  return invoke("sftp_rename", { id, from, to });
+}

--- a/src/modules/ssh/lib/useOsc7FallbackHint.test.tsx
+++ b/src/modules/ssh/lib/useOsc7FallbackHint.test.tsx
@@ -1,0 +1,80 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { remoteCwdStore } from "./remoteCwdStore";
+import { useConnectionsStore } from "@/stores/connectionsStore";
+import {
+  OSC7_HINT_TIMEOUT_MS,
+  resetShownThisSession,
+  useOsc7FallbackHint,
+} from "./useOsc7FallbackHint";
+
+let lastHint: string | null = null;
+let lastDismiss: () => void = () => {};
+
+function Probe({ id }: { id: string | null }) {
+  const { hintConnectionId, dismissHint } = useOsc7FallbackHint(id);
+  lastHint = hintConnectionId;
+  lastDismiss = dismissHint;
+  return null;
+}
+
+function seedConnection(id: string, osc7HintDismissed?: boolean) {
+  useConnectionsStore.setState({
+    connections: [
+      {
+        id,
+        name: id,
+        host: "h",
+        port: 22,
+        user: "u",
+        authMethod: "password",
+        rememberSecret: false,
+        osc7HintDismissed,
+      },
+    ],
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  remoteCwdStore.setState({ cwds: {} });
+  resetShownThisSession();
+  lastHint = null;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useOsc7FallbackHint", () => {
+  it("fires once after the timeout when no OSC 7 report arrives", () => {
+    seedConnection("c1");
+    render(<Probe id="c1" />);
+    act(() => vi.advanceTimersByTime(OSC7_HINT_TIMEOUT_MS));
+    expect(lastHint).toBe("c1");
+  });
+
+  it("stays quiet when a report arrives before the timeout", () => {
+    seedConnection("c1");
+    render(<Probe id="c1" />);
+    act(() => {
+      remoteCwdStore.getState().report("c1", "/home/me");
+      vi.advanceTimersByTime(OSC7_HINT_TIMEOUT_MS);
+    });
+    expect(lastHint).toBeNull();
+  });
+
+  it("never fires for a dismissed connection, and dismiss persists the flag", () => {
+    seedConnection("c1");
+    render(<Probe id="c1" />);
+    act(() => vi.advanceTimersByTime(OSC7_HINT_TIMEOUT_MS));
+    act(() => lastDismiss());
+    expect(lastHint).toBeNull();
+    expect(useConnectionsStore.getState().getConnection("c1")?.osc7HintDismissed).toBe(true);
+
+    seedConnection("c2", true);
+    render(<Probe id="c2" />);
+    act(() => vi.advanceTimersByTime(OSC7_HINT_TIMEOUT_MS));
+    expect(lastHint).toBeNull();
+  });
+});

--- a/src/modules/ssh/lib/useOsc7FallbackHint.ts
+++ b/src/modules/ssh/lib/useOsc7FallbackHint.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { remoteCwdStore } from "./remoteCwdStore";
+import { useConnectionsStore } from "@/stores/connectionsStore";
+
+export const OSC7_HINT_TIMEOUT_MS = 10_000;
+
+/** Connections already hinted this session, so pane re-activation never re-nags
+ *  someone who closed the dialog without ticking the permanent dismiss. */
+let shownThisSession = new Set<string>();
+
+/** Test-only: forget which connections were hinted. */
+export function resetShownThisSession(): void {
+  shownThisSession = new Set();
+}
+
+/**
+ * One-time guidance when a remote shell never announces its cwd: after an SSH
+ * pane has been the active explorer driver for OSC7_HINT_TIMEOUT_MS with no
+ * OSC 7 report, surface a hint pointing at the connection form's setup snippet.
+ * A report cancels the timer; a per-connection `osc7HintDismissed` flag mutes
+ * it forever.
+ */
+export function useOsc7FallbackHint(activeSshConnectionId: string | null): {
+  hintConnectionId: string | null;
+  dismissHint: () => void;
+} {
+  const [hintConnectionId, setHintConnectionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const id = activeSshConnectionId;
+    if (!id || shownThisSession.has(id)) {
+      return;
+    }
+    if (useConnectionsStore.getState().getConnection(id)?.osc7HintDismissed) {
+      return;
+    }
+    if (remoteCwdStore.getState().cwds[id]) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      shownThisSession.add(id);
+      setHintConnectionId(id);
+    }, OSC7_HINT_TIMEOUT_MS);
+    const unsubscribe = remoteCwdStore.subscribe((state) => {
+      if (state.cwds[id]) {
+        clearTimeout(timer);
+        unsubscribe();
+      }
+    });
+    return () => {
+      clearTimeout(timer);
+      unsubscribe();
+    };
+  }, [activeSshConnectionId]);
+
+  const dismissHint = () => {
+    if (hintConnectionId) {
+      useConnectionsStore
+        .getState()
+        .updateConnection(hintConnectionId, { osc7HintDismissed: true });
+    }
+    setHintConnectionId(null);
+  };
+
+  return { hintConnectionId, dismissHint };
+}

--- a/src/modules/ssh/lib/useRemoteExplorerRoot.test.tsx
+++ b/src/modules/ssh/lib/useRemoteExplorerRoot.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/stores/workspaceStore", () => ({
 }));
 
 import { useRemoteExplorerRoot } from "./useRemoteExplorerRoot";
+import { remoteCwdStore } from "./remoteCwdStore";
 
 function Probe({ id }: { id: string | null }) {
   useRemoteExplorerRoot(id);
@@ -24,6 +25,7 @@ beforeEach(() => {
   ensure.mockReset();
   sftpHome.mockReset();
   setRoot.mockReset();
+  remoteCwdStore.setState({ cwds: {} });
 });
 
 describe("useRemoteExplorerRoot", () => {
@@ -40,5 +42,24 @@ describe("useRemoteExplorerRoot", () => {
     await Promise.resolve();
     expect(ensure).not.toHaveBeenCalled();
     expect(setRoot).not.toHaveBeenCalled();
+  });
+
+  it("roots at the last OSC 7 cwd instead of home when one is known", async () => {
+    remoteCwdStore.getState().report("c1", "/home/me/proj");
+    render(<Probe id="c1" />);
+    await vi.waitFor(() => expect(setRoot).toHaveBeenCalledWith("ssh://c1/home/me/proj"));
+    expect(sftpHome).not.toHaveBeenCalled();
+  });
+
+  it("drops the home result when an OSC 7 report raced it", async () => {
+    ensure.mockResolvedValue(7);
+    let resolveHome: (v: string) => void = () => {};
+    sftpHome.mockReturnValue(new Promise((r) => { resolveHome = r; }));
+    render(<Probe id="c1" />);
+    await vi.waitFor(() => expect(sftpHome).toHaveBeenCalled());
+    remoteCwdStore.getState().report("c1", "/home/me/proj");
+    resolveHome("/home/me");
+    await Promise.resolve();
+    expect(setRoot).not.toHaveBeenCalledWith("ssh://c1/home/me");
   });
 });

--- a/src/modules/ssh/lib/useRemoteExplorerRoot.ts
+++ b/src/modules/ssh/lib/useRemoteExplorerRoot.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { sftpSessionStore } from "./sftpSessionStore";
 import { sftpHome } from "./sftp-bridge";
 import { buildRemoteUri } from "./remotePath";
+import { remoteCwdStore } from "./remoteCwdStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 /**
@@ -14,14 +15,26 @@ export function useRemoteExplorerRoot(activeSshConnectionId: string | null): voi
     if (!activeSshConnectionId) {
       return;
     }
+    // The shell's own report is fresher than the SFTP home — prefer it, and
+    // skip the connect round-trip entirely (fsReadDir ensures a session later).
+    const known = remoteCwdStore.getState().cwds[activeSshConnectionId];
+    if (known) {
+      useWorkspaceStore.getState().setRoot(buildRemoteUri(activeSshConnectionId, known));
+      return;
+    }
     let cancelled = false;
     void (async () => {
       try {
         const id = await sftpSessionStore.getState().ensure(activeSshConnectionId);
         const home = await sftpHome(id);
-        if (!cancelled) {
-          useWorkspaceStore.getState().setRoot(buildRemoteUri(activeSshConnectionId, home));
+        if (cancelled) {
+          return;
         }
+        // An OSC 7 report that arrived while home was in flight wins.
+        if (remoteCwdStore.getState().cwds[activeSshConnectionId]) {
+          return;
+        }
+        useWorkspaceStore.getState().setRoot(buildRemoteUri(activeSshConnectionId, home));
       } catch {
         // Connect/auth failed; the explorer shows its empty/error state.
       }

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -52,6 +52,7 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useUiStore, selectAnyOverlayOpen } from "@/stores/uiStore";
 import { shouldShowPreview } from "@/modules/preview/lib/previewWebview";
 import { useRemoteExplorerRoot } from "@/modules/ssh/lib/useRemoteExplorerRoot";
+import { useOsc7FallbackHint } from "@/modules/ssh/lib/useOsc7FallbackHint";
 
 const MIN_FRACTION = 0.1;
 const MAX_FRACTION = 0.9;
@@ -150,6 +151,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
       ? activeLeaf.content.ssh.connectionId
       : null;
   useRemoteExplorerRoot(activeSshConnectionId);
+  const { hintConnectionId, dismissHint } = useOsc7FallbackHint(activeSshConnectionId);
   // The splitter currently being dragged, used to drive the drag overlay's
   // resize cursor (see the overlay below).
   const draggingSplitter = draggingSplitterId
@@ -594,6 +596,15 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
           message={t("connectionsPanel.alreadyOpenAlert", { name: sshAlreadyConnectedName })}
           confirmLabel={t("actions.confirm")}
           onConfirm={() => setSshAlreadyConnected(false)}
+        />
+      )}
+
+      {hintConnectionId && (
+        <InfoDialog
+          title={t("osc7Hint.title")}
+          message={t("osc7Hint.message")}
+          confirmLabel={t("osc7Hint.confirm")}
+          onConfirm={dismissHint}
         />
       )}
     </div>

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -468,10 +468,9 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                     active={active}
                     isActiveTab={isActiveTab}
                     cwdTracking={
-                      active &&
-                      isActiveTab &&
-                      // SSH panes have no cwd; skip cwd tracking for them.
-                      (pane.content.kind !== "terminal" || !pane.content.ssh)
+                      // SSH panes track cwd through OSC 7 reports from the
+                      // remote shell instead of the local poll.
+                      active && isActiveTab
                     }
                     cwd={resolveTerminalCwd(
                       pane.content.kind === "terminal" ? pane.content.cwd : undefined,

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -78,7 +78,9 @@ import { ActionCard } from "./ActionCard";
 import { buildCellPositions, gatherLogicalLine } from "./lib/cellPositions";
 import { terminalKeySequence } from "./lib/terminalKeymap";
 import { shouldCdToRoot } from "./lib/cwdSync";
-import { parseOsc7Cwd } from "./lib/osc7";
+import { parseOsc7Cwd, parseOsc7RemotePath } from "./lib/osc7";
+import { remoteCwdStore } from "@/modules/ssh/lib/remoteCwdStore";
+import { buildRemoteUri } from "@/modules/ssh/lib/remotePath";
 import { applyTerminalPadding } from "./lib/terminalPadding";
 import { debounce } from "@/lib/debounce";
 import { dropOverlayClassName } from "@/components/EntryDropOverlay";
@@ -340,15 +342,24 @@ export function TerminalView({
       return true; // consume so the sequence never reaches the screen
     });
 
-    // On Windows the injected shell integration reports the shell's cwd with
-    // OSC 7 at every prompt (see lib/osc7.ts for why Windows can't poll the OS
-    // the way macOS/Linux do). Record it for session restore and pane
-    // activation, and forward it live to the cwd-tracking effect. SSH panes are
-    // skipped like the polling path skips them — a remote cwd means nothing to
-    // the local explorer, and parseOsc7Cwd rejects non-local reports anyway.
-    const osc7Handler = IS_WINDOWS
+    // OSC 7 cwd reports. Two emitters use this pane-lifetime handler: the
+    // Windows local shell integration (see lib/osc7.ts), and — on every
+    // platform — a remote shell over SSH that the user has configured to
+    // announce its cwd (see the connection form's setup snippet). Local
+    // macOS/Linux panes keep polling the OS instead and register no handler.
+    const osc7Handler = IS_WINDOWS || sshRef.current
       ? term.parser.registerOscHandler(7, (payload) => {
-          if (!sshRef.current) {
+          const paneSsh = sshRef.current;
+          if (paneSsh) {
+            const dir = parseOsc7RemotePath(payload);
+            if (dir) {
+              // Record for pane re-activation and the fallback hint even while
+              // inactive; the cwd-tracking effect applies it live when active.
+              remoteCwdStore.getState().report(paneSsh.connectionId, dir);
+              osc7CwdRef.current = dir;
+              osc7ApplyRef.current?.(dir);
+            }
+          } else {
             const dir = parseOsc7Cwd(payload);
             if (dir) {
               osc7CwdRef.current = dir;
@@ -842,7 +853,7 @@ export function TerminalView({
         // A freshly opened tracking pane drives the explorer to its start dir
         // right away instead of waiting for the next cwd poll. (Lets "open in
         // terminal" sync the explorer via the NEW pane, leaving others untouched.)
-        if (cwdTracking && cwdRef.current) {
+        if (cwdTracking && !sshRef.current && cwdRef.current) {
           useWorkspaceStore.getState().setRoot(cwdRef.current);
         }
         setSshDisconnected(false);
@@ -1051,11 +1062,36 @@ export function TerminalView({
   }, [terminalPadding]);
 
   // While this pane is the live one, follow its shell's working directory so
-  // the file explorer tracks `cd`. SSH panes skip this entirely — they have no
-  // cwd() or foregroundCommand() methods.
+  // the file explorer tracks `cd`. SSH panes take a different path below — no
+  // cwd() or foregroundCommand() methods, so they ride OSC 7 reports instead.
   useEffect(() => {
-    if (!cwdTracking || sshRef.current) {
+    if (!cwdTracking) {
       return;
+    }
+    const paneSsh = sshRef.current;
+    if (paneSsh) {
+      // Remote pane: OSC 7 reports (already recorded by the mount handler)
+      // drive the explorer root while this pane is the active driver. No lsof
+      // poll (the shell is on another machine), no reverse explorer→shell cd,
+      // and no tab title sync — SSH tabs are user-named.
+      let last = "";
+      let firstSync = true;
+      const applyRemote = (dir: string) => {
+        if (dir !== last || firstSync) {
+          last = dir;
+          firstSync = false;
+          useWorkspaceStore.getState().setRoot(buildRemoteUri(paneSsh.connectionId, dir));
+        }
+      };
+      osc7ApplyRef.current = applyRemote;
+      if (osc7CwdRef.current) {
+        applyRemote(osc7CwdRef.current);
+      }
+      return () => {
+        if (osc7ApplyRef.current === applyRemote) {
+          osc7ApplyRef.current = null;
+        }
+      };
     }
     let cancelled = false;
     // Seed with the shell's starting dir so the mount-time setRoot (which fires

--- a/src/modules/terminal/lib/osc7.test.ts
+++ b/src/modules/terminal/lib/osc7.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseOsc7Cwd } from "./osc7";
+import { parseOsc7Cwd, parseOsc7RemotePath } from "./osc7";
 
 describe("parseOsc7Cwd", () => {
   it("parses PowerShell's percent-encoded file URI", () => {
@@ -89,3 +89,24 @@ describe("parseOsc7Cwd", () => {
     );
   });
 });
+
+describe("parseOsc7RemotePath", () => {
+  it("accepts any host and returns the POSIX path", () => {
+    expect(parseOsc7RemotePath("file://myserver/home/me/proj")).toBe("/home/me/proj");
+    expect(parseOsc7RemotePath("file:///home/me")).toBe("/home/me");
+  });
+
+  it("percent-decodes and trims trailing slashes", () => {
+    expect(parseOsc7RemotePath("file://h/home/f%20o")).toBe("/home/f o");
+    expect(parseOsc7RemotePath("file://h/home/me/")).toBe("/home/me");
+    expect(parseOsc7RemotePath("file://h/")).toBe("/");
+  });
+
+  it("rejects non-file payloads, relative paths and control characters", () => {
+    expect(parseOsc7RemotePath("not-a-uri")).toBeNull();
+    expect(parseOsc7RemotePath("file://host-only")).toBeNull();
+    expect(parseOsc7RemotePath("file://h/home/%0abad")).toBeNull();
+    expect(parseOsc7RemotePath(`file://h/${"a".repeat(9000)}`)).toBeNull();
+  });
+});
+

--- a/src/modules/terminal/lib/osc7.ts
+++ b/src/modules/terminal/lib/osc7.ts
@@ -69,3 +69,33 @@ export function parseOsc7Cwd(payload: string): string | null {
   }
   return win;
 }
+
+/**
+ * Parse an OSC 7 payload from a *remote* shell into a POSIX absolute path, or
+ * null when it isn't one. Unlike `parseOsc7Cwd` (Windows-local, drive-lettered,
+ * localhost-only) this accepts any host: the report arrives on an SSH pane's
+ * own byte stream, so the pane's connectionId — not the URI host — identifies
+ * the machine. Applies the same size and control-character hardening, since the
+ * result becomes the persisted workspace root.
+ */
+export function parseOsc7RemotePath(payload: string): string | null {
+  if (payload.length > 8192 || !payload.startsWith("file://")) {
+    return null;
+  }
+  const rest = payload.slice("file://".length);
+  const cut = rest.indexOf("/");
+  if (cut === -1) {
+    return null;
+  }
+  let path = rest.slice(cut);
+  try {
+    path = decodeURIComponent(path);
+  } catch {
+    // A bare `%` from a naive emitter; keep the raw text.
+  }
+  const clean = path.replace(/\/+$/, "") || "/";
+  if (clean.length > 4096 || /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/.test(clean)) {
+    return null;
+  }
+  return clean;
+}

--- a/src/stores/connectionsStore.ts
+++ b/src/stores/connectionsStore.ts
@@ -22,6 +22,8 @@ export interface SshConnection {
   keyPath?: string;
   rememberSecret: boolean;
   portForwards?: PortForward[];
+  /** The OSC 7 setup hint was dismissed for this connection — never show it again. */
+  osc7HintDismissed?: boolean;
 }
 
 interface ConnectionsState {

--- a/src/stores/notesStore.test.ts
+++ b/src/stores/notesStore.test.ts
@@ -147,7 +147,7 @@ describe("notesStore.moveNote", () => {
 describe("notesStore.deleteNote / read / write", () => {
   it("deletes via fsDelete", async () => {
     await useNotesStore.getState().deleteNote("/root/a.md");
-    expect(mocked.fsDelete).toHaveBeenCalledWith("/root/a.md");
+    expect(mocked.fsDelete).toHaveBeenCalledWith("/root/a.md", false);
   });
 
   it("reads and writes note content via the bridge", async () => {

--- a/src/stores/notesStore.ts
+++ b/src/stores/notesStore.ts
@@ -161,7 +161,7 @@ export const useNotesStore = create<NotesState>()((set, get) => ({
   },
 
   deleteNote: async (path) => {
-    await fsDelete(path);
+    await fsDelete(path, false);
     await get().refresh();
   },
 


### PR DESCRIPTION
## Summary

Builds on the SSH remote file explorer (#48) and closes two of its deferred items, plus the setup guidance around them:

**1. Remote create / delete / rename over SFTP**
- Four new Rust commands (`sftp_create_file` / `sftp_create_dir` / `sftp_delete` / `sftp_rename`) on the existing SFTP worker-channel pattern; `sftp_delete` takes the entry kind since SFTP splits file/dir removal.
- `fsBridge` write ops now route `ssh://` paths to SFTP with the same `parseRemoteUri` branch the read path already uses; `fsDelete` gains a required `isDir` param (tsc-enforced at every call site).
- Rename becomes a first-class explorer action (context menu + inline input, local and remote alike).
- Remote deletes are permanent (no trash over SFTP), so they are gated behind a ConfirmDialog; local deletes keep the trash path untouched.

**2. Explorer follows the remote shell's cd (OSC 7)**
- New `parseOsc7RemotePath` (any-host, POSIX) beside the existing Windows-local parser, with the same control-character hardening.
- SSH panes register the xterm OSC 7 handler on every platform; reports land in a `remoteCwdStore` (per connection) and drive the explorer root while the pane is the active driver.
- `useRemoteExplorerRoot` prefers the shell's last-reported cwd over the SFTP home, with a race guard for reports that land mid home-lookup.
- Strictly one-way (shell → explorer): no `cd` is ever written into the remote shell.

**3. Setup guidance + fallback**
- Connection form gains a collapsible section with a copy-pasteable bash/zsh OSC 7 snippet (byte-exactness independently verified).
- If an active SSH pane reports no OSC 7 within 10s, a one-time InfoDialog points at the snippet; dismissal persists per connection (`osc7HintDismissed`).
- Explorer header gains a manual Refresh button (local + remote) that re-fetches the tree and drops cached subfolder listings.
- Shared new-entry/rename input now guards Enter against IME composition (isComposing / keyCode 229).

Out of scope (unchanged from the v1 deferrals): upload/download, remote fuzzy-find/grep, git panel awareness of remote roots, OSC 7 auto-injection.

## Test plan

Automated (all green):
- [x] Frontend: 1200 tests / 149 files (vitest), including new suites for sftp-bridge wrappers, fsBridge routing, OSC 7 parsing, remoteCwdStore, useRemoteExplorerRoot race guard, useOsc7FallbackHint timers, FileTree rename + IME guard + remote-delete confirm, ConnectionForm snippet, ExplorerView refresh
- [x] `tsc --noEmit` clean
- [x] Rust: `cargo check` clean, 213 tests passing
- [x] Whole-branch review (all gates re-run independently): zero Critical/Important findings

Manual smoke against a live SSH host (Ubuntu):
- [x] Explorer roots at remote home when an SSH pane is active（SSH 連上後，檔案總管自動切到遠端家目錄）
- [x] Remote New File / New Folder from the context menu（遠端右鍵新增檔案、新增資料夾）
- [ ] Remote Rename; remote Delete shows the red ConfirmDialog（遠端改名；遠端刪除要跳紅色確認框）
- [ ] CJK rename: Enter during IME composition must not commit early（中文檔名改名，選字中按 Enter 不會提早送出）
- [ ] Terminal `cd` moves the explorer root (OSC 7 snippet installed)（終端機 `cd` 後，檔案總管跟著切換目錄）
- [ ] Switching to a local pane and back returns to the last remote cwd, not home（切到本機 pane 再切回來，回到最後的遠端目錄而不是家目錄）
- [ ] Refresh button re-syncs after terminal-side deletes（終端機刪目錄後，按重新整理鈕，總管同步消失）
- [ ] Connection without the snippet: one-time hint after 10s, never again once dismissed（沒裝 snippet 的連線，停 10 秒跳一次提示，關掉後不再出現）
- [ ] Local regression: rename works, delete stays trash-backed with no dialog（本機回歸：改名正常，刪除進垃圾桶且不跳確認框）