### PR TITLE
feat: AI sessions view (P1) — cross-agent session browser

### DIFF
--- a/docs/superpowers/plans/2026-07-06-ai-sessions-view-p1.md
+++ b/docs/superpowers/plans/2026-07-06-ai-sessions-view-p1.md
@@ -1,0 +1,1576 @@
+# AI Sessions View P1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A sidebar "AI Sessions" view listing every historical Claude Code / Codex / Antigravity CLI session on this machine, with a main-area viewer tab, live-session section, pinning, and one-click resume.
+
+**Architecture:** A new Rust module `sessions_index` scans the three agents' on-disk session stores, parses them defensively into a metadata-only SQLite index (message bodies are re-parsed from source files on demand), and watches the roots for changes. The frontend adds a sidebar view + one singleton "sessions" content tab (same pattern as `git-graph`).
+
+**Tech Stack:** Rust (Tauri 2, rusqlite, notify 6, chrono, serde_json), React 19 + zustand + Tailwind v4, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-06-ai-sessions-view-design.md`
+
+## Global Constraints
+
+- **No new npm dependencies.** Charts and all UI are hand-rolled.
+- **Only new Rust crate: `rusqlite`** — system SQLite on macOS, `bundled` feature on Windows/Linux only.
+- Code comments, commit messages in **English**; all user-visible strings go through i18next with **both** `en` and `zh-Hant` values.
+- Conventional commits (`feat:`, `test:`, `docs:` …). No AI attribution lines.
+- All filesystem access happens in Rust commands (the app never uses `@tauri-apps/plugin-fs`).
+- Session file formats are unofficial internals: **parse defensively** — a malformed line/blob is skipped, never an error that aborts a batch.
+- The index DB is a disposable cache: schema mismatch ⇒ drop data tables and rebuild. Never treat it as a source of truth.
+- Dialogs use the in-app components, never `window.confirm` / `alert`.
+- Branch: `feat/ai-sessions-view` in the `tempo-term-dev` worktree. Base: `master`.
+
+## Verified facts (do not re-derive)
+
+- Claude sessions: `~/.claude/projects/<mangled-cwd>/*.jsonl` (only top-level `.jsonl` files; `<session-id>/` companion dirs contain subagents/tool-results). Lines carry `type`, `uuid`, `parentUuid`, `timestamp` (ISO 8601), `isMeta`, `isSidechain`, `cwd`, `sessionId`, `message.{role,content,model,usage}`. Env override `CLAUDE_CONFIG_DIR`.
+- Codex sessions: `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` + `~/.codex/archived_sessions/*.jsonl`. Line shape `{timestamp, type, payload}` with types `session_meta` (payload.id, payload.cwd), `event_msg` (payload.type: `user_message` with `.message`, `token_count` with `.info`), `response_item` (payload.type `message` with `.role`/`.content[]`, `function_call` with `.name`), `turn_context`. Env override `CODEX_HOME`.
+- Antigravity CLI: `~/.gemini/antigravity-cli/conversations/<uuid>.db` (SQLite + `-wal`/`-shm`). Verified real schema: `steps(idx INTEGER PK, step_type INTEGER, status, …, step_payload BLOB, step_format)`, `gen_metadata(idx INTEGER PK, data BLOB, size)`. step_type 14 = user input, 15 = planner (assistant) response. In `step_payload` protobuf: field 5 = google.protobuf.Timestamp (seconds=field 1, nanos=field 2), field 17 = message text.
+- Existing patterns to copy: `src-tauri/src/modules/claude_progress/mod.rs` (watcher + tail + command + tests style), `codex_progress/mod.rs`. Reusable helpers already public enough: `claude_progress::{config_base_dir, extract_session_title}`.
+- Tab plumbing: `TabKind`/`openGitGraphTab` in `src/stores/tabsStore.ts` (singleton content tab pattern), `PaneContent` union in `src/modules/terminal/lib/terminalLayout.ts:15`, render switch in `src/modules/terminal/PaneTabContent.tsx:460`, icon switch in `src/components/TabBar.tsx:62`, tab title i18n at `tabs.*` in `src/i18n/locales/{en,zh-Hant}/common.json` (key `"git-graph"` exists at line ~237).
+- Run a command in a fresh terminal: `useTabsStore.getState().newTerminalTab(cwd)` then `writeToTerminal(leafId, "cmd\n")` from `src/modules/terminal/lib/terminalBus.ts` — writes queue until the PTY registers, so no race.
+- Live status: `useSessionStatusStore` (`src/modules/claude-progress/lib/sessionStatusStore.ts`) — `statuses`/`agents` are `Record<leafId, …>`; map leafId→tab via `useTabsStore` + `computeLayout`.
+- Test commands: Rust `cd src-tauri && cargo test <filter>`; frontend `pnpm test` (vitest run), `pnpm typecheck`.
+- lib.rs wiring: `.manage(XState::new())` around `src-tauri/src/lib.rs:95-103`, command list in `tauri::generate_handler![ … ]` at `src-tauri/src/lib.rs:142`; module list in `src-tauri/src/modules/mod.rs`.
+
+## File Structure
+
+```
+src-tauri/src/modules/sessions_index/
+  mod.rs           state + 4 Tauri commands + event emit
+  types.rs         ParsedSession / ActivityBucket / SessionSummary / TranscriptMessage
+  index.rs         SQLite cache: schema, upsert, list, pin, lookup, prune
+  scanner.rs       discover session files across the three roots
+  claude.rs        Claude JSONL → ParsedSession / transcript (DAG main path)
+  codex.rs         Codex rollout JSONL → ParsedSession / transcript
+  antigravity.rs   Antigravity CLI .db → ParsedSession / transcript
+  proto.rs         minimal protobuf wire-format reader (no prost)
+  sync.rs          full + per-file sync orchestration
+  watch.rs         notify watchers + 500 ms debounce thread
+
+src/modules/sessions/
+  SessionsPanel.tsx        sidebar view (Live / search / filters / pins / list)
+  SessionsTabContent.tsx   main-area tab (empty state ↔ transcript viewer)
+  lib/sessionsBridge.ts    invoke + event wrappers, TS types
+  lib/sessionsStore.ts     zustand store (list, filters, selection)
+  lib/sessionsStore.test.ts
+  lib/liveSessions.ts      derive live entries from tabs + status stores
+  lib/liveSessions.test.ts
+  lib/resume.ts            open terminal tab + type resume command
+  lib/relativeTime.ts (+test)
+
+Modified: src-tauri/Cargo.toml, src-tauri/src/lib.rs, src-tauri/src/modules/mod.rs,
+src/stores/uiStore.ts, src/stores/tabsStore.ts, src/components/Sidebar.tsx,
+src/components/TabBar.tsx, src/modules/terminal/lib/terminalLayout.ts,
+src/modules/terminal/PaneTabContent.tsx, src/i18n/locales/{en,zh-Hant}/common.json
+```
+
+---
+
+### Task 1: rusqlite dependency + module skeleton + shared types
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml`
+- Modify: `src-tauri/src/modules/mod.rs`
+- Create: `src-tauri/src/modules/sessions_index/mod.rs`
+- Create: `src-tauri/src/modules/sessions_index/types.rs`
+
+**Interfaces:**
+- Produces: `ParsedSession`, `ActivityBucket`, `SessionSummary`, `TranscriptMessage` — every later task uses these exact shapes.
+
+- [ ] **Step 1: Add rusqlite to Cargo.toml**
+
+In `[dependencies]` (after `notify = "6"`):
+
+```toml
+# Reads the Antigravity CLI's per-session SQLite trajectory databases and backs
+# the sessions index cache. macOS links the system libsqlite3 to keep the
+# binary lean; Windows/Linux have no system SQLite so they compile it in.
+rusqlite = "0.32"
+```
+
+And target-specific feature additions (append to the existing `[target.'cfg(target_os = "windows")'.dependencies]` block, and to the linux one):
+
+```toml
+# in [target.'cfg(target_os = "windows")'.dependencies]
+rusqlite = { version = "0.32", features = ["bundled"] }
+
+# in [target.'cfg(target_os = "linux")'.dependencies]
+rusqlite = { version = "0.32", features = ["bundled"] }
+```
+
+- [ ] **Step 2: Register the module**
+
+In `src-tauri/src/modules/mod.rs` add (alphabetical order, near `session_log`):
+
+```rust
+pub mod sessions_index;
+```
+
+- [ ] **Step 3: Create types.rs**
+
+```rust
+//! Shared shapes for the sessions index: what parsers produce and what the
+//! frontend receives. Timestamps are epoch milliseconds (UTC); activity
+//! buckets use the local calendar so the heatmap matches the user's day.
+
+/// One agent's parsed session, ready to upsert into the index.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedSession {
+    pub id: String,
+    /// "claude" | "codex" | "antigravity"
+    pub agent: &'static str,
+    pub project_cwd: String,
+    pub title: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+    pub message_count: i64,
+    pub user_message_count: i64,
+    /// None when the source format exposes no token counts.
+    pub output_tokens: Option<i64>,
+    pub model: Option<String>,
+    /// Per local-day/hour message buckets, for the P2 heatmap.
+    pub activity: Vec<ActivityBucket>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ActivityBucket {
+    /// Local date, "YYYY-MM-DD".
+    pub date: String,
+    pub hour: u8,
+    pub messages: i64,
+    pub user_messages: i64,
+    pub output_tokens: i64,
+}
+
+/// What `sessions_list` returns to the frontend.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionSummary {
+    pub id: String,
+    pub agent: String,
+    pub project_cwd: String,
+    pub title: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+    pub message_count: i64,
+    pub user_message_count: i64,
+    pub output_tokens: Option<i64>,
+    pub model: Option<String>,
+    pub file_path: String,
+    pub pinned: bool,
+}
+
+/// One rendered message for the viewer, re-parsed from the source file on
+/// demand (the index never stores message bodies).
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct TranscriptMessage {
+    /// "user" | "assistant" | "tool" | "system"
+    pub role: String,
+    pub text: String,
+    pub timestamp: Option<i64>,
+    pub tool_name: Option<String>,
+}
+```
+
+- [ ] **Step 4: Create mod.rs (skeleton only for now)**
+
+```rust
+//! Historical AI CLI sessions: scans Claude Code / Codex / Antigravity CLI
+//! session stores into a metadata-only SQLite index and serves the sidebar
+//! sessions view. Message bodies are re-parsed from source files on demand —
+//! the index is a disposable cache, the files stay the source of truth.
+
+pub mod antigravity;
+pub mod claude;
+pub mod codex;
+pub mod index;
+pub mod proto;
+pub mod scanner;
+pub mod sync;
+pub mod types;
+pub mod watch;
+```
+
+(Create empty placeholder files `index.rs`, `scanner.rs`, `claude.rs`, `codex.rs`, `antigravity.rs`, `proto.rs`, `sync.rs`, `watch.rs` each containing only a module doc-comment so the build passes; each later task fills its file.)
+
+- [ ] **Step 5: Verify build**
+
+Run: `cd src-tauri && cargo check`
+Expected: success (warnings about unused code are fine at this point).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/src/modules/mod.rs src-tauri/src/modules/sessions_index
+git commit -m "feat(sessions): add sessions_index module skeleton and rusqlite dependency"
+```
+
+---
+
+### Task 2: SQLite index layer
+
+**Files:**
+- Create: `src-tauri/src/modules/sessions_index/index.rs` (tests inline `#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `types::{ParsedSession, SessionSummary}`
+- Produces:
+  - `Index::open(path: &Path) -> Result<Index, String>`
+  - `Index::upsert_session(&self, s: &ParsedSession, file_path: &str, file_mtime: i64, file_size: i64) -> Result<(), String>`
+  - `Index::needs_sync(&self, file_path: &str, file_mtime: i64, file_size: i64) -> bool`
+  - `Index::list(&self) -> Vec<SessionSummary>` (newest `ended_at` first)
+  - `Index::set_pinned(&self, id: &str, pinned: bool) -> Result<(), String>`
+  - `Index::lookup_file(&self, id: &str) -> Option<(String, String)>` (agent, file_path)
+  - `Index::prune_missing(&self, existing: &std::collections::HashSet<String>) -> Result<(), String>`
+
+- [ ] **Step 1: Write failing tests** (inline in `index.rs`)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::sessions_index::types::{ActivityBucket, ParsedSession};
+
+    fn sample(id: &str) -> ParsedSession {
+        ParsedSession {
+            id: id.into(),
+            agent: "claude",
+            project_cwd: "/tmp/proj".into(),
+            title: "hello".into(),
+            started_at: 1000,
+            ended_at: 2000,
+            message_count: 4,
+            user_message_count: 2,
+            output_tokens: Some(50),
+            model: Some("claude-sonnet-5".into()),
+            activity: vec![ActivityBucket {
+                date: "2026-07-06".into(),
+                hour: 9,
+                messages: 4,
+                user_messages: 2,
+                output_tokens: 50,
+            }],
+        }
+    }
+
+    fn temp_db(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-sessions-index-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("index.db")
+    }
+
+    #[test]
+    fn upsert_then_list_roundtrips_a_session() {
+        let index = Index::open(&temp_db("roundtrip")).unwrap();
+        index.upsert_session(&sample("s1"), "/f/s1.jsonl", 111, 222).unwrap();
+        let rows = index.list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "s1");
+        assert_eq!(rows[0].agent, "claude");
+        assert_eq!(rows[0].message_count, 4);
+        assert_eq!(rows[0].file_path, "/f/s1.jsonl");
+        assert!(!rows[0].pinned);
+    }
+
+    #[test]
+    fn upsert_replaces_instead_of_duplicating() {
+        let index = Index::open(&temp_db("replace")).unwrap();
+        index.upsert_session(&sample("s1"), "/f/s1.jsonl", 1, 1).unwrap();
+        let mut updated = sample("s1");
+        updated.message_count = 9;
+        index.upsert_session(&updated, "/f/s1.jsonl", 2, 2).unwrap();
+        let rows = index.list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].message_count, 9);
+    }
+
+    #[test]
+    fn needs_sync_is_false_only_for_unchanged_fingerprint() {
+        let index = Index::open(&temp_db("fingerprint")).unwrap();
+        index.upsert_session(&sample("s1"), "/f/s1.jsonl", 111, 222).unwrap();
+        assert!(!index.needs_sync("/f/s1.jsonl", 111, 222));
+        assert!(index.needs_sync("/f/s1.jsonl", 112, 222));
+        assert!(index.needs_sync("/f/s1.jsonl", 111, 223));
+        assert!(index.needs_sync("/f/other.jsonl", 111, 222));
+    }
+
+    #[test]
+    fn pins_survive_and_order_is_newest_first() {
+        let index = Index::open(&temp_db("pins")).unwrap();
+        index.upsert_session(&sample("old"), "/f/a.jsonl", 1, 1).unwrap();
+        let mut newer = sample("new");
+        newer.ended_at = 9999;
+        index.upsert_session(&newer, "/f/b.jsonl", 1, 1).unwrap();
+        index.set_pinned("old", true).unwrap();
+        let rows = index.list();
+        assert_eq!(rows[0].id, "new");
+        assert!(rows.iter().find(|r| r.id == "old").unwrap().pinned);
+    }
+
+    #[test]
+    fn lookup_file_returns_agent_and_path() {
+        let index = Index::open(&temp_db("lookup")).unwrap();
+        index.upsert_session(&sample("s1"), "/f/s1.jsonl", 1, 1).unwrap();
+        assert_eq!(
+            index.lookup_file("s1"),
+            Some(("claude".to_string(), "/f/s1.jsonl".to_string()))
+        );
+        assert_eq!(index.lookup_file("nope"), None);
+    }
+
+    #[test]
+    fn prune_missing_drops_sessions_whose_file_is_gone() {
+        let index = Index::open(&temp_db("prune")).unwrap();
+        index.upsert_session(&sample("s1"), "/f/a.jsonl", 1, 1).unwrap();
+        index.upsert_session(&sample("s2"), "/f/b.jsonl", 1, 1).unwrap();
+        let existing: std::collections::HashSet<String> = ["/f/a.jsonl".to_string()].into();
+        index.prune_missing(&existing).unwrap();
+        let rows = index.list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "s1");
+    }
+
+    #[test]
+    fn schema_version_bump_rebuilds_data_but_keeps_pins() {
+        let path = temp_db("version");
+        {
+            let index = Index::open(&path).unwrap();
+            index.upsert_session(&sample("s1"), "/f/a.jsonl", 1, 1).unwrap();
+            index.set_pinned("s1", true).unwrap();
+            index.conn.execute("UPDATE meta SET value='0' WHERE key='schema_version'", []).unwrap();
+        }
+        let reopened = Index::open(&path).unwrap();
+        assert!(reopened.list().is_empty()); // data table was rebuilt
+        // pins table persisted; re-upserting the session shows it pinned again
+        reopened.upsert_session(&sample("s1"), "/f/a.jsonl", 1, 1).unwrap();
+        assert!(reopened.list()[0].pinned);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd src-tauri && cargo test sessions_index::index`
+Expected: compile error (`Index` not defined).
+
+- [ ] **Step 3: Implement**
+
+```rust
+//! The metadata index: a disposable SQLite cache of session summaries and
+//! per-day activity buckets. Message bodies are never stored here. If the
+//! schema version doesn't match, data tables are dropped and rebuilt from
+//! source files; the pins table survives rebuilds because it's user state.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use rusqlite::{params, Connection};
+
+use super::types::{ParsedSession, SessionSummary};
+
+pub const SCHEMA_VERSION: &str = "1";
+
+pub struct Index {
+    pub(crate) conn: Connection,
+}
+
+impl Index {
+    pub fn open(path: &Path) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let conn = Connection::open(path).map_err(|e| e.to_string())?;
+        conn.pragma_update(None, "journal_mode", "WAL").map_err(|e| e.to_string())?;
+        let index = Self { conn };
+        index.migrate()?;
+        Ok(index)
+    }
+
+    fn migrate(&self) -> Result<(), String> {
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 CREATE TABLE IF NOT EXISTS pins(session_id TEXT PRIMARY KEY);",
+            )
+            .map_err(|e| e.to_string())?;
+        let version: Option<String> = self
+            .conn
+            .query_row("SELECT value FROM meta WHERE key='schema_version'", [], |r| r.get(0))
+            .ok();
+        if version.as_deref() != Some(SCHEMA_VERSION) {
+            // Stale or missing schema: drop derived data (cheap to rebuild from
+            // source files) but keep pins (user state with no other home).
+            self.conn
+                .execute_batch("DROP TABLE IF EXISTS sessions; DROP TABLE IF EXISTS activity;")
+                .map_err(|e| e.to_string())?;
+        }
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS sessions(
+                   id TEXT PRIMARY KEY,
+                   agent TEXT NOT NULL,
+                   project_cwd TEXT NOT NULL,
+                   title TEXT NOT NULL,
+                   started_at INTEGER NOT NULL,
+                   ended_at INTEGER NOT NULL,
+                   message_count INTEGER NOT NULL,
+                   user_message_count INTEGER NOT NULL,
+                   output_tokens INTEGER,
+                   model TEXT,
+                   file_path TEXT NOT NULL,
+                   file_mtime INTEGER NOT NULL,
+                   file_size INTEGER NOT NULL
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_sessions_file ON sessions(file_path);
+                 CREATE TABLE IF NOT EXISTS activity(
+                   session_id TEXT NOT NULL,
+                   date TEXT NOT NULL,
+                   hour INTEGER NOT NULL,
+                   messages INTEGER NOT NULL,
+                   user_messages INTEGER NOT NULL,
+                   output_tokens INTEGER NOT NULL,
+                   PRIMARY KEY(session_id, date, hour)
+                 );",
+            )
+            .map_err(|e| e.to_string())?;
+        self.conn
+            .execute(
+                "INSERT INTO meta(key,value) VALUES('schema_version',?1)
+                 ON CONFLICT(key) DO UPDATE SET value=?1",
+                params![SCHEMA_VERSION],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn upsert_session(
+        &self,
+        s: &ParsedSession,
+        file_path: &str,
+        file_mtime: i64,
+        file_size: i64,
+    ) -> Result<(), String> {
+        self.conn
+            .execute(
+                "INSERT INTO sessions(id,agent,project_cwd,title,started_at,ended_at,
+                   message_count,user_message_count,output_tokens,model,file_path,file_mtime,file_size)
+                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13)
+                 ON CONFLICT(id) DO UPDATE SET agent=?2,project_cwd=?3,title=?4,started_at=?5,
+                   ended_at=?6,message_count=?7,user_message_count=?8,output_tokens=?9,model=?10,
+                   file_path=?11,file_mtime=?12,file_size=?13",
+                params![
+                    s.id, s.agent, s.project_cwd, s.title, s.started_at, s.ended_at,
+                    s.message_count, s.user_message_count, s.output_tokens, s.model,
+                    file_path, file_mtime, file_size
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+        // Activity rows are keyed by session id and replaced wholesale with the
+        // session, so a whole-file re-parse can never double-count a bucket.
+        self.conn
+            .execute("DELETE FROM activity WHERE session_id=?1", params![s.id])
+            .map_err(|e| e.to_string())?;
+        for b in &s.activity {
+            self.conn
+                .execute(
+                    "INSERT INTO activity(session_id,date,hour,messages,user_messages,output_tokens)
+                     VALUES(?1,?2,?3,?4,?5,?6)",
+                    params![s.id, b.date, b.hour, b.messages, b.user_messages, b.output_tokens],
+                )
+                .map_err(|e| e.to_string())?;
+        }
+        Ok(())
+    }
+
+    /// True when the file is unknown or its mtime/size fingerprint changed.
+    pub fn needs_sync(&self, file_path: &str, file_mtime: i64, file_size: i64) -> bool {
+        let known: Option<(i64, i64)> = self
+            .conn
+            .query_row(
+                "SELECT file_mtime, file_size FROM sessions WHERE file_path=?1 LIMIT 1",
+                params![file_path],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .ok();
+        known != Some((file_mtime, file_size))
+    }
+
+    pub fn list(&self) -> Vec<SessionSummary> {
+        let mut stmt = match self.conn.prepare(
+            "SELECT s.id,s.agent,s.project_cwd,s.title,s.started_at,s.ended_at,
+                    s.message_count,s.user_message_count,s.output_tokens,s.model,s.file_path,
+                    (p.session_id IS NOT NULL) AS pinned
+             FROM sessions s LEFT JOIN pins p ON p.session_id = s.id
+             ORDER BY s.ended_at DESC",
+        ) {
+            Ok(stmt) => stmt,
+            Err(_) => return Vec::new(),
+        };
+        let rows = stmt.query_map([], |r| {
+            Ok(SessionSummary {
+                id: r.get(0)?,
+                agent: r.get(1)?,
+                project_cwd: r.get(2)?,
+                title: r.get(3)?,
+                started_at: r.get(4)?,
+                ended_at: r.get(5)?,
+                message_count: r.get(6)?,
+                user_message_count: r.get(7)?,
+                output_tokens: r.get(8)?,
+                model: r.get(9)?,
+                file_path: r.get(10)?,
+                pinned: r.get(11)?,
+            })
+        });
+        match rows {
+            Ok(iter) => iter.flatten().collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    pub fn set_pinned(&self, id: &str, pinned: bool) -> Result<(), String> {
+        let sql = if pinned {
+            "INSERT OR IGNORE INTO pins(session_id) VALUES(?1)"
+        } else {
+            "DELETE FROM pins WHERE session_id=?1"
+        };
+        self.conn.execute(sql, params![id]).map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn lookup_file(&self, id: &str) -> Option<(String, String)> {
+        self.conn
+            .query_row(
+                "SELECT agent, file_path FROM sessions WHERE id=?1",
+                params![id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .ok()
+    }
+
+    /// Drop sessions whose source file no longer exists on disk.
+    pub fn prune_missing(&self, existing: &HashSet<String>) -> Result<(), String> {
+        let paths: Vec<String> = {
+            let mut stmt = self
+                .conn
+                .prepare("SELECT DISTINCT file_path FROM sessions")
+                .map_err(|e| e.to_string())?;
+            let iter = stmt
+                .query_map([], |r| r.get::<_, String>(0))
+                .map_err(|e| e.to_string())?;
+            iter.flatten().collect()
+        };
+        for path in paths {
+            if !existing.contains(&path) {
+                self.conn
+                    .execute("DELETE FROM activity WHERE session_id IN (SELECT id FROM sessions WHERE file_path=?1)", params![path])
+                    .map_err(|e| e.to_string())?;
+                self.conn
+                    .execute("DELETE FROM sessions WHERE file_path=?1", params![path])
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd src-tauri && cargo test sessions_index::index`
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/modules/sessions_index
+git commit -m "feat(sessions): SQLite metadata index with pins and rebuild-on-version-bump"
+```
+
+---
+
+### Task 3: Claude parser
+
+**Files:**
+- Create: `src-tauri/src/modules/sessions_index/claude.rs`
+
+**Interfaces:**
+- Consumes: `types::{ParsedSession, ActivityBucket, TranscriptMessage}`, `claude_progress::extract_session_title`
+- Produces:
+  - `pub fn parse_claude_meta(path: &Path) -> Option<ParsedSession>`
+  - `pub fn parse_claude_transcript(path: &Path) -> Vec<TranscriptMessage>`
+  - `pub(crate) fn epoch_ms(iso: &str) -> Option<i64>` and `pub(crate) fn local_bucket(ms: i64) -> (String, u8)` — codex.rs reuses both.
+
+**Parsing rules (port of agentsview's logic, simplified):**
+- Only lines whose `type` is `user`/`assistant` with a non-empty `message` count as messages. Skip `isMeta == true` and `isSidechain == true` lines. Skip user lines whose content holds only `tool_result` items (no text).
+- DAG main path: entries carry `uuid`/`parentUuid`. Build a children map; start from the first root (no parent, or parent unknown); at a fork, if the subtree under the *first* child contains ≤ 3 user messages, follow the *last* child (small retry gap), otherwise follow the first child. If any user/assistant line lacks a `uuid`, fall back to linear order.
+- `project_cwd`: first line with a non-empty `cwd` field; fallback: parent dir name.
+- Session id: first line's `sessionId`; fallback: file stem.
+- Title: `claude_progress::extract_session_title` on the full contents.
+- Tokens: sum of assistant `message.usage.output_tokens`. Model: last assistant `message.model`.
+- Timestamps: min/max `timestamp` across all lines (even skipped ones).
+
+- [ ] **Step 1: Write failing tests** (inline; build JSONL fixtures with `concat!` like `claude_progress` tests)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_fixture(tag: &str, contents: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-claude-parse-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("abc-session.jsonl");
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    const BASIC: &str = concat!(
+        r#"{"type":"user","uuid":"u1","parentUuid":null,"sessionId":"sess-1","cwd":"/p/alpha","timestamp":"2026-07-06T01:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a1","parentUuid":"u1","sessionId":"sess-1","timestamp":"2026-07-06T01:00:05.000Z","message":{"role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"hi"}],"usage":{"output_tokens":7}}}"#, "\n",
+        r#"{"type":"user","uuid":"u2","parentUuid":"a1","isMeta":true,"timestamp":"2026-07-06T01:00:06.000Z","message":{"role":"user","content":[{"type":"text","text":"meta noise"}]}}"#, "\n",
+        r#"{"type":"user","uuid":"u3","parentUuid":"a1","timestamp":"2026-07-06T01:01:00.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a2","parentUuid":"u3","timestamp":"2026-07-06T01:02:00.000Z","message":{"role":"assistant","model":"claude-sonnet-5","content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}},{"type":"text","text":"done"}],"usage":{"output_tokens":13}}}"#, "\n",
+    );
+
+    #[test]
+    fn meta_counts_titles_and_tokens() {
+        let path = write_fixture("basic", BASIC);
+        let meta = parse_claude_meta(&path).unwrap();
+        assert_eq!(meta.id, "sess-1");
+        assert_eq!(meta.agent, "claude");
+        assert_eq!(meta.project_cwd, "/p/alpha");
+        assert_eq!(meta.title, "hello");
+        // u1, a1, a2 count; the isMeta line and tool_result-only user line do not.
+        assert_eq!(meta.message_count, 3);
+        assert_eq!(meta.user_message_count, 1);
+        assert_eq!(meta.output_tokens, Some(20));
+        assert_eq!(meta.model.as_deref(), Some("claude-sonnet-5"));
+        assert!(meta.started_at < meta.ended_at);
+        assert!(!meta.activity.is_empty());
+    }
+
+    #[test]
+    fn transcript_extracts_text_and_tool_entries_in_order() {
+        let path = write_fixture("transcript", BASIC);
+        let t = parse_claude_transcript(&path);
+        let roles: Vec<&str> = t.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["user", "assistant", "tool", "assistant"]);
+        assert_eq!(t[2].tool_name.as_deref(), Some("Bash"));
+        assert_eq!(t[3].text, "done");
+    }
+
+    // A fork where the first child's branch has only 1 user turn (<= threshold 3):
+    // the walk takes the LAST child, so "retry" wins over "abandoned".
+    const FORKED: &str = concat!(
+        r#"{"type":"user","uuid":"u1","parentUuid":null,"sessionId":"s","timestamp":"2026-07-06T01:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"root"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a-abandoned","parentUuid":"u1","timestamp":"2026-07-06T01:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"first try"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a-kept","parentUuid":"u1","timestamp":"2026-07-06T01:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"second try"}]}}"#, "\n",
+        r#"{"type":"user","uuid":"u2","parentUuid":"a-kept","timestamp":"2026-07-06T01:00:03.000Z","message":{"role":"user","content":[{"type":"text","text":"go on"}]}}"#, "\n",
+    );
+
+    #[test]
+    fn fork_follows_the_retry_branch() {
+        let path = write_fixture("fork", FORKED);
+        let t = parse_claude_transcript(&path);
+        let texts: Vec<&str> = t.iter().map(|m| m.text.as_str()).collect();
+        assert_eq!(texts, vec!["root", "second try", "go on"]);
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped_not_fatal() {
+        let contents = format!("not json\n{}", BASIC);
+        let path = write_fixture("malformed", &contents);
+        assert!(parse_claude_meta(&path).is_some());
+    }
+
+    #[test]
+    fn empty_or_unreadable_file_yields_none() {
+        let path = write_fixture("empty", "");
+        assert!(parse_claude_meta(&path).is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd src-tauri && cargo test sessions_index::claude`
+Expected: compile error (functions not defined).
+
+- [ ] **Step 3: Implement**
+
+Implementation outline (write full code following these exact semantics; keep every helper `fn` small and unit-testable):
+
+```rust
+//! Claude Code JSONL parser: walks the uuid/parentUuid DAG's main path and
+//! produces session metadata and viewer transcripts. Ported (simplified) from
+//! agentsview's claude parser (MIT); see the design spec for the rules.
+
+use std::path::Path;
+
+use chrono::{DateTime, Datelike, Local, Timelike};
+use serde_json::Value;
+
+use super::types::{ActivityBucket, ParsedSession, TranscriptMessage};
+
+const FORK_USER_TURN_THRESHOLD: usize = 3;
+
+pub(crate) fn epoch_ms(iso: &str) -> Option<i64> {
+    DateTime::parse_from_rfc3339(iso).ok().map(|t| t.timestamp_millis())
+}
+
+/// Local calendar bucket for an epoch-ms timestamp: ("YYYY-MM-DD", hour).
+pub(crate) fn local_bucket(ms: i64) -> (String, u8) {
+    let local = DateTime::from_timestamp_millis(ms)
+        .map(|utc| utc.with_timezone(&Local))
+        .unwrap_or_else(Local::now);
+    (
+        format!("{:04}-{:02}-{:02}", local.year(), local.month(), local.day()),
+        local.hour() as u8,
+    )
+}
+
+struct Entry {
+    uuid: Option<String>,
+    parent: Option<String>,
+    value: Value,
+}
+
+// 1. read_to_string; parse each line into Entry (skip unparseable lines).
+// 2. is_countable(value): type is user/assistant, !isMeta, !isSidechain, and
+//    message content has a text item / tool_use item (user tool_result-only → false).
+// 3. main_path(entries) -> Vec<usize>:
+//    - if any countable entry lacks uuid → return linear order (all indices).
+//    - children: HashMap<parent-uuid, Vec<index>> in file order; roots = entries
+//      whose parent is None or unknown. Walk from first root; at each node push
+//      index, then among children: if user_turns_under(first_child) <= FORK_USER_TURN_THRESHOLD
+//      → descend last child, else descend first child.
+//    - user_turns_under(i): DFS counting countable user entries.
+// 4. parse_claude_meta: fold main-path entries into counts/tokens/model;
+//    timestamps min/max over ALL lines; activity buckets from countable
+//    main-path entries via local_bucket(ts); title via
+//    crate::modules::claude_progress::extract_session_title(&contents);
+//    id from first sessionId, else file stem; cwd from first non-empty cwd,
+//    else parent dir name. Return None when there are no countable messages.
+// 5. parse_claude_transcript: main-path entries → TranscriptMessage list:
+//    - user text → role "user" (join text items with \n)
+//    - assistant content items in order: text → role "assistant";
+//      tool_use → role "tool", tool_name = item.name, text = compact JSON of
+//      item.input truncated to 400 chars.
+```
+
+- [ ] **Step 4: Run tests until green**
+
+Run: `cd src-tauri && cargo test sessions_index::claude`
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Sanity check against real data** (manual, not a unit test)
+
+Add a temporary `#[test] #[ignore]` that parses the newest real transcript and prints the meta, then:
+Run: `cd src-tauri && cargo test sessions_index::claude -- --ignored --nocapture`
+Expected: plausible title/counts for a real session. Delete or keep the ignored test (keep is fine — it only runs on demand).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/modules/sessions_index/claude.rs
+git commit -m "feat(sessions): Claude JSONL parser with DAG main-path selection"
+```
+
+---
+
+### Task 4: Codex parser
+
+**Files:**
+- Create: `src-tauri/src/modules/sessions_index/codex.rs`
+
+**Interfaces:**
+- Consumes: `claude::{epoch_ms, local_bucket}`, `types::*`
+- Produces: `pub fn parse_codex_meta(path: &Path) -> Option<ParsedSession>`, `pub fn parse_codex_transcript(path: &Path) -> Vec<TranscriptMessage>`
+
+**Parsing rules** (before implementing, skim `src/modules/claude-progress/lib/codexNormalize.ts` to keep event interpretation consistent with the live-progress path):
+- `session_meta` → id = `payload.id`, cwd = `payload.cwd`, started_at = its `timestamp`.
+- User messages: `event_msg` with `payload.type == "user_message"` → text `payload.message`. (Do **not** also count `response_item` `role:"user"` — the rollout replays them; counting both double-counts.)
+- Assistant messages: `response_item` with `payload.type == "message"` and `payload.role == "assistant"` → join `payload.content[]` items' `.text` fields.
+- Tool calls: `response_item` with `payload.type == "function_call"` → role "tool", tool_name = `payload.name`.
+- Skip `response_item` `role` `developer`/`system`.
+- Tokens: `event_msg` with `payload.type == "token_count"` → keep the **last** `payload.info.total_token_usage.output_tokens` (cumulative). All accesses defensive; absent ⇒ `None`.
+- Model: last `turn_context` `payload.model` when present.
+- Title: first user message text, trimmed, truncated to 80 chars.
+- ended_at: max line `timestamp`.
+
+- [ ] **Step 1: Discover the real token_count shape** (grounding step, 2 min)
+
+Run: `grep -h '"token_count"' ~/.codex/sessions/2026/*/*/rollout-*.jsonl 2>/dev/null | tail -1 | python3 -m json.tool | head -40`
+Expected: one event; confirm the path `payload.info.total_token_usage.output_tokens` (adjust the implementation + fixture to the real shape if it differs — record the actual shape in a code comment).
+
+- [ ] **Step 2: Write failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ROLLOUT: &str = concat!(
+        r#"{"timestamp":"2026-07-06T02:00:00.000Z","type":"session_meta","payload":{"id":"codex-1","cwd":"/p/beta"}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"fix the bug"}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:02.000Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"instructions"}]}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:03.000Z","type":"turn_context","payload":{"model":"gpt-5.2-codex"}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:04.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{}"}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:05.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"fixed"}]}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:06.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":42}}}}"#, "\n",
+    );
+
+    fn write_fixture(tag: &str, contents: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-codex-parse-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rollout-x.jsonl");
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn meta_from_rollout_events() {
+        let meta = parse_codex_meta(&write_fixture("meta", ROLLOUT)).unwrap();
+        assert_eq!(meta.id, "codex-1");
+        assert_eq!(meta.agent, "codex");
+        assert_eq!(meta.project_cwd, "/p/beta");
+        assert_eq!(meta.title, "fix the bug");
+        assert_eq!(meta.user_message_count, 1);
+        assert_eq!(meta.message_count, 2); // user + assistant; developer/tool excluded
+        assert_eq!(meta.output_tokens, Some(42));
+        assert_eq!(meta.model.as_deref(), Some("gpt-5.2-codex"));
+    }
+
+    #[test]
+    fn transcript_orders_user_tool_assistant() {
+        let t = parse_codex_transcript(&write_fixture("transcript", ROLLOUT));
+        let roles: Vec<&str> = t.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["user", "tool", "assistant"]);
+        assert_eq!(t[1].tool_name.as_deref(), Some("shell"));
+    }
+
+    #[test]
+    fn missing_session_meta_falls_back_to_file_stem_and_survives() {
+        let contents = concat!(
+            r#"{"timestamp":"2026-07-06T02:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"hi"}}"#, "\n",
+        );
+        let path = write_fixture("nometa", contents);
+        let meta = parse_codex_meta(&path).unwrap();
+        assert_eq!(meta.id, "rollout-x");
+        assert_eq!(meta.project_cwd, "");
+    }
+
+    #[test]
+    fn garbage_lines_are_skipped() {
+        let contents = format!("garbage\n{}", ROLLOUT);
+        assert!(parse_codex_meta(&write_fixture("garbage", &contents)).is_some());
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify failure, then implement**
+
+Run: `cd src-tauri && cargo test sessions_index::codex` → compile error → implement per the rules above (single pass over lines, defensive `.get()` chains, reuse `epoch_ms`/`local_bucket`). Session with zero user and zero assistant messages ⇒ return `None`.
+
+- [ ] **Step 4: Run tests until green**
+
+Run: `cd src-tauri && cargo test sessions_index::codex`
+Expected: 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/modules/sessions_index/codex.rs
+git commit -m "feat(sessions): Codex rollout JSONL parser"
+```
+
+---
+
+### Task 5: Protobuf wire reader
+
+**Files:**
+- Create: `src-tauri/src/modules/sessions_index/proto.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub enum ProtoValue { Varint(u64), Fixed64(u64), Bytes(Vec<u8>), Fixed32(u32) }`
+  - `pub fn parse_fields(buf: &[u8]) -> Vec<(u32, ProtoValue)>` (best-effort; stops at the first malformed byte)
+  - `pub fn first_bytes<'a>(fields: &'a [(u32, ProtoValue)], field_no: u32) -> Option<&'a [u8]>`
+  - `pub fn first_varint(fields: &[(u32, ProtoValue)], field_no: u32) -> Option<u64>`
+  - `pub fn timestamp_ms(fields: &[(u32, ProtoValue)], field_no: u32) -> Option<i64>` (nested Timestamp: seconds field 1 varint, nanos field 2 varint)
+
+- [ ] **Step 1: Write failing tests** — include a tiny test-only encoder so fixtures are readable:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test-only encoder helpers (wire format: tag = field_no << 3 | wire_type).
+    fn varint(mut v: u64, out: &mut Vec<u8>) {
+        loop {
+            let byte = (v & 0x7f) as u8;
+            v >>= 7;
+            if v == 0 { out.push(byte); break; }
+            out.push(byte | 0x80);
+        }
+    }
+    fn field_varint(no: u32, v: u64, out: &mut Vec<u8>) {
+        varint(((no as u64) << 3) | 0, out);
+        varint(v, out);
+    }
+    fn field_bytes(no: u32, data: &[u8], out: &mut Vec<u8>) {
+        varint(((no as u64) << 3) | 2, out);
+        varint(data.len() as u64, out);
+        out.extend_from_slice(data);
+    }
+
+    #[test]
+    fn parses_varint_and_length_delimited_fields() {
+        let mut buf = Vec::new();
+        field_varint(3, 150, &mut buf);
+        field_bytes(17, b"hello", &mut buf);
+        let fields = parse_fields(&buf);
+        assert_eq!(first_varint(&fields, 3), Some(150));
+        assert_eq!(first_bytes(&fields, 17), Some(&b"hello"[..]));
+    }
+
+    #[test]
+    fn decodes_a_nested_timestamp() {
+        let mut ts = Vec::new();
+        field_varint(1, 1_751_760_000, &mut ts); // seconds
+        field_varint(2, 500_000_000, &mut ts);   // nanos
+        let mut buf = Vec::new();
+        field_bytes(5, &ts, &mut buf);
+        let fields = parse_fields(&buf);
+        assert_eq!(timestamp_ms(&fields, 5), Some(1_751_760_000_500));
+    }
+
+    #[test]
+    fn malformed_input_yields_partial_fields_not_panic() {
+        let mut buf = Vec::new();
+        field_varint(1, 7, &mut buf);
+        buf.extend_from_slice(&[0xff, 0xff]); // truncated garbage tail
+        let fields = parse_fields(&buf);
+        assert_eq!(first_varint(&fields, 1), Some(7));
+    }
+
+    #[test]
+    fn skips_fixed32_and_fixed64_without_losing_position() {
+        let mut buf = Vec::new();
+        varint((2 << 3) | 1, &mut buf); buf.extend_from_slice(&8u64.to_le_bytes());
+        varint((4 << 3) | 5, &mut buf); buf.extend_from_slice(&9u32.to_le_bytes());
+        field_varint(6, 1, &mut buf);
+        let fields = parse_fields(&buf);
+        assert_eq!(first_varint(&fields, 6), Some(1));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure, then implement** — a cursor over `&[u8]` reading varint tags; wire types 0/1/2/5; any decode error (overlong varint, length past end) ⇒ return the fields collected so far.
+
+- [ ] **Step 3: Run tests until green**
+
+Run: `cd src-tauri && cargo test sessions_index::proto`
+Expected: 4 tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/modules/sessions_index/proto.rs
+git commit -m "feat(sessions): minimal protobuf wire-format reader"
+```
+
+---
+
+### Task 6: Antigravity parser (includes the gen_metadata spike)
+
+**Files:**
+- Create: `src-tauri/src/modules/sessions_index/antigravity.rs`
+
+**Interfaces:**
+- Consumes: `proto::*`, `claude::local_bucket`, `types::*`, rusqlite
+- Produces: `pub fn parse_antigravity_meta(path: &Path) -> Option<ParsedSession>`, `pub fn parse_antigravity_transcript(path: &Path) -> Vec<TranscriptMessage>`
+
+**Rules:**
+- Open read-only: `Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI | OpenFlags::SQLITE_OPEN_NO_MUTEX)`. A locked/corrupt DB ⇒ `None` (sync retries next round).
+- `SELECT idx, step_type, step_payload FROM steps ORDER BY idx` — step_type 14 ⇒ user, 15 ⇒ assistant; payload field 17 = text, field 5 = timestamp. Steps with other types are ignored.
+- Session id = file stem (the `<uuid>`). project_cwd = "" (Antigravity CLI does not expose a cwd here; the sidebar shows the agent badge instead of a project for these).
+- Title = first user step's text (trim, 80 chars). Sessions with no user/assistant steps ⇒ `None`.
+- Tokens/model: **spike step below decides**; ship `None` when fields can't be confidently identified.
+
+- [ ] **Step 1: Spike — dump real gen_metadata blobs** (time-box ~30 min)
+
+Write an `#[ignore]`d test `dump_real_gen_metadata` that opens 2–3 real DBs from `~/.gemini/antigravity-cli/conversations/`, runs `parse_fields` on each `gen_metadata.data` blob, and prints per-field: field number, wire type, varint value / UTF-8 preview.
+Run: `cd src-tauri && cargo test sessions_index::antigravity -- --ignored --nocapture`
+Decide from the output: which field holds the model string (expect something like `gemini-3-pro`), which nested message holds input/output token varints. Record findings as code comments on the extraction fn. **If not identifiable within the time box: leave `model=None, output_tokens=None` and move on** (documented degradation per spec).
+
+- [ ] **Step 2: Write failing tests** — build a fixture DB in the test with rusqlite, encoding payloads with the same test-only encoder pattern as proto.rs (copy the 3 helper fns into this test module):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::{params, Connection};
+
+    // (varint / field_varint / field_bytes helpers copied from proto.rs tests)
+
+    fn step_payload(ts_seconds: u64, text: &str) -> Vec<u8> {
+        let mut ts = Vec::new();
+        field_varint(1, ts_seconds, &mut ts);
+        let mut buf = Vec::new();
+        field_bytes(5, &ts, &mut buf);
+        field_bytes(17, text.as_bytes(), &mut buf);
+        buf
+    }
+
+    fn fixture_db(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-ag-parse-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("11111111-2222-3333-4444-555555555555.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE steps(idx INTEGER PRIMARY KEY, step_type INTEGER NOT NULL DEFAULT 0,
+               status INTEGER NOT NULL DEFAULT 0, step_payload BLOB, step_format INTEGER NOT NULL DEFAULT 0);
+             CREATE TABLE gen_metadata(idx INTEGER PRIMARY KEY, data BLOB, size INTEGER NOT NULL DEFAULT 0);",
+        ).unwrap();
+        conn.execute("INSERT INTO steps(idx, step_type, step_payload) VALUES(0, 14, ?1)",
+            params![step_payload(1_751_760_000, "build me a thing")]).unwrap();
+        conn.execute("INSERT INTO steps(idx, step_type, step_payload) VALUES(1, 15, ?1)",
+            params![step_payload(1_751_760_060, "here is the thing")]).unwrap();
+        conn.execute("INSERT INTO steps(idx, step_type, step_payload) VALUES(2, 7, ?1)",
+            params![step_payload(1_751_760_070, "ignored step type")]).unwrap();
+        path
+    }
+
+    #[test]
+    fn meta_from_trajectory_db() {
+        let meta = parse_antigravity_meta(&fixture_db("meta")).unwrap();
+        assert_eq!(meta.id, "11111111-2222-3333-4444-555555555555");
+        assert_eq!(meta.agent, "antigravity");
+        assert_eq!(meta.title, "build me a thing");
+        assert_eq!(meta.message_count, 2);
+        assert_eq!(meta.user_message_count, 1);
+        assert_eq!(meta.started_at, 1_751_760_000_000);
+        assert_eq!(meta.ended_at, 1_751_760_060_000);
+    }
+
+    #[test]
+    fn transcript_maps_step_types_to_roles() {
+        let t = parse_antigravity_transcript(&fixture_db("transcript"));
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0].role, "user");
+        assert_eq!(t[1].role, "assistant");
+        assert_eq!(t[1].text, "here is the thing");
+    }
+
+    #[test]
+    fn missing_or_invalid_db_yields_none() {
+        assert!(parse_antigravity_meta(std::path::Path::new("/nope/x.db")).is_none());
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify failure, then implement** (query steps; decode payloads with proto helpers; skip steps whose payload lacks field 17 text; timestamps fall back to file mtime when field 5 is absent; wire the token/model extraction per the spike's findings).
+
+- [ ] **Step 4: Run tests until green**
+
+Run: `cd src-tauri && cargo test sessions_index::antigravity`
+Expected: 3 tests PASS (plus the ignored dump test).
+
+- [ ] **Step 5: Sanity check against a real conversation DB** via the ignored dump test output (titles/messages look right).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/modules/sessions_index/antigravity.rs
+git commit -m "feat(sessions): Antigravity CLI trajectory DB parser"
+```
+
+---
+
+### Task 7: Scanner
+
+**Files:**
+- Create: `src-tauri/src/modules/sessions_index/scanner.rs`
+
+**Interfaces:**
+- Consumes: `claude_progress::config_base_dir`
+- Produces:
+  - `#[derive(Debug, Clone, PartialEq)] pub struct SessionFile { pub agent: &'static str, pub path: PathBuf }`
+  - `pub fn roots(home: &Path) -> Vec<(&'static str, PathBuf)>` — resolved (agent, root dir) pairs honoring `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `ANTIGRAVITY_CLI_DIR`; claude root is `<base>/projects`, codex roots are `<home>/.codex/sessions` and `<home>/.codex/archived_sessions`, antigravity root is `<dir>/conversations`.
+  - `pub fn discover(home: &Path) -> Vec<SessionFile>`
+
+**Rules:**
+- Claude: for each subdir of `projects/`, every top-level `*.jsonl` file (never recurse into `<session-id>/` subdirs).
+- Codex: recurse `sessions/` up to 3 nested dirs (YYYY/MM/DD) collecting `rollout-*.jsonl`; plus flat `archived_sessions/*.jsonl`.
+- Antigravity: `conversations/*.db` only (skip `-wal`/`-shm`/`.db-journal`).
+- Missing roots ⇒ contribute nothing (no error).
+
+- [ ] **Step 1: Write failing tests** — build a fake home dir in temp with the three trees (a few files each, plus decoys: a subdir jsonl under a claude session dir, a `-wal` file), assert `discover` returns exactly the expected set with the right agents.
+
+- [ ] **Step 2: Run to verify failure, then implement** (plain `read_dir` loops; a small recursive helper for codex with a depth limit of 4).
+
+- [ ] **Step 3: Run tests until green**
+
+Run: `cd src-tauri && cargo test sessions_index::scanner`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/modules/sessions_index/scanner.rs
+git commit -m "feat(sessions): session file discovery across three agent roots"
+```
+
+---
+
+### Task 8: Sync + watcher + Tauri commands + registration
+
+**Files:**
+- Create: `src-tauri/src/modules/sessions_index/sync.rs`
+- Create: `src-tauri/src/modules/sessions_index/watch.rs`
+- Modify: `src-tauri/src/modules/sessions_index/mod.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces (frontend contract):
+  - Commands: `sessions_index_start()`, `sessions_list() -> Vec<SessionSummary>`, `sessions_get(id: String) -> Vec<TranscriptMessage>`, `sessions_pin(id: String, pinned: bool)`
+  - Event `"sessions-index:updated"` with payload `{ "count": number }` after every sync batch.
+  - State: `pub struct SessionsIndexState` (managed in lib.rs).
+
+- [ ] **Step 1: Write failing tests for sync.rs** — pure parts only:
+
+```rust
+// sync_file(index, agent, path) -> bool  (true when something was upserted)
+// - stats the file; skips via index.needs_sync; dispatches to the right parser;
+//   upserts on Some. Antigravity fingerprint: mtime/size of .db + companions
+//   (-wal/-shm) summed, via fingerprint(path) helper.
+// Tests: temp dir + fixture jsonl (reuse Task 3's BASIC constant semantics):
+//   1) first sync_file returns true and index.list() has the session,
+//   2) second sync_file without changes returns false (skip cache),
+//   3) touching the file (rewrite with +1 line) re-syncs.
+// full_sync(index, home) -> usize: discover + sync each + prune_missing.
+//   Test with a fake home from Task 7's fixture builder: after deleting one
+//   file and re-running full_sync, its session is gone.
+```
+
+- [ ] **Step 2: Implement sync.rs** — `fingerprint(path: &Path) -> (i64, i64)` (mtime ms + size; for `.db` add companions' mtime/size so WAL-only commits change the fingerprint), `sync_file`, `full_sync`. All errors swallowed per-file (log with `eprintln!` only in debug).
+
+- [ ] **Step 3: Implement watch.rs** (thin, hard to unit test — keep logic minimal and lean on the debounced-drain being trivially readable):
+
+```rust
+//! Watches the three agent roots and re-syncs changed files, debounced.
+//! One mpsc channel; notify callbacks push paths; a worker thread drains with
+//! recv_timeout(500ms) batches, maps each path to its agent by root prefix
+//! (a -wal/-shm path maps back to its .db), syncs, then emits one
+//! "sessions-index:updated" event per batch.
+```
+
+Watchers: claude projects root **recursive** (new project dirs appear), codex `sessions` recursive + `archived_sessions` non-recursive, antigravity `conversations` non-recursive. Store `Vec<RecommendedWatcher>` in state to keep subscriptions alive. Roots that don't exist are skipped.
+
+- [ ] **Step 4: Implement mod.rs state + commands**
+
+```rust
+pub struct SessionsIndexState {
+    inner: std::sync::Arc<std::sync::Mutex<Option<StateInner>>>,
+}
+struct StateInner {
+    index: std::sync::Arc<std::sync::Mutex<index::Index>>,
+    _watchers: Vec<notify::RecommendedWatcher>,
+}
+
+#[tauri::command]
+pub fn sessions_index_start(app: tauri::AppHandle, state: tauri::State<SessionsIndexState>) -> Result<(), String>
+// - no-op if already started
+// - db path: app.path().app_data_dir()?.join("sessions-index.db")
+// - open index; spawn a thread doing full_sync(home) then emit updated event
+// - start watch::start(app, index_arc) and stash watchers
+
+#[tauri::command]
+pub fn sessions_list(state: tauri::State<SessionsIndexState>) -> Vec<types::SessionSummary>
+// empty vec when not started
+
+#[tauri::command]
+pub async fn sessions_get(state: tauri::State<'_, SessionsIndexState>, id: String) -> Result<Vec<types::TranscriptMessage>, String>
+// lookup_file → dispatch parse_*_transcript on a spawn_blocking thread
+// (transcripts can be MBs; never parse on the main thread)
+
+#[tauri::command]
+pub fn sessions_pin(state: tauri::State<SessionsIndexState>, id: String, pinned: bool) -> Result<(), String>
+```
+
+- [ ] **Step 5: Register in lib.rs** — add `.manage(SessionsIndexState::new())` beside the other `.manage(...)` calls (`src-tauri/src/lib.rs:95-103`), add the four command names to `generate_handler![...]` (`src-tauri/src/lib.rs:142`), and the matching `use` alongside the other `use modules::...` imports.
+
+- [ ] **Step 6: Run the full Rust suite**
+
+Run: `cd src-tauri && cargo test sessions_index && cargo check`
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src
+git commit -m "feat(sessions): sync engine, filesystem watchers, and Tauri commands"
+```
+
+---
+
+### Task 9: TS bridge + store
+
+**Files:**
+- Create: `src/modules/sessions/lib/sessionsBridge.ts`
+- Create: `src/modules/sessions/lib/sessionsStore.ts`
+- Create: `src/modules/sessions/lib/sessionsStore.test.ts`
+- Create: `src/modules/sessions/lib/relativeTime.ts`, `src/modules/sessions/lib/relativeTime.test.ts`
+
+**Interfaces (produces — later tasks import these exact names):**
+
+```ts
+// sessionsBridge.ts
+export type SessionAgent = "claude" | "codex" | "antigravity";
+export interface SessionSummary {
+  id: string; agent: SessionAgent; project_cwd: string; title: string;
+  started_at: number; ended_at: number; message_count: number;
+  user_message_count: number; output_tokens: number | null;
+  model: string | null; file_path: string; pinned: boolean;
+}
+export interface TranscriptMessage {
+  role: "user" | "assistant" | "tool" | "system";
+  text: string; timestamp: number | null; tool_name: string | null;
+}
+export function sessionsStart(): Promise<void>;           // invoke("sessions_index_start")
+export function sessionsList(): Promise<SessionSummary[]>; // invoke("sessions_list")
+export function sessionsGet(id: string): Promise<TranscriptMessage[]>;
+export function sessionsPin(id: string, pinned: boolean): Promise<void>;
+export function onSessionsUpdated(cb: () => void): Promise<() => void>; // listen("sessions-index:updated")
+
+// sessionsStore.ts (zustand, same style as other stores)
+interface SessionsState {
+  sessions: SessionSummary[];
+  loaded: boolean;
+  query: string;
+  agentFilter: SessionAgent | "all";
+  selectedId: string | null;
+  refresh(): Promise<void>;                 // sessionsList → set
+  start(): Promise<void>;                   // sessionsStart + refresh
+  setQuery(q: string): void;
+  setAgentFilter(f: SessionAgent | "all"): void;
+  select(id: string | null): void;
+  togglePin(id: string): Promise<void>;     // optimistic flip + sessionsPin + refresh on error
+}
+export const useSessionsStore: UseBoundStore<StoreApi<SessionsState>>;
+// Pure selector, exported for tests and the panel:
+export function visibleSessions(sessions: SessionSummary[], query: string, agentFilter: SessionAgent | "all"):
+  { pinned: SessionSummary[]; history: SessionSummary[] };
+// query matches title or project_cwd, case-insensitive; pinned sorted by ended_at desc; history excludes pinned.
+
+// relativeTime.ts
+export function formatRelativeTime(epochMs: number, now?: number): string;
+// "just now" (<60s), "5m ago", "3h ago", "2d ago", else "2026-07-06"
+```
+
+- [ ] **Step 1: Write failing tests** for `visibleSessions` (filtering by query/agent, pin split, ordering) and `formatRelativeTime` (each band + boundary). Mock nothing — both are pure.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test src/modules/sessions`
+Expected: FAIL (modules missing).
+
+- [ ] **Step 3: Implement bridge, store, relativeTime**
+
+Bridge is thin `invoke`/`listen` wrappers (copy the style of `fsBridge.ts`; `listen` comes from `@tauri-apps/api/event`). Store methods wrap bridge calls in `try/catch` that leaves state unchanged on error.
+
+- [ ] **Step 4: Run until green, plus typecheck**
+
+Run: `pnpm test src/modules/sessions && pnpm typecheck`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modules/sessions
+git commit -m "feat(sessions): frontend bridge, store, and relative-time helper"
+```
+
+---
+
+### Task 10: Sidebar registration + list UI
+
+**Files:**
+- Modify: `src/stores/uiStore.ts:3` (add `"sessions"` to `SidebarView`)
+- Modify: `src/components/Sidebar.tsx` (import + `SIDEBAR_TABS` entry + conditional render)
+- Modify: `src/i18n/locales/en/common.json`, `src/i18n/locales/zh-Hant/common.json`
+- Create: `src/modules/sessions/SessionsPanel.tsx`
+
+**Interfaces:**
+- Consumes: `useSessionsStore`, `visibleSessions`, `formatRelativeTime`, `openSessionsTab` (Task 12 — until then clicking a row only calls `select(id)`; wire the tab-open in Task 12).
+
+- [ ] **Step 1: Register the view**
+
+`uiStore.ts:3`:
+```ts
+export type SidebarView = "workspaces" | "explorer" | "sourceControl" | "ai" | "notes" | "connections" | "sessions";
+```
+
+`Sidebar.tsx` — add to imports `History` from lucide-react and the panel; append to `SIDEBAR_TABS`:
+```ts
+{ id: "sessions", icon: History, labelKey: "nav.sessions" },
+```
+and to the body:
+```tsx
+{sidebarView === "sessions" && <SessionsPanel />}
+```
+
+i18n `nav` blocks — en: `"sessions": "AI Sessions"`; zh-Hant: `"sessions": "AI 對話"`.
+
+- [ ] **Step 2: Add the remaining i18n keys** (both locales, new top-level `"sessions"` object):
+
+```json
+// en
+"sessions": {
+  "live": "Live",
+  "pinned": "Pinned",
+  "searchPlaceholder": "Search sessions…",
+  "all": "All",
+  "empty": "No sessions found",
+  "messages": "{{count}} msgs",
+  "resume": "Resume",
+  "pin": "Pin",
+  "unpin": "Unpin",
+  "selectPrompt": "Select a session from the sidebar",
+  "resumeUnavailable": "Resume is not available for this agent",
+  "indexing": "Indexing sessions…"
+}
+// zh-Hant
+"sessions": {
+  "live": "進行中",
+  "pinned": "已釘選",
+  "searchPlaceholder": "搜尋對話…",
+  "all": "全部",
+  "empty": "沒有符合的對話",
+  "messages": "{{count}} 則訊息",
+  "resume": "接續對話",
+  "pin": "釘選",
+  "unpin": "取消釘選",
+  "selectPrompt": "從側邊欄選一場對話",
+  "resumeUnavailable": "這個 agent 不支援接續",
+  "indexing": "正在建立索引…"
+}
+```
+
+- [ ] **Step 3: Implement SessionsPanel.tsx**
+
+Structure (Tailwind semantic tokens, list styling patterned on `NotesSidebar`/`ConnectionsPanel`):
+
+```tsx
+export function SessionsPanel() {
+  // on mount: useSessionsStore.getState().start(); subscribe onSessionsUpdated → refresh (cleanup unlisten)
+  // <LiveSection /> placeholder comment until Task 11
+  // search input (value=query onChange=setQuery)
+  // agent chips: all / claude / codex / antigravity (aria-pressed styling like Sidebar tabs)
+  // visibleSessions(...) → Pinned group then history list
+  // row: title (truncate), badge = agent label colored per agent
+  //      (claude: text-accent, codex: text-fg-subtle, antigravity: text-warning — reuse
+  //      whatever warning/info token exists in src/index.css; check before inventing),
+  //      basename(project_cwd) · formatRelativeTime(ended_at) · t("sessions.messages", {count})
+  // row onClick: select(id) + openSessionsTab() (import added in Task 12; until then select only)
+  // pin toggle button on row hover (Pin/PinOff icons)
+  // empty state: t("sessions.empty"); loading state: t("sessions.indexing") until loaded
+}
+```
+
+IME note: the search input filters as-you-type only (no Enter-to-submit handler), so no `isComposing` guard is needed. Do not add an Enter handler.
+
+- [ ] **Step 4: Verify manually**
+
+Run: `pnpm tauri dev` → open the sidebar's new History icon (⌥7 range extends automatically). Expect: list populates after initial indexing; search and agent chips filter; pin toggles persist across app restart.
+
+- [ ] **Step 5: Typecheck + tests still green**
+
+Run: `pnpm typecheck && pnpm test src/modules/sessions`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/stores/uiStore.ts src/components/Sidebar.tsx src/i18n src/modules/sessions
+git commit -m "feat(sessions): sidebar sessions panel with search, filters, and pins"
+```
+
+---
+
+### Task 11: Live section
+
+**Files:**
+- Create: `src/modules/sessions/lib/liveSessions.ts`, `src/modules/sessions/lib/liveSessions.test.ts`
+- Modify: `src/modules/sessions/SessionsPanel.tsx`
+
+**Interfaces:**
+- Consumes: `useSessionStatusStore` (`statuses`, `agents` — `Record<leafId, …>`), `useTabsStore` (`tabs`, `setActive`, `setActiveLeaf`), `computeLayout`/`findPaneContent` from `terminalLayout`.
+- Produces:
+
+```ts
+export interface LiveSession {
+  tabId: string; leafId: string; tabTitle: string;
+  agent: string;             // from sessionStatusStore.agents
+  status: string;            // from sessionStatusStore.statuses
+  cwd: string | null;        // pane cwd ?? tab.cwd ?? null
+}
+// Pure: derive from plain snapshots so it's trivially testable.
+export function deriveLiveSessions(
+  tabs: Tab[],
+  statuses: Record<string, string>,
+  agents: Record<string, string>,
+): LiveSession[];
+```
+
+- [ ] **Step 1: Write failing tests** — fabricate two tabs (one with a terminal pane whose leafId has a status, one without), assert only the live one is returned with the right tab/leaf ids and cwd fallback order.
+
+- [ ] **Step 2: Implement** `deriveLiveSessions` (walk `computeLayout(tab.paneTree)`, keep panes whose id is in `statuses`), then the `LiveSection` component inside SessionsPanel: subscribe to the three stores, render status dot + agent + tab title, `onClick: setActive(tabId); setActiveLeaf(tabId, leafId)`. Hide the section when empty.
+
+- [ ] **Step 3: Run until green**
+
+Run: `pnpm test src/modules/sessions && pnpm typecheck`
+
+- [ ] **Step 4: Manual check** — run `claude` in a terminal tab, confirm the Live entry appears (status hooks must be enabled in settings) and clicking it focuses the pane.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modules/sessions
+git commit -m "feat(sessions): live section jumping to the running terminal pane"
+```
+
+---
+
+### Task 12: Sessions content tab + transcript viewer
+
+**Files:**
+- Modify: `src/modules/terminal/lib/terminalLayout.ts:15` (PaneContent union: add `| { kind: "sessions" }`)
+- Modify: `src/stores/tabsStore.ts` (TabKind union + `openSessionsTab`)
+- Modify: `src/modules/terminal/PaneTabContent.tsx` (lazy import + render branch before the terminal fallback)
+- Modify: `src/components/TabBar.tsx:62` area (icon case: `History`)
+- Modify: `src/i18n/locales/{en,zh-Hant}/common.json` (`tabs`: `"sessions": "AI Sessions"` / `"AI 對話"`)
+- Create: `src/modules/sessions/SessionsTabContent.tsx`
+- Modify: `src/modules/sessions/SessionsPanel.tsx` (row click → `select(id)` + `openSessionsTab()`)
+
+**Interfaces:**
+- Produces: `openSessionsTab(): string` in tabsStore — copy `openGitGraphTab` verbatim with `kind: "sessions"`, content `{ kind: "sessions" }`, title `"AI Sessions"` (singleton per space).
+- `SessionsTabContent` reads `selectedId` from `useSessionsStore`; `null` ⇒ empty state (`sessions.selectPrompt` + total count); else fetch `sessionsGet(selectedId)` in an effect (cancel stale responses by comparing ids) and render the transcript.
+
+- [ ] **Step 1: tabsStore test first** — `src/stores/tabsStore.test.ts` already exists; add a test that `openSessionsTab` creates a singleton (second call focuses the first) mirroring the existing git-graph test if present, else a minimal new one.
+
+- [ ] **Step 2: Run to verify failure, implement store change, run until green**
+
+Run: `pnpm test src/stores`
+
+- [ ] **Step 3: Wire PaneContent / PaneTabContent / TabBar / i18n**
+
+PaneTabContent: add beside the git-graph lazy import and branch:
+```tsx
+const SessionsTabContent = lazy(() =>
+  import("@/modules/sessions/SessionsTabContent").then((m) => ({ default: m.SessionsTabContent })),
+);
+// …
+) : pane.content.kind === "sessions" ? (
+  <SessionsTabContent />
+```
+TabBar icon `case "sessions": return History;`.
+
+- [ ] **Step 4: Implement SessionsTabContent.tsx**
+
+```tsx
+// Header: back-less (empty state doubles as home in P1), session title,
+// agent badge, project path, action buttons: Resume (Task 13), Pin toggle.
+// Body: message list — role label + bubble-less blocks:
+//   user: left border accent, assistant: plain, tool: collapsed <details>
+//   with tool_name as <summary>, system: muted italic.
+// Timestamps via formatRelativeTime. Long transcripts: plain scroll (no
+// virtualization in P1 — re-parse already capped by on-demand fetch).
+// Loading and error states (error: keep previous transcript, show a muted line).
+```
+
+- [ ] **Step 5: Manual verify** — click sessions in the sidebar: tab opens/reuses, transcript renders for all three agents (pick one real session each), empty state shows when nothing selected.
+
+- [ ] **Step 6: Typecheck + full frontend tests**
+
+Run: `pnpm typecheck && pnpm test`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src
+git commit -m "feat(sessions): sessions content tab with transcript viewer"
+```
+
+---
+
+### Task 13: Resume + final verification
+
+**Files:**
+- Create: `src/modules/sessions/lib/resume.ts`, `src/modules/sessions/lib/resume.test.ts`
+- Modify: `src/modules/sessions/SessionsTabContent.tsx` (Resume button), `src/modules/sessions/SessionsPanel.tsx` (row context/hover Resume button)
+
+**Interfaces:**
+- Consumes: `useTabsStore.getState().newTerminalTab(cwd)`, `writeToTerminal(leafId, text)` from `terminalBus`.
+- Produces:
+
+```ts
+// Pure command builder — unit-tested; null means resume unsupported (button hidden).
+export function resumeCommand(agent: SessionAgent, sessionId: string): string | null;
+// claude → `claude --resume ${sessionId}`
+// codex  → `codex resume ${sessionId}`
+// antigravity → null (CLI resume unverified; hide the button)
+export function resumeSession(s: SessionSummary): boolean;
+// resumeCommand null → false. Else newTerminalTab(s.project_cwd || undefined),
+// read back the created tab's activeLeafId from the store (pattern in
+// terminalBus.runCommandInTerminal), writeToTerminal(leafId, cmd + "\n"), true.
+```
+
+- [ ] **Step 1: Verify the codex CLI syntax** (grounding, 1 min)
+
+Run: `codex resume --help 2>&1 | head -20`
+Expected: usage text confirming `codex resume <SESSION_ID>`. If it differs, adjust `resumeCommand` and its test to the real syntax; note the verified syntax in a code comment. Session ids must be shell-quoted only if they can contain non-alphanumerics — all three id formats are UUID-like, so interpolation is safe; assert that in the test (id matches `/^[A-Za-z0-9-]+$/` guard in `resumeCommand`, returning null otherwise).
+
+- [ ] **Step 2: Write failing tests for `resumeCommand`** (three agents + malicious id rejected), run, implement, green.
+
+Run: `pnpm test src/modules/sessions`
+
+- [ ] **Step 3: Wire buttons** — Resume in the viewer header and on row hover; hidden when `resumeCommand(...) === null`; tooltip `sessions.resumeUnavailable` shown for antigravity via a disabled state instead of hiding, pick one and keep it consistent: **hide on rows, disabled-with-tooltip in the viewer header**.
+
+- [ ] **Step 4: Manual verify** — resume a real Claude session and a real Codex session: new terminal tab opens at the project cwd and the CLI resumes the right conversation.
+
+- [ ] **Step 5: Full verification sweep**
+
+```bash
+cd src-tauri && cargo test && cargo check
+cd .. && pnpm typecheck && pnpm test && pnpm build
+```
+Expected: everything green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src
+git commit -m "feat(sessions): one-click resume into a new terminal tab"
+```
+
+---
+
+### Task 14: PR
+
+- [ ] **Step 1:** Re-read the spec's P1 row; confirm every bullet is shipped (parsers ×3, index, watcher, sidebar list with Live/search/filter/pins, viewer, resume).
+- [ ] **Step 2:** Push and open the PR per project rules:
+
+```bash
+git push -u origin feat/ai-sessions-view
+MILESTONE=$(gh api repos/mukiwu/tempo-term/milestones --jq '.[0].title')
+gh pr create --title "feat: AI sessions view (P1) — cross-agent session browser" --body "<summary + test plan>"
+gh pr edit <n> --add-label enhancement --milestone "$MILESTONE" --add-assignee mukiwu
+```
+- [ ] **Step 3:** Wait for `gemini-code-assist[bot]` review and triage per project rules.

--- a/docs/superpowers/specs/2026-07-06-ai-sessions-view-design.md
+++ b/docs/superpowers/specs/2026-07-06-ai-sessions-view-design.md
@@ -32,8 +32,8 @@ databases that agentsview reads directly without decryption. Feasible.
   dashboard (default), session transcript viewer, project view.
 - Dashboard: stat cards, calendar activity heatmap, Top Sessions
   (must-have), date range filter, weekly digest card.
-- Management: resume in a new terminal tab, pin, delete (to system trash),
-  export to Markdown.
+- Management: resume in a new terminal tab, pin, delete (to system trash via
+  the `trash` crate already in Cargo.toml), export to Markdown.
 - Differentiators over AgentsView (it is an offline viewer; tempo-term is
   where sessions actually happen): Live section that jumps to the running
   tab, project view with one-click "new tab at this cwd", session ↔ git
@@ -41,8 +41,8 @@ databases that agentsview reads directly without decryption. Feasible.
 - Hard constraint: keep the app lightweight. No new npm packages (charts
   are hand-rolled CSS/SVG). Only new Rust crate is `rusqlite` — linked
   against the system SQLite on macOS, `bundled` only on Windows (~+1 MB).
-  Protobuf is hand-decoded (no prost). Trash uses `osascript` /
-  PowerShell shell-out (no trash crate). Watching reuses existing `notify`.
+  Protobuf is hand-decoded (no prost). Trash reuses the `trash` crate the
+  file explorer already depends on. Watching reuses existing `notify`.
 
 ## Non-goals (v1)
 
@@ -119,11 +119,14 @@ daily_stats(agent, project_cwd, date, hour,
 meta(key PK, value)   -- schema_version, last_full_scan
 ```
 
-Incremental sync: per-file `mtime`/`size`/`offset`; JSONL files parse only
-appended lines (reuse `claude_progress::read_new_lines` tail primitives);
-Antigravity uses a composite fingerprint (db + `-wal` + `-shm` mtime/size)
-and re-parses the whole file on change. Daily-stat rows for a changed
-session are recomputed by delta, not full rescan. Initial full index runs
+Incremental sync (v1): per-file `mtime`/`size` skip-cache; a changed file is
+re-parsed whole (per-file cost, on a background thread), unchanged files are
+skipped entirely. Byte-offset tail parsing is a later optimization if
+profiling demands it — Claude's DAG main-path selection makes append-only
+counting fragile, so whole-file re-parse is the simpler correct baseline.
+Antigravity uses a composite fingerprint (db + `-wal` + `-shm` mtime/size).
+Per-day activity rows are keyed by session id and replaced together with
+their session row, so a re-parse never double-counts. Initial full index runs
 on a background thread at first watch, never blocking the UI. After each
 sync batch the backend emits `sessions-index:updated`; the frontend
 re-queries lazily only while the view is visible.

--- a/docs/superpowers/specs/2026-07-06-ai-sessions-view-design.md
+++ b/docs/superpowers/specs/2026-07-06-ai-sessions-view-design.md
@@ -1,0 +1,221 @@
+# AI sessions view (AgentsView-style session browser) (v1)
+
+Status: approved design, ready for planning
+Date: 2026-07-06
+Branch: feat/ai-sessions-view
+
+## Problem
+
+tempo-term already tracks *live* AI CLI activity: `claude_progress` /
+`codex_progress` tail the newest JSONL from end-of-file and stream appends,
+and OSC 6973 status hooks drive per-pane badges. But there is no way to
+browse, search, or manage *historical* sessions, and no aggregate view of
+AI usage across agents and projects.
+
+AgentsView (`kenn-io/agentsview`, Go, MIT, ~3.9k stars) solves this as a
+standalone app: it indexes session logs from many agents into SQLite and
+serves a dashboard (stat cards, activity heatmap, top sessions) plus a
+session browser. The user wants that experience inside tempo-term — a
+sidebar session list plus a main-area dashboard/viewer — covering the three
+agents used on this machine: Claude Code, Codex, and Antigravity CLI.
+
+Antigravity feasibility was verified: the local install is Antigravity CLI
+(not the IDE), and its sessions are per-conversation SQLite trajectory
+databases that agentsview reads directly without decryption. Feasible.
+
+## Goals
+
+- Sidebar "AI Sessions" view: session list for Claude / Codex / Antigravity
+  with search, agent filter, pinned group, and a Live section at top bound
+  to running terminal panes.
+- Main-area "Sessions" content tab with three internal screens:
+  dashboard (default), session transcript viewer, project view.
+- Dashboard: stat cards, calendar activity heatmap, Top Sessions
+  (must-have), date range filter, weekly digest card.
+- Management: resume in a new terminal tab, pin, delete (to system trash),
+  export to Markdown.
+- Differentiators over AgentsView (it is an offline viewer; tempo-term is
+  where sessions actually happen): Live section that jumps to the running
+  tab, project view with one-click "new tab at this cwd", session ↔ git
+  commit correlation, weekly digest.
+- Hard constraint: keep the app lightweight. No new npm packages (charts
+  are hand-rolled CSS/SVG). Only new Rust crate is `rusqlite` — linked
+  against the system SQLite on macOS, `bundled` only on Windows (~+1 MB).
+  Protobuf is hand-decoded (no prost). Trash uses `osascript` /
+  PowerShell shell-out (no trash crate). Watching reuses existing `notify`.
+
+## Non-goals (v1)
+
+- Antigravity IDE format (`~/.gemini/antigravity/`) — not installed here;
+  the parser registry keeps a slot for it.
+- Full-text search over message content (needs FTS5 or stored bodies) — P3.
+- AgentsView's sync/import/publish/MCP features (multi-machine sync,
+  session publishing, chat import). Out of scope entirely.
+- Modifying live-tracking modules (`claude_progress`, `codex_progress`,
+  status hooks). The new module is read-only alongside them.
+
+## Data sources (verified on this machine, 2026-07-06)
+
+| Agent | Location | Format |
+|---|---|---|
+| Claude Code | `~/.claude/projects/<mangled-cwd>/*.jsonl` (top level only; `<session-id>/subagents/` and `tool-results/` are companions, not sessions) | JSONL; entries form a DAG via `uuid`/`parentUuid`; `message.usage` carries token counts |
+| Codex | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` and `~/.codex/archived_sessions/*.jsonl` | JSONL event stream: `session_meta` (id, cwd, source), `event_msg` (`user_message`, `task_started`, …), `response_item` (role + content), `turn_context` |
+| Antigravity CLI | `~/.gemini/antigravity-cli/conversations/<uuid>.db` | SQLite, open read-only (`mode=ro`; WAL/SHM handled by SQLite). `steps` table: `idx`, `step_type` (14 = user, 15 = assistant), `step_payload` protobuf (field 5 timestamp, field 17 text). `gen_metadata` table: per-step protobuf with model name and input/output/reasoning tokens |
+
+Existing env overrides are honored: `CLAUDE_CONFIG_DIR` (see
+`claude_progress::config_base_dir`) and `CODEX_HOME`; add
+`ANTIGRAVITY_CLI_DIR` equivalent.
+
+Parsing rules ported from agentsview (logic reference, MIT):
+
+- **Claude**: walk the DAG main path (at forks, follow last child when the
+  abandoned branch has ≤ 3 user turns — retry gap — else first child);
+  skip `isMeta` entries, command envelopes, and empty messages; title from
+  `displayName` or first real user message (reuse
+  `claude_progress::extract_session_title`); tokens from `message.usage`
+  (context = `input_tokens` + `cache_creation_input_tokens` +
+  `cache_read_input_tokens`; output = `output_tokens`); duration from
+  first/last timestamps across all lines.
+- **Codex**: session id + cwd from `session_meta`; title = first
+  `user_message` event (reuse `codex_progress::extract_codex_title`);
+  count `response_item` messages with role user/assistant, skip
+  `developer` role and replayed instructions; token usage from token-count
+  events where present (exact shape verified during implementation).
+- **Antigravity**: messages from `steps` as above; model + tokens from
+  `gen_metadata` joined on `idx`; title = first user step (check
+  `conversation_summaries.db` as a richer title source during
+  implementation).
+
+## Architecture
+
+New Rust module `src-tauri/src/modules/sessions_index/`:
+
+```
+scanner.rs      enumerate session files across the three roots
+claude.rs       parser → SessionMeta (+ full transcript on demand)
+codex.rs        parser → SessionMeta (+ full transcript on demand)
+antigravity.rs  parser → SessionMeta (+ full transcript on demand)
+index.rs        SQLite index: schema, upserts, queries, stats
+watch.rs        notify watchers (500 ms debounce) → incremental sync
+mod.rs          Tauri commands + state
+```
+
+**Index stores metadata and aggregates only — never message bodies.**
+Clicking a session re-parses its source file on demand, so the viewer is
+always fresh and the index stays a few MB. The DB is a disposable cache in
+the app data dir; schema version bump or corruption → delete and rebuild.
+Source files remain the single source of truth.
+
+Schema sketch:
+
+```sql
+sessions(id PK, agent, project_cwd, title, started_at, ended_at,
+         message_count, user_message_count, output_tokens,
+         context_peak_tokens, model, file_path, file_mtime, file_size,
+         file_offset, pinned, updated_at)
+daily_stats(agent, project_cwd, date, hour,
+            messages, user_messages, sessions_started, output_tokens,
+            PRIMARY KEY(agent, project_cwd, date, hour))
+meta(key PK, value)   -- schema_version, last_full_scan
+```
+
+Incremental sync: per-file `mtime`/`size`/`offset`; JSONL files parse only
+appended lines (reuse `claude_progress::read_new_lines` tail primitives);
+Antigravity uses a composite fingerprint (db + `-wal` + `-shm` mtime/size)
+and re-parses the whole file on change. Daily-stat rows for a changed
+session are recomputed by delta, not full rescan. Initial full index runs
+on a background thread at first watch, never blocking the UI. After each
+sync batch the backend emits `sessions-index:updated`; the frontend
+re-queries lazily only while the view is visible.
+
+## IPC surface
+
+```
+sessions_list(filter)       → Vec<SessionSummary>
+                              filter: agent?, project?, query? (title/project match),
+                              date_range?, pinned_only?
+sessions_get(id)            → SessionTranscript (on-demand parse of source file)
+sessions_stats(range)       → { cards, heatmap_buckets, top_sessions, weekly_digest }
+sessions_pin(id, pinned)    → ()
+sessions_delete(id)         → ()   move to system trash (osascript / PowerShell),
+                              including companions (Claude: <id>/ dir;
+                              Antigravity: -wal/-shm); frontend shows ConfirmDialog first
+sessions_export(id)         → String (Markdown); frontend saves via existing save-dialog path
+sessions_git_commits(id)    → Vec<CommitInfo>  git log in project_cwd
+                              between started_at and ended_at
+```
+
+Event: `sessions-index:updated { agent, dirty_count }`.
+
+Resume is frontend-only: open a new terminal tab at the session's cwd and
+run `claude --resume <id>` / `codex resume <id>` (exact Codex syntax
+verified during implementation). Antigravity resume support is unverified;
+its resume button stays hidden until confirmed.
+
+Live section bypasses the index entirely: it reads the existing
+`sessionStatusStore` / `progressStore` / title stores and uses `tabsStore`
+to focus the pane.
+
+## Frontend
+
+New module `src/modules/sessions/` (component + `lib/` store + invoke
+bridge), registered via the standard 4-step recipe: `SidebarView` union in
+`uiStore.ts`, `SIDEBAR_TABS` entry in `Sidebar.tsx`, conditional render,
+`nav.*` labels in en + zh-Hant. The next ⌥N shortcut comes free from
+`SIDEBAR_VIEW_ORDER`.
+
+Sidebar panel, top to bottom:
+
+1. **Live** — running sessions with status badge; click focuses the tab.
+2. Search box + agent filter chips (Claude / Codex / Antigravity).
+3. **Pinned** group.
+4. History list, newest first, with a project-grouping toggle. Row =
+   title, project basename, agent badge, relative time, message count.
+
+Main area: one "Sessions" content tab with internal routing
+(`dashboard` | `session/<id>` | `project/<cwd>`), never multiple tabs.
+The editor already proves non-terminal main-area content; the exact tab
+mechanism is verified at planning time.
+
+- **Dashboard** (default): stat cards (Sessions, Messages, Projects,
+  Active Days, Messages/Session), calendar heatmap (CSS grid, messages
+  metric in v1), Top Sessions by messages / output tokens, date range
+  filter, weekly digest card (per-agent sessions, messages, tokens, rough
+  cost from a small built-in pricing map, active hours).
+- **Session viewer**: transcript grouped by role, tool calls collapsed by
+  default, "commits during this session" section, action bar
+  (resume / pin / delete / export). Back returns to dashboard.
+- **Project view**: per-cwd aggregates, recent sessions, "open terminal
+  here" button.
+
+All charts hand-rolled (CSS grid heatmap, div bars). No chart library.
+
+## Error handling
+
+All three formats are unofficial internals — parse defensively: skip
+malformed lines and undecodable protobuf fields, treat missing dirs as
+empty, retry a locked Antigravity DB on the next sync round, clamp absurd
+token values. A parse failure of one file never aborts a sync batch.
+Everything is local; no network access.
+
+## Testing
+
+TDD throughout. Rust: fixture-based parser tests per agent (scrubbed
+real samples), incremental-sync tests (append / new file / rotation /
+reset), daily-stats aggregation tests, index rebuild test. Frontend:
+store/normalizer unit tests (vitest) and cheap component smoke tests.
+
+## Phasing (one PR each)
+
+| Phase | Scope |
+|---|---|
+| P1 | sessions_index module (3 parsers, SQLite index, watcher, incremental sync); sidebar view (Live, search, filter, pins, history list); session viewer; resume |
+| P2 | dashboard (stat cards, calendar heatmap, Top Sessions, date range), weekly digest card; delete to trash; export Markdown |
+| P3 | project view; git commit correlation; day/hour distribution; model filter; CSV export; FTS full-text search |
+
+## Open questions (resolve during planning/implementation)
+
+- Exact `codex resume` CLI syntax and whether Antigravity CLI has resume.
+- Codex token-count event shape in rollout files.
+- Whether `conversation_summaries.db` yields better Antigravity titles.
+- Main-area content-tab mechanism (editor precedent) details.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -46,6 +46,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1529,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2243,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2234,6 +2261,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2967,6 +3003,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4545,6 +4592,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "russh"
 version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6008,6 +6069,7 @@ dependencies = [
  "orion",
  "portable-pty",
  "reqwest 0.12.28",
+ "rusqlite",
  "russh",
  "russh-sftp",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,6 +57,10 @@ wait-timeout = "0.2"
 # Windows (and Linux); no subprocess spawning. get_all() returns TCP+UDP and all
 # socket states, so the caller filters to TCP + LISTEN.
 listeners = "0.6"
+# Reads the Antigravity CLI's per-session SQLite trajectory databases and backs
+# the sessions index cache. macOS links the system libsqlite3 to keep the
+# binary lean; Windows/Linux have no system SQLite so they compile it in.
+rusqlite = "0.32"
 
 # keyring 3.x ships no credential store by default; each platform must opt into
 # its native backend or every keychain operation fails silently.
@@ -68,6 +72,8 @@ keyring = { version = "3", features = ["windows-native"] }
 # Synchronous Win32 clipboard access (text + copied-file list) for terminal
 # paste, so Ctrl+V never spawns a subprocess on the hot path.
 clipboard-win = "5"
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3", features = ["sync-secret-service"] }
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,6 +55,9 @@ use modules::session_log::session_logs_enforce_retention;
 use modules::sysmon::{system_stats, SysinfoState};
 use modules::ports::{kill_port_process, list_ports, PortsState};
 use modules::editor_watch::{editor_watch_set, EditorWatchState};
+use modules::sessions_index::{
+    sessions_get, sessions_index_start, sessions_list, sessions_pin, SessionsIndexState,
+};
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -101,6 +104,7 @@ pub fn run() {
         .manage(SysinfoState::new())
         .manage(PortsState::new())
         .manage(EditorWatchState::new())
+        .manage(SessionsIndexState::new())
         .setup(|app| {
             // window-state restores the last size/position, but it can persist a
             // corrupt tiny / off-screen value (observed 360x240 at a negative
@@ -249,7 +253,11 @@ pub fn run() {
             system_stats,
             list_ports,
             kill_port_process,
-            editor_watch_set
+            editor_watch_set,
+            sessions_index_start,
+            sessions_list,
+            sessions_get,
+            sessions_pin
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -18,5 +18,6 @@ pub mod preview;
 pub mod pty;
 pub mod secrets;
 pub mod session_log;
+pub mod sessions_index;
 pub mod sysmon;
 pub mod terminal_history;

--- a/src-tauri/src/modules/sessions_index/antigravity.rs
+++ b/src-tauri/src/modules/sessions_index/antigravity.rs
@@ -396,6 +396,104 @@ mod tests {
         assert!(parse_antigravity_meta(std::path::Path::new("/nope/x.db")).is_none());
     }
 
+    /// Encodes a `step_payload` using the REAL nested shape observed in
+    /// production DBs (see the module doc's "Correction" section):
+    ///
+    ///   - field 5 = step-metadata wrapper whose sub-field 1 is the
+    ///     `Timestamp` message (seconds field 1, nanos field 2), alongside
+    ///     sibling bookkeeping fields the parser must ignore;
+    ///   - text inside a role-specific wrapper: field 19 sub-field 2 for
+    ///     user steps, field 20 sub-field 3 for assistant steps, again with
+    ///     sibling fields present.
+    ///
+    /// `text: None` builds a tool-call-only turn: the role wrapper exists
+    /// but carries no text sub-field, which the parser must skip.
+    fn real_step_payload(is_user: bool, ts_seconds: u64, ts_nanos: u64, text: Option<&str>) -> Vec<u8> {
+        let mut ts = Vec::new();
+        field_varint(1, ts_seconds, &mut ts);
+        field_varint(2, ts_nanos, &mut ts);
+        let mut ts_wrapper = Vec::new();
+        field_bytes(1, &ts, &mut ts_wrapper);
+        field_varint(3, 4, &mut ts_wrapper); // sibling status code, as in real data
+
+        let (wrapper_no, text_no) = if is_user { (19u32, 2u32) } else { (20u32, 3u32) };
+        let mut content = Vec::new();
+        field_bytes(6, b"bot-uuid-noise", &mut content); // sibling field, as in real data
+        if let Some(text) = text {
+            field_bytes(text_no, text.as_bytes(), &mut content);
+        }
+
+        let mut buf = Vec::new();
+        field_varint(1, if is_user { 14 } else { 15 }, &mut buf); // step type echo, as in real data
+        field_bytes(5, &ts_wrapper, &mut buf);
+        field_bytes(wrapper_no, &content, &mut buf);
+        buf
+    }
+
+    /// A fixture DB whose payloads use the real nested encoding, plus one
+    /// `gen_metadata` row shaped like production (field 1 submessage with
+    /// the model display name at sub-field 21).
+    fn real_shape_fixture_db(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-ag-real-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE steps(idx INTEGER PRIMARY KEY, step_type INTEGER NOT NULL DEFAULT 0,
+               status INTEGER NOT NULL DEFAULT 0, step_payload BLOB, step_format INTEGER NOT NULL DEFAULT 0);
+             CREATE TABLE gen_metadata(idx INTEGER PRIMARY KEY, data BLOB, size INTEGER NOT NULL DEFAULT 0);",
+        ).unwrap();
+        conn.execute("INSERT INTO steps(idx, step_type, step_payload) VALUES(0, 14, ?1)",
+            params![real_step_payload(true, 1_751_760_000, 500_000_000, Some("real user prompt"))]).unwrap();
+        conn.execute("INSERT INTO steps(idx, step_type, step_payload) VALUES(1, 15, ?1)",
+            params![real_step_payload(false, 1_751_760_060, 0, Some("real assistant reply"))]).unwrap();
+        // Tool-call-only assistant turn: wrapper present, no text sub-field.
+        conn.execute("INSERT INTO steps(idx, step_type, step_payload) VALUES(2, 15, ?1)",
+            params![real_step_payload(false, 1_751_760_070, 0, None)]).unwrap();
+        // Non-conversational step type, ignored outright.
+        conn.execute("INSERT INTO steps(idx, step_type, step_payload) VALUES(3, 7, ?1)",
+            params![real_step_payload(true, 1_751_760_080, 0, Some("ignored step type"))]).unwrap();
+
+        let mut inner = Vec::new();
+        field_bytes(19, b"gemini-slug-noise", &mut inner);
+        field_bytes(21, b"Gemini Test Model", &mut inner);
+        let mut gm = Vec::new();
+        field_bytes(1, &inner, &mut gm);
+        conn.execute("INSERT INTO gen_metadata(idx, data, size) VALUES(0, ?1, ?2)",
+            params![gm.clone(), gm.len() as i64]).unwrap();
+        path
+    }
+
+    #[test]
+    fn meta_from_real_shape_trajectory_db() {
+        let meta = parse_antigravity_meta(&real_shape_fixture_db("meta")).unwrap();
+        assert_eq!(meta.id, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        assert_eq!(meta.agent, "antigravity");
+        assert_eq!(meta.title, "real user prompt");
+        // The text-less tool-call-only turn and the type-7 step don't count.
+        assert_eq!(meta.message_count, 2);
+        assert_eq!(meta.user_message_count, 1);
+        // Exact values prove the nested Timestamp (incl. nanos -> ms) was
+        // decoded, not the file-mtime fallback.
+        assert_eq!(meta.started_at, 1_751_760_000_500);
+        assert_eq!(meta.ended_at, 1_751_760_060_000);
+        assert_eq!(meta.model.as_deref(), Some("Gemini Test Model"));
+        assert_eq!(meta.output_tokens, None);
+    }
+
+    #[test]
+    fn transcript_from_real_shape_maps_roles_and_text() {
+        let t = parse_antigravity_transcript(&real_shape_fixture_db("transcript"));
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0].role, "user");
+        assert_eq!(t[0].text, "real user prompt");
+        assert_eq!(t[0].timestamp, Some(1_751_760_000_500));
+        assert_eq!(t[1].role, "assistant");
+        assert_eq!(t[1].text, "real assistant reply");
+        assert_eq!(t[1].timestamp, Some(1_751_760_060_000));
+    }
+
     /// Prints one decoded protobuf field for the spike/sanity dumps: field
     /// number, wire type, and either the varint value or a UTF-8/hex preview
     /// of bytes. Recurses (bounded by `depth`) into `Bytes` fields since the
@@ -410,7 +508,9 @@ mod tests {
             ProtoValue::Bytes(data) => {
                 let preview = match std::str::from_utf8(data) {
                     Ok(s) if !s.chars().any(|c| c.is_control() && c != '\n' && c != '\t') => {
-                        format!("UTF8 {:?}", &s[..s.len().min(120)])
+                        // chars(), not a byte slice: slicing at byte 120 can
+                        // panic on a multibyte (e.g. CJK) char boundary.
+                        format!("UTF8 {:?}", s.chars().take(120).collect::<String>())
                     }
                     _ => format!("hex {}", data.iter().take(24).map(|b| format!("{b:02x}")).collect::<String>()),
                 };

--- a/src-tauri/src/modules/sessions_index/antigravity.rs
+++ b/src-tauri/src/modules/sessions_index/antigravity.rs
@@ -1,0 +1,1 @@
+//! Parser for Antigravity CLI session trajectories.

--- a/src-tauri/src/modules/sessions_index/antigravity.rs
+++ b/src-tauri/src/modules/sessions_index/antigravity.rs
@@ -1,1 +1,520 @@
 //! Parser for Antigravity CLI session trajectories.
+//!
+//! Antigravity CLI stores each session as a SQLite "trajectory" DB under
+//! `~/.gemini/antigravity-cli/conversations/<uuid>.db`. Unlike Claude's
+//! JSONL uuid/parentUuid DAG or Codex's flat event log, conversational turns
+//! live in a `steps` table (`step_type` 14 = user, 15 = assistant), with the
+//! message text and timestamp packed into a `step_payload` protobuf blob.
+//! The schema exposes no project cwd anywhere, so `project_cwd` is always
+//! empty for this agent — the sidebar shows the agent badge instead of a
+//! project.
+//!
+//! Grounded against real DBs on this machine
+//! (`~/.gemini/antigravity-cli/conversations/*.db`, 2026-07-07): confirmed
+//! `steps(idx, step_type, status, ..., step_payload BLOB, step_format)` and
+//! `gen_metadata(idx, data BLOB, size)` match the brief exactly.
+//!
+//! ## Correction: `step_payload`'s text/timestamp fields
+//!
+//! The brief (based on an earlier check) expected a flat shape: field 17 =
+//! text, field 5 = the `Timestamp` message directly. Decoding ~1,000 real
+//! steps across 100 real DBs on this machine found **zero** occurrences of a
+//! top-level field 17, in any step, ever. The real shape is one level
+//! deeper, and role-specific:
+//!
+//!   - Text: a user step's (`step_type` 14) payload wraps its content in
+//!     field 19, whose sub-field 2 is the plain-text prompt. An assistant
+//!     step's (`step_type` 15) payload wraps its content in field 20, whose
+//!     sub-field 3 is the visible text — present only on turns that produce
+//!     visible content; tool-call-only turns (~57% of assistant steps
+//!     sampled) omit it entirely and are legitimately skipped, per the
+//!     brief's "skip steps whose payload lacks text" rule.
+//!   - Timestamp: field 5 is itself a step-metadata wrapper (also carrying a
+//!     status code, step/trajectory uuids, ...), not the `Timestamp`
+//!     message itself. The real `Timestamp` (seconds field 1, nanos field
+//!     2) sits at field 5's own sub-field 1.
+//!
+//! `extract_text` and `extract_timestamp_ms` below try this real shape
+//! first, then fall back to the brief's original flat shape (field 17 /
+//! field 5-is-`Timestamp`) — both so a future/alternate encoding degrades
+//! gracefully instead of going silently blank, and because the brief's
+//! mandated fixture tests (`meta_from_trajectory_db`,
+//! `transcript_maps_step_types_to_roles`) encode exactly that flat shape.
+//!
+//! Verified end-to-end against real conversations, via `parse_antigravity_meta`
+//! and `parse_antigravity_transcript` themselves rather than raw field dumps:
+//! titles, message counts, timestamps, and the resolved model all come out
+//! plausible, e.g. a one-line greeting session titled "你好，只回我一句問候"
+//! (message_count 1) and a 7-message reflection-assistant trajectory with
+//! alternating user/assistant text. A handful of real DBs transiently
+//! yielded `None` on the first attempt because Antigravity CLI itself had
+//! them open (`SQLITE_CANTOPEN` on a live WAL/shm pair) — re-running moments
+//! later parsed them fine, confirming this is the documented "locked DB ⇒
+//! None, sync retries next round" case, not a parsing defect.
+//!
+//! ## Spike findings (model/token fields, see `dump_real_gen_metadata`)
+//!
+//! Each `gen_metadata` row's `data` blob is itself a small protobuf message
+//! whose field 1 is one large nested "generation metadata" submessage (deep
+//! internal bookkeeping: cache keys, region/latency stats, tool-schema
+//! blobs). Inside that submessage, sampled across ~10 real DBs:
+//!
+//!   - field 19 (bytes/UTF-8): a short internal generation-config name, e.g.
+//!     `"gemini-3-flash-a"` or `"gemini-default"` — varies per row/DB, reads
+//!     like an internal slug rather than a stable display name.
+//!   - field 21 (bytes/UTF-8): a human-readable model display string, e.g.
+//!     `"Gemini 3.5 Flash (Medium)"` — present on every sampled row across
+//!     every sampled DB, so this is what `model` is extracted from below
+//!     (last `gen_metadata` row wins, mirroring Codex's "last
+//!     `turn_context`'s model wins" convention, in case a session switches
+//!     models mid-way).
+//!   - No field anywhere in the sampled blobs carries a labelled
+//!     input/output token count: the numeric fields near the model info are
+//!     unlabelled varints (byte offsets, hashes, latency numbers) with no
+//!     way to confidently tell "output tokens" apart from other counters.
+//!     Per the brief's documented-degradation rule, `output_tokens` ships as
+//!     `None` for this agent.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rusqlite::{Connection, OpenFlags};
+
+use super::claude::local_bucket;
+use super::proto::{first_bytes, first_varint, parse_fields, timestamp_ms, ProtoValue};
+use super::types::{ActivityBucket, ParsedSession, TranscriptMessage};
+
+const STEP_TYPE_USER: i64 = 14;
+const STEP_TYPE_ASSISTANT: i64 = 15;
+const PAYLOAD_FIELD_TIMESTAMP: u32 = 5;
+
+/// Legacy/fixture text shape: a flat top-level field holding the text
+/// directly (see the module doc's "Correction" section).
+const PAYLOAD_FIELD_TEXT_LEGACY: u32 = 17;
+/// Real shape: role-specific wrapper field, and the text sub-field inside it.
+const PAYLOAD_FIELD_USER_WRAPPER: u32 = 19;
+const PAYLOAD_FIELD_USER_TEXT: u32 = 2;
+const PAYLOAD_FIELD_ASSISTANT_WRAPPER: u32 = 20;
+const PAYLOAD_FIELD_ASSISTANT_TEXT: u32 = 3;
+/// Real shape: field 5 is a step-metadata wrapper; the actual `Timestamp`
+/// submessage is one level deeper, at this sub-field.
+const TIMESTAMP_WRAPPER_INNER_FIELD: u32 = 1;
+
+const MAX_TITLE_CHARS: usize = 80;
+
+/// Field numbers inside a `gen_metadata` row's nested generation-metadata
+/// submessage (see the module doc for how these were identified).
+const GEN_METADATA_INNER_FIELD: u32 = 1;
+const GEN_METADATA_MODEL_NAME_FIELD: u32 = 21;
+
+/// Opens a trajectory DB read-only. Any failure (missing file, locked by the
+/// Antigravity CLI process, corrupt SQLite header, ...) yields `None` rather
+/// than an error — the sync loop just retries next round.
+fn open_read_only(path: &Path) -> Option<Connection> {
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()
+}
+
+/// One decoded conversational step: role + text + (best-effort) timestamp.
+struct Step {
+    is_user: bool,
+    text: String,
+    timestamp_ms: Option<i64>,
+}
+
+/// Extracts a step's message text: the real role-specific wrapper shape
+/// first, falling back to the flat legacy/fixture shape (field 17) — see
+/// the module doc's "Correction" section. `None` when neither shape yields
+/// non-blank text (e.g. a tool-call-only assistant turn).
+fn extract_text(fields: &[(u32, ProtoValue)], is_user: bool) -> Option<String> {
+    let (wrapper_field, text_subfield) = if is_user {
+        (PAYLOAD_FIELD_USER_WRAPPER, PAYLOAD_FIELD_USER_TEXT)
+    } else {
+        (PAYLOAD_FIELD_ASSISTANT_WRAPPER, PAYLOAD_FIELD_ASSISTANT_TEXT)
+    };
+    let real_shape = first_bytes(fields, wrapper_field)
+        .map(parse_fields)
+        .and_then(|inner| first_bytes(&inner, text_subfield).map(<[u8]>::to_vec));
+    let text_bytes = real_shape.or_else(|| first_bytes(fields, PAYLOAD_FIELD_TEXT_LEGACY).map(<[u8]>::to_vec))?;
+    let text = std::str::from_utf8(&text_bytes).ok()?.to_string();
+    if text.trim().is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+/// Extracts a step's timestamp: the real nested-wrapper shape first,
+/// falling back to treating field 5 as the `Timestamp` message directly
+/// (the legacy/fixture shape) — see the module doc's "Correction" section.
+fn extract_timestamp_ms(fields: &[(u32, ProtoValue)]) -> Option<i64> {
+    let wrapper_bytes = first_bytes(fields, PAYLOAD_FIELD_TIMESTAMP);
+    let real_shape = wrapper_bytes.and_then(|wrapper_bytes| {
+        let wrapper = parse_fields(wrapper_bytes);
+        let ts_bytes = first_bytes(&wrapper, TIMESTAMP_WRAPPER_INNER_FIELD)?;
+        let ts_fields = parse_fields(ts_bytes);
+        let seconds = first_varint(&ts_fields, 1)? as i64;
+        let nanos = first_varint(&ts_fields, 2).unwrap_or(0) as i64;
+        seconds.checked_mul(1000)?.checked_add(nanos / 1_000_000)
+    });
+    real_shape.or_else(|| timestamp_ms(fields, PAYLOAD_FIELD_TIMESTAMP))
+}
+
+/// Reads every user/assistant step in `idx` order, decoding each payload's
+/// text and timestamp (see `extract_text`/`extract_timestamp_ms`). Steps of
+/// any other `step_type`, and steps whose payload can't be decoded or
+/// carries no (non-blank) text, are skipped entirely — they never count
+/// toward message totals or appear in the transcript.
+fn read_steps(conn: &Connection) -> Vec<Step> {
+    let mut stmt = match conn.prepare("SELECT step_type, step_payload FROM steps ORDER BY idx") {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let rows = stmt.query_map([], |row| {
+        let step_type: i64 = row.get(0)?;
+        let payload: Option<Vec<u8>> = row.get(1)?;
+        Ok((step_type, payload))
+    });
+    let Ok(rows) = rows else { return Vec::new() };
+
+    let mut steps = Vec::new();
+    for (step_type, payload) in rows.flatten() {
+        let is_user = match step_type {
+            STEP_TYPE_USER => true,
+            STEP_TYPE_ASSISTANT => false,
+            _ => continue,
+        };
+        let Some(payload) = payload else { continue };
+        let fields = parse_fields(&payload);
+        let Some(text) = extract_text(&fields, is_user) else { continue };
+        let ts = extract_timestamp_ms(&fields);
+        steps.push(Step { is_user, text, timestamp_ms: ts });
+    }
+    steps
+}
+
+/// The DB file's mtime in epoch milliseconds, used as a step's timestamp
+/// when its payload lacks field 5. `None` if the file's metadata can't be
+/// read (e.g. it vanished under us) — the step then simply has no timestamp.
+fn file_mtime_ms(path: &Path) -> Option<i64> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    let since_epoch = modified.duration_since(std::time::UNIX_EPOCH).ok()?;
+    i64::try_from(since_epoch.as_millis()).ok()
+}
+
+/// Extracts the model display name from the most recent `gen_metadata` row
+/// (last row wins, mirroring Codex's "last `turn_context`'s model wins", in
+/// case a session switches models mid-way). See the module doc for how
+/// field 21 was identified. `None` when there are no `gen_metadata` rows,
+/// the blob can't be decoded, or the field is missing/blank.
+fn extract_model(conn: &Connection) -> Option<String> {
+    let data: Vec<u8> = conn
+        .query_row("SELECT data FROM gen_metadata ORDER BY idx DESC LIMIT 1", [], |row| row.get(0))
+        .ok()?;
+    let top = parse_fields(&data);
+    let inner_bytes = first_bytes(&top, GEN_METADATA_INNER_FIELD)?;
+    let inner = parse_fields(inner_bytes);
+    let model_bytes = first_bytes(&inner, GEN_METADATA_MODEL_NAME_FIELD)?;
+    let model = std::str::from_utf8(model_bytes).ok()?.trim();
+    if model.is_empty() {
+        None
+    } else {
+        Some(model.to_string())
+    }
+}
+
+/// Parse an Antigravity CLI trajectory DB into index metadata, or `None`
+/// when the DB can't be opened (missing/locked/corrupt) or has zero
+/// user/assistant steps carrying text.
+pub fn parse_antigravity_meta(path: &Path) -> Option<ParsedSession> {
+    let conn = open_read_only(path)?;
+    let steps = read_steps(&conn);
+    if steps.is_empty() {
+        return None;
+    }
+
+    let fallback_ts = file_mtime_ms(path);
+    let mut message_count: i64 = 0;
+    let mut user_message_count: i64 = 0;
+    let mut title: Option<String> = None;
+    let mut started_at = i64::MAX;
+    let mut ended_at = i64::MIN;
+    let mut buckets: HashMap<(String, u8), ActivityBucket> = HashMap::new();
+
+    for step in &steps {
+        message_count += 1;
+        if step.is_user {
+            user_message_count += 1;
+            if title.is_none() {
+                title = Some(step.text.trim().chars().take(MAX_TITLE_CHARS).collect());
+            }
+        }
+
+        let Some(ts) = step.timestamp_ms.or(fallback_ts) else { continue };
+        started_at = started_at.min(ts);
+        ended_at = ended_at.max(ts);
+        let (date, hour) = local_bucket(ts);
+        let bucket = buckets.entry((date.clone(), hour)).or_insert_with(|| ActivityBucket {
+            date,
+            hour,
+            messages: 0,
+            user_messages: 0,
+            output_tokens: 0,
+        });
+        bucket.messages += 1;
+        if step.is_user {
+            bucket.user_messages += 1;
+        }
+    }
+
+    if started_at > ended_at {
+        started_at = 0;
+        ended_at = 0;
+    }
+
+    let id = path.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default();
+    let mut activity: Vec<ActivityBucket> = buckets.into_values().collect();
+    activity.sort_by(|a, b| (a.date.as_str(), a.hour).cmp(&(b.date.as_str(), b.hour)));
+
+    Some(ParsedSession {
+        id,
+        agent: "antigravity",
+        project_cwd: String::new(),
+        title: title.unwrap_or_default(),
+        started_at,
+        ended_at,
+        message_count,
+        user_message_count,
+        output_tokens: None, // see module doc: no confidently identifiable field
+        model: extract_model(&conn),
+        activity,
+    })
+}
+
+/// Parse an Antigravity CLI trajectory DB into the viewer's message list,
+/// re-derived from the source file on demand. Empty on any open/read
+/// failure — the viewer just shows nothing rather than panicking.
+pub fn parse_antigravity_transcript(path: &Path) -> Vec<TranscriptMessage> {
+    let Some(conn) = open_read_only(path) else { return Vec::new() };
+    let steps = read_steps(&conn);
+    let fallback_ts = file_mtime_ms(path);
+
+    steps
+        .into_iter()
+        .map(|step| TranscriptMessage {
+            role: if step.is_user { "user".to_string() } else { "assistant".to_string() },
+            text: step.text,
+            timestamp: step.timestamp_ms.or(fallback_ts),
+            tool_name: None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::{params, Connection};
+
+    // Test-only encoder helpers (wire format: tag = field_no << 3 | wire_type),
+    // copied verbatim from proto.rs's test module.
+    fn varint(mut v: u64, out: &mut Vec<u8>) {
+        loop {
+            let byte = (v & 0x7f) as u8;
+            v >>= 7;
+            if v == 0 {
+                out.push(byte);
+                break;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+    fn field_varint(no: u32, v: u64, out: &mut Vec<u8>) {
+        varint(((no as u64) << 3) | 0, out);
+        varint(v, out);
+    }
+    fn field_bytes(no: u32, data: &[u8], out: &mut Vec<u8>) {
+        varint(((no as u64) << 3) | 2, out);
+        varint(data.len() as u64, out);
+        out.extend_from_slice(data);
+    }
+
+    fn step_payload(ts_seconds: u64, text: &str) -> Vec<u8> {
+        let mut ts = Vec::new();
+        field_varint(1, ts_seconds, &mut ts);
+        let mut buf = Vec::new();
+        field_bytes(5, &ts, &mut buf);
+        field_bytes(17, text.as_bytes(), &mut buf);
+        buf
+    }
+
+    fn fixture_db(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-ag-parse-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("11111111-2222-3333-4444-555555555555.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE steps(idx INTEGER PRIMARY KEY, step_type INTEGER NOT NULL DEFAULT 0,
+               status INTEGER NOT NULL DEFAULT 0, step_payload BLOB, step_format INTEGER NOT NULL DEFAULT 0);
+             CREATE TABLE gen_metadata(idx INTEGER PRIMARY KEY, data BLOB, size INTEGER NOT NULL DEFAULT 0);",
+        ).unwrap();
+        conn.execute("INSERT INTO steps(idx, step_type, step_payload) VALUES(0, 14, ?1)",
+            params![step_payload(1_751_760_000, "build me a thing")]).unwrap();
+        conn.execute("INSERT INTO steps(idx, step_type, step_payload) VALUES(1, 15, ?1)",
+            params![step_payload(1_751_760_060, "here is the thing")]).unwrap();
+        conn.execute("INSERT INTO steps(idx, step_type, step_payload) VALUES(2, 7, ?1)",
+            params![step_payload(1_751_760_070, "ignored step type")]).unwrap();
+        path
+    }
+
+    #[test]
+    fn meta_from_trajectory_db() {
+        let meta = parse_antigravity_meta(&fixture_db("meta")).unwrap();
+        assert_eq!(meta.id, "11111111-2222-3333-4444-555555555555");
+        assert_eq!(meta.agent, "antigravity");
+        assert_eq!(meta.title, "build me a thing");
+        assert_eq!(meta.message_count, 2);
+        assert_eq!(meta.user_message_count, 1);
+        assert_eq!(meta.started_at, 1_751_760_000_000);
+        assert_eq!(meta.ended_at, 1_751_760_060_000);
+    }
+
+    #[test]
+    fn transcript_maps_step_types_to_roles() {
+        let t = parse_antigravity_transcript(&fixture_db("transcript"));
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0].role, "user");
+        assert_eq!(t[1].role, "assistant");
+        assert_eq!(t[1].text, "here is the thing");
+    }
+
+    #[test]
+    fn missing_or_invalid_db_yields_none() {
+        assert!(parse_antigravity_meta(std::path::Path::new("/nope/x.db")).is_none());
+    }
+
+    /// Prints one decoded protobuf field for the spike/sanity dumps: field
+    /// number, wire type, and either the varint value or a UTF-8/hex preview
+    /// of bytes. Recurses (bounded by `depth`) into `Bytes` fields since the
+    /// interesting model data in `gen_metadata` sits inside a nested
+    /// submessage (field 1) — see the module doc.
+    fn print_field(no: u32, value: &super::super::proto::ProtoValue, indent: &str, depth: u32) {
+        use super::super::proto::ProtoValue;
+        match value {
+            ProtoValue::Varint(v) => println!("{indent}field {no} (varint): {v}"),
+            ProtoValue::Fixed64(v) => println!("{indent}field {no} (fixed64): {v}"),
+            ProtoValue::Fixed32(v) => println!("{indent}field {no} (fixed32): {v}"),
+            ProtoValue::Bytes(data) => {
+                let preview = match std::str::from_utf8(data) {
+                    Ok(s) if !s.chars().any(|c| c.is_control() && c != '\n' && c != '\t') => {
+                        format!("UTF8 {:?}", &s[..s.len().min(120)])
+                    }
+                    _ => format!("hex {}", data.iter().take(24).map(|b| format!("{b:02x}")).collect::<String>()),
+                };
+                println!("{indent}field {no} (bytes, len={}): {preview}", data.len());
+                if depth > 0 && !data.is_empty() {
+                    let nested = parse_fields(data);
+                    let deeper = format!("{indent}  ");
+                    for (nno, nvalue) in &nested {
+                        print_field(*nno, nvalue, &deeper, depth - 1);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Real DBs on this machine, newest first, for the spike/sanity checks.
+    fn real_conversation_dbs(limit: usize) -> Vec<std::path::PathBuf> {
+        let home = std::env::var("HOME").expect("HOME must be set to locate ~/.gemini/antigravity-cli");
+        let dir = std::path::Path::new(&home).join(".gemini").join("antigravity-cli").join("conversations");
+        let entries = std::fs::read_dir(&dir).expect("read ~/.gemini/antigravity-cli/conversations");
+
+        let mut dbs: Vec<(std::time::SystemTime, std::path::PathBuf)> = entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("db"))
+            .filter_map(|p| std::fs::metadata(&p).and_then(|m| m.modified()).ok().map(|t| (t, p)))
+            .collect();
+        dbs.sort_by(|a, b| b.0.cmp(&a.0));
+        dbs.truncate(limit);
+        dbs.into_iter().map(|(_, p)| p).collect()
+    }
+
+    /// Spike (Step 1): dumps decoded `gen_metadata` fields from 2-3 real DBs
+    /// so the model/token fields can be identified by eye. Not run in CI;
+    /// run with `cargo test sessions_index::antigravity -- --ignored
+    /// --nocapture`.
+    ///
+    /// Findings are recorded in the module doc comment and baked into
+    /// `extract_model`; this test is kept so the spike can be re-run if
+    /// Antigravity CLI's schema ever changes.
+    #[test]
+    #[ignore]
+    fn dump_real_gen_metadata() {
+        let dbs = real_conversation_dbs(3);
+        assert!(!dbs.is_empty(), "no real Antigravity CLI DBs found for the spike");
+
+        for path in &dbs {
+            println!("=== {} ===", path.display());
+            let Some(conn) = open_read_only(path) else {
+                println!("  (could not open: locked/corrupt)");
+                continue;
+            };
+            let mut stmt = match conn.prepare("SELECT idx, data FROM gen_metadata ORDER BY idx DESC") {
+                Ok(s) => s,
+                Err(e) => {
+                    println!("  (no gen_metadata table: {e})");
+                    continue;
+                }
+            };
+            let rows = stmt.query_map([], |row| {
+                let idx: i64 = row.get(0)?;
+                let data: Vec<u8> = row.get(1)?;
+                Ok((idx, data))
+            });
+            let Ok(rows) = rows else { continue };
+            for (idx, data) in rows.flatten().take(2) {
+                println!("  gen_metadata idx={idx} len={}", data.len());
+                let top = parse_fields(&data);
+                for (no, value) in &top {
+                    print_field(*no, value, "    ", 1);
+                }
+            }
+        }
+    }
+
+    /// Sanity check (Step 5) against real conversation DBs on this machine.
+    /// Not run in CI; run with `cargo test sessions_index::antigravity --
+    /// --ignored --nocapture` and eyeball the printed metadata/transcript
+    /// for plausibility (title reads like a real request, roles alternate
+    /// sensibly, model looks like a real Gemini model name).
+    #[test]
+    #[ignore]
+    fn sanity_check_against_real_conversations() {
+        let dbs = real_conversation_dbs(3);
+        assert!(!dbs.is_empty(), "no real Antigravity CLI DBs found for the sanity check");
+
+        for path in &dbs {
+            println!("sanity-checking real conversation: {}", path.display());
+            let Some(meta) = parse_antigravity_meta(path) else {
+                println!("  -> None (no user/assistant steps, or DB locked/corrupt)");
+                continue;
+            };
+            println!("  id = {}", meta.id);
+            println!("  title = {:?}", meta.title);
+            println!("  message_count = {}  user_message_count = {}", meta.message_count, meta.user_message_count);
+            println!("  started_at = {}  ended_at = {}", meta.started_at, meta.ended_at);
+            println!("  model = {:?}", meta.model);
+            println!("  output_tokens = {:?}", meta.output_tokens);
+
+            let transcript = parse_antigravity_transcript(path);
+            println!("  transcript entries = {}", transcript.len());
+            for m in transcript.iter().take(3) {
+                println!("    [{}] {:.80}", m.role, m.text);
+            }
+        }
+    }
+}

--- a/src-tauri/src/modules/sessions_index/claude.rs
+++ b/src-tauri/src/modules/sessions_index/claude.rs
@@ -1,1 +1,560 @@
-//! Parser for Claude Code session files.
+//! Claude Code JSONL parser: walks the uuid/parentUuid DAG's main path and
+//! produces session metadata and viewer transcripts. Ported (simplified) from
+//! agentsview's claude parser (MIT); see the design spec for the rules.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use chrono::{DateTime, Datelike, Local, Timelike};
+use serde_json::Value;
+
+use super::types::{ActivityBucket, ParsedSession, TranscriptMessage};
+
+/// A fork whose first child's subtree holds this many user turns or fewer is
+/// treated as an abandoned attempt: the walk takes the last (retry) child
+/// instead of the first.
+const FORK_USER_TURN_THRESHOLD: usize = 3;
+
+pub(crate) fn epoch_ms(iso: &str) -> Option<i64> {
+    DateTime::parse_from_rfc3339(iso).ok().map(|t| t.timestamp_millis())
+}
+
+/// Local calendar bucket for an epoch-ms timestamp: ("YYYY-MM-DD", hour).
+pub(crate) fn local_bucket(ms: i64) -> (String, u8) {
+    let local = DateTime::from_timestamp_millis(ms)
+        .map(|utc| utc.with_timezone(&Local))
+        .unwrap_or_else(Local::now);
+    (
+        format!("{:04}-{:02}-{:02}", local.year(), local.month(), local.day()),
+        local.hour() as u8,
+    )
+}
+
+/// One parsed JSONL line, with its DAG identity pulled out for convenience.
+struct Entry {
+    uuid: Option<String>,
+    parent: Option<String>,
+    value: Value,
+}
+
+/// Parse every line into an `Entry`, silently dropping lines that aren't valid
+/// JSON. Blank lines are ignored too. Never panics on malformed input.
+fn parse_entries(contents: &str) -> Vec<Entry> {
+    contents
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+            let value: Value = serde_json::from_str(line).ok()?;
+            let uuid = value.get("uuid").and_then(Value::as_str).map(str::to_string);
+            let parent = value.get("parentUuid").and_then(Value::as_str).map(str::to_string);
+            Some(Entry { uuid, parent, value })
+        })
+        .collect()
+}
+
+/// A line counts as a message when it's a `user`/`assistant` line, isn't a
+/// meta or sidechain line, and carries non-empty message content. A `user`
+/// line whose content is only `tool_result` items (no text) doesn't count —
+/// it's plumbing, not a conversational turn.
+fn is_countable(value: &Value) -> bool {
+    let type_ = value.get("type").and_then(Value::as_str);
+    let is_user = type_ == Some("user");
+    let is_assistant = type_ == Some("assistant");
+    if !is_user && !is_assistant {
+        return false;
+    }
+    if value.get("isMeta").and_then(Value::as_bool).unwrap_or(false) {
+        return false;
+    }
+    if value.get("isSidechain").and_then(Value::as_bool).unwrap_or(false) {
+        return false;
+    }
+    let content = match value.get("message").and_then(|m| m.get("content")) {
+        Some(c) => c,
+        None => return false,
+    };
+    let non_empty = match content {
+        Value::String(s) => !s.trim().is_empty(),
+        Value::Array(items) => !items.is_empty(),
+        _ => false,
+    };
+    if !non_empty {
+        return false;
+    }
+    if is_user {
+        if let Value::Array(items) = content {
+            let only_tool_result = items
+                .iter()
+                .all(|item| item.get("type").and_then(Value::as_str) == Some("tool_result"));
+            if only_tool_result {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// DFS count of countable `user` entries in the subtree rooted at `i`
+/// (inclusive). Guards against cyclic parent data so malformed input can
+/// never hang the walk.
+fn user_turns_under(entries: &[Entry], children: &HashMap<&str, Vec<usize>>, i: usize) -> usize {
+    let mut count = 0;
+    let mut stack = vec![i];
+    let mut visited: HashSet<usize> = HashSet::new();
+    while let Some(idx) = stack.pop() {
+        if !visited.insert(idx) {
+            continue;
+        }
+        let entry = &entries[idx];
+        if entry.value.get("type").and_then(Value::as_str) == Some("user") && is_countable(&entry.value) {
+            count += 1;
+        }
+        if let Some(uuid) = &entry.uuid {
+            if let Some(kids) = children.get(uuid.as_str()) {
+                stack.extend(kids.iter().copied());
+            }
+        }
+    }
+    count
+}
+
+/// The indices (in file order) of the entries that make up the session's main
+/// conversational path. Walks the uuid/parentUuid DAG from the first root; at
+/// each fork, follows the last child unless the first child's subtree already
+/// holds more than `FORK_USER_TURN_THRESHOLD` user turns, treating a
+/// short-lived first attempt as an abandoned retry. Falls back to file order
+/// when any countable line lacks a `uuid` (the DAG can't be trusted).
+fn main_path(entries: &[Entry]) -> Vec<usize> {
+    if entries.iter().any(|e| is_countable(&e.value) && e.uuid.is_none()) {
+        return (0..entries.len()).collect();
+    }
+
+    let mut uuid_index: HashMap<&str, usize> = HashMap::new();
+    for (i, e) in entries.iter().enumerate() {
+        if let Some(uuid) = &e.uuid {
+            uuid_index.insert(uuid.as_str(), i);
+        }
+    }
+
+    let mut children: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (i, e) in entries.iter().enumerate() {
+        if let Some(parent) = &e.parent {
+            if uuid_index.contains_key(parent.as_str()) {
+                children.entry(parent.as_str()).or_default().push(i);
+            }
+        }
+    }
+
+    // A root must itself have a uuid (so children can be looked up from it).
+    // Real transcripts interleave house-keeping records (mode, last-prompt,
+    // hook attachments...) that carry no `uuid`/`parentUuid` at all; those
+    // aren't DAG nodes and must never be mistaken for the conversation root.
+    let root = entries.iter().position(|e| {
+        e.uuid.is_some()
+            && match &e.parent {
+                None => true,
+                Some(parent) => !uuid_index.contains_key(parent.as_str()),
+            }
+    });
+    let Some(root_idx) = root else {
+        return (0..entries.len()).collect();
+    };
+
+    let mut path = Vec::new();
+    let mut visited: HashSet<usize> = HashSet::new();
+    let mut current = root_idx;
+    loop {
+        if !visited.insert(current) {
+            break; // cyclic parent data; stop rather than loop forever
+        }
+        path.push(current);
+        let uuid = match &entries[current].uuid {
+            Some(uuid) => uuid.as_str(),
+            None => break,
+        };
+        let kids = match children.get(uuid) {
+            Some(kids) if !kids.is_empty() => kids,
+            _ => break,
+        };
+        current = if kids.len() == 1 {
+            kids[0]
+        } else {
+            let first = kids[0];
+            let last = *kids.last().expect("fork has at least one child");
+            if user_turns_under(entries, &children, first) <= FORK_USER_TURN_THRESHOLD {
+                last
+            } else {
+                first
+            }
+        };
+    }
+    path
+}
+
+/// Parse a Claude Code session transcript into index metadata, or `None` when
+/// the file is empty, unreadable, or has no countable messages.
+pub fn parse_claude_meta(path: &Path) -> Option<ParsedSession> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let entries = parse_entries(&contents);
+    if entries.is_empty() {
+        return None;
+    }
+    let main = main_path(&entries);
+
+    let mut message_count: i64 = 0;
+    let mut user_message_count: i64 = 0;
+    let mut output_tokens: Option<i64> = None;
+    let mut model: Option<String> = None;
+    let mut buckets: HashMap<(String, u8), ActivityBucket> = HashMap::new();
+
+    for &i in &main {
+        let entry = &entries[i];
+        if !is_countable(&entry.value) {
+            continue;
+        }
+        let is_user = entry.value.get("type").and_then(Value::as_str) == Some("user");
+        message_count += 1;
+        if is_user {
+            user_message_count += 1;
+        }
+
+        let tokens = entry
+            .value
+            .get("message")
+            .and_then(|m| m.get("usage"))
+            .and_then(|u| u.get("output_tokens"))
+            .and_then(Value::as_i64);
+        if let Some(tokens) = tokens {
+            *output_tokens.get_or_insert(0) += tokens;
+        }
+        if !is_user {
+            if let Some(m) = entry.value.get("message").and_then(|m| m.get("model")).and_then(Value::as_str) {
+                model = Some(m.to_string());
+            }
+        }
+
+        if let Some(ts) = entry.value.get("timestamp").and_then(Value::as_str).and_then(epoch_ms) {
+            let (date, hour) = local_bucket(ts);
+            let bucket = buckets.entry((date.clone(), hour)).or_insert_with(|| ActivityBucket {
+                date,
+                hour,
+                messages: 0,
+                user_messages: 0,
+                output_tokens: 0,
+            });
+            bucket.messages += 1;
+            if is_user {
+                bucket.user_messages += 1;
+            }
+            if let Some(tokens) = tokens {
+                bucket.output_tokens += tokens;
+            }
+        }
+    }
+
+    if message_count == 0 {
+        return None;
+    }
+
+    // Timestamps span every line in the file, even ones skipped as
+    // non-countable (meta/sidechain/tool-result-only), so the session's
+    // start/end reflects real wall-clock activity.
+    let mut started_at = i64::MAX;
+    let mut ended_at = i64::MIN;
+    for entry in &entries {
+        if let Some(ts) = entry.value.get("timestamp").and_then(Value::as_str).and_then(epoch_ms) {
+            started_at = started_at.min(ts);
+            ended_at = ended_at.max(ts);
+        }
+    }
+    if started_at > ended_at {
+        started_at = 0;
+        ended_at = 0;
+    }
+
+    let id = entries
+        .iter()
+        .find_map(|e| e.value.get("sessionId").and_then(Value::as_str))
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| path.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default());
+
+    let project_cwd = entries
+        .iter()
+        .find_map(|e| e.value.get("cwd").and_then(Value::as_str))
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            path.parent()
+                .and_then(|p| p.file_name())
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        });
+
+    let title = crate::modules::claude_progress::extract_session_title(&contents).unwrap_or_default();
+
+    let mut activity: Vec<ActivityBucket> = buckets.into_values().collect();
+    activity.sort_by(|a, b| (a.date.as_str(), a.hour).cmp(&(b.date.as_str(), b.hour)));
+
+    Some(ParsedSession {
+        id,
+        agent: "claude",
+        project_cwd,
+        title,
+        started_at,
+        ended_at,
+        message_count,
+        user_message_count,
+        output_tokens,
+        model,
+        activity,
+    })
+}
+
+/// The text of a `user` message's content: the plain string, or its `text`
+/// items joined with `\n`. `None` when there's no text at all (e.g. a
+/// tool-result-only user line).
+fn user_text_from_content(content: &Value) -> Option<String> {
+    match content {
+        Value::String(s) if !s.trim().is_empty() => Some(s.clone()),
+        Value::Array(items) => {
+            let texts: Vec<&str> = items
+                .iter()
+                .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|item| item.get("text").and_then(Value::as_str))
+                .collect();
+            if texts.is_empty() {
+                None
+            } else {
+                Some(texts.join("\n"))
+            }
+        }
+        _ => None,
+    }
+}
+
+const TOOL_INPUT_PREVIEW_CHARS: usize = 400;
+
+/// Parse a Claude Code session transcript into the viewer's message list,
+/// re-derived from the source file on demand. Empty on any read/parse
+/// failure — the viewer just shows nothing rather than panicking.
+pub fn parse_claude_transcript(path: &Path) -> Vec<TranscriptMessage> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let entries = parse_entries(&contents);
+    if entries.is_empty() {
+        return Vec::new();
+    }
+    let main = main_path(&entries);
+
+    let mut out = Vec::new();
+    for &i in &main {
+        let entry = &entries[i];
+        let type_ = entry.value.get("type").and_then(Value::as_str).unwrap_or("");
+        let timestamp = entry.value.get("timestamp").and_then(Value::as_str).and_then(epoch_ms);
+        let content = match entry.value.get("message").and_then(|m| m.get("content")) {
+            Some(c) => c,
+            None => continue,
+        };
+
+        match type_ {
+            "user" => {
+                if let Some(text) = user_text_from_content(content) {
+                    out.push(TranscriptMessage {
+                        role: "user".to_string(),
+                        text,
+                        timestamp,
+                        tool_name: None,
+                    });
+                }
+            }
+            "assistant" => match content {
+                Value::Array(items) => {
+                    for item in items {
+                        match item.get("type").and_then(Value::as_str) {
+                            Some("text") => {
+                                if let Some(text) = item.get("text").and_then(Value::as_str) {
+                                    out.push(TranscriptMessage {
+                                        role: "assistant".to_string(),
+                                        text: text.to_string(),
+                                        timestamp,
+                                        tool_name: None,
+                                    });
+                                }
+                            }
+                            Some("tool_use") => {
+                                let name = item.get("name").and_then(Value::as_str).unwrap_or("tool").to_string();
+                                let input = item.get("input").cloned().unwrap_or(Value::Null);
+                                let text: String = serde_json::to_string(&input)
+                                    .unwrap_or_default()
+                                    .chars()
+                                    .take(TOOL_INPUT_PREVIEW_CHARS)
+                                    .collect();
+                                out.push(TranscriptMessage {
+                                    role: "tool".to_string(),
+                                    text,
+                                    timestamp,
+                                    tool_name: Some(name),
+                                });
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                Value::String(s) if !s.trim().is_empty() => {
+                    out.push(TranscriptMessage {
+                        role: "assistant".to_string(),
+                        text: s.clone(),
+                        timestamp,
+                        tool_name: None,
+                    });
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_fixture(tag: &str, contents: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-claude-parse-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("abc-session.jsonl");
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    const BASIC: &str = concat!(
+        r#"{"type":"user","uuid":"u1","parentUuid":null,"sessionId":"sess-1","cwd":"/p/alpha","timestamp":"2026-07-06T01:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a1","parentUuid":"u1","sessionId":"sess-1","timestamp":"2026-07-06T01:00:05.000Z","message":{"role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"hi"}],"usage":{"output_tokens":7}}}"#, "\n",
+        r#"{"type":"user","uuid":"u2","parentUuid":"a1","isMeta":true,"timestamp":"2026-07-06T01:00:06.000Z","message":{"role":"user","content":[{"type":"text","text":"meta noise"}]}}"#, "\n",
+        r#"{"type":"user","uuid":"u3","parentUuid":"a1","timestamp":"2026-07-06T01:01:00.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a2","parentUuid":"u3","timestamp":"2026-07-06T01:02:00.000Z","message":{"role":"assistant","model":"claude-sonnet-5","content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}},{"type":"text","text":"done"}],"usage":{"output_tokens":13}}}"#, "\n",
+    );
+
+    #[test]
+    fn meta_counts_titles_and_tokens() {
+        let path = write_fixture("basic", BASIC);
+        let meta = parse_claude_meta(&path).unwrap();
+        assert_eq!(meta.id, "sess-1");
+        assert_eq!(meta.agent, "claude");
+        assert_eq!(meta.project_cwd, "/p/alpha");
+        assert_eq!(meta.title, "hello");
+        // u1, a1, a2 count; the isMeta line and tool_result-only user line do not.
+        assert_eq!(meta.message_count, 3);
+        assert_eq!(meta.user_message_count, 1);
+        assert_eq!(meta.output_tokens, Some(20));
+        assert_eq!(meta.model.as_deref(), Some("claude-sonnet-5"));
+        assert!(meta.started_at < meta.ended_at);
+        assert!(!meta.activity.is_empty());
+    }
+
+    #[test]
+    fn transcript_extracts_text_and_tool_entries_in_order() {
+        let path = write_fixture("transcript", BASIC);
+        let t = parse_claude_transcript(&path);
+        let roles: Vec<&str> = t.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["user", "assistant", "tool", "assistant"]);
+        assert_eq!(t[2].tool_name.as_deref(), Some("Bash"));
+        assert_eq!(t[3].text, "done");
+    }
+
+    // A fork where the first child's branch has only 1 user turn (<= threshold 3):
+    // the walk takes the LAST child, so "retry" wins over "abandoned".
+    const FORKED: &str = concat!(
+        r#"{"type":"user","uuid":"u1","parentUuid":null,"sessionId":"s","timestamp":"2026-07-06T01:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"root"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a-abandoned","parentUuid":"u1","timestamp":"2026-07-06T01:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"first try"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a-kept","parentUuid":"u1","timestamp":"2026-07-06T01:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"second try"}]}}"#, "\n",
+        r#"{"type":"user","uuid":"u2","parentUuid":"a-kept","timestamp":"2026-07-06T01:00:03.000Z","message":{"role":"user","content":[{"type":"text","text":"go on"}]}}"#, "\n",
+    );
+
+    #[test]
+    fn fork_follows_the_retry_branch() {
+        let path = write_fixture("fork", FORKED);
+        let t = parse_claude_transcript(&path);
+        let texts: Vec<&str> = t.iter().map(|m| m.text.as_str()).collect();
+        assert_eq!(texts, vec!["root", "second try", "go on"]);
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped_not_fatal() {
+        let contents = format!("not json\n{}", BASIC);
+        let path = write_fixture("malformed", &contents);
+        assert!(parse_claude_meta(&path).is_some());
+    }
+
+    #[test]
+    fn empty_or_unreadable_file_yields_none() {
+        let path = write_fixture("empty", "");
+        assert!(parse_claude_meta(&path).is_none());
+    }
+
+    /// Manual sanity check against a real transcript on this machine. Not run
+    /// in CI; run with `cargo test sessions_index::claude -- --ignored --nocapture`
+    /// and eyeball the printed metadata for plausibility.
+    #[test]
+    #[ignore]
+    fn sanity_check_against_real_transcript() {
+        let home = std::env::var("HOME").expect("HOME must be set to locate ~/.claude/projects");
+        let projects_dir = std::path::Path::new(&home).join(".claude").join("projects");
+
+        let mut newest: Option<(std::time::SystemTime, std::path::PathBuf)> = None;
+        let project_dirs = std::fs::read_dir(&projects_dir).expect("read ~/.claude/projects");
+        for project_dir in project_dirs.flatten() {
+            let project_path = project_dir.path();
+            if !project_path.is_dir() {
+                continue;
+            }
+            let Ok(files) = std::fs::read_dir(&project_path) else { continue };
+            for file in files.flatten() {
+                let path = file.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                    continue;
+                }
+                if let Ok(modified) = file.metadata().and_then(|m| m.modified()) {
+                    if newest.as_ref().map_or(true, |(t, _)| modified > *t) {
+                        newest = Some((modified, path));
+                    }
+                }
+            }
+        }
+
+        let (_, path) = newest.expect("no real transcript found under ~/.claude/projects");
+        println!("sanity-checking real transcript: {}", path.display());
+        let meta = parse_claude_meta(&path).expect("expected a parseable session");
+        println!("id = {}", meta.id);
+        println!("project_cwd = {}", meta.project_cwd);
+        println!("title = {}", meta.title);
+        println!("started_at = {}  ended_at = {}", meta.started_at, meta.ended_at);
+        println!(
+            "message_count = {}  user_message_count = {}",
+            meta.message_count, meta.user_message_count
+        );
+        println!("output_tokens = {:?}", meta.output_tokens);
+        println!("model = {:?}", meta.model);
+        println!("activity buckets = {}", meta.activity.len());
+        for bucket in meta.activity.iter().take(5) {
+            println!(
+                "  {} h{:02}  messages={} user_messages={} output_tokens={}",
+                bucket.date, bucket.hour, bucket.messages, bucket.user_messages, bucket.output_tokens
+            );
+        }
+
+        let transcript = parse_claude_transcript(&path);
+        println!("transcript entries = {}", transcript.len());
+        for m in transcript.iter().take(3) {
+            println!("  [{}] {:.80}", m.role, m.text);
+        }
+    }
+}

--- a/src-tauri/src/modules/sessions_index/claude.rs
+++ b/src-tauri/src/modules/sessions_index/claude.rs
@@ -651,3 +651,18 @@ mod tests {
         }
     }
 }
+
+#[test]
+#[ignore]
+fn repro_transcript_json_size() {
+    // throwaway: measure the serialized IPC payload size for big transcripts
+    for p in [
+        "/Users/muki/.claude/projects/-Users-muki-Documents-01-project-tempo-term/885f7e3a-3e3f-4565-911e-23b55cdaea50.jsonl",
+        "/Users/muki/.claude/projects/-Users-muki-Documents-01-project-hyday-source/a22e255d-db43-40e3-bb77-ab3be5e82ed5.jsonl",
+    ] {
+        let t = parse_claude_transcript(std::path::Path::new(p));
+        let json = serde_json::to_string(&t).unwrap();
+        let max = t.iter().map(|m| m.text.len()).max().unwrap_or(0);
+        println!("{}: {} msgs, JSON {} bytes ({:.1} MB), largest text {} bytes", p.rsplit('/').next().unwrap(), t.len(), json.len(), json.len() as f64/1e6, max);
+    }
+}

--- a/src-tauri/src/modules/sessions_index/claude.rs
+++ b/src-tauri/src/modules/sessions_index/claude.rs
@@ -228,7 +228,10 @@ pub fn parse_claude_meta(path: &Path) -> Option<ParsedSession> {
             .and_then(|u| u.get("output_tokens"))
             .and_then(Value::as_i64);
         if let Some(tokens) = tokens {
-            *output_tokens.get_or_insert(0) += tokens;
+            // Saturate rather than overflow on absurd token counts from
+            // corrupt files.
+            let total = output_tokens.get_or_insert(0);
+            *total = total.saturating_add(tokens);
         }
         if !is_user {
             if let Some(m) = entry.value.get("message").and_then(|m| m.get("model")).and_then(Value::as_str) {
@@ -250,7 +253,7 @@ pub fn parse_claude_meta(path: &Path) -> Option<ParsedSession> {
                 bucket.user_messages += 1;
             }
             if let Some(tokens) = tokens {
-                bucket.output_tokens += tokens;
+                bucket.output_tokens = bucket.output_tokens.saturating_add(tokens);
             }
         }
     }
@@ -275,17 +278,19 @@ pub fn parse_claude_meta(path: &Path) -> Option<ParsedSession> {
         ended_at = 0;
     }
 
+    // First NON-EMPTY value wins; a present-but-empty field on an early line
+    // must not short-circuit the search.
     let id = entries
         .iter()
-        .find_map(|e| e.value.get("sessionId").and_then(Value::as_str))
-        .filter(|s| !s.is_empty())
+        .filter_map(|e| e.value.get("sessionId").and_then(Value::as_str))
+        .find(|s| !s.is_empty())
         .map(str::to_string)
         .unwrap_or_else(|| path.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default());
 
     let project_cwd = entries
         .iter()
-        .find_map(|e| e.value.get("cwd").and_then(Value::as_str))
-        .filter(|s| !s.is_empty())
+        .filter_map(|e| e.value.get("cwd").and_then(Value::as_str))
+        .find(|s| !s.is_empty())
         .map(str::to_string)
         .unwrap_or_else(|| {
             path.parent()
@@ -355,6 +360,12 @@ pub fn parse_claude_transcript(path: &Path) -> Vec<TranscriptMessage> {
     let mut out = Vec::new();
     for &i in &main {
         let entry = &entries[i];
+        // Same skip rules as the meta pass: meta/sidechain lines and
+        // tool_result-only user lines never render in the viewer, even when
+        // they sit on the main path.
+        if !is_countable(&entry.value) {
+            continue;
+        }
         let type_ = entry.value.get("type").and_then(Value::as_str).unwrap_or("");
         let timestamp = entry.value.get("timestamp").and_then(Value::as_str).and_then(epoch_ms);
         let content = match entry.value.get("message").and_then(|m| m.get("content")) {
@@ -485,6 +496,88 @@ mod tests {
         let t = parse_claude_transcript(&path);
         let texts: Vec<&str> = t.iter().map(|m| m.text.as_str()).collect();
         assert_eq!(texts, vec!["root", "second try", "go on"]);
+    }
+
+    // An isMeta user line with real text sitting on a NON-forked (single-child)
+    // main-path segment: the skip rule itself must hide it from the transcript,
+    // not fork selection (BASIC's isMeta line is only dropped because it loses
+    // a fork).
+    const META_ON_MAIN_PATH: &str = concat!(
+        r#"{"type":"user","uuid":"u1","parentUuid":null,"sessionId":"s","timestamp":"2026-07-06T01:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-07-06T01:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}"#, "\n",
+        r#"{"type":"user","uuid":"m1","parentUuid":"a1","isMeta":true,"timestamp":"2026-07-06T01:00:02.000Z","message":{"role":"user","content":[{"type":"text","text":"meta noise"}]}}"#, "\n",
+        r#"{"type":"user","uuid":"u2","parentUuid":"m1","timestamp":"2026-07-06T01:00:03.000Z","message":{"role":"user","content":[{"type":"text","text":"next"}]}}"#, "\n",
+    );
+
+    #[test]
+    fn transcript_skips_meta_lines_on_the_main_path() {
+        let path = write_fixture("meta-main", META_ON_MAIN_PATH);
+        let t = parse_claude_transcript(&path);
+        let texts: Vec<&str> = t.iter().map(|m| m.text.as_str()).collect();
+        assert_eq!(texts, vec!["hello", "hi", "next"]);
+    }
+
+    // Real transcripts open with house-keeping records (last-prompt, mode,
+    // permission-mode...) that carry no uuid at all. They must never be
+    // mistaken for the conversation root, or the DAG walk dead-ends at once.
+    #[test]
+    fn uuid_less_housekeeping_lines_never_claim_the_root() {
+        let contents = format!(
+            "{}\n{}",
+            r#"{"type":"last-prompt","leafUuid":"x","sessionId":"sess-1"}"#,
+            BASIC
+        );
+        let path = write_fixture("housekeeping-root", &contents);
+        let meta = parse_claude_meta(&path).unwrap();
+        assert_eq!(meta.message_count, 3);
+        assert_eq!(meta.user_message_count, 1);
+    }
+
+    // A present-but-empty sessionId/cwd on an early line must not shadow a
+    // later non-empty value.
+    #[test]
+    fn later_non_empty_session_id_and_cwd_win_over_empty_ones() {
+        let contents = concat!(
+            r#"{"type":"user","uuid":"u1","parentUuid":null,"sessionId":"","cwd":"","timestamp":"2026-07-06T01:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#, "\n",
+            r#"{"type":"assistant","uuid":"a1","parentUuid":"u1","sessionId":"sess-9","cwd":"/p/beta","timestamp":"2026-07-06T01:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}"#, "\n",
+        );
+        let path = write_fixture("empty-ids", contents);
+        let meta = parse_claude_meta(&path).unwrap();
+        assert_eq!(meta.id, "sess-9");
+        assert_eq!(meta.project_cwd, "/p/beta");
+    }
+
+    // Corrupt DAG data: a mutual parentUuid cycle (a2 <-> a3) and a
+    // self-referencing entry alongside a normal rooted chain. Parsing must
+    // terminate and keep the rooted chain.
+    const CYCLIC: &str = concat!(
+        r#"{"type":"user","uuid":"u1","parentUuid":null,"sessionId":"s","timestamp":"2026-07-06T01:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"start"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-07-06T01:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"one"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a2","parentUuid":"a3","timestamp":"2026-07-06T01:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"two"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a3","parentUuid":"a2","timestamp":"2026-07-06T01:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"three"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"x","parentUuid":"x","timestamp":"2026-07-06T01:00:04.000Z","message":{"role":"assistant","content":[{"type":"text","text":"selfie"}]}}"#, "\n",
+    );
+
+    // A file where EVERY entry sits in a cycle (no root at all): the walk must
+    // fall back to linear order instead of returning nothing or hanging.
+    const ALL_CYCLIC: &str = concat!(
+        r#"{"type":"user","uuid":"a","parentUuid":"b","sessionId":"s","timestamp":"2026-07-06T01:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"ping"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"b","parentUuid":"a","timestamp":"2026-07-06T01:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"pong"}]}}"#, "\n",
+    );
+
+    #[test]
+    fn cyclic_parent_data_terminates_with_sane_output() {
+        let path = write_fixture("cycle", CYCLIC);
+        let meta = parse_claude_meta(&path).unwrap();
+        // The unreachable cycles are dropped; the rooted u1 -> a1 chain remains.
+        assert_eq!(meta.message_count, 2);
+        assert_eq!(parse_claude_transcript(&path).len(), 2);
+
+        let path = write_fixture("all-cycle", ALL_CYCLIC);
+        let meta = parse_claude_meta(&path).unwrap();
+        // No root exists, so linear order keeps both countable messages.
+        assert_eq!(meta.message_count, 2);
+        assert_eq!(meta.user_message_count, 1);
     }
 
     #[test]

--- a/src-tauri/src/modules/sessions_index/claude.rs
+++ b/src-tauri/src/modules/sessions_index/claude.rs
@@ -1,0 +1,1 @@
+//! Parser for Claude Code session files.

--- a/src-tauri/src/modules/sessions_index/claude.rs
+++ b/src-tauri/src/modules/sessions_index/claude.rs
@@ -97,6 +97,27 @@ fn is_countable(value: &Value) -> bool {
     true
 }
 
+/// Classifies a user turn's text as a harness injection rather than the
+/// user's own words, returning the source tag the viewer shows on the
+/// collapsed card. Claude Code records teammate messages, system reminders,
+/// background task notifications, and slash-command envelopes all as
+/// `type: "user"` turns; labelling them "user" in the viewer is misleading
+/// and counting them inflates user_message_count.
+fn injected_source(text: &str) -> Option<&'static str> {
+    let t = text.trim_start();
+    if t.starts_with("<teammate-message") || t.starts_with("Another Claude session sent a message:") {
+        Some("teammate")
+    } else if t.starts_with("<system-reminder>") {
+        Some("system-reminder")
+    } else if t.starts_with("<task-notification>") {
+        Some("task-notification")
+    } else if t.starts_with("<local-command-caveat>") || t.starts_with("<command-name>") {
+        Some("command")
+    } else {
+        None
+    }
+}
+
 /// DFS count of countable `user` entries in the subtree rooted at `i`
 /// (inclusive). Guards against cyclic parent data so malformed input can
 /// never hang the walk.
@@ -215,7 +236,15 @@ pub fn parse_claude_meta(path: &Path) -> Option<ParsedSession> {
         if !is_countable(&entry.value) {
             continue;
         }
-        let is_user = entry.value.get("type").and_then(Value::as_str) == Some("user");
+        // Injected harness turns (teammate messages, reminders, …) are still
+        // messages, but they are not the user speaking.
+        let is_user = entry.value.get("type").and_then(Value::as_str) == Some("user")
+            && entry
+                .value
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(user_text_from_content)
+                .map_or(true, |text| injected_source(&text).is_none());
         message_count += 1;
         if is_user {
             user_message_count += 1;
@@ -376,12 +405,20 @@ pub fn parse_claude_transcript(path: &Path) -> Vec<TranscriptMessage> {
         match type_ {
             "user" => {
                 if let Some(text) = user_text_from_content(content) {
-                    out.push(TranscriptMessage {
-                        role: "user".to_string(),
-                        text,
-                        timestamp,
-                        tool_name: None,
-                    });
+                    match injected_source(&text) {
+                        Some(source) => out.push(TranscriptMessage {
+                            role: "injected".to_string(),
+                            text,
+                            timestamp,
+                            tool_name: Some(source.to_string()),
+                        }),
+                        None => out.push(TranscriptMessage {
+                            role: "user".to_string(),
+                            text,
+                            timestamp,
+                            tool_name: None,
+                        }),
+                    }
                 }
             }
             "assistant" => match content {
@@ -479,6 +516,43 @@ mod tests {
         assert_eq!(roles, vec!["user", "assistant", "tool", "assistant"]);
         assert_eq!(t[2].tool_name.as_deref(), Some("Bash"));
         assert_eq!(t[3].text, "done");
+    }
+
+    // Harness-injected turns are recorded as `type: "user"` but are not the
+    // user's own words: teammate messages, system reminders, background task
+    // notifications, and slash-command envelopes.
+    const INJECTED: &str = concat!(
+        r#"{"type":"user","uuid":"u1","parentUuid":null,"sessionId":"s","cwd":"/p","timestamp":"2026-07-06T01:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"real question"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-07-06T01:00:05.000Z","message":{"role":"assistant","content":[{"type":"text","text":"answer"}]}}"#, "\n",
+        r#"{"type":"user","uuid":"u2","parentUuid":"a1","timestamp":"2026-07-06T01:01:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Another Claude session sent a message:\n<teammate-message teammate_id=\"scan\">## report\n- **finding** one</teammate-message>"}]}}"#, "\n",
+        r#"{"type":"assistant","uuid":"a2","parentUuid":"u2","timestamp":"2026-07-06T01:02:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"noted"}]}}"#, "\n",
+        r#"{"type":"user","uuid":"u3","parentUuid":"a2","timestamp":"2026-07-06T01:03:00.000Z","message":{"role":"user","content":[{"type":"text","text":"<system-reminder>hooks fired</system-reminder>"}]}}"#, "\n",
+        r#"{"type":"user","uuid":"u4","parentUuid":"u3","timestamp":"2026-07-06T01:04:00.000Z","message":{"role":"user","content":[{"type":"text","text":"<task-notification>\n<task-id>x</task-id>\n</task-notification>"}]}}"#, "\n",
+    );
+
+    #[test]
+    fn injected_turns_render_as_injected_role_with_their_source() {
+        let path = write_fixture("injected", INJECTED);
+        let t = parse_claude_transcript(&path);
+        let roles: Vec<&str> = t.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["user", "assistant", "injected", "assistant", "injected", "injected"]);
+        assert_eq!(t[2].tool_name.as_deref(), Some("teammate"));
+        assert_eq!(t[4].tool_name.as_deref(), Some("system-reminder"));
+        assert_eq!(t[5].tool_name.as_deref(), Some("task-notification"));
+        // The full injected text is preserved for the expanded view.
+        assert!(t[2].text.contains("**finding** one"));
+    }
+
+    #[test]
+    fn injected_turns_do_not_count_as_user_messages() {
+        let path = write_fixture("injected-meta", INJECTED);
+        let meta = parse_claude_meta(&path).unwrap();
+        // u1 is the only real user turn; u2/u3/u4 are injected. All six
+        // countable entries still count as messages.
+        assert_eq!(meta.user_message_count, 1);
+        assert_eq!(meta.message_count, 6);
+        // The title never comes from an injected turn.
+        assert_eq!(meta.title, "real question");
     }
 
     // A fork where the first child's branch has only 1 user turn (<= threshold 3):

--- a/src-tauri/src/modules/sessions_index/codex.rs
+++ b/src-tauri/src/modules/sessions_index/codex.rs
@@ -1,1 +1,373 @@
-//! Parser for Codex session files.
+//! Codex rollout JSONL parser. Codex sessions are a flat event log (no
+//! uuid/parentUuid DAG like Claude's), so parsing is a single linear pass:
+//! `session_meta` gives identity, `event_msg`/`user_message` and
+//! `response_item`/`message` (role "assistant") are the conversational
+//! turns, `response_item`/`function_call` is a tool call, and
+//! `event_msg`/`token_count` carries the running token totals.
+//!
+//! Grounded against real files on this machine
+//! (`~/.codex/sessions/2026/*/*/rollout-*.jsonl`, 2026-07-07): a
+//! `token_count` event's actual shape is
+//! `payload.info.total_token_usage.{input_tokens,cached_input_tokens,
+//! output_tokens,reasoning_output_tokens,total_tokens}` plus a sibling
+//! `model_context_window` and a `rate_limits` block — matches the brief's
+//! expected `payload.info.total_token_usage.output_tokens` path. Out of
+//! 2300 sampled `token_count` events, 15 had `payload.info == null` (no
+//! usage yet on that turn), so every access along that path must be a
+//! defensive `.get()` chain, never an index/unwrap.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::claude::{epoch_ms, local_bucket};
+use super::types::{ActivityBucket, ParsedSession, TranscriptMessage};
+
+/// Tool call argument preview length, matching claude.rs's convention.
+const TOOL_INPUT_PREVIEW_CHARS: usize = 400;
+
+/// Title convention shared with claude_progress::MAX_TITLE_CHARS.
+const MAX_TITLE_CHARS: usize = 80;
+
+/// Parse every line into a `Value`, silently dropping lines that aren't
+/// valid JSON. Blank lines are ignored too. Never panics on malformed input.
+fn parse_lines(contents: &str) -> Vec<Value> {
+    contents
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+            serde_json::from_str(line).ok()
+        })
+        .collect()
+}
+
+/// The joined `.text` fields of a `response_item` message's `content[]`,
+/// e.g. `[{"type":"output_text","text":"..."}]`. Items without a string
+/// `text` field (images, refusals, ...) are skipped rather than failing the
+/// whole message.
+fn join_content_text(content: Option<&Value>) -> String {
+    let Some(Value::Array(items)) = content else {
+        return String::new();
+    };
+    items
+        .iter()
+        .filter_map(|item| item.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Add one message to its local-day/hour activity bucket.
+fn bump_message_bucket(buckets: &mut HashMap<(String, u8), ActivityBucket>, ts: i64, is_user: bool) {
+    let (date, hour) = local_bucket(ts);
+    let bucket = buckets.entry((date.clone(), hour)).or_insert_with(|| ActivityBucket {
+        date,
+        hour,
+        messages: 0,
+        user_messages: 0,
+        output_tokens: 0,
+    });
+    bucket.messages += 1;
+    if is_user {
+        bucket.user_messages += 1;
+    }
+}
+
+/// Parse a Codex rollout transcript into index metadata, or `None` when the
+/// file is empty, unreadable, or has zero user AND zero assistant messages.
+pub fn parse_codex_meta(path: &Path) -> Option<ParsedSession> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let lines = parse_lines(&contents);
+    if lines.is_empty() {
+        return None;
+    }
+
+    let mut id: Option<String> = None;
+    let mut project_cwd: Option<String> = None;
+    let mut title: Option<String> = None;
+    let mut message_count: i64 = 0;
+    let mut user_message_count: i64 = 0;
+    let mut output_tokens: Option<i64> = None;
+    let mut model: Option<String> = None;
+    let mut started_at = i64::MAX;
+    let mut ended_at = i64::MIN;
+    let mut buckets: HashMap<(String, u8), ActivityBucket> = HashMap::new();
+
+    for value in &lines {
+        let ts = value.get("timestamp").and_then(Value::as_str).and_then(epoch_ms);
+        if let Some(ts) = ts {
+            started_at = started_at.min(ts);
+            ended_at = ended_at.max(ts);
+        }
+
+        let type_ = value.get("type").and_then(Value::as_str).unwrap_or("");
+        let Some(payload) = value.get("payload") else { continue };
+
+        match type_ {
+            "session_meta" => {
+                // First non-empty value wins; a later duplicate session_meta
+                // (shouldn't happen, but the log is defensive) never
+                // overwrites an already-found id/cwd.
+                if id.is_none() {
+                    if let Some(v) = payload.get("id").and_then(Value::as_str) {
+                        if !v.is_empty() {
+                            id = Some(v.to_string());
+                        }
+                    }
+                }
+                if project_cwd.is_none() {
+                    if let Some(v) = payload.get("cwd").and_then(Value::as_str) {
+                        if !v.is_empty() {
+                            project_cwd = Some(v.to_string());
+                        }
+                    }
+                }
+            }
+            "turn_context" => {
+                // Last turn_context's model wins: later lines simply
+                // overwrite earlier ones as the scan proceeds in order.
+                if let Some(m) = payload.get("model").and_then(Value::as_str) {
+                    model = Some(m.to_string());
+                }
+            }
+            "event_msg" => {
+                let etype = payload.get("type").and_then(Value::as_str).unwrap_or("");
+                match etype {
+                    "user_message" => {
+                        let text = payload.get("message").and_then(Value::as_str).map(str::trim).unwrap_or("");
+                        if text.is_empty() {
+                            continue;
+                        }
+                        message_count += 1;
+                        user_message_count += 1;
+                        if title.is_none() {
+                            title = Some(text.chars().take(MAX_TITLE_CHARS).collect());
+                        }
+                        if let Some(ts) = ts {
+                            bump_message_bucket(&mut buckets, ts, true);
+                        }
+                    }
+                    "token_count" => {
+                        // Cumulative counter: keep the last value seen (not a
+                        // running sum), but saturate the bucket delta so a
+                        // corrupt/decreasing value can't underflow.
+                        if let Some(total) = payload
+                            .get("info")
+                            .and_then(|i| i.get("total_token_usage"))
+                            .and_then(|u| u.get("output_tokens"))
+                            .and_then(Value::as_i64)
+                        {
+                            let delta = total.saturating_sub(output_tokens.unwrap_or(0));
+                            output_tokens = Some(total);
+                            if delta > 0 {
+                                if let Some(ts) = ts {
+                                    let (date, hour) = local_bucket(ts);
+                                    let bucket = buckets.entry((date.clone(), hour)).or_insert_with(|| ActivityBucket {
+                                        date,
+                                        hour,
+                                        messages: 0,
+                                        user_messages: 0,
+                                        output_tokens: 0,
+                                    });
+                                    bucket.output_tokens = bucket.output_tokens.saturating_add(delta);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            "response_item" => {
+                let rtype = payload.get("type").and_then(Value::as_str).unwrap_or("");
+                if rtype == "message" {
+                    // Only the assistant's own turns count. The rollout also
+                    // replays the user's turn as a response_item with
+                    // role:"user" (already counted via event_msg above), and
+                    // carries developer/system instructions — both must be
+                    // skipped here or messages get double-counted.
+                    let role = payload.get("role").and_then(Value::as_str).unwrap_or("");
+                    if role == "assistant" {
+                        let text = join_content_text(payload.get("content"));
+                        if !text.is_empty() {
+                            message_count += 1;
+                            if let Some(ts) = ts {
+                                bump_message_bucket(&mut buckets, ts, false);
+                            }
+                        }
+                    }
+                }
+                // function_call/function_call_output are tool plumbing, not
+                // conversational messages; they don't affect message_count.
+            }
+            _ => {}
+        }
+    }
+
+    if message_count == 0 {
+        return None;
+    }
+
+    if started_at > ended_at {
+        started_at = 0;
+        ended_at = 0;
+    }
+
+    let id = id.unwrap_or_else(|| path.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default());
+    let project_cwd = project_cwd.unwrap_or_default();
+    let title = title.unwrap_or_default();
+
+    let mut activity: Vec<ActivityBucket> = buckets.into_values().collect();
+    activity.sort_by(|a, b| (a.date.as_str(), a.hour).cmp(&(b.date.as_str(), b.hour)));
+
+    Some(ParsedSession {
+        id,
+        agent: "codex",
+        project_cwd,
+        title,
+        started_at,
+        ended_at,
+        message_count,
+        user_message_count,
+        output_tokens,
+        model,
+        activity,
+    })
+}
+
+/// Parse a Codex rollout transcript into the viewer's message list,
+/// re-derived from the source file on demand. Empty on any read failure.
+pub fn parse_codex_transcript(path: &Path) -> Vec<TranscriptMessage> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let lines = parse_lines(&contents);
+
+    let mut out = Vec::new();
+    for value in &lines {
+        let ts = value.get("timestamp").and_then(Value::as_str).and_then(epoch_ms);
+        let type_ = value.get("type").and_then(Value::as_str).unwrap_or("");
+        let Some(payload) = value.get("payload") else { continue };
+
+        match type_ {
+            "event_msg" => {
+                if payload.get("type").and_then(Value::as_str) == Some("user_message") {
+                    let text = payload.get("message").and_then(Value::as_str).map(str::trim).unwrap_or("");
+                    if !text.is_empty() {
+                        out.push(TranscriptMessage {
+                            role: "user".to_string(),
+                            text: text.to_string(),
+                            timestamp: ts,
+                            tool_name: None,
+                        });
+                    }
+                }
+            }
+            "response_item" => {
+                let rtype = payload.get("type").and_then(Value::as_str).unwrap_or("");
+                match rtype {
+                    "message" => {
+                        let role = payload.get("role").and_then(Value::as_str).unwrap_or("");
+                        // Same skip rule as parse_codex_meta: developer,
+                        // system, and the replayed user role never render.
+                        if role == "assistant" {
+                            let text = join_content_text(payload.get("content"));
+                            if !text.is_empty() {
+                                out.push(TranscriptMessage {
+                                    role: "assistant".to_string(),
+                                    text,
+                                    timestamp: ts,
+                                    tool_name: None,
+                                });
+                            }
+                        }
+                    }
+                    "function_call" => {
+                        let name = payload.get("name").and_then(Value::as_str).unwrap_or("tool").to_string();
+                        let text: String = payload
+                            .get("arguments")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .chars()
+                            .take(TOOL_INPUT_PREVIEW_CHARS)
+                            .collect();
+                        out.push(TranscriptMessage {
+                            role: "tool".to_string(),
+                            text,
+                            timestamp: ts,
+                            tool_name: Some(name),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ROLLOUT: &str = concat!(
+        r#"{"timestamp":"2026-07-06T02:00:00.000Z","type":"session_meta","payload":{"id":"codex-1","cwd":"/p/beta"}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"fix the bug"}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:02.000Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"instructions"}]}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:03.000Z","type":"turn_context","payload":{"model":"gpt-5.2-codex"}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:04.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{}"}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:05.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"fixed"}]}}"#, "\n",
+        r#"{"timestamp":"2026-07-06T02:00:06.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":42}}}}"#, "\n",
+    );
+
+    fn write_fixture(tag: &str, contents: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-codex-parse-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rollout-x.jsonl");
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn meta_from_rollout_events() {
+        let meta = parse_codex_meta(&write_fixture("meta", ROLLOUT)).unwrap();
+        assert_eq!(meta.id, "codex-1");
+        assert_eq!(meta.agent, "codex");
+        assert_eq!(meta.project_cwd, "/p/beta");
+        assert_eq!(meta.title, "fix the bug");
+        assert_eq!(meta.user_message_count, 1);
+        assert_eq!(meta.message_count, 2); // user + assistant; developer/tool excluded
+        assert_eq!(meta.output_tokens, Some(42));
+        assert_eq!(meta.model.as_deref(), Some("gpt-5.2-codex"));
+    }
+
+    #[test]
+    fn transcript_orders_user_tool_assistant() {
+        let t = parse_codex_transcript(&write_fixture("transcript", ROLLOUT));
+        let roles: Vec<&str> = t.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["user", "tool", "assistant"]);
+        assert_eq!(t[1].tool_name.as_deref(), Some("shell"));
+    }
+
+    #[test]
+    fn missing_session_meta_falls_back_to_file_stem_and_survives() {
+        let contents = concat!(
+            r#"{"timestamp":"2026-07-06T02:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"hi"}}"#, "\n",
+        );
+        let path = write_fixture("nometa", contents);
+        let meta = parse_codex_meta(&path).unwrap();
+        assert_eq!(meta.id, "rollout-x");
+        assert_eq!(meta.project_cwd, "");
+    }
+
+    #[test]
+    fn garbage_lines_are_skipped() {
+        let contents = format!("garbage\n{}", ROLLOUT);
+        assert!(parse_codex_meta(&write_fixture("garbage", &contents)).is_some());
+    }
+}

--- a/src-tauri/src/modules/sessions_index/codex.rs
+++ b/src-tauri/src/modules/sessions_index/codex.rs
@@ -1,0 +1,1 @@
+//! Parser for Codex session files.

--- a/src-tauri/src/modules/sessions_index/codex.rs
+++ b/src-tauri/src/modules/sessions_index/codex.rs
@@ -60,16 +60,21 @@ fn join_content_text(content: Option<&Value>) -> String {
         .join("\n")
 }
 
-/// Add one message to its local-day/hour activity bucket.
-fn bump_message_bucket(buckets: &mut HashMap<(String, u8), ActivityBucket>, ts: i64, is_user: bool) {
+/// The local-day/hour activity bucket for a timestamp, created on first use.
+fn get_or_create_bucket(buckets: &mut HashMap<(String, u8), ActivityBucket>, ts: i64) -> &mut ActivityBucket {
     let (date, hour) = local_bucket(ts);
-    let bucket = buckets.entry((date.clone(), hour)).or_insert_with(|| ActivityBucket {
+    buckets.entry((date.clone(), hour)).or_insert_with(|| ActivityBucket {
         date,
         hour,
         messages: 0,
         user_messages: 0,
         output_tokens: 0,
-    });
+    })
+}
+
+/// Add one message to its local-day/hour activity bucket.
+fn bump_message_bucket(buckets: &mut HashMap<(String, u8), ActivityBucket>, ts: i64, is_user: bool) {
+    let bucket = get_or_create_bucket(buckets, ts);
     bucket.messages += 1;
     if is_user {
         bucket.user_messages += 1;
@@ -164,14 +169,7 @@ pub fn parse_codex_meta(path: &Path) -> Option<ParsedSession> {
                             output_tokens = Some(total);
                             if delta > 0 {
                                 if let Some(ts) = ts {
-                                    let (date, hour) = local_bucket(ts);
-                                    let bucket = buckets.entry((date.clone(), hour)).or_insert_with(|| ActivityBucket {
-                                        date,
-                                        hour,
-                                        messages: 0,
-                                        user_messages: 0,
-                                        output_tokens: 0,
-                                    });
+                                    let bucket = get_or_create_bucket(&mut buckets, ts);
                                     bucket.output_tokens = bucket.output_tokens.saturating_add(delta);
                                 }
                             }
@@ -199,8 +197,9 @@ pub fn parse_codex_meta(path: &Path) -> Option<ParsedSession> {
                         }
                     }
                 }
-                // function_call/function_call_output are tool plumbing, not
-                // conversational messages; they don't affect message_count.
+                // function_call/custom_tool_call and their *_output records
+                // are tool plumbing, not conversational messages; they don't
+                // affect message_count.
             }
             _ => {}
         }
@@ -285,10 +284,15 @@ pub fn parse_codex_transcript(path: &Path) -> Vec<TranscriptMessage> {
                             }
                         }
                     }
-                    "function_call" => {
+                    // custom_tool_call is the same thing under another name
+                    // (real files: apply_patch arrives this way, with the
+                    // payload in `input` instead of `arguments`) — same as
+                    // codexNormalize.ts, which treats the two as equivalent.
+                    "function_call" | "custom_tool_call" => {
                         let name = payload.get("name").and_then(Value::as_str).unwrap_or("tool").to_string();
                         let text: String = payload
                             .get("arguments")
+                            .or_else(|| payload.get("input"))
                             .and_then(Value::as_str)
                             .unwrap_or("")
                             .chars()
@@ -369,5 +373,29 @@ mod tests {
     fn garbage_lines_are_skipped() {
         let contents = format!("garbage\n{}", ROLLOUT);
         assert!(parse_codex_meta(&write_fixture("garbage", &contents)).is_some());
+    }
+
+    // Real rollouts carry apply_patch (and other custom tools) as
+    // `custom_tool_call` with the payload in `input` rather than
+    // `arguments`; it must render as a tool row exactly like function_call
+    // (consistent with codexNormalize.ts, which treats them as equivalent).
+    #[test]
+    fn custom_tool_call_renders_as_tool_row() {
+        let contents = concat!(
+            r#"{"timestamp":"2026-07-06T02:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"patch it"}}"#, "\n",
+            r#"{"timestamp":"2026-07-06T02:00:02.000Z","type":"response_item","payload":{"type":"custom_tool_call","status":"completed","call_id":"call_1","name":"apply_patch","input":"*** Begin Patch"}}"#, "\n",
+            r#"{"timestamp":"2026-07-06T02:00:03.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}"#, "\n",
+        );
+        let path = write_fixture("customtool", contents);
+
+        let t = parse_codex_transcript(&path);
+        let roles: Vec<&str> = t.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["user", "tool", "assistant"]);
+        assert_eq!(t[1].tool_name.as_deref(), Some("apply_patch"));
+        assert_eq!(t[1].text, "*** Begin Patch");
+
+        // Tool plumbing still never counts as a conversational message.
+        let meta = parse_codex_meta(&path).unwrap();
+        assert_eq!(meta.message_count, 2);
     }
 }

--- a/src-tauri/src/modules/sessions_index/index.rs
+++ b/src-tauri/src/modules/sessions_index/index.rs
@@ -1,1 +1,339 @@
-//! SQLite index layer for sessions metadata.
+//! The metadata index: a disposable SQLite cache of session summaries and
+//! per-day activity buckets. Message bodies are never stored here. If the
+//! schema version doesn't match, data tables are dropped and rebuilt from
+//! source files; the pins table survives rebuilds because it's user state.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use rusqlite::{params, Connection};
+
+use super::types::{ParsedSession, SessionSummary};
+
+pub const SCHEMA_VERSION: &str = "1";
+
+pub struct Index {
+    pub(crate) conn: Connection,
+}
+
+impl Index {
+    pub fn open(path: &Path) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let conn = Connection::open(path).map_err(|e| e.to_string())?;
+        conn.pragma_update(None, "journal_mode", "WAL").map_err(|e| e.to_string())?;
+        let index = Self { conn };
+        index.migrate()?;
+        Ok(index)
+    }
+
+    fn migrate(&self) -> Result<(), String> {
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 CREATE TABLE IF NOT EXISTS pins(session_id TEXT PRIMARY KEY);",
+            )
+            .map_err(|e| e.to_string())?;
+        let version: Option<String> = self
+            .conn
+            .query_row("SELECT value FROM meta WHERE key='schema_version'", [], |r| r.get(0))
+            .ok();
+        if version.as_deref() != Some(SCHEMA_VERSION) {
+            // Stale or missing schema: drop derived data (cheap to rebuild from
+            // source files) but keep pins (user state with no other home).
+            self.conn
+                .execute_batch("DROP TABLE IF EXISTS sessions; DROP TABLE IF EXISTS activity;")
+                .map_err(|e| e.to_string())?;
+        }
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS sessions(
+                   id TEXT PRIMARY KEY,
+                   agent TEXT NOT NULL,
+                   project_cwd TEXT NOT NULL,
+                   title TEXT NOT NULL,
+                   started_at INTEGER NOT NULL,
+                   ended_at INTEGER NOT NULL,
+                   message_count INTEGER NOT NULL,
+                   user_message_count INTEGER NOT NULL,
+                   output_tokens INTEGER,
+                   model TEXT,
+                   file_path TEXT NOT NULL,
+                   file_mtime INTEGER NOT NULL,
+                   file_size INTEGER NOT NULL
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_sessions_file ON sessions(file_path);
+                 CREATE TABLE IF NOT EXISTS activity(
+                   session_id TEXT NOT NULL,
+                   date TEXT NOT NULL,
+                   hour INTEGER NOT NULL,
+                   messages INTEGER NOT NULL,
+                   user_messages INTEGER NOT NULL,
+                   output_tokens INTEGER NOT NULL,
+                   PRIMARY KEY(session_id, date, hour)
+                 );",
+            )
+            .map_err(|e| e.to_string())?;
+        self.conn
+            .execute(
+                "INSERT INTO meta(key,value) VALUES('schema_version',?1)
+                 ON CONFLICT(key) DO UPDATE SET value=?1",
+                params![SCHEMA_VERSION],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn upsert_session(
+        &self,
+        s: &ParsedSession,
+        file_path: &str,
+        file_mtime: i64,
+        file_size: i64,
+    ) -> Result<(), String> {
+        self.conn
+            .execute(
+                "INSERT INTO sessions(id,agent,project_cwd,title,started_at,ended_at,
+                   message_count,user_message_count,output_tokens,model,file_path,file_mtime,file_size)
+                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13)
+                 ON CONFLICT(id) DO UPDATE SET agent=?2,project_cwd=?3,title=?4,started_at=?5,
+                   ended_at=?6,message_count=?7,user_message_count=?8,output_tokens=?9,model=?10,
+                   file_path=?11,file_mtime=?12,file_size=?13",
+                params![
+                    s.id, s.agent, s.project_cwd, s.title, s.started_at, s.ended_at,
+                    s.message_count, s.user_message_count, s.output_tokens, s.model,
+                    file_path, file_mtime, file_size
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+        // Activity rows are keyed by session id and replaced wholesale with the
+        // session, so a whole-file re-parse can never double-count a bucket.
+        self.conn
+            .execute("DELETE FROM activity WHERE session_id=?1", params![s.id])
+            .map_err(|e| e.to_string())?;
+        for b in &s.activity {
+            self.conn
+                .execute(
+                    "INSERT INTO activity(session_id,date,hour,messages,user_messages,output_tokens)
+                     VALUES(?1,?2,?3,?4,?5,?6)",
+                    params![s.id, b.date, b.hour, b.messages, b.user_messages, b.output_tokens],
+                )
+                .map_err(|e| e.to_string())?;
+        }
+        Ok(())
+    }
+
+    /// True when the file is unknown or its mtime/size fingerprint changed.
+    pub fn needs_sync(&self, file_path: &str, file_mtime: i64, file_size: i64) -> bool {
+        let known: Option<(i64, i64)> = self
+            .conn
+            .query_row(
+                "SELECT file_mtime, file_size FROM sessions WHERE file_path=?1 LIMIT 1",
+                params![file_path],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .ok();
+        known != Some((file_mtime, file_size))
+    }
+
+    pub fn list(&self) -> Vec<SessionSummary> {
+        let mut stmt = match self.conn.prepare(
+            "SELECT s.id,s.agent,s.project_cwd,s.title,s.started_at,s.ended_at,
+                    s.message_count,s.user_message_count,s.output_tokens,s.model,s.file_path,
+                    (p.session_id IS NOT NULL) AS pinned
+             FROM sessions s LEFT JOIN pins p ON p.session_id = s.id
+             ORDER BY s.ended_at DESC",
+        ) {
+            Ok(stmt) => stmt,
+            Err(_) => return Vec::new(),
+        };
+        let rows = stmt.query_map([], |r| {
+            Ok(SessionSummary {
+                id: r.get(0)?,
+                agent: r.get(1)?,
+                project_cwd: r.get(2)?,
+                title: r.get(3)?,
+                started_at: r.get(4)?,
+                ended_at: r.get(5)?,
+                message_count: r.get(6)?,
+                user_message_count: r.get(7)?,
+                output_tokens: r.get(8)?,
+                model: r.get(9)?,
+                file_path: r.get(10)?,
+                pinned: r.get(11)?,
+            })
+        });
+        match rows {
+            Ok(iter) => iter.flatten().collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    pub fn set_pinned(&self, id: &str, pinned: bool) -> Result<(), String> {
+        let sql = if pinned {
+            "INSERT OR IGNORE INTO pins(session_id) VALUES(?1)"
+        } else {
+            "DELETE FROM pins WHERE session_id=?1"
+        };
+        self.conn.execute(sql, params![id]).map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn lookup_file(&self, id: &str) -> Option<(String, String)> {
+        self.conn
+            .query_row(
+                "SELECT agent, file_path FROM sessions WHERE id=?1",
+                params![id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .ok()
+    }
+
+    /// Drop sessions whose source file no longer exists on disk.
+    pub fn prune_missing(&self, existing: &HashSet<String>) -> Result<(), String> {
+        let paths: Vec<String> = {
+            let mut stmt = self
+                .conn
+                .prepare("SELECT DISTINCT file_path FROM sessions")
+                .map_err(|e| e.to_string())?;
+            let iter = stmt
+                .query_map([], |r| r.get::<_, String>(0))
+                .map_err(|e| e.to_string())?;
+            iter.flatten().collect()
+        };
+        for path in paths {
+            if !existing.contains(&path) {
+                self.conn
+                    .execute("DELETE FROM activity WHERE session_id IN (SELECT id FROM sessions WHERE file_path=?1)", params![path])
+                    .map_err(|e| e.to_string())?;
+                self.conn
+                    .execute("DELETE FROM sessions WHERE file_path=?1", params![path])
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::sessions_index::types::{ActivityBucket, ParsedSession};
+
+    fn sample(id: &str) -> ParsedSession {
+        ParsedSession {
+            id: id.into(),
+            agent: "claude",
+            project_cwd: "/tmp/proj".into(),
+            title: "hello".into(),
+            started_at: 1000,
+            ended_at: 2000,
+            message_count: 4,
+            user_message_count: 2,
+            output_tokens: Some(50),
+            model: Some("claude-sonnet-5".into()),
+            activity: vec![ActivityBucket {
+                date: "2026-07-06".into(),
+                hour: 9,
+                messages: 4,
+                user_messages: 2,
+                output_tokens: 50,
+            }],
+        }
+    }
+
+    fn temp_db(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-sessions-index-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("index.db")
+    }
+
+    #[test]
+    fn upsert_then_list_roundtrips_a_session() {
+        let index = Index::open(&temp_db("roundtrip")).unwrap();
+        index.upsert_session(&sample("s1"), "/f/s1.jsonl", 111, 222).unwrap();
+        let rows = index.list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "s1");
+        assert_eq!(rows[0].agent, "claude");
+        assert_eq!(rows[0].message_count, 4);
+        assert_eq!(rows[0].file_path, "/f/s1.jsonl");
+        assert!(!rows[0].pinned);
+    }
+
+    #[test]
+    fn upsert_replaces_instead_of_duplicating() {
+        let index = Index::open(&temp_db("replace")).unwrap();
+        index.upsert_session(&sample("s1"), "/f/s1.jsonl", 1, 1).unwrap();
+        let mut updated = sample("s1");
+        updated.message_count = 9;
+        index.upsert_session(&updated, "/f/s1.jsonl", 2, 2).unwrap();
+        let rows = index.list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].message_count, 9);
+    }
+
+    #[test]
+    fn needs_sync_is_false_only_for_unchanged_fingerprint() {
+        let index = Index::open(&temp_db("fingerprint")).unwrap();
+        index.upsert_session(&sample("s1"), "/f/s1.jsonl", 111, 222).unwrap();
+        assert!(!index.needs_sync("/f/s1.jsonl", 111, 222));
+        assert!(index.needs_sync("/f/s1.jsonl", 112, 222));
+        assert!(index.needs_sync("/f/s1.jsonl", 111, 223));
+        assert!(index.needs_sync("/f/other.jsonl", 111, 222));
+    }
+
+    #[test]
+    fn pins_survive_and_order_is_newest_first() {
+        let index = Index::open(&temp_db("pins")).unwrap();
+        index.upsert_session(&sample("old"), "/f/a.jsonl", 1, 1).unwrap();
+        let mut newer = sample("new");
+        newer.ended_at = 9999;
+        index.upsert_session(&newer, "/f/b.jsonl", 1, 1).unwrap();
+        index.set_pinned("old", true).unwrap();
+        let rows = index.list();
+        assert_eq!(rows[0].id, "new");
+        assert!(rows.iter().find(|r| r.id == "old").unwrap().pinned);
+    }
+
+    #[test]
+    fn lookup_file_returns_agent_and_path() {
+        let index = Index::open(&temp_db("lookup")).unwrap();
+        index.upsert_session(&sample("s1"), "/f/s1.jsonl", 1, 1).unwrap();
+        assert_eq!(
+            index.lookup_file("s1"),
+            Some(("claude".to_string(), "/f/s1.jsonl".to_string()))
+        );
+        assert_eq!(index.lookup_file("nope"), None);
+    }
+
+    #[test]
+    fn prune_missing_drops_sessions_whose_file_is_gone() {
+        let index = Index::open(&temp_db("prune")).unwrap();
+        index.upsert_session(&sample("s1"), "/f/a.jsonl", 1, 1).unwrap();
+        index.upsert_session(&sample("s2"), "/f/b.jsonl", 1, 1).unwrap();
+        let existing: std::collections::HashSet<String> = ["/f/a.jsonl".to_string()].into();
+        index.prune_missing(&existing).unwrap();
+        let rows = index.list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "s1");
+    }
+
+    #[test]
+    fn schema_version_bump_rebuilds_data_but_keeps_pins() {
+        let path = temp_db("version");
+        {
+            let index = Index::open(&path).unwrap();
+            index.upsert_session(&sample("s1"), "/f/a.jsonl", 1, 1).unwrap();
+            index.set_pinned("s1", true).unwrap();
+            index.conn.execute("UPDATE meta SET value='0' WHERE key='schema_version'", []).unwrap();
+        }
+        let reopened = Index::open(&path).unwrap();
+        assert!(reopened.list().is_empty()); // data table was rebuilt
+        // pins table persisted; re-upserting the session shows it pinned again
+        reopened.upsert_session(&sample("s1"), "/f/a.jsonl", 1, 1).unwrap();
+        assert!(reopened.list()[0].pinned);
+    }
+}

--- a/src-tauri/src/modules/sessions_index/index.rs
+++ b/src-tauri/src/modules/sessions_index/index.rs
@@ -1,0 +1,1 @@
+//! SQLite index layer for sessions metadata.

--- a/src-tauri/src/modules/sessions_index/mod.rs
+++ b/src-tauri/src/modules/sessions_index/mod.rs
@@ -1,0 +1,14 @@
+//! Historical AI CLI sessions: scans Claude Code / Codex / Antigravity CLI
+//! session stores into a metadata-only SQLite index and serves the sidebar
+//! sessions view. Message bodies are re-parsed from source files on demand —
+//! the index is a disposable cache, the files stay the source of truth.
+
+pub mod antigravity;
+pub mod claude;
+pub mod codex;
+pub mod index;
+pub mod proto;
+pub mod scanner;
+pub mod sync;
+pub mod types;
+pub mod watch;

--- a/src-tauri/src/modules/sessions_index/mod.rs
+++ b/src-tauri/src/modules/sessions_index/mod.rs
@@ -79,7 +79,10 @@ pub fn sessions_index_start(app: AppHandle, state: State<SessionsIndexState>) ->
     // while this background sync is still running.
     let app_bg = app.clone();
     std::thread::spawn(move || {
+        let started = std::time::Instant::now();
+        eprintln!("[sessions] full sync: begin");
         let count = sync::full_sync(&index, &home);
+        eprintln!("[sessions] full sync: {count} dirty in {:?}", started.elapsed());
         watch::emit_updated(&app_bg, count);
     });
 
@@ -114,20 +117,24 @@ pub async fn sessions_list(state: State<'_, SessionsIndexState>) -> Result<Vec<S
 /// viewer. Never reads from the index (it stores metadata only).
 #[tauri::command]
 pub async fn sessions_get(state: State<'_, SessionsIndexState>, id: String) -> Result<Vec<TranscriptMessage>, String> {
-    let lookup = {
+    let started = std::time::Instant::now();
+    eprintln!("[sessions] get {id}: begin");
+    let index = {
         let guard = state.inner.lock().unwrap();
         let inner = guard.as_ref().ok_or_else(|| "sessions index not started".to_string())?;
-        let result = inner.index.lock().unwrap().lookup_file(&id);
-        result
-    };
-    let Some((agent, file_path)) = lookup else {
-        return Ok(Vec::new());
+        Arc::clone(&inner.index)
     };
 
-    // A transcript can be multiple MBs; parsing it must never run inline on
-    // whatever thread is awaiting this command (see claude_session_title for
-    // the same rationale).
-    tauri::async_runtime::spawn_blocking(move || {
+    // Both the id lookup and the transcript parse run on a blocking-pool
+    // thread: the lookup so this async worker never parks on the index
+    // mutex while a sync batch holds it, and the parse because a transcript
+    // can be multiple MBs (see claude_session_title for the same rationale).
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let lookup = index.lock().unwrap().lookup_file(&id);
+        let Some((agent, file_path)) = lookup else {
+            eprintln!("[sessions] get {id}: not in index");
+            return Vec::new();
+        };
         let path = Path::new(&file_path);
         match agent.as_str() {
             "claude" => claude::parse_claude_transcript(path),
@@ -137,7 +144,16 @@ pub async fn sessions_get(state: State<'_, SessionsIndexState>, id: String) -> R
         }
     })
     .await
-    .map_err(|e| e.to_string())
+    .map_err(|e| e.to_string());
+    match &result {
+        Ok(messages) => eprintln!(
+            "[sessions] get: {} messages in {:?}",
+            messages.len(),
+            started.elapsed()
+        ),
+        Err(err) => eprintln!("[sessions] get: error after {:?}: {err}", started.elapsed()),
+    }
+    result
 }
 
 /// Pin or unpin a session. Errors if the index hasn't been started yet.

--- a/src-tauri/src/modules/sessions_index/mod.rs
+++ b/src-tauri/src/modules/sessions_index/mod.rs
@@ -73,13 +73,13 @@ pub fn sessions_index_start(app: AppHandle, state: State<SessionsIndexState>) ->
 
     // A full sync walks every session file on disk, which can take a while
     // on a machine with years of history; never block this command (and
-    // therefore the caller awaiting it) on that.
+    // therefore the caller awaiting it) on that. `full_sync` itself never
+    // holds `index`'s lock across that whole walk either — see its doc
+    // comment — so `sessions_list` stays responsive on the main thread
+    // while this background sync is still running.
     let app_bg = app.clone();
     std::thread::spawn(move || {
-        let count = {
-            let index = index.lock().unwrap();
-            sync::full_sync(&index, &home)
-        };
+        let count = sync::full_sync(&index, &home);
         watch::emit_updated(&app_bg, count);
     });
 
@@ -88,13 +88,26 @@ pub fn sessions_index_start(app: AppHandle, state: State<SessionsIndexState>) ->
 
 /// Every indexed session, newest-first, pinned sessions flagged. Empty
 /// before `sessions_index_start` has run.
+///
+/// Async and offloaded to a blocking pool thread — mirrors `sessions_get`'s
+/// rationale — so that even brief, incidental contention on the index lock
+/// (e.g. the startup full sync mid-commit) never blocks the main thread the
+/// IPC runtime would otherwise run this on. Returns `Result` only because
+/// Tauri requires it of async commands taking a `State` reference; the
+/// error case here is just `spawn_blocking`'s own join failure, never a
+/// real lookup failure (those already degrade to an empty `Vec`).
 #[tauri::command]
-pub fn sessions_list(state: State<SessionsIndexState>) -> Vec<SessionSummary> {
-    let guard = state.inner.lock().unwrap();
-    match guard.as_ref() {
-        Some(inner) => inner.index.lock().unwrap().list(),
-        None => Vec::new(),
-    }
+pub async fn sessions_list(state: State<'_, SessionsIndexState>) -> Result<Vec<SessionSummary>, String> {
+    let index = {
+        let guard = state.inner.lock().unwrap();
+        guard.as_ref().map(|inner| Arc::clone(&inner.index))
+    };
+    let Some(index) = index else {
+        return Ok(Vec::new());
+    };
+    tauri::async_runtime::spawn_blocking(move || index.lock().unwrap().list())
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Re-parses a session's full transcript from its source file, for the

--- a/src-tauri/src/modules/sessions_index/mod.rs
+++ b/src-tauri/src/modules/sessions_index/mod.rs
@@ -12,3 +12,126 @@ pub mod scanner;
 pub mod sync;
 pub mod types;
 pub mod watch;
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use tauri::{AppHandle, Manager, State};
+
+use index::Index;
+use types::{SessionSummary, TranscriptMessage};
+
+/// The index's on-disk file, under the app's data directory.
+const DB_FILE_NAME: &str = "sessions-index.db";
+
+/// Everything that exists once `sessions_index_start` has run: the open
+/// index and the live filesystem watchers keeping it in sync.
+struct StateInner {
+    index: Arc<Mutex<Index>>,
+    /// Held only to keep the OS-level watch subscriptions alive for the
+    /// app's lifetime; never read again after `sessions_index_start`.
+    _watchers: Vec<notify::RecommendedWatcher>,
+}
+
+/// Lazily-started sessions index. `None` until `sessions_index_start` runs
+/// (called once by the frontend when the sessions view first mounts); every
+/// other command degrades gracefully (empty list / an error) until then.
+pub struct SessionsIndexState {
+    inner: Arc<Mutex<Option<StateInner>>>,
+}
+
+impl SessionsIndexState {
+    pub fn new() -> Self {
+        Self { inner: Arc::new(Mutex::new(None)) }
+    }
+}
+
+impl Default for SessionsIndexState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Open the index, start the filesystem watchers, and kick off a background
+/// full sync. No-op if already started — the frontend may call this more
+/// than once (e.g. re-mounting the sessions view), and re-opening the same
+/// DB file + re-watching the same roots would just duplicate watchers.
+#[tauri::command]
+pub fn sessions_index_start(app: AppHandle, state: State<SessionsIndexState>) -> Result<(), String> {
+    let mut guard = state.inner.lock().unwrap();
+    if guard.is_some() {
+        return Ok(());
+    }
+
+    let db_path = app.path().app_data_dir().map_err(|e| e.to_string())?.join(DB_FILE_NAME);
+    let index = Arc::new(Mutex::new(Index::open(&db_path)?));
+    let home = app.path().home_dir().map_err(|e| e.to_string())?;
+
+    let watchers = watch::start(&app, &home, Arc::clone(&index));
+    *guard = Some(StateInner { index: Arc::clone(&index), _watchers: watchers });
+    drop(guard); // release before the background thread might want it
+
+    // A full sync walks every session file on disk, which can take a while
+    // on a machine with years of history; never block this command (and
+    // therefore the caller awaiting it) on that.
+    let app_bg = app.clone();
+    std::thread::spawn(move || {
+        let count = {
+            let index = index.lock().unwrap();
+            sync::full_sync(&index, &home)
+        };
+        watch::emit_updated(&app_bg, count);
+    });
+
+    Ok(())
+}
+
+/// Every indexed session, newest-first, pinned sessions flagged. Empty
+/// before `sessions_index_start` has run.
+#[tauri::command]
+pub fn sessions_list(state: State<SessionsIndexState>) -> Vec<SessionSummary> {
+    let guard = state.inner.lock().unwrap();
+    match guard.as_ref() {
+        Some(inner) => inner.index.lock().unwrap().list(),
+        None => Vec::new(),
+    }
+}
+
+/// Re-parses a session's full transcript from its source file, for the
+/// viewer. Never reads from the index (it stores metadata only).
+#[tauri::command]
+pub async fn sessions_get(state: State<'_, SessionsIndexState>, id: String) -> Result<Vec<TranscriptMessage>, String> {
+    let lookup = {
+        let guard = state.inner.lock().unwrap();
+        let inner = guard.as_ref().ok_or_else(|| "sessions index not started".to_string())?;
+        let result = inner.index.lock().unwrap().lookup_file(&id);
+        result
+    };
+    let Some((agent, file_path)) = lookup else {
+        return Ok(Vec::new());
+    };
+
+    // A transcript can be multiple MBs; parsing it must never run inline on
+    // whatever thread is awaiting this command (see claude_session_title for
+    // the same rationale).
+    tauri::async_runtime::spawn_blocking(move || {
+        let path = Path::new(&file_path);
+        match agent.as_str() {
+            "claude" => claude::parse_claude_transcript(path),
+            "codex" => codex::parse_codex_transcript(path),
+            "antigravity" => antigravity::parse_antigravity_transcript(path),
+            _ => Vec::new(),
+        }
+    })
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// Pin or unpin a session. Errors if the index hasn't been started yet.
+#[tauri::command]
+pub fn sessions_pin(state: State<SessionsIndexState>, id: String, pinned: bool) -> Result<(), String> {
+    let guard = state.inner.lock().unwrap();
+    let inner = guard.as_ref().ok_or_else(|| "sessions index not started".to_string())?;
+    let result = inner.index.lock().unwrap().set_pinned(&id, pinned);
+    result
+}

--- a/src-tauri/src/modules/sessions_index/proto.rs
+++ b/src-tauri/src/modules/sessions_index/proto.rs
@@ -1,1 +1,212 @@
 //! Protobuf wire reader for parsing trajectory binary data.
+//!
+//! This is a minimal, best-effort decoder for the protobuf wire format
+//! (no schema, no external crate). It only needs to pull known field
+//! numbers out of a byte blob, so it does not validate messages: any
+//! decode error simply stops parsing early and returns the fields
+//! collected so far.
+
+/// A decoded protobuf field value, keyed by wire type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProtoValue {
+    /// Wire type 0.
+    Varint(u64),
+    /// Wire type 1.
+    Fixed64(u64),
+    /// Wire type 2 (length-delimited: bytes, strings, embedded messages).
+    Bytes(Vec<u8>),
+    /// Wire type 5.
+    Fixed32(u32),
+}
+
+/// Reads a single wire-format varint starting at `pos`.
+///
+/// Returns the decoded value and the position just past it, or `None`
+/// if the varint runs past the end of the buffer or exceeds 10 bytes
+/// (the max length for a 64-bit varint).
+fn read_varint(buf: &[u8], pos: usize) -> Option<(u64, usize)> {
+    let mut result: u64 = 0;
+    let mut shift: u32 = 0;
+    let mut i = pos;
+    loop {
+        if i >= buf.len() || shift >= 70 {
+            return None;
+        }
+        let byte = buf[i];
+        i += 1;
+        result |= ((byte & 0x7f) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return Some((result, i));
+        }
+        shift += 7;
+    }
+}
+
+/// Parses a buffer of consecutive protobuf fields into a flat list of
+/// `(field_number, value)` pairs, in encounter order.
+///
+/// Best-effort: stops as soon as it hits a malformed tag, an unknown/
+/// unsupported wire type (3, 4, 6, 7), an overlong varint, or a
+/// length-delimited field whose length runs past the end of `buf`. In
+/// every such case, the fields decoded up to that point are returned
+/// rather than panicking or erroring out.
+pub fn parse_fields(buf: &[u8]) -> Vec<(u32, ProtoValue)> {
+    let mut fields = Vec::new();
+    let mut pos = 0;
+
+    while pos < buf.len() {
+        let (tag, next_pos) = match read_varint(buf, pos) {
+            Some(v) => v,
+            None => break,
+        };
+        pos = next_pos;
+
+        let field_no = (tag >> 3) as u32;
+        let wire_type = tag & 0x7;
+
+        match wire_type {
+            0 => {
+                let (value, next_pos) = match read_varint(buf, pos) {
+                    Some(v) => v,
+                    None => break,
+                };
+                pos = next_pos;
+                fields.push((field_no, ProtoValue::Varint(value)));
+            }
+            1 => {
+                if pos + 8 > buf.len() {
+                    break;
+                }
+                let bytes: [u8; 8] = buf[pos..pos + 8].try_into().unwrap();
+                pos += 8;
+                fields.push((field_no, ProtoValue::Fixed64(u64::from_le_bytes(bytes))));
+            }
+            2 => {
+                let (len, next_pos) = match read_varint(buf, pos) {
+                    Some(v) => v,
+                    None => break,
+                };
+                pos = next_pos;
+                let len = len as usize;
+                if pos + len > buf.len() {
+                    break;
+                }
+                let data = buf[pos..pos + len].to_vec();
+                pos += len;
+                fields.push((field_no, ProtoValue::Bytes(data)));
+            }
+            5 => {
+                if pos + 4 > buf.len() {
+                    break;
+                }
+                let bytes: [u8; 4] = buf[pos..pos + 4].try_into().unwrap();
+                pos += 4;
+                fields.push((field_no, ProtoValue::Fixed32(u32::from_le_bytes(bytes))));
+            }
+            _ => break, // wire types 3/4 (group markers) and 6/7 (invalid): stop.
+        }
+    }
+
+    fields
+}
+
+/// Returns the raw bytes of the first `Bytes` field matching `field_no`.
+pub fn first_bytes<'a>(fields: &'a [(u32, ProtoValue)], field_no: u32) -> Option<&'a [u8]> {
+    fields.iter().find_map(|(no, value)| {
+        if *no != field_no {
+            return None;
+        }
+        match value {
+            ProtoValue::Bytes(data) => Some(data.as_slice()),
+            _ => None,
+        }
+    })
+}
+
+/// Returns the value of the first `Varint` field matching `field_no`.
+pub fn first_varint(fields: &[(u32, ProtoValue)], field_no: u32) -> Option<u64> {
+    fields.iter().find_map(|(no, value)| {
+        if *no != field_no {
+            return None;
+        }
+        match value {
+            ProtoValue::Varint(v) => Some(*v),
+            _ => None,
+        }
+    })
+}
+
+/// Decodes a nested `google.protobuf.Timestamp`-shaped message stored as
+/// the `Bytes` field `field_no` (seconds in sub-field 1, nanos in
+/// sub-field 2), returning the value in milliseconds since epoch.
+pub fn timestamp_ms(fields: &[(u32, ProtoValue)], field_no: u32) -> Option<i64> {
+    let ts_bytes = first_bytes(fields, field_no)?;
+    let ts_fields = parse_fields(ts_bytes);
+    let seconds = first_varint(&ts_fields, 1)? as i64;
+    let nanos = first_varint(&ts_fields, 2).unwrap_or(0) as i64;
+    Some(seconds * 1000 + nanos / 1_000_000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test-only encoder helpers (wire format: tag = field_no << 3 | wire_type).
+    fn varint(mut v: u64, out: &mut Vec<u8>) {
+        loop {
+            let byte = (v & 0x7f) as u8;
+            v >>= 7;
+            if v == 0 { out.push(byte); break; }
+            out.push(byte | 0x80);
+        }
+    }
+    fn field_varint(no: u32, v: u64, out: &mut Vec<u8>) {
+        varint(((no as u64) << 3) | 0, out);
+        varint(v, out);
+    }
+    fn field_bytes(no: u32, data: &[u8], out: &mut Vec<u8>) {
+        varint(((no as u64) << 3) | 2, out);
+        varint(data.len() as u64, out);
+        out.extend_from_slice(data);
+    }
+
+    #[test]
+    fn parses_varint_and_length_delimited_fields() {
+        let mut buf = Vec::new();
+        field_varint(3, 150, &mut buf);
+        field_bytes(17, b"hello", &mut buf);
+        let fields = parse_fields(&buf);
+        assert_eq!(first_varint(&fields, 3), Some(150));
+        assert_eq!(first_bytes(&fields, 17), Some(&b"hello"[..]));
+    }
+
+    #[test]
+    fn decodes_a_nested_timestamp() {
+        let mut ts = Vec::new();
+        field_varint(1, 1_751_760_000, &mut ts); // seconds
+        field_varint(2, 500_000_000, &mut ts);   // nanos
+        let mut buf = Vec::new();
+        field_bytes(5, &ts, &mut buf);
+        let fields = parse_fields(&buf);
+        assert_eq!(timestamp_ms(&fields, 5), Some(1_751_760_000_500));
+    }
+
+    #[test]
+    fn malformed_input_yields_partial_fields_not_panic() {
+        let mut buf = Vec::new();
+        field_varint(1, 7, &mut buf);
+        buf.extend_from_slice(&[0xff, 0xff]); // truncated garbage tail
+        let fields = parse_fields(&buf);
+        assert_eq!(first_varint(&fields, 1), Some(7));
+    }
+
+    #[test]
+    fn skips_fixed32_and_fixed64_without_losing_position() {
+        let mut buf = Vec::new();
+        varint((2 << 3) | 1, &mut buf); buf.extend_from_slice(&8u64.to_le_bytes());
+        varint((4 << 3) | 5, &mut buf); buf.extend_from_slice(&9u32.to_le_bytes());
+        field_varint(6, 1, &mut buf);
+        let fields = parse_fields(&buf);
+        assert_eq!(first_varint(&fields, 6), Some(1));
+    }
+}

--- a/src-tauri/src/modules/sessions_index/proto.rs
+++ b/src-tauri/src/modules/sessions_index/proto.rs
@@ -87,12 +87,18 @@ pub fn parse_fields(buf: &[u8]) -> Vec<(u32, ProtoValue)> {
                     None => break,
                 };
                 pos = next_pos;
-                let len = len as usize;
-                if pos + len > buf.len() {
-                    break;
-                }
-                let data = buf[pos..pos + len].to_vec();
-                pos += len;
+                // Checked math: `len` is attacker-controlled and can be up to
+                // u64::MAX, so a plain `pos + len` could overflow usize.
+                let end = match len
+                    .try_into()
+                    .ok()
+                    .and_then(|len: usize| pos.checked_add(len))
+                {
+                    Some(end) if end <= buf.len() => end,
+                    _ => break,
+                };
+                let data = buf[pos..end].to_vec();
+                pos = end;
                 fields.push((field_no, ProtoValue::Bytes(data)));
             }
             5 => {
@@ -139,12 +145,15 @@ pub fn first_varint(fields: &[(u32, ProtoValue)], field_no: u32) -> Option<u64> 
 /// Decodes a nested `google.protobuf.Timestamp`-shaped message stored as
 /// the `Bytes` field `field_no` (seconds in sub-field 1, nanos in
 /// sub-field 2), returning the value in milliseconds since epoch.
+///
+/// Returns `None` if the field is missing, malformed, or if the
+/// millisecond math would overflow `i64` (absurd varint values).
 pub fn timestamp_ms(fields: &[(u32, ProtoValue)], field_no: u32) -> Option<i64> {
     let ts_bytes = first_bytes(fields, field_no)?;
     let ts_fields = parse_fields(ts_bytes);
     let seconds = first_varint(&ts_fields, 1)? as i64;
     let nanos = first_varint(&ts_fields, 2).unwrap_or(0) as i64;
-    Some(seconds * 1000 + nanos / 1_000_000)
+    seconds.checked_mul(1000)?.checked_add(nanos / 1_000_000)
 }
 
 #[cfg(test)]
@@ -208,5 +217,46 @@ mod tests {
         field_varint(6, 1, &mut buf);
         let fields = parse_fields(&buf);
         assert_eq!(first_varint(&fields, 6), Some(1));
+    }
+
+    #[test]
+    fn huge_length_delimited_length_does_not_overflow_usize() {
+        // A valid field first, so we can assert partial collection.
+        let mut buf = Vec::new();
+        field_varint(1, 7, &mut buf);
+        // Field 2, wire type 2, length = u64::MAX (10-byte varint) plus a
+        // couple of stray bytes: `pos + len` must not overflow usize.
+        varint((2 << 3) | 2, &mut buf);
+        buf.extend_from_slice(&[
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01,
+        ]);
+        buf.extend_from_slice(&[0xaa, 0xbb]);
+        let fields = parse_fields(&buf);
+        assert_eq!(first_varint(&fields, 1), Some(7));
+        assert_eq!(first_bytes(&fields, 2), None);
+    }
+
+    #[test]
+    fn moderate_length_past_buffer_end_stops_cleanly() {
+        let mut buf = Vec::new();
+        field_varint(1, 7, &mut buf);
+        // Field 2, wire type 2, claims 100 bytes but only 3 follow.
+        varint((2 << 3) | 2, &mut buf);
+        varint(100, &mut buf);
+        buf.extend_from_slice(&[0x01, 0x02, 0x03]);
+        let fields = parse_fields(&buf);
+        assert_eq!(first_varint(&fields, 1), Some(7));
+        assert_eq!(first_bytes(&fields, 2), None);
+    }
+
+    #[test]
+    fn timestamp_overflow_returns_none_not_panic() {
+        let mut ts = Vec::new();
+        field_varint(1, i64::MAX as u64, &mut ts); // seconds too large for ms math
+        field_varint(2, 0, &mut ts);
+        let mut buf = Vec::new();
+        field_bytes(5, &ts, &mut buf);
+        let fields = parse_fields(&buf);
+        assert_eq!(timestamp_ms(&fields, 5), None);
     }
 }

--- a/src-tauri/src/modules/sessions_index/proto.rs
+++ b/src-tauri/src/modules/sessions_index/proto.rs
@@ -1,0 +1,1 @@
+//! Protobuf wire reader for parsing trajectory binary data.

--- a/src-tauri/src/modules/sessions_index/scanner.rs
+++ b/src-tauri/src/modules/sessions_index/scanner.rs
@@ -1,0 +1,1 @@
+//! Scanner for discovering and parsing session sources.

--- a/src-tauri/src/modules/sessions_index/scanner.rs
+++ b/src-tauri/src/modules/sessions_index/scanner.rs
@@ -87,7 +87,9 @@ pub fn discover(home: &Path) -> Vec<SessionFile> {
 
 /// Core discovery logic, decoupled from env resolution so it can be tested
 /// against arbitrary temp-dir roots without ever touching process env.
-fn discover_from_roots(roots: &[(&'static str, PathBuf)]) -> Vec<SessionFile> {
+/// `pub(crate)` (rather than private) so sync.rs's full-sync tests can reuse
+/// the same hermetic, env-free entry point instead of mutating process env.
+pub(crate) fn discover_from_roots(roots: &[(&'static str, PathBuf)]) -> Vec<SessionFile> {
     let mut out = Vec::new();
     for (agent, root) in roots {
         match *agent {

--- a/src-tauri/src/modules/sessions_index/scanner.rs
+++ b/src-tauri/src/modules/sessions_index/scanner.rs
@@ -1,1 +1,438 @@
-//! Scanner for discovering and parsing session sources.
+//! Discovers session source files across the three agent roots (Claude Code,
+//! Codex, Antigravity CLI) without ever reading their contents. A missing
+//! root (an agent the user has never run) contributes nothing and is never
+//! an error.
+//!
+//! Each agent's layout gets its own, deliberately narrow, discovery rule:
+//! - Claude: only top-level `*.jsonl` files inside each project subdir of
+//!   `projects/`. Never recurses into a `<session-id>/` companion directory.
+//! - Codex: `rollout-*.jsonl` files nested up to three directories deep under
+//!   `sessions/` (the `YYYY/MM/DD` layout), plus flat, unfiltered `*.jsonl`
+//!   files directly under `archived_sessions/`.
+//! - Antigravity: only `*.db` files directly under `conversations/`; SQLite's
+//!   `-wal`/`-shm` companions and `.db-journal` are excluded because their
+//!   file extension is never exactly `db`.
+
+use std::path::{Path, PathBuf};
+
+/// One discovered session source file, tagged with the agent that owns it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionFile {
+    /// "claude" | "codex" | "antigravity"
+    pub agent: &'static str,
+    pub path: PathBuf,
+}
+
+/// How many nested directories under Codex's `sessions/` root are walked
+/// (the `YYYY/MM/DD` layout); a `rollout-*.jsonl` file one level deeper than
+/// this is silently excluded rather than found.
+const CODEX_SESSIONS_MAX_NESTED_DIRS: u32 = 3;
+
+/// Resolved (agent, root dir) pairs, honoring env overrides passed in as
+/// plain values rather than read from `std::env` directly, so callers (tests
+/// especially) can exercise every override combination without mutating
+/// process env. Use `roots_from_env` at real call sites.
+pub fn roots(
+    home: &Path,
+    claude_config_dir: Option<&str>,
+    codex_home: Option<&str>,
+    antigravity_cli_dir: Option<&str>,
+) -> Vec<(&'static str, PathBuf)> {
+    let claude_base = crate::modules::claude_progress::config_base_dir(home, claude_config_dir);
+    let codex_base = expand_base_dir(home, codex_home, || home.join(".codex"));
+    let antigravity_base =
+        expand_base_dir(home, antigravity_cli_dir, || home.join(".gemini").join("antigravity-cli"));
+
+    vec![
+        ("claude", claude_base.join("projects")),
+        ("codex", codex_base.join("sessions")),
+        ("codex", codex_base.join("archived_sessions")),
+        ("antigravity", antigravity_base.join("conversations")),
+    ]
+}
+
+/// Thin wrapper reading the real `CLAUDE_CONFIG_DIR` / `CODEX_HOME` /
+/// `ANTIGRAVITY_CLI_DIR` env vars, for production call sites.
+pub fn roots_from_env(home: &Path) -> Vec<(&'static str, PathBuf)> {
+    roots(
+        home,
+        std::env::var("CLAUDE_CONFIG_DIR").ok().as_deref(),
+        std::env::var("CODEX_HOME").ok().as_deref(),
+        std::env::var("ANTIGRAVITY_CLI_DIR").ok().as_deref(),
+    )
+}
+
+/// Resolves a base directory from an optional env override, expanding a
+/// leading `~` against `home` (mirroring `claude_progress::config_base_dir`'s
+/// convention), or falling back to `default()` when the override is unset or
+/// blank.
+fn expand_base_dir(home: &Path, env_value: Option<&str>, default: impl FnOnce() -> PathBuf) -> PathBuf {
+    match env_value {
+        Some(value) if !value.trim().is_empty() => {
+            let path = Path::new(value);
+            match path.strip_prefix("~") {
+                Ok(rest) => home.join(rest),
+                Err(_) => path.to_path_buf(),
+            }
+        }
+        _ => default(),
+    }
+}
+
+/// Discover every session source file across all three agents' roots, using
+/// the real process env for root overrides.
+pub fn discover(home: &Path) -> Vec<SessionFile> {
+    discover_from_roots(&roots_from_env(home))
+}
+
+/// Core discovery logic, decoupled from env resolution so it can be tested
+/// against arbitrary temp-dir roots without ever touching process env.
+fn discover_from_roots(roots: &[(&'static str, PathBuf)]) -> Vec<SessionFile> {
+    let mut out = Vec::new();
+    for (agent, root) in roots {
+        match *agent {
+            "claude" => discover_claude(root, &mut out),
+            "codex" => {
+                // The two Codex roots share the "codex" tag; tell them apart
+                // by directory name, which is always exactly "sessions" or
+                // "archived_sessions" no matter how CODEX_HOME is set.
+                if root.file_name().and_then(|n| n.to_str()) == Some("archived_sessions") {
+                    discover_codex_archived(root, &mut out);
+                } else {
+                    discover_codex_sessions(root, &mut out);
+                }
+            }
+            "antigravity" => discover_antigravity(root, &mut out),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// True when `path`'s extension is exactly `ext` (case-sensitive, no dot).
+fn has_extension(path: &Path, ext: &str) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some(ext)
+}
+
+/// Every top-level `*.jsonl` file inside each project subdir of `root`.
+/// Never recurses further: a `<session-id>/` companion directory inside a
+/// project is a real thing Claude Code creates, and its contents are never
+/// session transcripts.
+fn discover_claude(root: &Path, out: &mut Vec<SessionFile>) {
+    let Ok(project_dirs) = std::fs::read_dir(root) else { return };
+    for project_entry in project_dirs.flatten() {
+        let project_path = project_entry.path();
+        if !project_path.is_dir() {
+            continue;
+        }
+        let Ok(files) = std::fs::read_dir(&project_path) else { continue };
+        for file_entry in files.flatten() {
+            let path = file_entry.path();
+            if path.is_file() && has_extension(&path, "jsonl") {
+                out.push(SessionFile { agent: "claude", path });
+            }
+        }
+    }
+}
+
+/// True when `name` matches Codex's rollout file naming, `rollout-*.jsonl`.
+fn is_rollout_jsonl(name: &str) -> bool {
+    name.starts_with("rollout-") && name.ends_with(".jsonl")
+}
+
+/// `rollout-*.jsonl` files under `root`, recursing into the `YYYY/MM/DD`
+/// directory layout but never past `CODEX_SESSIONS_MAX_NESTED_DIRS` levels.
+fn discover_codex_sessions(root: &Path, out: &mut Vec<SessionFile>) {
+    walk_codex_sessions(root, 0, out);
+}
+
+fn walk_codex_sessions(dir: &Path, depth: u32, out: &mut Vec<SessionFile>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Only descend while the subdirectory itself would still be
+            // within the allowed nesting (YYYY/MM/DD); anything deeper is
+            // silently excluded by never being visited at all.
+            if depth < CODEX_SESSIONS_MAX_NESTED_DIRS {
+                walk_codex_sessions(&path, depth + 1, out);
+            }
+            continue;
+        }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if is_rollout_jsonl(name) {
+                out.push(SessionFile { agent: "codex", path: path.clone() });
+            }
+        }
+    }
+}
+
+/// Every top-level `*.jsonl` file directly under `archived_sessions/`; flat,
+/// no recursion, and (unlike `sessions/`) no `rollout-` prefix filter.
+fn discover_codex_archived(root: &Path, out: &mut Vec<SessionFile>) {
+    let Ok(entries) = std::fs::read_dir(root) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() && has_extension(&path, "jsonl") {
+            out.push(SessionFile { agent: "codex", path });
+        }
+    }
+}
+
+/// Every top-level `*.db` file directly under `conversations/`. SQLite's
+/// `-wal`/`-shm` companions and a `.db-journal` file all fail the exact
+/// `db` extension check, so they're excluded without any special-casing.
+fn discover_antigravity(root: &Path, out: &mut Vec<SessionFile>) {
+    let Ok(entries) = std::fs::read_dir(root) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() && has_extension(&path, "db") {
+            out.push(SessionFile { agent: "antigravity", path });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_home(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-scanner-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Creates an empty file at `path`, creating any missing parent dirs.
+    /// Discovery only ever looks at names/extensions/dir structure, so an
+    /// empty file is a perfectly good fixture.
+    fn touch(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"").unwrap();
+    }
+
+    fn sorted(mut files: Vec<SessionFile>) -> Vec<SessionFile> {
+        files.sort_by(|a, b| (a.agent, &a.path).cmp(&(b.agent, &b.path)));
+        files
+    }
+
+    // --- discover_from_roots: the main discovery-rules test -----------------
+
+    #[test]
+    fn discover_returns_expected_files_and_excludes_all_decoys() {
+        let home = temp_home("discover-all");
+
+        // Claude: two projects, each with top-level jsonl files; a nested
+        // session-id-style subdir with its own jsonl is a decoy that must
+        // never be picked up (never recurse past the project directory).
+        let claude_a1 = home.join(".claude/projects/projA/session1.jsonl");
+        let claude_a2 = home.join(".claude/projects/projA/session2.jsonl");
+        let claude_decoy = home.join(".claude/projects/projA/session-id-dir/nested.jsonl");
+        let claude_b1 = home.join(".claude/projects/projB/other.jsonl");
+        for p in [&claude_a1, &claude_a2, &claude_decoy, &claude_b1] {
+            touch(p);
+        }
+
+        // Codex sessions/: rollout files nested three levels deep
+        // (YYYY/MM/DD) are kept; a non-rollout jsonl at the same depth is a
+        // decoy, and a rollout file one level deeper than allowed is too.
+        let codex_1 = home.join(".codex/sessions/2026/07/07/rollout-abc.jsonl");
+        let codex_2 = home.join(".codex/sessions/2026/07/07/rollout-def.jsonl");
+        let codex_decoy_pattern = home.join(".codex/sessions/2026/07/07/not-a-rollout.jsonl");
+        let codex_decoy_depth = home.join(".codex/sessions/2026/07/07/extra/rollout-toodeep.jsonl");
+        for p in [&codex_1, &codex_2, &codex_decoy_pattern, &codex_decoy_depth] {
+            touch(p);
+        }
+
+        // Codex archived_sessions/: flat, any *.jsonl, no recursion.
+        let codex_archived = home.join(".codex/archived_sessions/rollout-old.jsonl");
+        touch(&codex_archived);
+
+        // Antigravity conversations/: only *.db; -wal/-shm/.db-journal
+        // companions are decoys.
+        let ag_db = home.join(".gemini/antigravity-cli/conversations/convo1.db");
+        let ag_wal = home.join(".gemini/antigravity-cli/conversations/convo1.db-wal");
+        let ag_shm = home.join(".gemini/antigravity-cli/conversations/convo1.db-shm");
+        let ag_journal = home.join(".gemini/antigravity-cli/conversations/convo1.db-journal");
+        for p in [&ag_db, &ag_wal, &ag_shm, &ag_journal] {
+            touch(p);
+        }
+
+        let root_list = roots(&home, None, None, None);
+        let found = sorted(discover_from_roots(&root_list));
+
+        let expected = sorted(vec![
+            SessionFile { agent: "antigravity", path: ag_db },
+            SessionFile { agent: "claude", path: claude_a1 },
+            SessionFile { agent: "claude", path: claude_a2 },
+            SessionFile { agent: "claude", path: claude_b1 },
+            SessionFile { agent: "codex", path: codex_1 },
+            SessionFile { agent: "codex", path: codex_2 },
+            SessionFile { agent: "codex", path: codex_archived },
+        ]);
+
+        assert_eq!(found, expected);
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn claude_never_recurses_into_a_session_id_subdirectory() {
+        let home = temp_home("claude-no-recurse");
+        let kept = home.join(".claude/projects/proj/top.jsonl");
+        let decoy = home.join(".claude/projects/proj/abc-session-id/nested.jsonl");
+        touch(&kept);
+        touch(&decoy);
+
+        let found = discover_from_roots(&roots(&home, None, None, None));
+        assert_eq!(found, vec![SessionFile { agent: "claude", path: kept }]);
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn codex_sessions_stops_recursing_past_three_nested_directories() {
+        let home = temp_home("codex-depth");
+        let kept = home.join(".codex/sessions/2026/07/07/rollout-ok.jsonl");
+        let too_deep = home.join(".codex/sessions/2026/07/07/extra/rollout-nope.jsonl");
+        touch(&kept);
+        touch(&too_deep);
+
+        let found = discover_from_roots(&roots(&home, None, None, None));
+        assert_eq!(found, vec![SessionFile { agent: "codex", path: kept }]);
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn codex_sessions_filters_out_non_rollout_files() {
+        let home = temp_home("codex-filter");
+        let kept = home.join(".codex/sessions/2026/07/07/rollout-ok.jsonl");
+        let decoy = home.join(".codex/sessions/2026/07/07/notes.jsonl");
+        touch(&kept);
+        touch(&decoy);
+
+        let found = discover_from_roots(&roots(&home, None, None, None));
+        assert_eq!(found, vec![SessionFile { agent: "codex", path: kept }]);
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn codex_archived_sessions_is_flat_and_unfiltered_by_rollout_prefix() {
+        let home = temp_home("codex-archived");
+        let kept = home.join(".codex/archived_sessions/anything.jsonl");
+        let nested_decoy = home.join(".codex/archived_sessions/sub/rollout-nope.jsonl");
+        touch(&kept);
+        touch(&nested_decoy);
+
+        let found = discover_from_roots(&roots(&home, None, None, None));
+        assert_eq!(found, vec![SessionFile { agent: "codex", path: kept }]);
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn antigravity_skips_wal_shm_and_journal_companion_files() {
+        let home = temp_home("antigravity-companions");
+        let kept = home.join(".gemini/antigravity-cli/conversations/a.db");
+        let wal = home.join(".gemini/antigravity-cli/conversations/a.db-wal");
+        let shm = home.join(".gemini/antigravity-cli/conversations/a.db-shm");
+        let journal = home.join(".gemini/antigravity-cli/conversations/a.db-journal");
+        for p in [&kept, &wal, &shm, &journal] {
+            touch(p);
+        }
+
+        let found = discover_from_roots(&roots(&home, None, None, None));
+        assert_eq!(found, vec![SessionFile { agent: "antigravity", path: kept }]);
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn missing_roots_contribute_nothing_without_error() {
+        // Only the antigravity tree exists; the claude/codex roots are
+        // entirely absent. Discovery must not error and must return only
+        // what actually exists on disk.
+        let home = temp_home("missing-roots");
+        let kept = home.join(".gemini/antigravity-cli/conversations/only.db");
+        touch(&kept);
+
+        let found = discover_from_roots(&roots(&home, None, None, None));
+        assert_eq!(found, vec![SessionFile { agent: "antigravity", path: kept }]);
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn discover_on_a_home_with_no_agent_trees_returns_empty() {
+        // Exercises the public discover() entry point (env-backed roots)
+        // against a home dir with none of the three trees present at all.
+        let home = temp_home("empty-home");
+        let found = discover(&home);
+        assert!(found.is_empty());
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    // --- roots(): env override resolution, no filesystem involved -----------
+
+    #[test]
+    fn roots_uses_defaults_when_all_overrides_are_absent() {
+        let home = Path::new("/home/u");
+        let result = roots(home, None, None, None);
+        assert_eq!(
+            result,
+            vec![
+                ("claude", PathBuf::from("/home/u/.claude/projects")),
+                ("codex", PathBuf::from("/home/u/.codex/sessions")),
+                ("codex", PathBuf::from("/home/u/.codex/archived_sessions")),
+                ("antigravity", PathBuf::from("/home/u/.gemini/antigravity-cli/conversations")),
+            ]
+        );
+    }
+
+    #[test]
+    fn roots_honors_claude_config_dir_override() {
+        let home = Path::new("/home/u");
+        let result = roots(home, Some("/custom/cc"), None, None);
+        assert_eq!(result[0], ("claude", PathBuf::from("/custom/cc/projects")));
+    }
+
+    #[test]
+    fn roots_honors_codex_home_override() {
+        let home = Path::new("/home/u");
+        let result = roots(home, None, Some("/custom/codex"), None);
+        assert_eq!(result[1], ("codex", PathBuf::from("/custom/codex/sessions")));
+        assert_eq!(result[2], ("codex", PathBuf::from("/custom/codex/archived_sessions")));
+    }
+
+    #[test]
+    fn roots_honors_antigravity_cli_dir_override() {
+        let home = Path::new("/home/u");
+        let result = roots(home, None, None, Some("/custom/ag"));
+        assert_eq!(result[3], ("antigravity", PathBuf::from("/custom/ag/conversations")));
+    }
+
+    #[test]
+    fn roots_expands_a_leading_tilde_against_home_for_codex_and_antigravity() {
+        let home = Path::new("/home/u");
+        let result = roots(home, None, Some("~/.codex_custom"), Some("~/.ag_custom"));
+        assert_eq!(result[1], ("codex", PathBuf::from("/home/u/.codex_custom/sessions")));
+        assert_eq!(result[3], ("antigravity", PathBuf::from("/home/u/.ag_custom/conversations")));
+    }
+
+    #[test]
+    fn roots_treats_a_blank_override_as_unset() {
+        let home = Path::new("/home/u");
+        let result = roots(home, Some("  "), Some(""), Some("   "));
+        assert_eq!(
+            result,
+            vec![
+                ("claude", PathBuf::from("/home/u/.claude/projects")),
+                ("codex", PathBuf::from("/home/u/.codex/sessions")),
+                ("codex", PathBuf::from("/home/u/.codex/archived_sessions")),
+                ("antigravity", PathBuf::from("/home/u/.gemini/antigravity-cli/conversations")),
+            ]
+        );
+    }
+}

--- a/src-tauri/src/modules/sessions_index/scanner.rs
+++ b/src-tauri/src/modules/sessions_index/scanner.rs
@@ -96,6 +96,8 @@ fn discover_from_roots(roots: &[(&'static str, PathBuf)]) -> Vec<SessionFile> {
                 // The two Codex roots share the "codex" tag; tell them apart
                 // by directory name, which is always exactly "sessions" or
                 // "archived_sessions" no matter how CODEX_HOME is set.
+                // Implicit contract: roots() is the only producer of these
+                // pairs, so the basename check can't misclassify a root.
                 if root.file_name().and_then(|n| n.to_str()) == Some("archived_sessions") {
                     discover_codex_archived(root, &mut out);
                 } else {
@@ -366,10 +368,14 @@ mod tests {
 
     #[test]
     fn discover_on_a_home_with_no_agent_trees_returns_empty() {
-        // Exercises the public discover() entry point (env-backed roots)
-        // against a home dir with none of the three trees present at all.
+        // A home dir with none of the three trees present at all yields
+        // nothing. Blank overrides mean "unset" (falling back to the
+        // home-relative defaults), keeping the test hermetic on machines
+        // where the real CLAUDE_CONFIG_DIR / CODEX_HOME / ANTIGRAVITY_CLI_DIR
+        // env vars are set — the env-backed discover() would honor those and
+        // walk real data trees.
         let home = temp_home("empty-home");
-        let found = discover(&home);
+        let found = discover_from_roots(&roots(&home, Some(""), Some(""), Some("")));
         assert!(found.is_empty());
         let _ = std::fs::remove_dir_all(&home);
     }

--- a/src-tauri/src/modules/sessions_index/sync.rs
+++ b/src-tauri/src/modules/sessions_index/sync.rs
@@ -44,19 +44,25 @@ fn companion_path(path: &Path, suffix: &str) -> PathBuf {
 }
 
 /// Change-detection fingerprint for a session source file: mtime + size. For
-/// an Antigravity `.db` file, the fingerprint also folds in its `-wal` and
-/// `-shm` companions' mtime/size (summed into the same two numbers), so a
-/// commit that only touches the WAL file (not yet checkpointed back into the
-/// main `.db`) still changes the fingerprint and triggers a re-parse. Claude
-/// and Codex sources are plain single files with no such companions.
+/// an Antigravity `.db` file, the fingerprint also folds in its `-wal`
+/// companion's mtime/size (summed into the same two numbers), so a commit
+/// that only touches the WAL file (not yet checkpointed back into the main
+/// `.db`) still changes the fingerprint and triggers a re-parse. Claude and
+/// Codex sources are plain single files with no such companions.
+///
+/// The `-shm` companion is deliberately excluded: SQLite touches the
+/// shared-memory file merely from OPENING a WAL-mode database — even
+/// read-only, as our own parser does — so folding it in makes every re-parse
+/// move the fingerprint, which the watcher then treats as a fresh change and
+/// re-syncs, touching `-shm` again: a self-sustaining 500 ms sync loop
+/// (observed in the field). Real new data always reaches the WAL or the main
+/// file; `-shm` carries no persistent state.
 pub fn fingerprint(path: &Path) -> (i64, i64) {
     let (mut mtime, mut size) = stat(path);
     if path.extension().and_then(|e| e.to_str()) == Some("db") {
-        for suffix in ["-wal", "-shm"] {
-            let (m, s) = stat(&companion_path(path, suffix));
-            mtime += m;
-            size += s;
-        }
+        let (m, s) = stat(&companion_path(path, "-wal"));
+        mtime += m;
+        size += s;
     }
     (mtime, size)
 }
@@ -381,15 +387,36 @@ mod tests {
     }
 
     #[test]
-    fn fingerprint_of_a_db_sums_wal_and_shm_companions() {
+    fn fingerprint_of_a_db_sums_only_the_wal_companion() {
         let dir = temp_dir("fp-db-companions");
         let path = dir.join("convo.db");
         write(&path, "aaaa"); // 4
         write(&dir.join("convo.db-wal"), "bb"); // 2
-        write(&dir.join("convo.db-shm"), "c"); // 1
+        write(&dir.join("convo.db-shm"), "c"); // 1 — must NOT be folded in
 
         let (_, size) = fingerprint(&path);
-        assert_eq!(size, 7);
+        assert_eq!(size, 6);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fingerprint_is_stable_across_shm_only_touches() {
+        // Opening a WAL-mode SQLite database — even read-only, as our own
+        // parser does — touches the -shm file. If that moved the fingerprint,
+        // every re-parse would schedule the next one: a self-sustaining sync
+        // loop (observed in the field as a 500 ms watch-batch heartbeat).
+        let dir = temp_dir("fp-shm-only");
+        let path = dir.join("convo.db");
+        write(&path, "aaaa");
+        write(&dir.join("convo.db-wal"), "bb");
+        write(&dir.join("convo.db-shm"), "c");
+        let before = fingerprint(&path);
+
+        write(&dir.join("convo.db-shm"), "cccccccc"); // grew; db + wal untouched
+        let after = fingerprint(&path);
+
+        assert_eq!(before, after);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/modules/sessions_index/sync.rs
+++ b/src-tauri/src/modules/sessions_index/sync.rs
@@ -1,0 +1,1 @@
+//! Sync and update logic for the sessions index.

--- a/src-tauri/src/modules/sessions_index/sync.rs
+++ b/src-tauri/src/modules/sessions_index/sync.rs
@@ -1,1 +1,353 @@
-//! Sync and update logic for the sessions index.
+//! Sync and update logic for the sessions index: turns discovered files into
+//! upserts (or skips) via the fingerprint cache in `Index::needs_sync`, and
+//! reconciles the index with what is actually on disk. Every sync is a
+//! whole-file re-parse; there is no offset tailing here (unlike
+//! claude_progress/codex_progress), because the index only stores derived
+//! metadata, never message bodies, so re-deriving it from scratch is cheap
+//! and never needs to reconcile a partial update.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use super::index::Index;
+use super::scanner;
+use super::{antigravity, claude, codex};
+
+/// mtime (milliseconds since epoch) and size (bytes) for `path`, or `(0, 0)`
+/// if it cannot be stat'd. A missing file is not an error here: a watcher can
+/// observe a path mid-delete, and an Antigravity `.db`'s `-wal`/`-shm`
+/// companions are frequently absent entirely (no pending WAL is normal).
+fn stat(path: &Path) -> (i64, i64) {
+    match std::fs::metadata(path) {
+        Ok(meta) => {
+            let mtime = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            (mtime, meta.len() as i64)
+        }
+        Err(_) => (0, 0),
+    }
+}
+
+/// `path` with `suffix` appended to its file name, e.g. `a.db` + `-wal` ->
+/// `a.db-wal`. Plain string concatenation on the OS string, not
+/// `set_extension`, since the suffix is not a `.`-prefixed extension.
+fn companion_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = path.as_os_str().to_owned();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+/// Change-detection fingerprint for a session source file: mtime + size. For
+/// an Antigravity `.db` file, the fingerprint also folds in its `-wal` and
+/// `-shm` companions' mtime/size (summed into the same two numbers), so a
+/// commit that only touches the WAL file (not yet checkpointed back into the
+/// main `.db`) still changes the fingerprint and triggers a re-parse. Claude
+/// and Codex sources are plain single files with no such companions.
+pub fn fingerprint(path: &Path) -> (i64, i64) {
+    let (mut mtime, mut size) = stat(path);
+    if path.extension().and_then(|e| e.to_str()) == Some("db") {
+        for suffix in ["-wal", "-shm"] {
+            let (m, s) = stat(&companion_path(path, suffix));
+            mtime += m;
+            size += s;
+        }
+    }
+    (mtime, size)
+}
+
+/// Re-parse and upsert one session file if its fingerprint changed since the
+/// last sync. Returns `true` when something was upserted; `false` when the
+/// cached fingerprint already matched (skip, the common case on a debounced
+/// re-scan) or when parsing failed / found no session (a file mid-write, or
+/// genuinely malformed — never treated as a hard error, since the source
+/// files are outside our control).
+pub fn sync_file(index: &Index, agent: &'static str, path: &Path) -> bool {
+    let (mtime, size) = fingerprint(path);
+    let file_path = path.to_string_lossy().into_owned();
+    if !index.needs_sync(&file_path, mtime, size) {
+        return false;
+    }
+    let parsed = match agent {
+        "claude" => claude::parse_claude_meta(path),
+        "codex" => codex::parse_codex_meta(path),
+        "antigravity" => antigravity::parse_antigravity_meta(path),
+        _ => None,
+    };
+    let Some(session) = parsed else {
+        #[cfg(debug_assertions)]
+        eprintln!("sessions_index: could not parse {agent} session at {}", path.display());
+        return false;
+    };
+    match index.upsert_session(&session, &file_path, mtime, size) {
+        Ok(()) => true,
+        Err(err) => {
+            #[cfg(debug_assertions)]
+            eprintln!("sessions_index: failed to upsert {}: {err}", path.display());
+            false
+        }
+    }
+}
+
+/// Full reconciliation: discover every session file under `home` (honoring
+/// the real process env's `CLAUDE_CONFIG_DIR`/`CODEX_HOME`/
+/// `ANTIGRAVITY_CLI_DIR` overrides), sync each one, then prune index rows
+/// whose source file no longer exists on disk. Returns how many files were
+/// actually re-synced (upserted) — unchanged files that were skipped do not
+/// count. This is the entry point used at app startup and is not itself
+/// unit-tested against real env (see `sync_and_prune`, its hermetic core,
+/// exercised in tests via `scanner::discover_from_roots` instead).
+pub fn full_sync(index: &Index, home: &Path) -> usize {
+    sync_and_prune(index, scanner::discover(home))
+}
+
+/// The pure core of `full_sync`, decoupled from discovery so it can be
+/// exercised in tests against an arbitrary hand-built file list without
+/// depending on (or mutating) the real `CLAUDE_CONFIG_DIR`/`CODEX_HOME`/
+/// `ANTIGRAVITY_CLI_DIR` process env.
+fn sync_and_prune(index: &Index, files: Vec<scanner::SessionFile>) -> usize {
+    let existing: HashSet<String> = files.iter().map(|f| f.path.to_string_lossy().into_owned()).collect();
+    let dirty = files.iter().filter(|f| sync_file(index, f.agent, &f.path)).count();
+    let _ = index.prune_missing(&existing);
+    dirty
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::sessions_index::scanner::{discover_from_roots, roots, SessionFile};
+
+    /// Discovers under `home` without ever touching the real
+    /// `CLAUDE_CONFIG_DIR`/`CODEX_HOME`/`ANTIGRAVITY_CLI_DIR` process env,
+    /// mirroring scanner.rs's own hermetic tests. `full_sync` itself (the
+    /// public, env-backed entry point) is exercised indirectly through
+    /// `sync_and_prune`, its pure core.
+    fn discover_hermetic(home: &Path) -> Vec<SessionFile> {
+        discover_from_roots(&roots(home, Some(""), Some(""), Some("")))
+    }
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-sync-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    /// A minimal single-line Claude Code transcript: one countable user
+    /// message, enough for `parse_claude_meta` to return `Some`. Mirrors the
+    /// shape of claude.rs's own `BASIC` fixture (Task 3), just trimmed to one
+    /// line since sync.rs only cares about the sync mechanics, not the
+    /// parser's own DAG-walking rules.
+    fn claude_line(session_id: &str, text: &str) -> String {
+        format!(
+            r#"{{"type":"user","uuid":"u1","parentUuid":null,"sessionId":"{session_id}","cwd":"/p/alpha","timestamp":"2026-07-06T01:00:00.000Z","message":{{"role":"user","content":[{{"type":"text","text":"{text}"}}]}}}}"#
+        )
+    }
+
+    fn claude_two_lines(session_id: &str) -> String {
+        format!(
+            "{}\n{}\n",
+            claude_line(session_id, "hello"),
+            concat!(
+                r#"{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-07-06T01:00:05.000Z","#,
+                r#""message":{"role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"hi"}],"usage":{"output_tokens":7}}}"#
+            ),
+        )
+    }
+
+    // --- sync_file: skip / re-sync semantics --------------------------------
+
+    #[test]
+    fn sync_file_first_call_upserts_and_is_listed() {
+        let dir = temp_dir("first");
+        let index = Index::open(&dir.join("index.db")).unwrap();
+        let path = dir.join("sess-1.jsonl");
+        write(&path, &format!("{}\n", claude_line("sess-1", "hello")));
+
+        assert!(sync_file(&index, "claude", &path));
+        let rows = index.list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "sess-1");
+        assert_eq!(rows[0].message_count, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sync_file_without_changes_is_skipped() {
+        let dir = temp_dir("skip");
+        let index = Index::open(&dir.join("index.db")).unwrap();
+        let path = dir.join("sess-1.jsonl");
+        write(&path, &format!("{}\n", claude_line("sess-1", "hello")));
+
+        assert!(sync_file(&index, "claude", &path));
+        // Same fingerprint (file untouched): the cache short-circuits.
+        assert!(!sync_file(&index, "claude", &path));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn touching_the_file_triggers_a_re_sync() {
+        let dir = temp_dir("touch");
+        let index = Index::open(&dir.join("index.db")).unwrap();
+        let path = dir.join("sess-1.jsonl");
+        write(&path, &format!("{}\n", claude_line("sess-1", "hello")));
+        assert!(sync_file(&index, "claude", &path));
+        assert_eq!(index.list()[0].message_count, 1);
+
+        // Rewrite with one more line: size changes, so the fingerprint
+        // changes regardless of filesystem mtime resolution.
+        write(&path, &claude_two_lines("sess-1"));
+        assert!(sync_file(&index, "claude", &path));
+        let rows = index.list();
+        assert_eq!(rows.len(), 1); // same id: replaced, not duplicated
+        assert_eq!(rows[0].message_count, 2);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sync_file_skips_gracefully_on_a_missing_file() {
+        let dir = temp_dir("missing");
+        let index = Index::open(&dir.join("index.db")).unwrap();
+        let path = dir.join("does-not-exist.jsonl");
+
+        assert!(!sync_file(&index, "claude", &path));
+        assert!(index.list().is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sync_file_dispatches_by_agent() {
+        let dir = temp_dir("dispatch");
+        let index = Index::open(&dir.join("index.db")).unwrap();
+        let path = dir.join("unknown.jsonl");
+        write(&path, &claude_line("sess-1", "hello"));
+
+        // An agent tag with no parser wired up never upserts.
+        assert!(!sync_file(&index, "some-other-agent", &path));
+        assert!(index.list().is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // --- fingerprint: db + wal/shm companion summation ----------------------
+
+    #[test]
+    fn fingerprint_of_a_plain_file_ignores_unrelated_siblings() {
+        let dir = temp_dir("fp-plain");
+        let path = dir.join("sess.jsonl");
+        write(&path, "abcd"); // 4 bytes
+        // A sibling that merely happens to share a prefix must not be folded
+        // in: only exact ".db" files look at companions at all.
+        write(&path.with_extension("jsonl-wal"), "zzzzzzzzzz");
+
+        let (_, size) = fingerprint(&path);
+        assert_eq!(size, 4);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fingerprint_of_a_db_with_no_companions_is_just_its_own_size() {
+        let dir = temp_dir("fp-db-alone");
+        let path = dir.join("convo.db");
+        write(&path, "abcdefgh"); // 8 bytes, no -wal/-shm present
+
+        let (_, size) = fingerprint(&path);
+        assert_eq!(size, 8);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fingerprint_of_a_db_sums_wal_and_shm_companions() {
+        let dir = temp_dir("fp-db-companions");
+        let path = dir.join("convo.db");
+        write(&path, "aaaa"); // 4
+        write(&dir.join("convo.db-wal"), "bb"); // 2
+        write(&dir.join("convo.db-shm"), "c"); // 1
+
+        let (_, size) = fingerprint(&path);
+        assert_eq!(size, 7);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fingerprint_changes_on_a_wal_only_commit() {
+        // Antigravity CLI can append to the WAL without checkpointing it back
+        // into the main .db file; the fingerprint must still move so
+        // sync_file re-parses instead of trusting a stale cache.
+        let dir = temp_dir("fp-wal-only");
+        let path = dir.join("convo.db");
+        write(&path, "aaaa");
+        write(&dir.join("convo.db-wal"), "b");
+        let before = fingerprint(&path);
+
+        write(&dir.join("convo.db-wal"), "bbbbbbbbbb"); // grew, main db untouched
+        let after = fingerprint(&path);
+
+        assert_ne!(before, after);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // --- full_sync: discover + sync + prune ---------------------------------
+
+    #[test]
+    fn full_sync_indexes_discovered_files_and_prunes_deleted_ones() {
+        let home = temp_dir("full-sync-home");
+        let session_a = home.join(".claude/projects/projA/session1.jsonl");
+        let session_b = home.join(".claude/projects/projB/session2.jsonl");
+        write(&session_a, &format!("{}\n", claude_line("sess-a", "hello a")));
+        write(&session_b, &format!("{}\n", claude_line("sess-b", "hello b")));
+
+        let index = Index::open(&home.join("index.db")).unwrap();
+
+        let dirty = sync_and_prune(&index, discover_hermetic(&home));
+        assert_eq!(dirty, 2);
+        let ids: HashSet<String> = index.list().into_iter().map(|s| s.id).collect();
+        assert_eq!(ids, HashSet::from(["sess-a".to_string(), "sess-b".to_string()]));
+
+        // Re-running with nothing changed on disk re-syncs nothing.
+        assert_eq!(sync_and_prune(&index, discover_hermetic(&home)), 0);
+
+        // Delete one source file and re-sync: its session disappears, the
+        // other survives.
+        std::fs::remove_file(&session_b).unwrap();
+        let dirty = sync_and_prune(&index, discover_hermetic(&home));
+        assert_eq!(dirty, 0); // nothing new to parse, only a prune
+        let ids: HashSet<String> = index.list().into_iter().map(|s| s.id).collect();
+        assert_eq!(ids, HashSet::from(["sess-a".to_string()]));
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn full_sync_picks_up_a_newly_added_file_on_the_next_run() {
+        let home = temp_dir("full-sync-add");
+        let session_a = home.join(".claude/projects/projA/session1.jsonl");
+        write(&session_a, &format!("{}\n", claude_line("sess-a", "hello a")));
+        let index = Index::open(&home.join("index.db")).unwrap();
+
+        assert_eq!(sync_and_prune(&index, discover_hermetic(&home)), 1);
+
+        let session_c = home.join(".claude/projects/projC/session3.jsonl");
+        write(&session_c, &format!("{}\n", claude_line("sess-c", "hello c")));
+        assert_eq!(sync_and_prune(&index, discover_hermetic(&home)), 1);
+        assert_eq!(index.list().len(), 2);
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+}

--- a/src-tauri/src/modules/sessions_index/sync.rs
+++ b/src-tauri/src/modules/sessions_index/sync.rs
@@ -8,9 +8,11 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use super::index::Index;
 use super::scanner;
+use super::types::ParsedSession;
 use super::{antigravity, claude, codex};
 
 /// mtime (milliseconds since epoch) and size (bytes) for `path`, or `(0, 0)`
@@ -59,37 +61,78 @@ pub fn fingerprint(path: &Path) -> (i64, i64) {
     (mtime, size)
 }
 
-/// Re-parse and upsert one session file if its fingerprint changed since the
-/// last sync. Returns `true` when something was upserted; `false` when the
-/// cached fingerprint already matched (skip, the common case on a debounced
-/// re-scan) or when parsing failed / found no session (a file mid-write, or
-/// genuinely malformed — never treated as a hard error, since the source
-/// files are outside our control).
-pub fn sync_file(index: &Index, agent: &'static str, path: &Path) -> bool {
-    let (mtime, size) = fingerprint(path);
-    let file_path = path.to_string_lossy().into_owned();
-    if !index.needs_sync(&file_path, mtime, size) {
-        return false;
-    }
+/// Dispatches to the right parser for `agent`, logging (debug builds only)
+/// and returning `None` on a file mid-write or genuinely malformed input —
+/// never treated as a hard error, since the source files are outside our
+/// control. Shared by `sync_file` and `sync_file_unlocked` so the two don't
+/// duplicate the dispatch table.
+fn parse_meta(agent: &'static str, path: &Path) -> Option<ParsedSession> {
     let parsed = match agent {
         "claude" => claude::parse_claude_meta(path),
         "codex" => codex::parse_codex_meta(path),
         "antigravity" => antigravity::parse_antigravity_meta(path),
         _ => None,
     };
-    let Some(session) = parsed else {
+    if parsed.is_none() {
         #[cfg(debug_assertions)]
         eprintln!("sessions_index: could not parse {agent} session at {}", path.display());
-        return false;
-    };
-    match index.upsert_session(&session, &file_path, mtime, size) {
+    }
+    parsed
+}
+
+/// Upserts `session`, logging (debug builds only) and returning `false`
+/// instead of propagating on a write failure — same never-a-hard-error
+/// stance as `parse_meta`. Shared by `sync_file` and `sync_file_unlocked`.
+fn commit(index: &Index, session: &ParsedSession, file_path: &str, mtime: i64, size: i64) -> bool {
+    match index.upsert_session(session, file_path, mtime, size) {
         Ok(()) => true,
         Err(err) => {
             #[cfg(debug_assertions)]
-            eprintln!("sessions_index: failed to upsert {}: {err}", path.display());
+            eprintln!("sessions_index: failed to upsert {file_path}: {err}");
             false
         }
     }
+}
+
+/// Re-parse and upsert one session file if its fingerprint changed since the
+/// last sync. Returns `true` when something was upserted; `false` when the
+/// cached fingerprint already matched (skip, the common case on a debounced
+/// re-scan) or when parsing failed / found no session.
+///
+/// Takes an already-open `&Index` and does its own locking-free work in one
+/// shot — fine for a caller syncing a single file under a lock it already
+/// holds. Every production caller now loops over many files, so they use
+/// `sync_file_unlocked` instead (it never holds the lock while parsing);
+/// this stays as the simplest primitive to unit-test the check/parse/upsert
+/// semantics against, decoupled from locking.
+#[allow(dead_code)]
+pub fn sync_file(index: &Index, agent: &'static str, path: &Path) -> bool {
+    let (mtime, size) = fingerprint(path);
+    let file_path = path.to_string_lossy().into_owned();
+    if !index.needs_sync(&file_path, mtime, size) {
+        return false;
+    }
+    let Some(session) = parse_meta(agent, path) else { return false };
+    commit(index, &session, &file_path, mtime, size)
+}
+
+/// Same contract as `sync_file`, but for a caller that holds the index
+/// behind a shared `Mutex` and is syncing many files in a row (a full sync
+/// or a watcher batch): the `needs_sync` check and the final upsert each
+/// take (and immediately release) the lock on their own, so parsing —
+/// which can take real time on a multi-MB transcript — never happens while
+/// the lock is held. That keeps `sessions_list` (which just needs a quick
+/// lock+query) from ever blocking behind a bulk parse.
+pub fn sync_file_unlocked(index: &Mutex<Index>, agent: &'static str, path: &Path) -> bool {
+    let (mtime, size) = fingerprint(path);
+    let file_path = path.to_string_lossy().into_owned();
+    let needs = index.lock().unwrap().needs_sync(&file_path, mtime, size);
+    if !needs {
+        return false;
+    }
+    let Some(session) = parse_meta(agent, path) else { return false };
+    let guard = index.lock().unwrap();
+    commit(&guard, &session, &file_path, mtime, size)
 }
 
 /// Full reconciliation: discover every session file under `home` (honoring
@@ -100,7 +143,15 @@ pub fn sync_file(index: &Index, agent: &'static str, path: &Path) -> bool {
 /// count. This is the entry point used at app startup and is not itself
 /// unit-tested against real env (see `sync_and_prune`, its hermetic core,
 /// exercised in tests via `scanner::discover_from_roots` instead).
-pub fn full_sync(index: &Index, home: &Path) -> usize {
+///
+/// Takes `&Mutex<Index>` rather than `&Index` on purpose: on a machine with
+/// years of history this walks and re-parses every session file, which can
+/// take a while, and it must never hold the lock for that whole run — doing
+/// so would block `sessions_list` (and therefore the UI) until the entire
+/// sync finished. Discovery itself needs no lock at all; each file is then
+/// synced via `sync_file_unlocked`, which locks only for its brief
+/// check-then-commit steps.
+pub fn full_sync(index: &Mutex<Index>, home: &Path) -> usize {
     sync_and_prune(index, scanner::discover(home))
 }
 
@@ -108,10 +159,11 @@ pub fn full_sync(index: &Index, home: &Path) -> usize {
 /// exercised in tests against an arbitrary hand-built file list without
 /// depending on (or mutating) the real `CLAUDE_CONFIG_DIR`/`CODEX_HOME`/
 /// `ANTIGRAVITY_CLI_DIR` process env.
-fn sync_and_prune(index: &Index, files: Vec<scanner::SessionFile>) -> usize {
+fn sync_and_prune(index: &Mutex<Index>, files: Vec<scanner::SessionFile>) -> usize {
     let existing: HashSet<String> = files.iter().map(|f| f.path.to_string_lossy().into_owned()).collect();
-    let dirty = files.iter().filter(|f| sync_file(index, f.agent, &f.path)).count();
-    let _ = index.prune_missing(&existing);
+    let dirty = files.iter().filter(|f| sync_file_unlocked(index, f.agent, &f.path)).count();
+    // Short lock, taken only after every file has already been synced.
+    let _ = index.lock().unwrap().prune_missing(&existing);
     dirty
 }
 
@@ -119,6 +171,7 @@ fn sync_and_prune(index: &Index, files: Vec<scanner::SessionFile>) -> usize {
 mod tests {
     use super::*;
     use crate::modules::sessions_index::scanner::{discover_from_roots, roots, SessionFile};
+    use std::sync::Arc;
 
     /// Discovers under `home` without ever touching the real
     /// `CLAUDE_CONFIG_DIR`/`CODEX_HOME`/`ANTIGRAVITY_CLI_DIR` process env,
@@ -241,6 +294,63 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    // --- sync_file_unlocked: same semantics, lock only held briefly --------
+
+    #[test]
+    fn sync_file_unlocked_matches_sync_file_semantics() {
+        let dir = temp_dir("unlocked");
+        let index = Mutex::new(Index::open(&dir.join("index.db")).unwrap());
+        let path = dir.join("sess-1.jsonl");
+        write(&path, &format!("{}\n", claude_line("sess-1", "hello")));
+
+        // First call upserts...
+        assert!(sync_file_unlocked(&index, "claude", &path));
+        let rows = index.lock().unwrap().list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "sess-1");
+        assert_eq!(rows[0].message_count, 1);
+
+        // ...an unchanged fingerprint on the next call is skipped, same as
+        // sync_file, even though the check and the (skipped) commit are two
+        // separate lock acquisitions here rather than one.
+        assert!(!sync_file_unlocked(&index, "claude", &path));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sync_file_unlocked_never_holds_the_lock_while_parsing() {
+        // A crude but real proof that sync_file_unlocked's needs_sync check
+        // and its commit are each their own critical section: acquire the
+        // lock from this thread, spawn a sync in the background (which must
+        // block on the very first `needs_sync` call), then release — the
+        // background sync should complete promptly once released, rather
+        // than requiring the whole file to already have been parsed before
+        // it could even ask for the lock.
+        let dir = temp_dir("no-hold");
+        let index = Arc::new(Mutex::new(Index::open(&dir.join("index.db")).unwrap()));
+        let path = dir.join("sess-1.jsonl");
+        write(&path, &format!("{}\n", claude_line("sess-1", "hello")));
+
+        let guard = index.lock().unwrap();
+        let index_bg = Arc::clone(&index);
+        let path_bg = path.clone();
+        let handle = std::thread::spawn(move || sync_file_unlocked(&index_bg, "claude", &path_bg));
+
+        // Give the background thread a moment to reach (and block on) the
+        // lock, then release it — if sync_file_unlocked tried to parse
+        // before acquiring the lock, this ordering wouldn't matter either
+        // way, but it does prove the call doesn't deadlock or require the
+        // lock for longer than this brief hold.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        drop(guard);
+
+        assert!(handle.join().unwrap());
+        assert_eq!(index.lock().unwrap().list().len(), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     // --- fingerprint: db + wal/shm companion summation ----------------------
 
     #[test]
@@ -313,11 +423,11 @@ mod tests {
         write(&session_a, &format!("{}\n", claude_line("sess-a", "hello a")));
         write(&session_b, &format!("{}\n", claude_line("sess-b", "hello b")));
 
-        let index = Index::open(&home.join("index.db")).unwrap();
+        let index = Mutex::new(Index::open(&home.join("index.db")).unwrap());
 
         let dirty = sync_and_prune(&index, discover_hermetic(&home));
         assert_eq!(dirty, 2);
-        let ids: HashSet<String> = index.list().into_iter().map(|s| s.id).collect();
+        let ids: HashSet<String> = index.lock().unwrap().list().into_iter().map(|s| s.id).collect();
         assert_eq!(ids, HashSet::from(["sess-a".to_string(), "sess-b".to_string()]));
 
         // Re-running with nothing changed on disk re-syncs nothing.
@@ -328,7 +438,7 @@ mod tests {
         std::fs::remove_file(&session_b).unwrap();
         let dirty = sync_and_prune(&index, discover_hermetic(&home));
         assert_eq!(dirty, 0); // nothing new to parse, only a prune
-        let ids: HashSet<String> = index.list().into_iter().map(|s| s.id).collect();
+        let ids: HashSet<String> = index.lock().unwrap().list().into_iter().map(|s| s.id).collect();
         assert_eq!(ids, HashSet::from(["sess-a".to_string()]));
 
         let _ = std::fs::remove_dir_all(&home);
@@ -339,14 +449,14 @@ mod tests {
         let home = temp_dir("full-sync-add");
         let session_a = home.join(".claude/projects/projA/session1.jsonl");
         write(&session_a, &format!("{}\n", claude_line("sess-a", "hello a")));
-        let index = Index::open(&home.join("index.db")).unwrap();
+        let index = Mutex::new(Index::open(&home.join("index.db")).unwrap());
 
         assert_eq!(sync_and_prune(&index, discover_hermetic(&home)), 1);
 
         let session_c = home.join(".claude/projects/projC/session3.jsonl");
         write(&session_c, &format!("{}\n", claude_line("sess-c", "hello c")));
         assert_eq!(sync_and_prune(&index, discover_hermetic(&home)), 1);
-        assert_eq!(index.list().len(), 2);
+        assert_eq!(index.lock().unwrap().list().len(), 2);
 
         let _ = std::fs::remove_dir_all(&home);
     }

--- a/src-tauri/src/modules/sessions_index/types.rs
+++ b/src-tauri/src/modules/sessions_index/types.rs
@@ -1,0 +1,60 @@
+//! Shared shapes for the sessions index: what parsers produce and what the
+//! frontend receives. Timestamps are epoch milliseconds (UTC); activity
+//! buckets use the local calendar so the heatmap matches the user's day.
+
+/// One agent's parsed session, ready to upsert into the index.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedSession {
+    pub id: String,
+    /// "claude" | "codex" | "antigravity"
+    pub agent: &'static str,
+    pub project_cwd: String,
+    pub title: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+    pub message_count: i64,
+    pub user_message_count: i64,
+    /// None when the source format exposes no token counts.
+    pub output_tokens: Option<i64>,
+    pub model: Option<String>,
+    /// Per local-day/hour message buckets, for the P2 heatmap.
+    pub activity: Vec<ActivityBucket>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ActivityBucket {
+    /// Local date, "YYYY-MM-DD".
+    pub date: String,
+    pub hour: u8,
+    pub messages: i64,
+    pub user_messages: i64,
+    pub output_tokens: i64,
+}
+
+/// What `sessions_list` returns to the frontend.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionSummary {
+    pub id: String,
+    pub agent: String,
+    pub project_cwd: String,
+    pub title: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+    pub message_count: i64,
+    pub user_message_count: i64,
+    pub output_tokens: Option<i64>,
+    pub model: Option<String>,
+    pub file_path: String,
+    pub pinned: bool,
+}
+
+/// One rendered message for the viewer, re-parsed from the source file on
+/// demand (the index never stores message bodies).
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct TranscriptMessage {
+    /// "user" | "assistant" | "tool" | "system"
+    pub role: String,
+    pub text: String,
+    pub timestamp: Option<i64>,
+    pub tool_name: Option<String>,
+}

--- a/src-tauri/src/modules/sessions_index/watch.rs
+++ b/src-tauri/src/modules/sessions_index/watch.rs
@@ -6,7 +6,8 @@
 //! `recv_timeout(500ms)` batches, maps each drained path back to its owning
 //! agent by matching it against the resolved root list (a `-wal`/`-shm`
 //! companion maps back to its `.db` first), re-syncs the dirty files via
-//! `sync::sync_file`, and emits one `sessions-index:updated` event per batch
+//! `sync::sync_file_unlocked` (which only ever locks the index briefly, never
+//! while parsing), and emits one `sessions-index:updated` event per batch
 //! that actually changed something — so a burst of writes from an actively
 //! streaming session collapses into a single frontend refresh instead of one
 //! per filesystem event.
@@ -27,7 +28,7 @@ use tauri::{AppHandle, Emitter};
 
 use super::index::Index;
 use super::scanner;
-use super::sync::sync_file;
+use super::sync::sync_file_unlocked;
 
 /// How long the worker thread waits for another event before flushing the
 /// batch it has collected so far.
@@ -148,20 +149,22 @@ fn drain_loop(
             batch.push(path);
         }
 
+        // Each file is synced via sync_file_unlocked, which locks the index
+        // only for its brief needs_sync check and its commit — never while
+        // parsing — so a burst of changed files never holds the lock for
+        // the whole batch (see sync.rs's doc comment on the same shape in
+        // full_sync).
         let mut dirty = 0usize;
-        {
-            let index = index.lock().unwrap();
-            let mut synced_this_batch: HashSet<PathBuf> = HashSet::new();
-            for path in batch {
-                let Some((agent, session_path)) = resolve(&roots, &path) else { continue };
-                // A single write can fire several raw events for the same
-                // file (data + metadata); only sync it once per batch.
-                if !synced_this_batch.insert(session_path.clone()) {
-                    continue;
-                }
-                if sync_file(&index, agent, &session_path) {
-                    dirty += 1;
-                }
+        let mut synced_this_batch: HashSet<PathBuf> = HashSet::new();
+        for path in batch {
+            let Some((agent, session_path)) = resolve(&roots, &path) else { continue };
+            // A single write can fire several raw events for the same
+            // file (data + metadata); only sync it once per batch.
+            if !synced_this_batch.insert(session_path.clone()) {
+                continue;
+            }
+            if sync_file_unlocked(&index, agent, &session_path) {
+                dirty += 1;
             }
         }
 

--- a/src-tauri/src/modules/sessions_index/watch.rs
+++ b/src-tauri/src/modules/sessions_index/watch.rs
@@ -1,1 +1,232 @@
-//! File watcher for tracking changes to session sources.
+//! Watches the three agent roots and re-syncs changed files, debounced.
+//!
+//! Every notify callback (one per watched root) just pushes the paths it saw
+//! onto a single shared mpsc channel — no work happens on the notify
+//! callback thread itself. A single worker thread drains that channel in
+//! `recv_timeout(500ms)` batches, maps each drained path back to its owning
+//! agent by matching it against the resolved root list (a `-wal`/`-shm`
+//! companion maps back to its `.db` first), re-syncs the dirty files via
+//! `sync::sync_file`, and emits one `sessions-index:updated` event per batch
+//! that actually changed something — so a burst of writes from an actively
+//! streaming session collapses into a single frontend refresh instead of one
+//! per filesystem event.
+//!
+//! This module is intentionally thin: the interesting logic (fingerprinting,
+//! parsing, upserting) lives in `sync.rs` and is unit-tested there. Only the
+//! pure path-resolution helpers here get their own tests; the watcher
+//! thread's timing/OS integration is exercised by hand, not in CI.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use tauri::{AppHandle, Emitter};
+
+use super::index::Index;
+use super::scanner;
+use super::sync::sync_file;
+
+/// How long the worker thread waits for another event before flushing the
+/// batch it has collected so far.
+const DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// Frontend event name: sessions changed on disk, refetch `sessions_list`.
+pub const UPDATED_EVENT: &str = "sessions-index:updated";
+
+#[derive(Clone, serde::Serialize)]
+struct UpdatedPayload {
+    count: usize,
+}
+
+/// Emits `UPDATED_EVENT`; also used by `mod.rs` after the initial full sync
+/// completes, so the startup sync and the debounced re-sync share one
+/// payload shape.
+pub(crate) fn emit_updated(app: &AppHandle, count: usize) {
+    let _ = app.emit(UPDATED_EVENT, UpdatedPayload { count });
+}
+
+/// Which `RecursiveMode` a given (agent, root) pair should be watched with.
+/// Claude's `projects/` root is recursive because new project directories
+/// appear over time; Codex's `sessions/` root is recursive for its
+/// `YYYY/MM/DD` layout, but `archived_sessions/` is flat; Antigravity's
+/// `conversations/` root is flat too.
+fn watch_mode(agent: &str, root: &Path) -> RecursiveMode {
+    match agent {
+        "claude" => RecursiveMode::Recursive,
+        "codex" if root.file_name().and_then(|n| n.to_str()) == Some("archived_sessions") => {
+            RecursiveMode::NonRecursive
+        }
+        "codex" => RecursiveMode::Recursive,
+        _ => RecursiveMode::NonRecursive,
+    }
+}
+
+/// Maps a raw changed path back to its `.db` file when it is actually a
+/// SQLite `-wal`/`-shm` companion (Antigravity CLI checkpoints those into
+/// the main file lazily, so a write can land on the companion only). Any
+/// other path is returned unchanged.
+fn strip_wal_shm(path: &Path) -> PathBuf {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return path.to_path_buf();
+    };
+    match name.strip_suffix("-wal").or_else(|| name.strip_suffix("-shm")) {
+        Some(base) => path.with_file_name(base),
+        None => path.to_path_buf(),
+    }
+}
+
+/// Resolves a raw changed path to the (agent, session file path) it belongs
+/// to, or `None` when it falls outside every watched root (e.g. a
+/// `.db-journal` companion, or a decoy file the scanner would also reject).
+fn resolve(roots: &[(&'static str, PathBuf)], changed_path: &Path) -> Option<(&'static str, PathBuf)> {
+    let mapped = strip_wal_shm(changed_path);
+    roots
+        .iter()
+        .find(|(_, root)| mapped.starts_with(root))
+        .map(|(agent, _)| (*agent, mapped))
+}
+
+/// Start watching every agent root that already exists under `home`, and
+/// return the live watcher handles — the caller must keep them alive (e.g.
+/// in app state); dropping one stops its OS-level subscription. Roots that
+/// don't exist yet (an agent the user has never run) are simply skipped,
+/// never an error.
+pub fn start(app: &AppHandle, home: &Path, index: Arc<Mutex<Index>>) -> Vec<RecommendedWatcher> {
+    let (tx, rx) = mpsc::channel::<PathBuf>();
+    let roots = scanner::roots_from_env(home);
+
+    let mut watchers = Vec::new();
+    for (agent, root) in &roots {
+        if !root.is_dir() {
+            continue;
+        }
+        let mode = watch_mode(agent, root);
+        let tx = tx.clone();
+        let built = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            // No work here beyond forwarding paths: parsing/upserting must
+            // never happen on notify's own callback thread.
+            if let Ok(event) = res {
+                for path in event.paths {
+                    let _ = tx.send(path);
+                }
+            }
+        });
+        let Ok(mut watcher) = built else { continue };
+        if watcher.watch(root, mode).is_ok() {
+            watchers.push(watcher);
+        }
+    }
+
+    let app = app.clone();
+    std::thread::spawn(move || drain_loop(app, index, roots, rx));
+
+    watchers
+}
+
+/// Drains the channel in `DEBOUNCE`-spaced batches for the lifetime of the
+/// app, syncing whatever changed and emitting at most one event per batch.
+/// Returns (ending the thread) once every sender has been dropped, i.e. every
+/// watcher this batch belongs to was torn down.
+fn drain_loop(
+    app: AppHandle,
+    index: Arc<Mutex<Index>>,
+    roots: Vec<(&'static str, PathBuf)>,
+    rx: mpsc::Receiver<PathBuf>,
+) {
+    loop {
+        let first = match rx.recv_timeout(DEBOUNCE) {
+            Ok(path) => path,
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => return,
+        };
+        let mut batch = vec![first];
+        // Drain whatever else has piled up without waiting for it.
+        while let Ok(path) = rx.try_recv() {
+            batch.push(path);
+        }
+
+        let mut dirty = 0usize;
+        {
+            let index = index.lock().unwrap();
+            let mut synced_this_batch: HashSet<PathBuf> = HashSet::new();
+            for path in batch {
+                let Some((agent, session_path)) = resolve(&roots, &path) else { continue };
+                // A single write can fire several raw events for the same
+                // file (data + metadata); only sync it once per batch.
+                if !synced_this_batch.insert(session_path.clone()) {
+                    continue;
+                }
+                if sync_file(&index, agent, &session_path) {
+                    dirty += 1;
+                }
+            }
+        }
+
+        // Only emit when the batch actually changed something the frontend
+        // would need to refetch; a batch of decoy/no-op events stays silent.
+        if dirty > 0 {
+            emit_updated(&app, dirty);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_roots() -> Vec<(&'static str, PathBuf)> {
+        vec![
+            ("claude", PathBuf::from("/home/u/.claude/projects")),
+            ("codex", PathBuf::from("/home/u/.codex/sessions")),
+            ("codex", PathBuf::from("/home/u/.codex/archived_sessions")),
+            ("antigravity", PathBuf::from("/home/u/.gemini/antigravity-cli/conversations")),
+        ]
+    }
+
+    #[test]
+    fn strip_wal_shm_maps_companions_back_to_the_db() {
+        assert_eq!(strip_wal_shm(Path::new("/a/convo.db-wal")), PathBuf::from("/a/convo.db"));
+        assert_eq!(strip_wal_shm(Path::new("/a/convo.db-shm")), PathBuf::from("/a/convo.db"));
+    }
+
+    #[test]
+    fn strip_wal_shm_leaves_other_paths_unchanged() {
+        assert_eq!(strip_wal_shm(Path::new("/a/convo.db")), PathBuf::from("/a/convo.db"));
+        assert_eq!(strip_wal_shm(Path::new("/a/session.jsonl")), PathBuf::from("/a/session.jsonl"));
+    }
+
+    #[test]
+    fn resolve_matches_a_path_under_its_owning_root() {
+        let roots = sample_roots();
+        let path = Path::new("/home/u/.claude/projects/projA/session1.jsonl");
+        assert_eq!(resolve(&roots, path), Some(("claude", path.to_path_buf())));
+    }
+
+    #[test]
+    fn resolve_maps_a_wal_companion_back_to_its_db_before_matching() {
+        let roots = sample_roots();
+        let wal = Path::new("/home/u/.gemini/antigravity-cli/conversations/convo1.db-wal");
+        let expected = PathBuf::from("/home/u/.gemini/antigravity-cli/conversations/convo1.db");
+        assert_eq!(resolve(&roots, wal), Some(("antigravity", expected)));
+    }
+
+    #[test]
+    fn resolve_returns_none_outside_every_root() {
+        let roots = sample_roots();
+        assert_eq!(resolve(&roots, Path::new("/home/u/unrelated/file.txt")), None);
+    }
+
+    #[test]
+    fn watch_mode_is_recursive_for_claude_and_codex_sessions_but_flat_for_the_rest() {
+        assert_eq!(watch_mode("claude", Path::new("/x/projects")), RecursiveMode::Recursive);
+        assert_eq!(watch_mode("codex", Path::new("/x/sessions")), RecursiveMode::Recursive);
+        assert_eq!(
+            watch_mode("codex", Path::new("/x/archived_sessions")),
+            RecursiveMode::NonRecursive
+        );
+        assert_eq!(watch_mode("antigravity", Path::new("/x/conversations")), RecursiveMode::NonRecursive);
+    }
+}

--- a/src-tauri/src/modules/sessions_index/watch.rs
+++ b/src-tauri/src/modules/sessions_index/watch.rs
@@ -65,17 +65,21 @@ fn watch_mode(agent: &str, root: &Path) -> RecursiveMode {
     }
 }
 
-/// Maps a raw changed path back to its `.db` file when it is actually a
-/// SQLite `-wal`/`-shm` companion (Antigravity CLI checkpoints those into
-/// the main file lazily, so a write can land on the companion only). Any
-/// other path is returned unchanged.
-fn strip_wal_shm(path: &Path) -> PathBuf {
-    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-        return path.to_path_buf();
-    };
-    match name.strip_suffix("-wal").or_else(|| name.strip_suffix("-shm")) {
-        Some(base) => path.with_file_name(base),
-        None => path.to_path_buf(),
+/// Maps a raw changed path back to its `.db` file when it is a SQLite `-wal`
+/// companion (Antigravity CLI checkpoints the WAL into the main file lazily,
+/// so a write can land on the companion only). A `-shm` companion returns
+/// `None` — SQLite touches shared memory merely from opening the database
+/// (even read-only, as our own parser does), so reacting to `-shm` events
+/// turns every re-parse into the trigger for the next one. Real data changes
+/// always come with a `.db` or `-wal` event. Any other path passes through.
+fn strip_wal_shm(path: &Path) -> Option<PathBuf> {
+    let name = path.file_name().and_then(|n| n.to_str())?;
+    if name.ends_with("-shm") {
+        return None;
+    }
+    match name.strip_suffix("-wal") {
+        Some(base) => Some(path.with_file_name(base)),
+        None => Some(path.to_path_buf()),
     }
 }
 
@@ -83,7 +87,7 @@ fn strip_wal_shm(path: &Path) -> PathBuf {
 /// to, or `None` when it falls outside every watched root (e.g. a
 /// `.db-journal` companion, or a decoy file the scanner would also reject).
 fn resolve(roots: &[(&'static str, PathBuf)], changed_path: &Path) -> Option<(&'static str, PathBuf)> {
-    let mapped = strip_wal_shm(changed_path);
+    let mapped = strip_wal_shm(changed_path)?;
     let (agent, root) = roots.iter().find(|(_, root)| mapped.starts_with(root))?;
     if !is_session_file(agent, root, &mapped) {
         return None;
@@ -230,15 +234,36 @@ mod tests {
     }
 
     #[test]
-    fn strip_wal_shm_maps_companions_back_to_the_db() {
-        assert_eq!(strip_wal_shm(Path::new("/a/convo.db-wal")), PathBuf::from("/a/convo.db"));
-        assert_eq!(strip_wal_shm(Path::new("/a/convo.db-shm")), PathBuf::from("/a/convo.db"));
+    fn strip_wal_shm_maps_a_wal_companion_back_to_the_db() {
+        assert_eq!(
+            strip_wal_shm(Path::new("/a/convo.db-wal")),
+            Some(PathBuf::from("/a/convo.db"))
+        );
+    }
+
+    #[test]
+    fn strip_wal_shm_drops_shm_events_entirely() {
+        // -shm changes are a side effect of merely opening the DB (our own
+        // parser included); reacting to them re-arms the sync loop forever.
+        assert_eq!(strip_wal_shm(Path::new("/a/convo.db-shm")), None);
     }
 
     #[test]
     fn strip_wal_shm_leaves_other_paths_unchanged() {
-        assert_eq!(strip_wal_shm(Path::new("/a/convo.db")), PathBuf::from("/a/convo.db"));
-        assert_eq!(strip_wal_shm(Path::new("/a/session.jsonl")), PathBuf::from("/a/session.jsonl"));
+        assert_eq!(strip_wal_shm(Path::new("/a/convo.db")), Some(PathBuf::from("/a/convo.db")));
+        assert_eq!(
+            strip_wal_shm(Path::new("/a/session.jsonl")),
+            Some(PathBuf::from("/a/session.jsonl"))
+        );
+    }
+
+    #[test]
+    fn resolve_ignores_shm_events() {
+        let roots = sample_roots();
+        assert_eq!(
+            resolve(&roots, Path::new("/home/u/.gemini/antigravity-cli/conversations/convo1.db-shm")),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/src/modules/sessions_index/watch.rs
+++ b/src-tauri/src/modules/sessions_index/watch.rs
@@ -84,10 +84,45 @@ fn strip_wal_shm(path: &Path) -> PathBuf {
 /// `.db-journal` companion, or a decoy file the scanner would also reject).
 fn resolve(roots: &[(&'static str, PathBuf)], changed_path: &Path) -> Option<(&'static str, PathBuf)> {
     let mapped = strip_wal_shm(changed_path);
-    roots
-        .iter()
-        .find(|(_, root)| mapped.starts_with(root))
-        .map(|(agent, _)| (*agent, mapped))
+    let (agent, root) = roots.iter().find(|(_, root)| mapped.starts_with(root))?;
+    if !is_session_file(agent, root, &mapped) {
+        return None;
+    }
+    Some((*agent, mapped))
+}
+
+/// Mirrors the scanner's per-agent discovery rules for a single changed path,
+/// so watcher events only re-sync files the scanner would also index. The
+/// recursive Claude watch otherwise floods the sync loop with `subagents/`
+/// and `tool-results/` companion writes — every one a wasted whole-file
+/// parse whose result is always `None` (their entries are all sidechain).
+fn is_session_file(agent: &str, root: &Path, path: &Path) -> bool {
+    let ext = path.extension().and_then(|e| e.to_str());
+    match agent {
+        // Only `<root>/<project-dir>/<session>.jsonl` — exactly two levels
+        // below the projects root, never inside a session's companion dirs.
+        "claude" => {
+            ext == Some("jsonl")
+                && path
+                    .parent()
+                    .and_then(Path::parent)
+                    .is_some_and(|grandparent| grandparent == root)
+        }
+        // Rollouts under sessions/YYYY/MM/DD, plain .jsonl in archived_sessions.
+        "codex" => {
+            ext == Some("jsonl")
+                && path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|name| {
+                        name.starts_with("rollout-")
+                            || root.file_name().and_then(|n| n.to_str()) == Some("archived_sessions")
+                    })
+        }
+        // The strip_wal_shm mapping already folded companions into the .db.
+        "antigravity" => ext == Some("db"),
+        _ => false,
+    }
 }
 
 /// Start watching every agent root that already exists under `home`, and
@@ -171,6 +206,11 @@ fn drain_loop(
         // Only emit when the batch actually changed something the frontend
         // would need to refetch; a batch of decoy/no-op events stays silent.
         if dirty > 0 {
+            eprintln!(
+                "[sessions] watch batch: {} synced of {} events",
+                dirty,
+                synced_this_batch.len()
+            );
             emit_updated(&app, dirty);
         }
     }
@@ -206,6 +246,38 @@ mod tests {
         let roots = sample_roots();
         let path = Path::new("/home/u/.claude/projects/projA/session1.jsonl");
         assert_eq!(resolve(&roots, path), Some(("claude", path.to_path_buf())));
+    }
+
+    #[test]
+    fn resolve_rejects_claude_companion_files_the_scanner_would_skip() {
+        let roots = sample_roots();
+        // Subagent transcripts and tool-result dumps live BELOW a session's
+        // companion dir; the recursive watch sees them but they are not
+        // sessions and must not trigger a re-sync.
+        assert_eq!(
+            resolve(&roots, Path::new("/home/u/.claude/projects/projA/sess-1/subagents/agent-x.jsonl")),
+            None
+        );
+        assert_eq!(
+            resolve(&roots, Path::new("/home/u/.claude/projects/projA/sess-1/tool-results/t1.txt")),
+            None
+        );
+        // A directory-level event on the project dir itself is not a session.
+        assert_eq!(resolve(&roots, Path::new("/home/u/.claude/projects/projA")), None);
+    }
+
+    #[test]
+    fn resolve_rejects_codex_non_rollout_noise_but_keeps_archived_jsonl() {
+        let roots = sample_roots();
+        assert_eq!(
+            resolve(&roots, Path::new("/home/u/.codex/sessions/2026/07/07/rollout-x.jsonl")),
+            Some(("codex", PathBuf::from("/home/u/.codex/sessions/2026/07/07/rollout-x.jsonl")))
+        );
+        assert_eq!(resolve(&roots, Path::new("/home/u/.codex/sessions/2026/07/07/notes.txt")), None);
+        assert_eq!(
+            resolve(&roots, Path::new("/home/u/.codex/archived_sessions/old.jsonl")),
+            Some(("codex", PathBuf::from("/home/u/.codex/archived_sessions/old.jsonl")))
+        );
     }
 
     #[test]

--- a/src-tauri/src/modules/sessions_index/watch.rs
+++ b/src-tauri/src/modules/sessions_index/watch.rs
@@ -1,0 +1,1 @@
+//! File watcher for tracking changes to session sources.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,11 +1,12 @@
 import { useTranslation } from "react-i18next";
-import { Bot, FolderTree, GitBranch, LayoutGrid, NotebookPen, Server, type LucideIcon } from "lucide-react";
+import { Bot, FolderTree, GitBranch, History, LayoutGrid, NotebookPen, Server, type LucideIcon } from "lucide-react";
 import { ExplorerView } from "@/modules/explorer/ExplorerView";
 import { SourceControlView } from "@/modules/source-control/SourceControlView";
 import { AIView } from "@/modules/ai/AIView";
 import { NotesSidebar } from "@/modules/notes/NotesSidebar";
 import { WorkspacePanel } from "@/modules/workspace/WorkspacePanel";
 import { ConnectionsPanel } from "@/modules/ssh/ConnectionsPanel";
+import { SessionsPanel } from "@/modules/sessions/SessionsPanel";
 import { Tooltip } from "@/components/Tooltip";
 import { useUiStore, type SidebarView } from "@/stores/uiStore";
 import { probeStart } from "@/lib/perfProbe";
@@ -23,6 +24,7 @@ const SIDEBAR_TABS: SidebarTab[] = [
   { id: "notes", icon: NotebookPen, labelKey: "nav.notes" },
   { id: "ai", icon: Bot, labelKey: "nav.ai" },
   { id: "connections", icon: Server, labelKey: "nav.connections" },
+  { id: "sessions", icon: History, labelKey: "nav.sessions" },
 ];
 
 /**
@@ -82,6 +84,7 @@ export function Sidebar() {
         {sidebarView === "notes" && <NotesSidebar />}
         {sidebarView === "ai" && <AIView />}
         {sidebarView === "connections" && <ConnectionsPanel />}
+        {sidebarView === "sessions" && <SessionsPanel />}
       </div>
     </div>
   );

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -6,6 +6,7 @@ import {
   GitBranch,
   GitCompare,
   Globe,
+  History,
   LayoutGrid,
   PanelLeft,
   Plus,
@@ -63,6 +64,8 @@ function tabIcon(kind: Tab["kind"]): LucideIcon {
       return GitBranch;
     case "diff":
       return GitCompare;
+    case "sessions":
+      return History;
     case "launcher":
       return LayoutGrid;
   }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -48,7 +48,8 @@
     "notes": "Notes",
     "gitGraph": "Git Graph",
     "settings": "Settings",
-    "connections": "Connections"
+    "connections": "Connections",
+    "sessions": "AI Sessions"
   },
   "statusBar": {
     "ready": "Ready",
@@ -254,5 +255,19 @@
       "thinking": "Thinking",
       "waiting-approval": "Needs Approval"
     }
+  },
+  "sessions": {
+    "live": "Live",
+    "pinned": "Pinned",
+    "searchPlaceholder": "Search sessions…",
+    "all": "All",
+    "empty": "No sessions found",
+    "messages": "{{count}} msgs",
+    "resume": "Resume",
+    "pin": "Pin",
+    "unpin": "Unpin",
+    "selectPrompt": "Select a session from the sidebar",
+    "resumeUnavailable": "Resume is not available for this agent",
+    "indexing": "Indexing sessions…"
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -235,7 +235,8 @@
       "editor": "File",
       "note": "Note",
       "preview": "Preview",
-      "git-graph": "Git Graph"
+      "git-graph": "Git Graph",
+      "sessions": "AI Sessions"
     },
     "spaces": "Groups",
     "newSpace": "New group",
@@ -269,10 +270,18 @@
     "selectPrompt": "Select a session from the sidebar",
     "resumeUnavailable": "Resume is not available for this agent",
     "indexing": "Indexing sessions…",
+    "totalCount": "{{count}} sessions indexed",
+    "loading": "Loading transcript…",
+    "loadError": "Couldn't load this transcript",
     "agents": {
       "claude": "Claude",
       "codex": "Codex",
       "antigravity": "Antigravity"
+    },
+    "roles": {
+      "user": "You",
+      "assistant": "Assistant",
+      "tool": "Tool"
     }
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -281,7 +281,14 @@
     "roles": {
       "user": "You",
       "assistant": "Assistant",
-      "tool": "Tool"
+      "tool": "Tool",
+      "system": "System"
+    },
+    "time": {
+      "justNow": "just now",
+      "minutesAgo": "{{count}}m ago",
+      "hoursAgo": "{{count}}h ago",
+      "daysAgo": "{{count}}d ago"
     }
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -289,6 +289,12 @@
       "minutesAgo": "{{count}}m ago",
       "hoursAgo": "{{count}}h ago",
       "daysAgo": "{{count}}d ago"
+    },
+    "injected": {
+      "teammate": "Teammate message",
+      "system-reminder": "System reminder",
+      "task-notification": "Task notification",
+      "command": "Command"
     }
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -268,6 +268,11 @@
     "unpin": "Unpin",
     "selectPrompt": "Select a session from the sidebar",
     "resumeUnavailable": "Resume is not available for this agent",
-    "indexing": "Indexing sessions…"
+    "indexing": "Indexing sessions…",
+    "agents": {
+      "claude": "Claude",
+      "codex": "Codex",
+      "antigravity": "Antigravity"
+    }
   }
 }

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -281,7 +281,14 @@
     "roles": {
       "user": "你",
       "assistant": "Assistant",
-      "tool": "工具"
+      "tool": "工具",
+      "system": "系統"
+    },
+    "time": {
+      "justNow": "剛剛",
+      "minutesAgo": "{{count}} 分鐘前",
+      "hoursAgo": "{{count}} 小時前",
+      "daysAgo": "{{count}} 天前"
     }
   }
 }

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -235,7 +235,8 @@
       "editor": "檔案",
       "note": "筆記",
       "preview": "網頁預覽",
-      "git-graph": "Git 線圖"
+      "git-graph": "Git 線圖",
+      "sessions": "AI 對話"
     },
     "spaces": "群組",
     "newSpace": "新增群組",
@@ -269,10 +270,18 @@
     "selectPrompt": "從側邊欄選一場對話",
     "resumeUnavailable": "這個 agent 不支援接續",
     "indexing": "正在建立索引…",
+    "totalCount": "已索引 {{count}} 場對話",
+    "loading": "正在載入對話記錄…",
+    "loadError": "無法載入這場對話記錄",
     "agents": {
       "claude": "Claude",
       "codex": "Codex",
       "antigravity": "Antigravity"
+    },
+    "roles": {
+      "user": "你",
+      "assistant": "Assistant",
+      "tool": "工具"
     }
   }
 }

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -289,6 +289,12 @@
       "minutesAgo": "{{count}} 分鐘前",
       "hoursAgo": "{{count}} 小時前",
       "daysAgo": "{{count}} 天前"
+    },
+    "injected": {
+      "teammate": "協作訊息",
+      "system-reminder": "系統提醒",
+      "task-notification": "背景任務通知",
+      "command": "指令"
     }
   }
 }

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -48,7 +48,8 @@
     "notes": "筆記",
     "gitGraph": "Git 線圖",
     "settings": "設定",
-    "connections": "SSH 連線"
+    "connections": "SSH 連線",
+    "sessions": "AI 對話"
   },
   "statusBar": {
     "ready": "就緒",
@@ -254,5 +255,19 @@
       "thinking": "思考中",
       "waiting-approval": "等待批准"
     }
+  },
+  "sessions": {
+    "live": "進行中",
+    "pinned": "已釘選",
+    "searchPlaceholder": "搜尋對話…",
+    "all": "全部",
+    "empty": "沒有符合的對話",
+    "messages": "{{count}} 則訊息",
+    "resume": "接續對話",
+    "pin": "釘選",
+    "unpin": "取消釘選",
+    "selectPrompt": "從側邊欄選一場對話",
+    "resumeUnavailable": "這個 agent 不支援接續",
+    "indexing": "正在建立索引…"
   }
 }

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -268,6 +268,11 @@
     "unpin": "取消釘選",
     "selectPrompt": "從側邊欄選一場對話",
     "resumeUnavailable": "這個 agent 不支援接續",
-    "indexing": "正在建立索引…"
+    "indexing": "正在建立索引…",
+    "agents": {
+      "claude": "Claude",
+      "codex": "Codex",
+      "antigravity": "Antigravity"
+    }
   }
 }

--- a/src/modules/sessions/SessionsPanel.test.tsx
+++ b/src/modules/sessions/SessionsPanel.test.tsx
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionsPanel } from "./SessionsPanel";
 import { useSessionsStore } from "./lib/sessionsStore";
 import type { SessionSummary } from "./lib/sessionsBridge";
+import { useTabsStore, type Tab } from "@/stores/tabsStore";
+import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
+import { leaf } from "@/modules/terminal/lib/terminalLayout";
 
 // vi.mock is hoisted to the top of the file, so mocks must be created with
 // vi.hoisted() to be accessible inside the factory callbacks.
@@ -84,6 +87,8 @@ describe("SessionsPanel", () => {
       agentFilter: "all",
       selectedId: null,
     });
+    useTabsStore.setState({ spaces: [], activeSpaceId: null, tabs: [], activeId: null });
+    useSessionStatusStore.setState({ statuses: {}, agents: {} });
   });
 
   it("starts the backend index and subscribes to updates on mount", async () => {
@@ -195,6 +200,44 @@ describe("SessionsPanel", () => {
     unmount();
 
     expect(mockUnlisten).toHaveBeenCalled();
+  });
+
+  it("hides the Live section when nothing is running", async () => {
+    await renderSettled();
+    expect(screen.queryByText("sessions.live")).not.toBeInTheDocument();
+  });
+
+  it("shows a running session in the Live section and jumps to its pane on click", async () => {
+    const tab: Tab = {
+      id: "tab-1",
+      spaceId: "space-1",
+      title: "My Terminal",
+      kind: "terminal",
+      paneTree: leaf("leaf-1", { kind: "terminal", cwd: "/proj" }),
+      activeLeafId: "leaf-1",
+      paneOrder: ["leaf-1"],
+    };
+    useTabsStore.setState({
+      spaces: [{ id: "space-1", name: "Space" }],
+      activeSpaceId: "space-1",
+      tabs: [tab],
+      activeId: null,
+    });
+    useSessionStatusStore.setState({
+      statuses: { "leaf-1": "thinking" },
+      agents: { "leaf-1": "claude" },
+    });
+
+    await renderSettled();
+
+    expect(screen.getByText("sessions.live")).toBeInTheDocument();
+    expect(screen.getByText("My Terminal")).toBeInTheDocument();
+    expect(screen.getByText("sessions.agents.claude", { selector: "span" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("My Terminal"));
+
+    expect(useTabsStore.getState().activeId).toBe("tab-1");
+    expect(useTabsStore.getState().tabs[0].activeLeafId).toBe("leaf-1");
   });
 
   it("releases the listener when unmounted before the subscription resolves", async () => {

--- a/src/modules/sessions/SessionsPanel.test.tsx
+++ b/src/modules/sessions/SessionsPanel.test.tsx
@@ -213,6 +213,26 @@ describe("SessionsPanel", () => {
     expect(useSessionsStore.getState().sessions[0].pinned).toBe(true);
   });
 
+  it("resumes a session via the row's resume button without selecting the row", async () => {
+    seedSessions([session({ id: "a", agent: "claude", project_cwd: "/repo/app" })]);
+    await renderSettled();
+
+    fireEvent.click(screen.getByRole("button", { name: "sessions.resume" }));
+
+    expect(useSessionsStore.getState().selectedId).toBe(null);
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].kind).toBe("terminal");
+    expect(tabs[0].cwd).toBe("/repo/app");
+  });
+
+  it("hides the resume button on rows for agents with no supported resume command", async () => {
+    seedSessions([session({ id: "a", agent: "antigravity" })]);
+    await renderSettled();
+
+    expect(screen.queryByRole("button", { name: "sessions.resume" })).not.toBeInTheDocument();
+  });
+
   it("unsubscribes from session updates on unmount", async () => {
     const { unmount } = await renderSettled();
     await waitFor(() => expect(mockListen).toHaveBeenCalled());

--- a/src/modules/sessions/SessionsPanel.test.tsx
+++ b/src/modules/sessions/SessionsPanel.test.tsx
@@ -127,11 +127,11 @@ describe("SessionsPanel", () => {
 
     expect(screen.getByText("sessions.pinned")).toBeInTheDocument();
     expect(screen.getByText("Fix flaky test")).toBeInTheDocument();
-    // "Codex"/"Claude" also appear as filter-chip button labels, so scope the
+    // Agent labels also appear as filter-chip button labels, so scope the
     // badge assertion to the <span> the row renders it in.
-    expect(screen.getByText("Codex", { selector: "span" })).toBeInTheDocument();
+    expect(screen.getByText("sessions.agents.codex", { selector: "span" })).toBeInTheDocument();
     expect(screen.getByText("Refactor bridge")).toBeInTheDocument();
-    expect(screen.getByText("Claude", { selector: "span" })).toBeInTheDocument();
+    expect(screen.getByText("sessions.agents.claude", { selector: "span" })).toBeInTheDocument();
     expect(screen.getByText(/tempo-term/)).toBeInTheDocument();
     expect(screen.getByText(/sessions\.messages:4/)).toBeInTheDocument();
   });
@@ -158,7 +158,7 @@ describe("SessionsPanel", () => {
     ]);
     await renderSettled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Codex", pressed: false }));
+    fireEvent.click(screen.getByRole("button", { name: "sessions.agents.codex", pressed: false }));
 
     expect(screen.getByText("Codex session")).toBeInTheDocument();
     expect(screen.queryByText("Claude session")).not.toBeInTheDocument();
@@ -171,6 +171,11 @@ describe("SessionsPanel", () => {
     fireEvent.click(screen.getByText("Deploy script"));
 
     expect(useSessionsStore.getState().selectedId).toBe("a");
+    // The selected row's button is announced as current to assistive tech.
+    expect(screen.getByText("Deploy script").closest("button")).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
   });
 
   it("toggles pin via the row's pin button without selecting the row", async () => {
@@ -190,5 +195,26 @@ describe("SessionsPanel", () => {
     unmount();
 
     expect(mockUnlisten).toHaveBeenCalled();
+  });
+
+  it("releases the listener when unmounted before the subscription resolves", async () => {
+    // Hold the listen promise open so unmount happens first — the race that
+    // fast sidebar-tab switching hits in the real app.
+    let resolveListen!: (fn: () => void) => void;
+    mockListen.mockImplementation(
+      () =>
+        new Promise<() => void>((resolve) => {
+          resolveListen = resolve;
+        }),
+    );
+    const { unmount } = render(<SessionsPanel />);
+
+    unmount();
+    expect(mockUnlisten).not.toHaveBeenCalled();
+
+    resolveListen(mockUnlisten);
+
+    // The late-arriving unlisten fn must still be invoked, not leaked.
+    await waitFor(() => expect(mockUnlisten).toHaveBeenCalled());
   });
 });

--- a/src/modules/sessions/SessionsPanel.test.tsx
+++ b/src/modules/sessions/SessionsPanel.test.tsx
@@ -183,6 +183,26 @@ describe("SessionsPanel", () => {
     );
   });
 
+  it("opens the sessions content tab on row click, reusing it on a second click", async () => {
+    seedSessions([
+      session({ id: "a", title: "Deploy script" }),
+      session({ id: "b", title: "Refactor bridge" }),
+    ]);
+    await renderSettled();
+
+    fireEvent.click(screen.getByText("Deploy script"));
+    const tabId = useTabsStore.getState().activeId;
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    expect(useTabsStore.getState().tabs[0].kind).toBe("sessions");
+
+    fireEvent.click(screen.getByText("Refactor bridge"));
+    // Selecting a second session focuses the same singleton tab instead of
+    // opening a new one.
+    expect(useSessionsStore.getState().selectedId).toBe("b");
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    expect(useTabsStore.getState().activeId).toBe(tabId);
+  });
+
   it("toggles pin via the row's pin button without selecting the row", async () => {
     seedSessions([session({ id: "a", title: "Deploy script", pinned: false })]);
     await renderSettled();

--- a/src/modules/sessions/SessionsPanel.test.tsx
+++ b/src/modules/sessions/SessionsPanel.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionsPanel } from "./SessionsPanel";
+import { useSessionsStore } from "./lib/sessionsStore";
+import type { SessionSummary } from "./lib/sessionsBridge";
+
+// vi.mock is hoisted to the top of the file, so mocks must be created with
+// vi.hoisted() to be accessible inside the factory callbacks.
+const { mockInvoke, mockListen, mockUnlisten, sessionsFixture } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+  mockListen: vi.fn(),
+  mockUnlisten: vi.fn(),
+  // Backs the "sessions_list" invoke response. Kept in sync with whatever a
+  // test seeds into the store, so the panel's own on-mount refresh resolves
+  // to the same fixture instead of clobbering it with stale/empty data.
+  sessionsFixture: { current: [] as SessionSummary[] },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string) => {
+    mockInvoke(cmd);
+    if (cmd === "sessions_list") {
+      return Promise.resolve(sessionsFixture.current);
+    }
+    return Promise.resolve(undefined);
+  },
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mockListen,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts?.count !== undefined ? `${key}:${opts.count}` : key,
+  }),
+}));
+
+function session(overrides: Partial<SessionSummary>): SessionSummary {
+  return {
+    id: "id",
+    agent: "claude",
+    project_cwd: "/Users/muki/project",
+    title: "Untitled",
+    started_at: 0,
+    ended_at: 0,
+    message_count: 0,
+    user_message_count: 0,
+    output_tokens: null,
+    model: null,
+    file_path: "/tmp/session.jsonl",
+    pinned: false,
+    ...overrides,
+  };
+}
+
+/** Seeds both the store and the mocked backend response, so the panel's own
+ *  fire-and-forget `start()` on mount can't race the test with different data. */
+function seedSessions(sessions: SessionSummary[]) {
+  sessionsFixture.current = sessions;
+  useSessionsStore.setState({ sessions, loaded: true });
+}
+
+/** Renders the panel and waits for its on-mount `start()` (and the resulting
+ *  `refresh()`) to settle, so later assertions never race a pending state
+ *  update — and so that update happens inside `waitFor`'s act() wrapper. */
+async function renderSettled() {
+  const result = render(<SessionsPanel />);
+  await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith("sessions_index_start"));
+  return result;
+}
+
+describe("SessionsPanel", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    mockListen.mockReset().mockResolvedValue(mockUnlisten);
+    mockUnlisten.mockReset();
+    sessionsFixture.current = [];
+    useSessionsStore.setState({
+      sessions: [],
+      loaded: false,
+      query: "",
+      agentFilter: "all",
+      selectedId: null,
+    });
+  });
+
+  it("starts the backend index and subscribes to updates on mount", async () => {
+    await renderSettled();
+    expect(mockListen).toHaveBeenCalledWith("sessions-index:updated", expect.any(Function));
+  });
+
+  it("shows the indexing placeholder before the store has loaded", async () => {
+    render(<SessionsPanel />);
+    // Assert before the on-mount start()/refresh() pipeline can resolve.
+    expect(screen.getByText("sessions.indexing")).toBeInTheDocument();
+    // Then drain it under act(), so it can't update state after this test
+    // ends and spill an act() warning into whichever test runs next.
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith("sessions_index_start"));
+  });
+
+  it("shows the empty state once loaded with no sessions", async () => {
+    seedSessions([]);
+    await renderSettled();
+    expect(screen.getByText("sessions.empty")).toBeInTheDocument();
+  });
+
+  it("renders pinned and history sections with agent badge, project, and message count", async () => {
+    const pinnedSession = session({
+      id: "p1",
+      title: "Fix flaky test",
+      pinned: true,
+      agent: "codex",
+      project_cwd: "/Users/muki/tempo-term",
+      message_count: 4,
+    });
+    const historySession = session({
+      id: "h1",
+      title: "Refactor bridge",
+      agent: "claude",
+      message_count: 2,
+    });
+    seedSessions([pinnedSession, historySession]);
+
+    await renderSettled();
+
+    expect(screen.getByText("sessions.pinned")).toBeInTheDocument();
+    expect(screen.getByText("Fix flaky test")).toBeInTheDocument();
+    // "Codex"/"Claude" also appear as filter-chip button labels, so scope the
+    // badge assertion to the <span> the row renders it in.
+    expect(screen.getByText("Codex", { selector: "span" })).toBeInTheDocument();
+    expect(screen.getByText("Refactor bridge")).toBeInTheDocument();
+    expect(screen.getByText("Claude", { selector: "span" })).toBeInTheDocument();
+    expect(screen.getByText(/tempo-term/)).toBeInTheDocument();
+    expect(screen.getByText(/sessions\.messages:4/)).toBeInTheDocument();
+  });
+
+  it("filters the list as the search query changes", async () => {
+    seedSessions([
+      session({ id: "a", title: "Deploy script" }),
+      session({ id: "b", title: "Unrelated" }),
+    ]);
+    await renderSettled();
+
+    fireEvent.change(screen.getByPlaceholderText("sessions.searchPlaceholder"), {
+      target: { value: "deploy" },
+    });
+
+    expect(screen.getByText("Deploy script")).toBeInTheDocument();
+    expect(screen.queryByText("Unrelated")).not.toBeInTheDocument();
+  });
+
+  it("filters the list by agent chip", async () => {
+    seedSessions([
+      session({ id: "a", title: "Claude session", agent: "claude" }),
+      session({ id: "b", title: "Codex session", agent: "codex" }),
+    ]);
+    await renderSettled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Codex", pressed: false }));
+
+    expect(screen.getByText("Codex session")).toBeInTheDocument();
+    expect(screen.queryByText("Claude session")).not.toBeInTheDocument();
+  });
+
+  it("selects a session on row click", async () => {
+    seedSessions([session({ id: "a", title: "Deploy script" })]);
+    await renderSettled();
+
+    fireEvent.click(screen.getByText("Deploy script"));
+
+    expect(useSessionsStore.getState().selectedId).toBe("a");
+  });
+
+  it("toggles pin via the row's pin button without selecting the row", async () => {
+    seedSessions([session({ id: "a", title: "Deploy script", pinned: false })]);
+    await renderSettled();
+
+    fireEvent.click(screen.getByRole("button", { name: "sessions.pin" }));
+
+    expect(useSessionsStore.getState().selectedId).toBe(null);
+    expect(useSessionsStore.getState().sessions[0].pinned).toBe(true);
+  });
+
+  it("unsubscribes from session updates on unmount", async () => {
+    const { unmount } = await renderSettled();
+    await waitFor(() => expect(mockListen).toHaveBeenCalled());
+
+    unmount();
+
+    expect(mockUnlisten).toHaveBeenCalled();
+  });
+});

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -1,0 +1,192 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { History, Pin, PinOff, Search } from "lucide-react";
+import { Tooltip } from "@/components/Tooltip";
+import { onSessionsUpdated, type SessionAgent, type SessionSummary } from "./lib/sessionsBridge";
+import { useSessionsStore, visibleSessions } from "./lib/sessionsStore";
+import { formatRelativeTime } from "./lib/relativeTime";
+
+/** Filter chip order, "all" first. */
+const AGENT_FILTERS: Array<SessionAgent | "all"> = ["all", "claude", "codex", "antigravity"];
+
+/** Display label and accent color per agent, reusing the theme's existing
+ *  semantic color tokens — none of these are agent-specific, they're just
+ *  distinct enough to tell the three badges apart at a glance. */
+const AGENT_BADGE: Record<SessionAgent, { label: string; className: string }> = {
+  claude: { label: "Claude", className: "text-accent" },
+  codex: { label: "Codex", className: "text-fg-subtle" },
+  antigravity: { label: "Antigravity", className: "text-warning" },
+};
+
+/** The last path segment of a cwd, for the row's secondary line. Split on
+ *  both separators so a Windows path (C:\...) basenames correctly too. */
+function basename(path: string): string {
+  const parts = path.split(/[/\\]/).filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}
+
+interface SessionRowProps {
+  session: SessionSummary;
+  selected: boolean;
+}
+
+function SessionRow({ session, selected }: SessionRowProps) {
+  const { t } = useTranslation();
+  const select = useSessionsStore((s) => s.select);
+  const togglePin = useSessionsStore((s) => s.togglePin);
+  const badge = AGENT_BADGE[session.agent];
+  const pinLabel = t(session.pinned ? "sessions.unpin" : "sessions.pin");
+
+  return (
+    <li className="group flex items-center">
+      <button
+        type="button"
+        onClick={() => select(session.id)}
+        className={`flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left ${
+          selected ? "bg-bg-elevated" : "hover:bg-bg-elevated"
+        }`}
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span className="min-w-0 truncate text-sm text-fg-muted group-hover:text-fg">
+              {session.title}
+            </span>
+            <span className={`shrink-0 text-[10px] font-medium uppercase ${badge.className}`}>
+              {badge.label}
+            </span>
+          </div>
+          <div className="truncate text-xs text-fg-subtle">
+            {basename(session.project_cwd)} · {formatRelativeTime(session.ended_at)} ·{" "}
+            {t("sessions.messages", { count: session.message_count })}
+          </div>
+        </div>
+      </button>
+      <div className="flex shrink-0 items-center opacity-0 pr-2 group-hover:opacity-100">
+        <Tooltip label={pinLabel}>
+          <button
+            type="button"
+            aria-label={pinLabel}
+            onClick={(e) => {
+              e.stopPropagation();
+              void togglePin(session.id);
+            }}
+            className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
+          >
+            {session.pinned ? <PinOff size={13} /> : <Pin size={13} />}
+          </button>
+        </Tooltip>
+      </div>
+    </li>
+  );
+}
+
+export function SessionsPanel() {
+  const { t } = useTranslation();
+  const sessions = useSessionsStore((s) => s.sessions);
+  const loaded = useSessionsStore((s) => s.loaded);
+  const query = useSessionsStore((s) => s.query);
+  const agentFilter = useSessionsStore((s) => s.agentFilter);
+  const selectedId = useSessionsStore((s) => s.selectedId);
+  const setQuery = useSessionsStore((s) => s.setQuery);
+  const setAgentFilter = useSessionsStore((s) => s.setAgentFilter);
+
+  useEffect(() => {
+    void useSessionsStore.getState().start();
+
+    let unlisten: (() => void) | undefined;
+    void onSessionsUpdated(() => {
+      void useSessionsStore.getState().refresh();
+    }).then((fn) => {
+      unlisten = fn;
+    });
+
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  const { pinned, history } = visibleSessions(sessions, query, agentFilter);
+  const isEmpty = pinned.length === 0 && history.length === 0;
+
+  return (
+    <div className="flex h-full flex-col bg-bg-inset">
+      <div className="flex h-9 shrink-0 items-center border-b border-border px-3">
+        <span className="text-xs font-semibold uppercase tracking-wide text-fg-subtle">
+          {t("nav.sessions")}
+        </span>
+      </div>
+
+      <div className="shrink-0 border-b border-border px-3 py-2">
+        <div className="flex items-center gap-2 rounded-md border border-border bg-bg px-2 py-1">
+          <Search size={13} className="shrink-0 text-fg-subtle" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t("sessions.searchPlaceholder")}
+            aria-label={t("sessions.searchPlaceholder")}
+            className="w-full bg-transparent text-sm text-fg outline-none placeholder:text-fg-subtle"
+          />
+        </div>
+        <div className="mt-2 flex flex-wrap items-center gap-1">
+          {AGENT_FILTERS.map((key) => (
+            <button
+              key={key}
+              type="button"
+              aria-pressed={agentFilter === key}
+              onClick={() => setAgentFilter(key)}
+              className={`rounded px-2 py-0.5 text-[11px] transition-colors ${
+                agentFilter === key ? "bg-bg-elevated text-fg" : "text-fg-subtle hover:text-fg"
+              }`}
+            >
+              {key === "all" ? t("sessions.all") : AGENT_BADGE[key].label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto py-1">
+        {/* Live section (Task 11 fills this in with in-progress agent sessions). */}
+
+        {!loaded ? (
+          <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+            <History size={28} className="text-fg-subtle" />
+            <p className="text-xs text-fg-subtle">{t("sessions.indexing")}</p>
+          </div>
+        ) : isEmpty ? (
+          <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+            <History size={28} className="text-fg-subtle" />
+            <p className="text-xs text-fg-subtle">{t("sessions.empty")}</p>
+          </div>
+        ) : (
+          <>
+            {pinned.length > 0 && (
+              <div>
+                <div className="px-3 py-1 text-[11px] font-semibold uppercase text-fg-subtle">
+                  {t("sessions.pinned")}
+                </div>
+                <ul>
+                  {pinned.map((session) => (
+                    <SessionRow
+                      key={session.id}
+                      session={session}
+                      selected={session.id === selectedId}
+                    />
+                  ))}
+                </ul>
+              </div>
+            )}
+            <ul>
+              {history.map((session) => (
+                <SessionRow
+                  key={session.id}
+                  session={session}
+                  selected={session.id === selectedId}
+                />
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -1,10 +1,13 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { History, Pin, PinOff, Search } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
+import { useTabsStore } from "@/stores/tabsStore";
+import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
 import { onSessionsUpdated, type SessionAgent, type SessionSummary } from "./lib/sessionsBridge";
 import { useSessionsStore, visibleSessions } from "./lib/sessionsStore";
 import { formatRelativeTime } from "./lib/relativeTime";
+import { deriveLiveSessions, type LiveSession } from "./lib/liveSessions";
 
 /** Filter chip order, "all" first. */
 const AGENT_FILTERS: Array<SessionAgent | "all"> = ["all", "claude", "codex", "antigravity"];
@@ -19,11 +22,93 @@ const AGENT_BADGE_CLASS: Record<SessionAgent, string> = {
   antigravity: "text-warning",
 };
 
+/** `AGENT_BADGE_CLASS` lookup for a live session's agent, which is a plain
+ *  `string | undefined` (see liveSessions.ts) rather than the narrower
+ *  `SessionAgent` union — the foreground poll that classifies a pane can
+ *  lag its status, so the value isn't always a known agent yet. */
+function agentBadgeClass(agent: string | undefined): string {
+  return agent && agent in AGENT_BADGE_CLASS ? AGENT_BADGE_CLASS[agent as SessionAgent] : "text-fg-subtle";
+}
+
+/** Status dot color, same semantic tokens as WorkspacePanel's `STATUS_STYLE`
+ *  badge (`src/modules/workspace/WorkspacePanel.tsx`) so a session reads the
+ *  same way whether it's seen from the workspace cards or this sidebar. */
+const STATUS_DOT_CLASS: Record<string, string> = {
+  active: "bg-accent",
+  thinking: "bg-fg-muted",
+  "waiting-approval": "bg-danger",
+  idle: "bg-warning",
+};
+
 /** The last path segment of a cwd, for the row's secondary line. Split on
  *  both separators so a Windows path (C:\...) basenames correctly too. */
 function basename(path: string): string {
   const parts = path.split(/[/\\]/).filter(Boolean);
   return parts[parts.length - 1] ?? path;
+}
+
+/** One running session pinned in the Live section: status dot, agent badge
+ *  (when the pane's agent is already classified), and the tab it lives in.
+ *  Clicking jumps straight to that pane. */
+function LiveRow({ session }: { session: LiveSession }) {
+  const { t } = useTranslation();
+  const setActive = useTabsStore((s) => s.setActive);
+  const setActiveLeaf = useTabsStore((s) => s.setActiveLeaf);
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => {
+          setActive(session.tabId);
+          setActiveLeaf(session.tabId, session.leafId);
+        }}
+        className="flex w-full min-w-0 items-center gap-2 px-3 py-1.5 text-left hover:bg-bg-elevated"
+      >
+        <span
+          aria-hidden="true"
+          className={`h-1.5 w-1.5 shrink-0 rounded-full ${STATUS_DOT_CLASS[session.status] ?? "bg-fg-subtle"}`}
+        />
+        {session.agent && (
+          <span className={`shrink-0 text-[10px] font-medium uppercase ${agentBadgeClass(session.agent)}`}>
+            {t(`sessions.agents.${session.agent}`)}
+          </span>
+        )}
+        <span className="min-w-0 flex-1 truncate text-sm text-fg-muted">{session.tabTitle}</span>
+      </button>
+    </li>
+  );
+}
+
+/** Running agent sessions, pinned above the indexed history so jumping back
+ *  to one in progress never waits for it to end and get indexed. Hidden
+ *  entirely when nothing is currently running. */
+function LiveSection() {
+  const { t } = useTranslation();
+  const tabs = useTabsStore((s) => s.tabs);
+  const statuses = useSessionStatusStore((s) => s.statuses);
+  const agents = useSessionStatusStore((s) => s.agents);
+  const liveSessions = useMemo(
+    () => deriveLiveSessions(tabs, statuses, agents),
+    [tabs, statuses, agents],
+  );
+
+  if (liveSessions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className="px-3 py-1 text-[11px] font-semibold uppercase text-fg-subtle">
+        {t("sessions.live")}
+      </div>
+      <ul>
+        {liveSessions.map((session) => (
+          <LiveRow key={session.leafId} session={session} />
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 interface SessionRowProps {
@@ -158,7 +243,7 @@ export function SessionsPanel() {
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto py-1">
-        {/* Live section (Task 11 fills this in with in-progress agent sessions). */}
+        <LiveSection />
 
         {!loaded ? (
           <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { History, Pin, PinOff, Search } from "lucide-react";
+import { History, Pin, PinOff, Play, Search } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
 import { useTabsStore } from "@/stores/tabsStore";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
@@ -9,6 +9,7 @@ import { useSessionsStore, visibleSessions } from "./lib/sessionsStore";
 import { formatRelativeTime } from "./lib/relativeTime";
 import { deriveLiveSessions, type LiveSession } from "./lib/liveSessions";
 import { AGENT_BADGE_CLASS, agentBadgeClass } from "./lib/agentBadge";
+import { resumeCommand, resumeSession } from "./lib/resume";
 
 /** Filter chip order, "all" first. */
 const AGENT_FILTERS: Array<SessionAgent | "all"> = ["all", "claude", "codex", "antigravity"];
@@ -105,6 +106,11 @@ function SessionRow({ session, selected }: SessionRowProps) {
   const togglePin = useSessionsStore((s) => s.togglePin);
   const openSessionsTab = useTabsStore((s) => s.openSessionsTab);
   const pinLabel = t(session.pinned ? "sessions.unpin" : "sessions.pin");
+  const resumeLabel = t("sessions.resume");
+  // Rows have no room to explain an unsupported agent, so the button is
+  // hidden outright here — the viewer header shows it disabled-with-tooltip
+  // instead, since there's space there for the explanation.
+  const canResume = resumeCommand(session.agent, session.id) !== null;
 
   return (
     <li className="group flex items-center">
@@ -137,6 +143,21 @@ function SessionRow({ session, selected }: SessionRowProps) {
         </div>
       </button>
       <div className="flex shrink-0 items-center opacity-0 pr-2 group-hover:opacity-100">
+        {canResume && (
+          <Tooltip label={resumeLabel}>
+            <button
+              type="button"
+              aria-label={resumeLabel}
+              onClick={(e) => {
+                e.stopPropagation();
+                resumeSession(session);
+              }}
+              className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
+            >
+              <Play size={13} />
+            </button>
+          </Tooltip>
+        )}
         <Tooltip label={pinLabel}>
           <button
             type="button"

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -8,27 +8,10 @@ import { onSessionsUpdated, type SessionAgent, type SessionSummary } from "./lib
 import { useSessionsStore, visibleSessions } from "./lib/sessionsStore";
 import { formatRelativeTime } from "./lib/relativeTime";
 import { deriveLiveSessions, type LiveSession } from "./lib/liveSessions";
+import { AGENT_BADGE_CLASS, agentBadgeClass } from "./lib/agentBadge";
 
 /** Filter chip order, "all" first. */
 const AGENT_FILTERS: Array<SessionAgent | "all"> = ["all", "claude", "codex", "antigravity"];
-
-/** Badge color per agent, reusing the theme's existing semantic color
- *  tokens — none of these are agent-specific, they're just distinct enough
- *  to tell the three badges apart at a glance. Display labels live in i18n
- *  under `sessions.agents.*`. */
-const AGENT_BADGE_CLASS: Record<SessionAgent, string> = {
-  claude: "text-accent",
-  codex: "text-fg-subtle",
-  antigravity: "text-warning",
-};
-
-/** `AGENT_BADGE_CLASS` lookup for a live session's agent, which is a plain
- *  `string | undefined` (see liveSessions.ts) rather than the narrower
- *  `SessionAgent` union — the foreground poll that classifies a pane can
- *  lag its status, so the value isn't always a known agent yet. */
-function agentBadgeClass(agent: string | undefined): string {
-  return agent && agent in AGENT_BADGE_CLASS ? AGENT_BADGE_CLASS[agent as SessionAgent] : "text-fg-subtle";
-}
 
 /** Status dot color, same semantic tokens as WorkspacePanel's `STATUS_STYLE`
  *  badge (`src/modules/workspace/WorkspacePanel.tsx`) so a session reads the
@@ -120,6 +103,7 @@ function SessionRow({ session, selected }: SessionRowProps) {
   const { t } = useTranslation();
   const select = useSessionsStore((s) => s.select);
   const togglePin = useSessionsStore((s) => s.togglePin);
+  const openSessionsTab = useTabsStore((s) => s.openSessionsTab);
   const pinLabel = t(session.pinned ? "sessions.unpin" : "sessions.pin");
 
   return (
@@ -127,7 +111,10 @@ function SessionRow({ session, selected }: SessionRowProps) {
       <button
         type="button"
         aria-current={selected ? "true" : undefined}
-        onClick={() => select(session.id)}
+        onClick={() => {
+          select(session.id);
+          openSessionsTab();
+        }}
         className={`flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left ${
           selected ? "bg-bg-elevated" : "hover:bg-bg-elevated"
         }`}

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -137,7 +137,7 @@ function SessionRow({ session, selected }: SessionRowProps) {
             </span>
           </div>
           <div className="truncate text-xs text-fg-subtle">
-            {basename(session.project_cwd)} · {formatRelativeTime(session.ended_at)} ·{" "}
+            {basename(session.project_cwd)} · {formatRelativeTime(session.ended_at, t)} ·{" "}
             {t("sessions.messages", { count: session.message_count })}
           </div>
         </div>

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -9,13 +9,14 @@ import { formatRelativeTime } from "./lib/relativeTime";
 /** Filter chip order, "all" first. */
 const AGENT_FILTERS: Array<SessionAgent | "all"> = ["all", "claude", "codex", "antigravity"];
 
-/** Display label and accent color per agent, reusing the theme's existing
- *  semantic color tokens — none of these are agent-specific, they're just
- *  distinct enough to tell the three badges apart at a glance. */
-const AGENT_BADGE: Record<SessionAgent, { label: string; className: string }> = {
-  claude: { label: "Claude", className: "text-accent" },
-  codex: { label: "Codex", className: "text-fg-subtle" },
-  antigravity: { label: "Antigravity", className: "text-warning" },
+/** Badge color per agent, reusing the theme's existing semantic color
+ *  tokens — none of these are agent-specific, they're just distinct enough
+ *  to tell the three badges apart at a glance. Display labels live in i18n
+ *  under `sessions.agents.*`. */
+const AGENT_BADGE_CLASS: Record<SessionAgent, string> = {
+  claude: "text-accent",
+  codex: "text-fg-subtle",
+  antigravity: "text-warning",
 };
 
 /** The last path segment of a cwd, for the row's secondary line. Split on
@@ -34,13 +35,13 @@ function SessionRow({ session, selected }: SessionRowProps) {
   const { t } = useTranslation();
   const select = useSessionsStore((s) => s.select);
   const togglePin = useSessionsStore((s) => s.togglePin);
-  const badge = AGENT_BADGE[session.agent];
   const pinLabel = t(session.pinned ? "sessions.unpin" : "sessions.pin");
 
   return (
     <li className="group flex items-center">
       <button
         type="button"
+        aria-current={selected ? "true" : undefined}
         onClick={() => select(session.id)}
         className={`flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left ${
           selected ? "bg-bg-elevated" : "hover:bg-bg-elevated"
@@ -51,8 +52,10 @@ function SessionRow({ session, selected }: SessionRowProps) {
             <span className="min-w-0 truncate text-sm text-fg-muted group-hover:text-fg">
               {session.title}
             </span>
-            <span className={`shrink-0 text-[10px] font-medium uppercase ${badge.className}`}>
-              {badge.label}
+            <span
+              className={`shrink-0 text-[10px] font-medium uppercase ${AGENT_BADGE_CLASS[session.agent]}`}
+            >
+              {t(`sessions.agents.${session.agent}`)}
             </span>
           </div>
           <div className="truncate text-xs text-fg-subtle">
@@ -93,14 +96,24 @@ export function SessionsPanel() {
   useEffect(() => {
     void useSessionsStore.getState().start();
 
+    // The subscription resolves asynchronously. If the panel unmounts before
+    // it lands (fast sidebar-tab switching — the panel is conditionally
+    // rendered), release the listener the moment it arrives instead of
+    // leaking it for the rest of the app's lifetime.
+    let disposed = false;
     let unlisten: (() => void) | undefined;
     void onSessionsUpdated(() => {
       void useSessionsStore.getState().refresh();
     }).then((fn) => {
-      unlisten = fn;
+      if (disposed) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
     });
 
     return () => {
+      disposed = true;
       unlisten?.();
     };
   }, []);
@@ -138,7 +151,7 @@ export function SessionsPanel() {
                 agentFilter === key ? "bg-bg-elevated text-fg" : "text-fg-subtle hover:text-fg"
               }`}
             >
-              {key === "all" ? t("sessions.all") : AGENT_BADGE[key].label}
+              {key === "all" ? t("sessions.all") : t(`sessions.agents.${key}`)}
             </button>
           ))}
         </div>

--- a/src/modules/sessions/SessionsTabContent.test.tsx
+++ b/src/modules/sessions/SessionsTabContent.test.tsx
@@ -1,0 +1,186 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionsTabContent } from "./SessionsTabContent";
+import { useSessionsStore } from "./lib/sessionsStore";
+import type { SessionSummary, TranscriptMessage } from "./lib/sessionsBridge";
+
+// vi.mock is hoisted to the top of the file, so mocks must be created with
+// vi.hoisted() to be accessible inside the factory callbacks.
+const { mockInvoke, transcripts } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+  // Backs "sessions_get" invoke responses per session id. Each entry is a
+  // resolver the test controls directly, so responses can be made to land in
+  // any order (needed for the stale-response race test below).
+  transcripts: new Map<string, Promise<TranscriptMessage[]>>(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: { id?: string }) => {
+    mockInvoke(cmd, args);
+    if (cmd === "sessions_get" && args?.id) {
+      return transcripts.get(args.id) ?? Promise.resolve([]);
+    }
+    return Promise.resolve(undefined);
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts?.count !== undefined ? `${key}:${opts.count}` : key,
+  }),
+}));
+
+function session(overrides: Partial<SessionSummary>): SessionSummary {
+  return {
+    id: "id",
+    agent: "claude",
+    project_cwd: "/Users/muki/project",
+    title: "Untitled",
+    started_at: 0,
+    ended_at: 0,
+    message_count: 0,
+    user_message_count: 0,
+    output_tokens: null,
+    model: null,
+    file_path: "/tmp/session.jsonl",
+    pinned: false,
+    ...overrides,
+  };
+}
+
+function message(overrides: Partial<TranscriptMessage>): TranscriptMessage {
+  return {
+    role: "user",
+    text: "hello",
+    timestamp: null,
+    tool_name: null,
+    ...overrides,
+  };
+}
+
+describe("SessionsTabContent", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    transcripts.clear();
+    useSessionsStore.setState({
+      sessions: [],
+      loaded: false,
+      query: "",
+      agentFilter: "all",
+      selectedId: null,
+    });
+  });
+
+  it("shows the select prompt and total session count when nothing is selected", () => {
+    useSessionsStore.setState({
+      sessions: [session({ id: "a" }), session({ id: "b" })],
+      selectedId: null,
+    });
+
+    render(<SessionsTabContent />);
+
+    expect(screen.getByText("sessions.selectPrompt")).toBeInTheDocument();
+    expect(screen.getByText("sessions.totalCount:2")).toBeInTheDocument();
+  });
+
+  it("fetches and renders the transcript for the selected session", async () => {
+    const target = session({ id: "a", title: "Fix flaky test", agent: "codex" });
+    useSessionsStore.setState({ sessions: [target], selectedId: "a" });
+    transcripts.set(
+      "a",
+      Promise.resolve([
+        message({ role: "user", text: "Why is this test flaky?" }),
+        message({ role: "assistant", text: "Let me investigate." }),
+        message({ role: "tool", text: "grep output here", tool_name: "grep" }),
+        message({ role: "system", text: "Session resumed." }),
+      ]),
+    );
+
+    render(<SessionsTabContent />);
+
+    expect(mockInvoke).toHaveBeenCalledWith("sessions_get", { id: "a" });
+    await waitFor(() => expect(screen.getByText("Why is this test flaky?")).toBeInTheDocument());
+
+    expect(screen.getByText("Fix flaky test")).toBeInTheDocument();
+    expect(screen.getByText("sessions.agents.codex")).toBeInTheDocument();
+    expect(screen.getByText("/Users/muki/project")).toBeInTheDocument();
+    expect(screen.getByText("Let me investigate.")).toBeInTheDocument();
+    expect(screen.getByText("grep")).toBeInTheDocument();
+    expect(screen.getByText("Session resumed.")).toBeInTheDocument();
+  });
+
+  it("shows a loading indicator while the transcript is in flight", async () => {
+    useSessionsStore.setState({ sessions: [session({ id: "a" })], selectedId: "a" });
+    let resolve!: (messages: TranscriptMessage[]) => void;
+    transcripts.set(
+      "a",
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+
+    render(<SessionsTabContent />);
+
+    expect(screen.getByText("sessions.loading")).toBeInTheDocument();
+
+    resolve([message({ text: "done loading" })]);
+    await waitFor(() => expect(screen.getByText("done loading")).toBeInTheDocument());
+    expect(screen.queryByText("sessions.loading")).not.toBeInTheDocument();
+  });
+
+  it("keeps the previous transcript on screen and shows a muted error line when a new selection fails to load", async () => {
+    const sessionA = session({ id: "a" });
+    const sessionB = session({ id: "b" });
+    useSessionsStore.setState({ sessions: [sessionA, sessionB], selectedId: "a" });
+    transcripts.set("a", Promise.resolve([message({ text: "first load" })]));
+    const { rerender } = render(<SessionsTabContent />);
+    await waitFor(() => expect(screen.getByText("first load")).toBeInTheDocument());
+
+    // Switching to session b, whose fetch fails.
+    transcripts.set("b", Promise.reject(new Error("disk read failed")));
+    act(() => {
+      useSessionsStore.setState({ selectedId: "b" });
+    });
+    rerender(<SessionsTabContent />);
+
+    await waitFor(() =>
+      expect(screen.getByText("sessions.loadError: disk read failed")).toBeInTheDocument(),
+    );
+    // The transcript already on screen is untouched by the failed fetch.
+    expect(screen.getByText("first load")).toBeInTheDocument();
+  });
+
+  it("ignores a stale transcript response for a session the user has already navigated away from", async () => {
+    const sessionA = session({ id: "a" });
+    const sessionB = session({ id: "b" });
+    useSessionsStore.setState({ sessions: [sessionA, sessionB], selectedId: "a" });
+
+    let resolveA!: (messages: TranscriptMessage[]) => void;
+    transcripts.set(
+      "a",
+      new Promise((r) => {
+        resolveA = r;
+      }),
+    );
+    transcripts.set("b", Promise.resolve([message({ text: "session b message" })]));
+
+    const { rerender } = render(<SessionsTabContent />);
+
+    // Navigate to session b before a's fetch resolves.
+    act(() => {
+      useSessionsStore.setState({ selectedId: "b" });
+    });
+    rerender(<SessionsTabContent />);
+    await waitFor(() => expect(screen.getByText("session b message")).toBeInTheDocument());
+
+    // a's stale response now lands — it must not clobber b's transcript.
+    await act(async () => {
+      resolveA([message({ text: "session a message" })]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("session b message")).toBeInTheDocument();
+    expect(screen.queryByText("session a message")).not.toBeInTheDocument();
+  });
+});

--- a/src/modules/sessions/SessionsTabContent.test.tsx
+++ b/src/modules/sessions/SessionsTabContent.test.tsx
@@ -132,6 +132,31 @@ describe("SessionsTabContent", () => {
     expect(screen.getByText("please make **this** bold")).toBeInTheDocument();
   });
 
+  it("collapses injected harness turns behind a labelled card", async () => {
+    useSessionsStore.setState({ sessions: [session({ id: "a" })], selectedId: "a" });
+    transcripts.set(
+      "a",
+      Promise.resolve([
+        message({ role: "user", text: "real question" }),
+        message({
+          role: "injected",
+          text: "Another Claude session sent a message:\n## report with **bold**",
+          tool_name: "teammate",
+        }),
+      ]),
+    );
+
+    render(<SessionsTabContent />);
+
+    await waitFor(() => expect(screen.getByText("real question")).toBeInTheDocument());
+    // Collapsed by default: the source label is visible, the body is inside
+    // a <details> and renders as markdown when expanded.
+    const summary = screen.getByText("sessions.injected.teammate");
+    expect(summary.closest("details")).not.toBeNull();
+    // The body renders as markdown: "## report…" becomes a heading.
+    expect(screen.getByRole("heading", { level: 2, name: /report with/ })).toBeInTheDocument();
+  });
+
   it("shows a loading indicator while the transcript is in flight", async () => {
     useSessionsStore.setState({ sessions: [session({ id: "a" })], selectedId: "a" });
     let resolve!: (messages: TranscriptMessage[]) => void;

--- a/src/modules/sessions/SessionsTabContent.test.tsx
+++ b/src/modules/sessions/SessionsTabContent.test.tsx
@@ -112,6 +112,26 @@ describe("SessionsTabContent", () => {
     expect(screen.getByText("Session resumed.")).toBeInTheDocument();
   });
 
+  it("renders assistant messages as markdown but keeps user messages plain", async () => {
+    useSessionsStore.setState({ sessions: [session({ id: "a" })], selectedId: "a" });
+    transcripts.set(
+      "a",
+      Promise.resolve([
+        message({ role: "user", text: "please make **this** bold" }),
+        message({ role: "assistant", text: "Some **bold** and `code` here." }),
+      ]),
+    );
+
+    render(<SessionsTabContent />);
+
+    await waitFor(() => expect(screen.getByText("bold")).toBeInTheDocument());
+    // Assistant markdown is rendered: **bold** becomes a <strong> element.
+    expect(screen.getByText("bold").tagName).toBe("STRONG");
+    expect(screen.getByText("code").tagName).toBe("CODE");
+    // The user's own text is never interpreted as markdown.
+    expect(screen.getByText("please make **this** bold")).toBeInTheDocument();
+  });
+
   it("shows a loading indicator while the transcript is in flight", async () => {
     useSessionsStore.setState({ sessions: [session({ id: "a" })], selectedId: "a" });
     let resolve!: (messages: TranscriptMessage[]) => void;

--- a/src/modules/sessions/SessionsTabContent.test.tsx
+++ b/src/modules/sessions/SessionsTabContent.test.tsx
@@ -1,7 +1,8 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionsTabContent } from "./SessionsTabContent";
 import { useSessionsStore } from "./lib/sessionsStore";
+import { useTabsStore } from "@/stores/tabsStore";
 import type { SessionSummary, TranscriptMessage } from "./lib/sessionsBridge";
 
 // vi.mock is hoisted to the top of the file, so mocks must be created with
@@ -70,6 +71,7 @@ describe("SessionsTabContent", () => {
       agentFilter: "all",
       selectedId: null,
     });
+    useTabsStore.setState({ spaces: [], activeSpaceId: null, tabs: [], activeId: null });
   });
 
   it("shows the select prompt and total session count when nothing is selected", () => {
@@ -182,5 +184,34 @@ describe("SessionsTabContent", () => {
 
     expect(screen.getByText("session b message")).toBeInTheDocument();
     expect(screen.queryByText("session a message")).not.toBeInTheDocument();
+  });
+
+  it("resumes a claude session via the header button, opening a new terminal tab at its project cwd", async () => {
+    const target = session({ id: "a", agent: "claude", project_cwd: "/repo/app" });
+    useSessionsStore.setState({ sessions: [target], selectedId: "a" });
+    transcripts.set("a", Promise.resolve([]));
+
+    render(<SessionsTabContent />);
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith("sessions_get", { id: "a" }));
+
+    const button = screen.getByRole("button", { name: "sessions.resume" });
+    expect(button).not.toBeDisabled();
+    fireEvent.click(button);
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].kind).toBe("terminal");
+    expect(tabs[0].cwd).toBe("/repo/app");
+  });
+
+  it("disables the header resume button for antigravity sessions instead of hiding it", async () => {
+    const target = session({ id: "a", agent: "antigravity" });
+    useSessionsStore.setState({ sessions: [target], selectedId: "a" });
+    transcripts.set("a", Promise.resolve([]));
+
+    render(<SessionsTabContent />);
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith("sessions_get", { id: "a" }));
+
+    expect(screen.getByRole("button", { name: "sessions.resume" })).toBeDisabled();
   });
 });

--- a/src/modules/sessions/SessionsTabContent.tsx
+++ b/src/modules/sessions/SessionsTabContent.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { History, Loader2, Pin, PinOff } from "lucide-react";
+import { History, Loader2, Pin, PinOff, Play } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
 import { sessionsGet, type TranscriptMessage } from "./lib/sessionsBridge";
 import { useSessionsStore } from "./lib/sessionsStore";
 import { formatRelativeTime } from "./lib/relativeTime";
 import { AGENT_BADGE_CLASS } from "./lib/agentBadge";
+import { resumeCommand, resumeSession } from "./lib/resume";
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -139,8 +140,26 @@ export function SessionsTabContent() {
             <p className="truncate text-xs text-fg-subtle">{session.project_cwd}</p>
           </div>
           <div className="flex shrink-0 items-center gap-1">
-            {/* Resume (re-attach this session to a live agent process) ships
-                in Task 13 — this header only exposes pin for now. */}
+            {/* Header keeps Resume visible-but-disabled for antigravity
+                (tooltip explains why) instead of hiding it — rows hide it
+                outright, since there's no room there for an explanation. */}
+            <Tooltip
+              label={
+                resumeCommand(session.agent, session.id) === null
+                  ? t("sessions.resumeUnavailable")
+                  : t("sessions.resume")
+              }
+            >
+              <button
+                type="button"
+                aria-label={t("sessions.resume")}
+                disabled={resumeCommand(session.agent, session.id) === null}
+                onClick={() => resumeSession(session)}
+                className="rounded p-1 text-fg-subtle hover:bg-bg-elevated hover:text-fg disabled:pointer-events-none disabled:opacity-40"
+              >
+                <Play size={14} />
+              </button>
+            </Tooltip>
             <Tooltip label={t(session.pinned ? "sessions.unpin" : "sessions.pin")}>
               <button
                 type="button"

--- a/src/modules/sessions/SessionsTabContent.tsx
+++ b/src/modules/sessions/SessionsTabContent.tsx
@@ -40,6 +40,21 @@ function TranscriptEntry({ message }: { message: TranscriptMessage }) {
     );
   }
 
+  if (message.role === "injected") {
+    // A harness-generated turn (teammate report, system reminder, …):
+    // collapsed by default so long injected reports never bury the real
+    // conversation; the expanded body renders as markdown.
+    const source = message.tool_name ?? "teammate";
+    return (
+      <details className="rounded-md border border-border bg-bg-inset px-3 py-2">
+        <summary className="cursor-pointer select-none text-xs font-medium text-fg-subtle">
+          {t(`sessions.injected.${source}`)}
+        </summary>
+        <MarkdownView content={message.text} className="mt-2 text-sm" />
+      </details>
+    );
+  }
+
   if (message.role === "system") {
     return <p className="text-xs italic text-fg-subtle">{message.text}</p>;
   }

--- a/src/modules/sessions/SessionsTabContent.tsx
+++ b/src/modules/sessions/SessionsTabContent.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { History, Loader2, Pin, PinOff, Play } from "lucide-react";
+import { MarkdownView } from "@/components/MarkdownView";
 import { Tooltip } from "@/components/Tooltip";
 import { sessionsGet, type TranscriptMessage } from "./lib/sessionsBridge";
 import { useSessionsStore } from "./lib/sessionsStore";
@@ -17,9 +18,9 @@ function getErrorMessage(error: unknown): string {
 
 /**
  * One transcript entry, styled by role instead of as a chat bubble: a left
- * accent bar marks the user's own turns, the assistant's replies are plain
- * text, a tool call collapses behind its tool name, and system notices are
- * muted italic. Mirrors how `SessionRow` in SessionsPanel keeps chrome
+ * accent bar marks the user's own turns, the assistant's replies render as
+ * markdown, a tool call collapses behind its tool name, and system notices
+ * are muted italic. Mirrors how `SessionRow` in SessionsPanel keeps chrome
  * minimal — this is a transcript, not a chat UI.
  */
 function TranscriptEntry({ message }: { message: TranscriptMessage }) {
@@ -51,7 +52,14 @@ function TranscriptEntry({ message }: { message: TranscriptMessage }) {
         <span>{t(`sessions.roles.${message.role}`)}</span>
         {timestamp && <span className="font-normal normal-case">{timestamp}</span>}
       </div>
-      <p className="mt-1 whitespace-pre-wrap break-words text-sm text-fg">{message.text}</p>
+      {isUser ? (
+        // The user's own words are never interpreted as markup.
+        <p className="mt-1 whitespace-pre-wrap break-words text-sm text-fg">{message.text}</p>
+      ) : (
+        // Assistant replies render through the shared markdown component, so
+        // code blocks and tables look the same as notes and AI chat.
+        <MarkdownView content={message.text} className="mt-1 text-sm" />
+      )}
     </div>
   );
 }

--- a/src/modules/sessions/SessionsTabContent.tsx
+++ b/src/modules/sessions/SessionsTabContent.tsx
@@ -24,7 +24,7 @@ function getErrorMessage(error: unknown): string {
  */
 function TranscriptEntry({ message }: { message: TranscriptMessage }) {
   const { t } = useTranslation();
-  const timestamp = message.timestamp !== null ? formatRelativeTime(message.timestamp) : null;
+  const timestamp = message.timestamp !== null ? formatRelativeTime(message.timestamp, t) : null;
 
   if (message.role === "tool") {
     return (

--- a/src/modules/sessions/SessionsTabContent.tsx
+++ b/src/modules/sessions/SessionsTabContent.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { History, Loader2, Pin, PinOff } from "lucide-react";
+import { Tooltip } from "@/components/Tooltip";
+import { sessionsGet, type TranscriptMessage } from "./lib/sessionsBridge";
+import { useSessionsStore } from "./lib/sessionsStore";
+import { formatRelativeTime } from "./lib/relativeTime";
+import { AGENT_BADGE_CLASS } from "./lib/agentBadge";
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Unexpected error";
+}
+
+/**
+ * One transcript entry, styled by role instead of as a chat bubble: a left
+ * accent bar marks the user's own turns, the assistant's replies are plain
+ * text, a tool call collapses behind its tool name, and system notices are
+ * muted italic. Mirrors how `SessionRow` in SessionsPanel keeps chrome
+ * minimal — this is a transcript, not a chat UI.
+ */
+function TranscriptEntry({ message }: { message: TranscriptMessage }) {
+  const { t } = useTranslation();
+  const timestamp = message.timestamp !== null ? formatRelativeTime(message.timestamp) : null;
+
+  if (message.role === "tool") {
+    return (
+      <details className="rounded-md border border-border bg-bg-inset px-3 py-2">
+        <summary className="cursor-pointer select-none text-xs font-medium text-fg-subtle">
+          {message.tool_name ?? t("sessions.roles.tool")}
+        </summary>
+        <pre className="mt-2 whitespace-pre-wrap break-words text-xs text-fg-muted">
+          {message.text}
+        </pre>
+      </details>
+    );
+  }
+
+  if (message.role === "system") {
+    return <p className="text-xs italic text-fg-subtle">{message.text}</p>;
+  }
+
+  const isUser = message.role === "user";
+
+  return (
+    <div className={isUser ? "border-l-2 border-accent pl-3" : ""}>
+      <div className="flex items-center gap-2 text-[11px] font-medium uppercase text-fg-subtle">
+        <span>{t(`sessions.roles.${message.role}`)}</span>
+        {timestamp && <span className="font-normal normal-case">{timestamp}</span>}
+      </div>
+      <p className="mt-1 whitespace-pre-wrap break-words text-sm text-fg">{message.text}</p>
+    </div>
+  );
+}
+
+/**
+ * Main-area tab that shows a single indexed session's full transcript,
+ * re-parsed on demand from its source file (see sessionsBridge.sessionsGet —
+ * message bodies are never cached in the index). Opened as a singleton via
+ * `openSessionsTab`; which session it shows follows `useSessionsStore`'s
+ * `selectedId`, set by clicking a row in the sidebar SessionsPanel.
+ */
+export function SessionsTabContent() {
+  const { t } = useTranslation();
+  const sessions = useSessionsStore((s) => s.sessions);
+  const selectedId = useSessionsStore((s) => s.selectedId);
+  const togglePin = useSessionsStore((s) => s.togglePin);
+
+  const [transcript, setTranscript] = useState<TranscriptMessage[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setTranscript([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    // `cancelled` scopes this fetch to the selectedId that triggered it: a
+    // later selection change (or unmount) flips it before a stale resolution
+    // can land, so it never overwrites state for a session the user has
+    // already navigated away from.
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    sessionsGet(selectedId)
+      .then((messages) => {
+        if (cancelled) {
+          return;
+        }
+        setTranscript(messages);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) {
+          return;
+        }
+        // Leave `transcript` untouched — keep showing whatever was already
+        // loaded instead of blanking a transcript the user was reading.
+        setError(getErrorMessage(err));
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId]);
+
+  if (!selectedId) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 bg-bg-inset text-center text-fg-subtle">
+        <History size={32} strokeWidth={1} />
+        <p className="text-sm">{t("sessions.selectPrompt")}</p>
+        <p className="text-xs">{t("sessions.totalCount", { count: sessions.length })}</p>
+      </div>
+    );
+  }
+
+  const session = sessions.find((s) => s.id === selectedId) ?? null;
+
+  return (
+    <div className="flex h-full flex-col bg-bg">
+      {session && (
+        <div className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-2.5">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h2 className="truncate text-sm font-medium text-fg">{session.title}</h2>
+              <span
+                className={`shrink-0 text-[10px] font-medium uppercase ${AGENT_BADGE_CLASS[session.agent]}`}
+              >
+                {t(`sessions.agents.${session.agent}`)}
+              </span>
+            </div>
+            <p className="truncate text-xs text-fg-subtle">{session.project_cwd}</p>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {/* Resume (re-attach this session to a live agent process) ships
+                in Task 13 — this header only exposes pin for now. */}
+            <Tooltip label={t(session.pinned ? "sessions.unpin" : "sessions.pin")}>
+              <button
+                type="button"
+                aria-label={t(session.pinned ? "sessions.unpin" : "sessions.pin")}
+                onClick={() => void togglePin(session.id)}
+                className="rounded p-1 text-fg-subtle hover:bg-bg-elevated hover:text-fg"
+              >
+                {session.pinned ? <PinOff size={14} /> : <Pin size={14} />}
+              </button>
+            </Tooltip>
+          </div>
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+        {loading && (
+          <div className="mb-3 flex items-center gap-2 text-xs text-fg-subtle">
+            <Loader2 size={12} className="animate-spin" />
+            <span>{t("sessions.loading")}</span>
+          </div>
+        )}
+        {error && (
+          <p className="mb-3 text-xs text-danger/80">
+            {t("sessions.loadError")}: {error}
+          </p>
+        )}
+        <div className="flex flex-col gap-3">
+          {transcript.map((message, index) => (
+            <TranscriptEntry key={index} message={message} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/sessions/lib/agentBadge.ts
+++ b/src/modules/sessions/lib/agentBadge.ts
@@ -1,0 +1,22 @@
+import type { SessionAgent } from "./sessionsBridge";
+
+/** Badge color per agent, reusing the theme's existing semantic color
+ *  tokens — none of these are agent-specific, they're just distinct enough
+ *  to tell the three badges apart at a glance. Display labels live in i18n
+ *  under `sessions.agents.*`. Shared by the sidebar panel and the transcript
+ *  tab so both badges stay visually identical. */
+export const AGENT_BADGE_CLASS: Record<SessionAgent, string> = {
+  claude: "text-accent",
+  codex: "text-fg-subtle",
+  antigravity: "text-warning",
+};
+
+/** `AGENT_BADGE_CLASS` lookup for a value that may not be a known agent yet
+ *  (e.g. a live session's agent, which is a plain `string | undefined` — see
+ *  liveSessions.ts — because the foreground poll that classifies a pane can
+ *  lag its status). Falls back to the muted default badge color. */
+export function agentBadgeClass(agent: string | undefined): string {
+  return agent && agent in AGENT_BADGE_CLASS
+    ? AGENT_BADGE_CLASS[agent as SessionAgent]
+    : "text-fg-subtle";
+}

--- a/src/modules/sessions/lib/liveSessions.test.ts
+++ b/src/modules/sessions/lib/liveSessions.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { Tab } from "@/stores/tabsStore";
+import { leaf, type LayoutNode } from "@/modules/terminal/lib/terminalLayout";
+import { deriveLiveSessions } from "./liveSessions";
+
+function tabWith(id: string, title: string, paneTree: LayoutNode, cwd?: string): Tab {
+  return {
+    id,
+    spaceId: "space-1",
+    title,
+    kind: "terminal",
+    paneTree,
+    activeLeafId: "irrelevant",
+    paneOrder: [],
+    cwd,
+  };
+}
+
+describe("deriveLiveSessions", () => {
+  it("returns only the tab whose pane has a live status, with the right tab/leaf ids", () => {
+    const liveTab = tabWith("tab-live", "Live Tab", leaf("L1", { kind: "terminal", cwd: "/pane-cwd" }));
+    const idleTab = tabWith("tab-idle", "Idle Tab", leaf("L2", { kind: "terminal" }));
+
+    const result = deriveLiveSessions(
+      [liveTab, idleTab],
+      { L1: "thinking" },
+      { L1: "claude" },
+    );
+
+    expect(result).toEqual([
+      {
+        tabId: "tab-live",
+        leafId: "L1",
+        tabTitle: "Live Tab",
+        agent: "claude",
+        status: "thinking",
+        cwd: "/pane-cwd",
+      },
+    ]);
+  });
+
+  it("falls back to the tab's cwd when the pane has not reported its own", () => {
+    const tab = tabWith("tab-1", "Tab", leaf("L1", { kind: "terminal" }), "/tab-cwd");
+
+    const [session] = deriveLiveSessions([tab], { L1: "active" }, { L1: "codex" });
+
+    expect(session.cwd).toBe("/tab-cwd");
+  });
+
+  it("falls back to null when neither the pane nor the tab has a cwd", () => {
+    const tab = tabWith("tab-1", "Tab", leaf("L1", { kind: "terminal" }));
+
+    const [session] = deriveLiveSessions([tab], { L1: "active" }, { L1: "codex" });
+
+    expect(session.cwd).toBeNull();
+  });
+
+  it("ignores non-terminal panes even if a status happens to be keyed under their id", () => {
+    const tree: LayoutNode = {
+      kind: "split",
+      direction: "row",
+      sizes: [0.5, 0.5],
+      children: [
+        { kind: "leaf", id: "L1", pane: { kind: "terminal" } },
+        { kind: "leaf", id: "E1", pane: { kind: "editor", path: "/a.ts" } },
+      ],
+    };
+    const tab = tabWith("tab-1", "Tab", tree);
+
+    const result = deriveLiveSessions([tab], { E1: "active" }, {});
+
+    expect(result).toEqual([]);
+  });
+
+  it("includes a session whose agent has not yet been classified", () => {
+    const tab = tabWith("tab-1", "Tab", leaf("L1", { kind: "terminal" }), "/tab-cwd");
+
+    const [session] = deriveLiveSessions([tab], { L1: "idle" }, {});
+
+    expect(session.agent).toBeUndefined();
+    expect(session.status).toBe("idle");
+  });
+
+  it("returns an empty array when no tab has a live status", () => {
+    const tab = tabWith("tab-1", "Tab", leaf("L1", { kind: "terminal" }));
+
+    expect(deriveLiveSessions([tab], {}, {})).toEqual([]);
+  });
+});

--- a/src/modules/sessions/lib/liveSessions.ts
+++ b/src/modules/sessions/lib/liveSessions.ts
@@ -1,0 +1,61 @@
+import type { Tab } from "@/stores/tabsStore";
+import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
+
+/**
+ * One currently-running agent session, surfaced at the top of the sessions
+ * sidebar so it's a single click away instead of waiting for Task 8's
+ * historical index to pick it up once the session ends. Distinct from
+ * `SessionSummary` (the indexed, ended session) — this is a live view
+ * derived straight from the tabs and session-status stores.
+ *
+ * `agent` is `string | undefined` rather than the brief's plain `string`:
+ * the foreground-process poll that classifies a pane's agent runs
+ * independently of (and slightly behind) the status hook, so a session can
+ * have a live status before it has a known agent. `collectTabSessions`
+ * (Task 9, workspace module) already treats a tab's per-pane agent the same
+ * way — this mirrors that precedent instead of inventing a fallback agent
+ * label.
+ */
+export interface LiveSession {
+  tabId: string;
+  leafId: string;
+  tabTitle: string;
+  agent: string | undefined;
+  status: string;
+  cwd: string | null;
+}
+
+/**
+ * Every terminal pane, across all tabs, that currently has a live status —
+ * i.e. an agent is actively running in it. Pure over plain snapshots (not
+ * the zustand hooks themselves), so it's trivially testable and callers can
+ * subscribe to exactly the three inputs it needs without pulling in more of
+ * either store.
+ */
+export function deriveLiveSessions(
+  tabs: Tab[],
+  statuses: Record<string, string>,
+  agents: Record<string, string>,
+): LiveSession[] {
+  const sessions: LiveSession[] = [];
+  for (const tab of tabs) {
+    for (const pane of computeLayout(tab.paneTree)) {
+      if (pane.content.kind !== "terminal") {
+        continue;
+      }
+      const status = statuses[pane.id];
+      if (!status) {
+        continue;
+      }
+      sessions.push({
+        tabId: tab.id,
+        leafId: pane.id,
+        tabTitle: tab.title,
+        agent: agents[pane.id],
+        status,
+        cwd: pane.content.cwd ?? tab.cwd ?? null,
+      });
+    }
+  }
+  return sessions;
+}

--- a/src/modules/sessions/lib/relativeTime.test.ts
+++ b/src/modules/sessions/lib/relativeTime.test.ts
@@ -3,36 +3,43 @@ import { formatRelativeTime } from "./relativeTime";
 
 const NOW = new Date("2026-07-06T12:00:00.000Z").getTime();
 
+// Same stub convention as the sessions components' `react-i18next` mocks
+// (see SessionsPanel.test.tsx / SessionsTabContent.test.tsx): render the key
+// plus any `count` interpolation, instead of pulling in real i18next just to
+// exercise this pure function's branch selection.
+const t = (key: string, options?: Record<string, unknown>) =>
+  options?.count !== undefined ? `${key}:${options.count}` : key;
+
 describe("formatRelativeTime", () => {
-  it("shows 'just now' for anything under a minute old", () => {
-    expect(formatRelativeTime(NOW, NOW)).toBe("just now");
-    expect(formatRelativeTime(NOW - 59_000, NOW)).toBe("just now");
+  it("shows the just-now key for anything under a minute old", () => {
+    expect(formatRelativeTime(NOW, t, NOW)).toBe("sessions.time.justNow");
+    expect(formatRelativeTime(NOW - 59_000, t, NOW)).toBe("sessions.time.justNow");
   });
 
   it("shows minutes ago from 1 minute up to just under an hour", () => {
-    expect(formatRelativeTime(NOW - 60_000, NOW)).toBe("1m ago");
-    expect(formatRelativeTime(NOW - 5 * 60_000, NOW)).toBe("5m ago");
-    expect(formatRelativeTime(NOW - (60 * 60_000 - 1), NOW)).toBe("59m ago");
+    expect(formatRelativeTime(NOW - 60_000, t, NOW)).toBe("sessions.time.minutesAgo:1");
+    expect(formatRelativeTime(NOW - 5 * 60_000, t, NOW)).toBe("sessions.time.minutesAgo:5");
+    expect(formatRelativeTime(NOW - (60 * 60_000 - 1), t, NOW)).toBe("sessions.time.minutesAgo:59");
   });
 
   it("shows hours ago from 1 hour up to just under a day", () => {
-    expect(formatRelativeTime(NOW - 60 * 60_000, NOW)).toBe("1h ago");
-    expect(formatRelativeTime(NOW - 3 * 60 * 60_000, NOW)).toBe("3h ago");
-    expect(formatRelativeTime(NOW - (24 * 60 * 60_000 - 1), NOW)).toBe("23h ago");
+    expect(formatRelativeTime(NOW - 60 * 60_000, t, NOW)).toBe("sessions.time.hoursAgo:1");
+    expect(formatRelativeTime(NOW - 3 * 60 * 60_000, t, NOW)).toBe("sessions.time.hoursAgo:3");
+    expect(formatRelativeTime(NOW - (24 * 60 * 60_000 - 1), t, NOW)).toBe("sessions.time.hoursAgo:23");
   });
 
   it("shows days ago from 1 day up to just under a week", () => {
-    expect(formatRelativeTime(NOW - 24 * 60 * 60_000, NOW)).toBe("1d ago");
-    expect(formatRelativeTime(NOW - 2 * 24 * 60 * 60_000, NOW)).toBe("2d ago");
-    expect(formatRelativeTime(NOW - (7 * 24 * 60 * 60_000 - 1), NOW)).toBe("6d ago");
+    expect(formatRelativeTime(NOW - 24 * 60 * 60_000, t, NOW)).toBe("sessions.time.daysAgo:1");
+    expect(formatRelativeTime(NOW - 2 * 24 * 60 * 60_000, t, NOW)).toBe("sessions.time.daysAgo:2");
+    expect(formatRelativeTime(NOW - (7 * 24 * 60 * 60_000 - 1), t, NOW)).toBe("sessions.time.daysAgo:6");
   });
 
   it("falls back to an absolute local date at a week or older", () => {
     // NOW is 2026-07-06T12:00:00Z; exactly 7 days earlier is 2026-06-29T12:00:00Z.
-    expect(formatRelativeTime(NOW - 7 * 24 * 60 * 60_000, NOW)).toBe("2026-06-29");
+    expect(formatRelativeTime(NOW - 7 * 24 * 60 * 60_000, t, NOW)).toBe("2026-06-29");
   });
 
   it("defaults `now` to the current time when omitted", () => {
-    expect(formatRelativeTime(Date.now())).toBe("just now");
+    expect(formatRelativeTime(Date.now(), t)).toBe("sessions.time.justNow");
   });
 });

--- a/src/modules/sessions/lib/relativeTime.test.ts
+++ b/src/modules/sessions/lib/relativeTime.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { formatRelativeTime } from "./relativeTime";
+
+const NOW = new Date("2026-07-06T12:00:00.000Z").getTime();
+
+describe("formatRelativeTime", () => {
+  it("shows 'just now' for anything under a minute old", () => {
+    expect(formatRelativeTime(NOW, NOW)).toBe("just now");
+    expect(formatRelativeTime(NOW - 59_000, NOW)).toBe("just now");
+  });
+
+  it("shows minutes ago from 1 minute up to just under an hour", () => {
+    expect(formatRelativeTime(NOW - 60_000, NOW)).toBe("1m ago");
+    expect(formatRelativeTime(NOW - 5 * 60_000, NOW)).toBe("5m ago");
+    expect(formatRelativeTime(NOW - (60 * 60_000 - 1), NOW)).toBe("59m ago");
+  });
+
+  it("shows hours ago from 1 hour up to just under a day", () => {
+    expect(formatRelativeTime(NOW - 60 * 60_000, NOW)).toBe("1h ago");
+    expect(formatRelativeTime(NOW - 3 * 60 * 60_000, NOW)).toBe("3h ago");
+    expect(formatRelativeTime(NOW - (24 * 60 * 60_000 - 1), NOW)).toBe("23h ago");
+  });
+
+  it("shows days ago from 1 day up to just under a week", () => {
+    expect(formatRelativeTime(NOW - 24 * 60 * 60_000, NOW)).toBe("1d ago");
+    expect(formatRelativeTime(NOW - 2 * 24 * 60 * 60_000, NOW)).toBe("2d ago");
+    expect(formatRelativeTime(NOW - (7 * 24 * 60 * 60_000 - 1), NOW)).toBe("6d ago");
+  });
+
+  it("falls back to an absolute local date at a week or older", () => {
+    // NOW is 2026-07-06T12:00:00Z; exactly 7 days earlier is 2026-06-29T12:00:00Z.
+    expect(formatRelativeTime(NOW - 7 * 24 * 60 * 60_000, NOW)).toBe("2026-06-29");
+  });
+
+  it("defaults `now` to the current time when omitted", () => {
+    expect(formatRelativeTime(Date.now())).toBe("just now");
+  });
+});

--- a/src/modules/sessions/lib/relativeTime.ts
+++ b/src/modules/sessions/lib/relativeTime.ts
@@ -1,0 +1,33 @@
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+
+/**
+ * Formats `epochMs` relative to `now` (defaults to `Date.now()`) for the
+ * sessions list: "just now" under a minute, then minutes/hours/days ago up
+ * to a week, then an absolute local "YYYY-MM-DD" date once it's a week old
+ * or older — mirrors the Rust side's use of local-calendar dates.
+ */
+export function formatRelativeTime(epochMs: number, now: number = Date.now()): string {
+  const diff = now - epochMs;
+
+  if (diff < MINUTE_MS) {
+    return "just now";
+  }
+  if (diff < HOUR_MS) {
+    return `${Math.floor(diff / MINUTE_MS)}m ago`;
+  }
+  if (diff < DAY_MS) {
+    return `${Math.floor(diff / HOUR_MS)}h ago`;
+  }
+  if (diff < WEEK_MS) {
+    return `${Math.floor(diff / DAY_MS)}d ago`;
+  }
+
+  const date = new Date(epochMs);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}

--- a/src/modules/sessions/lib/relativeTime.ts
+++ b/src/modules/sessions/lib/relativeTime.ts
@@ -3,26 +3,36 @@ const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
 const WEEK_MS = 7 * DAY_MS;
 
+/** Minimal shape of an i18next `TFunction` needed here: a key plus optional
+ *  interpolation values, always returning a string. Kept narrow instead of
+ *  importing the full generic `TFunction` type, which fights structural
+ *  typing when a plain stub (as used in this module's own tests, and in the
+ *  sessions components' `react-i18next` mocks) is passed in its place. */
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
 /**
  * Formats `epochMs` relative to `now` (defaults to `Date.now()`) for the
  * sessions list: "just now" under a minute, then minutes/hours/days ago up
  * to a week, then an absolute local "YYYY-MM-DD" date once it's a week old
- * or older — mirrors the Rust side's use of local-calendar dates.
+ * or older — mirrors the Rust side's use of local-calendar dates. The
+ * relative phrasing goes through `t` (the `sessions.time.*` keys) so it
+ * localizes with the rest of the sessions UI; the absolute date fallback
+ * stays locale-neutral, same as the Rust side.
  */
-export function formatRelativeTime(epochMs: number, now: number = Date.now()): string {
+export function formatRelativeTime(epochMs: number, t: Translate, now: number = Date.now()): string {
   const diff = now - epochMs;
 
   if (diff < MINUTE_MS) {
-    return "just now";
+    return t("sessions.time.justNow");
   }
   if (diff < HOUR_MS) {
-    return `${Math.floor(diff / MINUTE_MS)}m ago`;
+    return t("sessions.time.minutesAgo", { count: Math.floor(diff / MINUTE_MS) });
   }
   if (diff < DAY_MS) {
-    return `${Math.floor(diff / HOUR_MS)}h ago`;
+    return t("sessions.time.hoursAgo", { count: Math.floor(diff / HOUR_MS) });
   }
   if (diff < WEEK_MS) {
-    return `${Math.floor(diff / DAY_MS)}d ago`;
+    return t("sessions.time.daysAgo", { count: Math.floor(diff / DAY_MS) });
   }
 
   const date = new Date(epochMs);

--- a/src/modules/sessions/lib/resume.test.ts
+++ b/src/modules/sessions/lib/resume.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { resumeCommand, resumeSession } from "./resume";
+import type { SessionSummary } from "./sessionsBridge";
+import { useTabsStore } from "@/stores/tabsStore";
+import { registerTerminal, unregisterTerminal } from "@/modules/terminal/lib/terminalBus";
+
+function session(overrides: Partial<SessionSummary>): SessionSummary {
+  return {
+    id: "abc-123",
+    agent: "claude",
+    project_cwd: "/Users/muki/project",
+    title: "Untitled",
+    started_at: 0,
+    ended_at: 0,
+    message_count: 0,
+    user_message_count: 0,
+    output_tokens: null,
+    model: null,
+    file_path: "/tmp/session.jsonl",
+    pinned: false,
+    ...overrides,
+  };
+}
+
+describe("resumeCommand", () => {
+  it("builds the claude resume command", () => {
+    expect(resumeCommand("claude", "abc-123")).toBe("claude --resume abc-123");
+  });
+
+  it("builds the codex resume command", () => {
+    expect(resumeCommand("codex", "abc-123")).toBe("codex resume abc-123");
+  });
+
+  it("returns null for antigravity — no verified CLI resume flag", () => {
+    expect(resumeCommand("antigravity", "abc-123")).toBeNull();
+  });
+
+  it("rejects a session id that doesn't match the shell-safe id guard", () => {
+    expect(resumeCommand("claude", "abc-123; rm -rf /")).toBeNull();
+    expect(resumeCommand("claude", "abc 123")).toBeNull();
+    expect(resumeCommand("claude", "$(whoami)")).toBeNull();
+  });
+});
+
+describe("resumeSession", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("returns false and opens no tab when the agent has no resume command", () => {
+    const before = useTabsStore.getState().tabs.length;
+    const result = resumeSession(session({ agent: "antigravity" }));
+    expect(result).toBe(false);
+    expect(useTabsStore.getState().tabs.length).toBe(before);
+  });
+
+  it("opens a new terminal tab at the session's project cwd and writes the resume command", () => {
+    const result = resumeSession(
+      session({ agent: "claude", id: "sess-1", project_cwd: "/Users/muki/my-app" }),
+    );
+    expect(result).toBe(true);
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    const tab = tabs[0];
+    expect(tab.kind).toBe("terminal");
+    expect(tab.cwd).toBe("/Users/muki/my-app");
+
+    // The PTY hasn't registered yet in this test, so the write sits queued —
+    // registering flushes it, proving `writeToTerminal` reached the right leaf.
+    const writes: string[] = [];
+    registerTerminal(tab.activeLeafId, (text) => writes.push(text));
+    expect(writes).toEqual(["claude --resume sess-1\n"]);
+    unregisterTerminal(tab.activeLeafId);
+  });
+
+  it("builds the codex resume command for a codex session", () => {
+    resumeSession(session({ agent: "codex", id: "sess-2", project_cwd: "/repo" }));
+    const tab = useTabsStore.getState().tabs[0];
+    const writes: string[] = [];
+    registerTerminal(tab.activeLeafId, (text) => writes.push(text));
+    expect(writes).toEqual(["codex resume sess-2\n"]);
+    unregisterTerminal(tab.activeLeafId);
+  });
+});

--- a/src/modules/sessions/lib/resume.ts
+++ b/src/modules/sessions/lib/resume.ts
@@ -1,0 +1,61 @@
+import { useTabsStore } from "@/stores/tabsStore";
+import { writeToTerminal } from "@/modules/terminal/lib/terminalBus";
+import type { SessionAgent, SessionSummary } from "./sessionsBridge";
+
+/**
+ * One-click resume: reopen a historical session in a fresh terminal tab by
+ * replaying the CLI's own resume command.
+ *
+ * Grounded against the real CLI before writing this (Task 13, step 1):
+ * `codex resume --help` →
+ *   "Usage: codex resume [OPTIONS] [SESSION_ID] [PROMPT]" — SESSION_ID is a
+ *   positional UUID or session name, confirming `codex resume <id>`.
+ * `claude --resume <id>` is documented Claude Code CLI usage.
+ * Antigravity has no verified CLI resume flag, so it resolves to null —
+ * callers hide (rows) or disable-with-tooltip (viewer header) the button.
+ */
+
+/** Session ids are UUID-like in all three agents. Interpolating one straight
+ *  into a shell line (via writeToTerminal) is only safe when it matches
+ *  this shape — anything else is rejected rather than escaped. */
+const VALID_SESSION_ID = /^[A-Za-z0-9-]+$/;
+
+/**
+ * Pure command builder — unit-tested. Returns null when resume is
+ * unsupported for the agent, or when `sessionId` fails the shell-safe guard.
+ */
+export function resumeCommand(agent: SessionAgent, sessionId: string): string | null {
+  if (!VALID_SESSION_ID.test(sessionId)) {
+    return null;
+  }
+  switch (agent) {
+    case "claude":
+      return `claude --resume ${sessionId}`;
+    case "codex":
+      return `codex resume ${sessionId}`;
+    case "antigravity":
+      return null;
+  }
+}
+
+/**
+ * Opens a new terminal tab at the session's project directory and replays
+ * the agent's resume command into it. Mirrors the reopen-and-write pattern
+ * in `terminalBus.runCommandInTerminal`: create the tab, read back its
+ * `activeLeafId` from the store, then `writeToTerminal` — which queues the
+ * write until the fresh PTY registers, so there's no startup race.
+ * Returns false (no tab opened) when the agent has no resume command.
+ */
+export function resumeSession(s: SessionSummary): boolean {
+  const cmd = resumeCommand(s.agent, s.id);
+  if (cmd === null) {
+    return false;
+  }
+  const tabId = useTabsStore.getState().newTerminalTab(s.project_cwd || undefined);
+  const created = useTabsStore.getState().tabs.find((t) => t.id === tabId);
+  if (!created || created.kind !== "terminal") {
+    return false;
+  }
+  writeToTerminal(created.activeLeafId, `${cmd}\n`);
+  return true;
+}

--- a/src/modules/sessions/lib/sessionsBridge.ts
+++ b/src/modules/sessions/lib/sessionsBridge.ts
@@ -1,0 +1,61 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+/**
+ * Frontend wrappers around the Rust sessions index (Task 8): a metadata-only
+ * SQLite cache of historical Claude Code / Codex / Antigravity CLI sessions,
+ * kept in sync by filesystem watchers. Message bodies are never cached —
+ * `sessionsGet` re-parses them from the source file on demand.
+ */
+
+export type SessionAgent = "claude" | "codex" | "antigravity";
+
+export interface SessionSummary {
+  id: string;
+  agent: SessionAgent;
+  project_cwd: string;
+  title: string;
+  started_at: number;
+  ended_at: number;
+  message_count: number;
+  user_message_count: number;
+  output_tokens: number | null;
+  model: string | null;
+  file_path: string;
+  pinned: boolean;
+}
+
+export interface TranscriptMessage {
+  role: "user" | "assistant" | "tool" | "system";
+  text: string;
+  timestamp: number | null;
+  tool_name: string | null;
+}
+
+/** Opens the index, starts the filesystem watchers, and kicks off a
+ *  background full sync. Safe to call more than once. */
+export function sessionsStart(): Promise<void> {
+  return invoke("sessions_index_start");
+}
+
+/** Every indexed session, newest-first, pinned sessions flagged. Empty
+ *  before `sessionsStart` has run. */
+export function sessionsList(): Promise<SessionSummary[]> {
+  return invoke<SessionSummary[]>("sessions_list");
+}
+
+/** Re-parses a session's full transcript from its source file. */
+export function sessionsGet(id: string): Promise<TranscriptMessage[]> {
+  return invoke<TranscriptMessage[]>("sessions_get", { id });
+}
+
+/** Pins or unpins a session. */
+export function sessionsPin(id: string, pinned: boolean): Promise<void> {
+  return invoke("sessions_pin", { id, pinned });
+}
+
+/** Subscribes to `sessions-index:updated`, emitted whenever a background
+ *  sync batch changes the index. Resolves with an unlisten function. */
+export function onSessionsUpdated(cb: () => void): Promise<() => void> {
+  return listen<{ count: number }>("sessions-index:updated", () => cb());
+}

--- a/src/modules/sessions/lib/sessionsBridge.ts
+++ b/src/modules/sessions/lib/sessionsBridge.ts
@@ -26,7 +26,10 @@ export interface SessionSummary {
 }
 
 export interface TranscriptMessage {
-  role: "user" | "assistant" | "tool" | "system";
+  /** "injected" marks harness-generated turns recorded as user input
+   *  (teammate messages, system reminders, task notifications, command
+   *  envelopes); `tool_name` then carries the source tag. */
+  role: "user" | "assistant" | "tool" | "system" | "injected";
   text: string;
   timestamp: number | null;
   tool_name: string | null;

--- a/src/modules/sessions/lib/sessionsStore.test.ts
+++ b/src/modules/sessions/lib/sessionsStore.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { visibleSessions } from "./sessionsStore";
+import type { SessionSummary } from "./sessionsBridge";
+
+function session(overrides: Partial<SessionSummary>): SessionSummary {
+  return {
+    id: "id",
+    agent: "claude",
+    project_cwd: "/Users/muki/project",
+    title: "Untitled",
+    started_at: 0,
+    ended_at: 0,
+    message_count: 0,
+    user_message_count: 0,
+    output_tokens: null,
+    model: null,
+    file_path: "/tmp/session.jsonl",
+    pinned: false,
+    ...overrides,
+  };
+}
+
+describe("visibleSessions", () => {
+  it("splits pinned from history", () => {
+    const a = session({ id: "a", pinned: true, ended_at: 1 });
+    const b = session({ id: "b", pinned: false, ended_at: 2 });
+
+    const { pinned, history } = visibleSessions([a, b], "", "all");
+
+    expect(pinned).toEqual([a]);
+    expect(history).toEqual([b]);
+  });
+
+  it("sorts pinned sessions by ended_at descending", () => {
+    const older = session({ id: "older", pinned: true, ended_at: 100 });
+    const newer = session({ id: "newer", pinned: true, ended_at: 200 });
+
+    const { pinned } = visibleSessions([older, newer], "", "all");
+
+    expect(pinned.map((s) => s.id)).toEqual(["newer", "older"]);
+  });
+
+  it("history excludes every pinned session regardless of order", () => {
+    const pinnedSession = session({ id: "p", pinned: true, ended_at: 50 });
+    const historySession = session({ id: "h", pinned: false, ended_at: 10 });
+
+    const { history } = visibleSessions([pinnedSession, historySession], "", "all");
+
+    expect(history).toEqual([historySession]);
+  });
+
+  it("filters by agent", () => {
+    const claude = session({ id: "c", agent: "claude" });
+    const codex = session({ id: "x", agent: "codex" });
+
+    const { history } = visibleSessions([claude, codex], "", "codex");
+
+    expect(history).toEqual([codex]);
+  });
+
+  it("keeps everything when agentFilter is 'all'", () => {
+    const claude = session({ id: "c", agent: "claude" });
+    const codex = session({ id: "x", agent: "codex" });
+
+    const { history } = visibleSessions([claude, codex], "", "all");
+
+    expect(history.map((s) => s.id)).toEqual(["c", "x"]);
+  });
+
+  it("matches query against title, case-insensitively", () => {
+    const match = session({ id: "m", title: "Refactor Auth Flow" });
+    const noMatch = session({ id: "n", title: "Unrelated" });
+
+    const { history } = visibleSessions([match, noMatch], "refactor", "all");
+
+    expect(history).toEqual([match]);
+  });
+
+  it("matches query against project_cwd, case-insensitively", () => {
+    const match = session({ id: "m", title: "x", project_cwd: "/Users/muki/Tempo-Term" });
+    const noMatch = session({ id: "n", title: "y", project_cwd: "/Users/muki/other" });
+
+    const { history } = visibleSessions([match, noMatch], "tempo-term", "all");
+
+    expect(history).toEqual([match]);
+  });
+
+  it("combines query and agent filter", () => {
+    const claudeMatch = session({ id: "cm", agent: "claude", title: "deploy script" });
+    const codexMatch = session({ id: "xm", agent: "codex", title: "deploy script" });
+    const claudeNoMatch = session({ id: "cn", agent: "claude", title: "unrelated" });
+
+    const { history } = visibleSessions(
+      [claudeMatch, codexMatch, claudeNoMatch],
+      "deploy",
+      "claude",
+    );
+
+    expect(history).toEqual([claudeMatch]);
+  });
+
+  it("returns empty arrays when nothing matches", () => {
+    const s = session({ id: "s", title: "foo" });
+
+    const { pinned, history } = visibleSessions([s], "nomatch", "all");
+
+    expect(pinned).toEqual([]);
+    expect(history).toEqual([]);
+  });
+
+  it("applies the query filter to pinned sessions too", () => {
+    const pinnedMatch = session({ id: "pm", pinned: true, title: "release notes" });
+    const pinnedNoMatch = session({ id: "pn", pinned: true, title: "unrelated" });
+
+    const { pinned } = visibleSessions([pinnedMatch, pinnedNoMatch], "release", "all");
+
+    expect(pinned).toEqual([pinnedMatch]);
+  });
+});

--- a/src/modules/sessions/lib/sessionsStore.ts
+++ b/src/modules/sessions/lib/sessionsStore.ts
@@ -1,0 +1,105 @@
+import { create } from "zustand";
+import {
+  sessionsList,
+  sessionsPin,
+  sessionsStart,
+  type SessionAgent,
+  type SessionSummary,
+} from "./sessionsBridge";
+
+interface SessionsState {
+  sessions: SessionSummary[];
+  loaded: boolean;
+  query: string;
+  agentFilter: SessionAgent | "all";
+  selectedId: string | null;
+  /** Reloads `sessions` from the index. Leaves state unchanged on error. */
+  refresh: () => Promise<void>;
+  /** Starts the backend index (idempotent), then refreshes. */
+  start: () => Promise<void>;
+  setQuery: (query: string) => void;
+  setAgentFilter: (filter: SessionAgent | "all") => void;
+  select: (id: string | null) => void;
+  /** Flips a session's pinned state optimistically, then persists it;
+   *  re-syncs from the backend if the write fails. */
+  togglePin: (id: string) => Promise<void>;
+}
+
+export const useSessionsStore = create<SessionsState>((set, get) => ({
+  sessions: [],
+  loaded: false,
+  query: "",
+  agentFilter: "all",
+  selectedId: null,
+
+  refresh: async () => {
+    try {
+      const sessions = await sessionsList();
+      set({ sessions, loaded: true });
+    } catch {
+      // Leave state unchanged; the caller can retry.
+    }
+  },
+
+  start: async () => {
+    try {
+      await sessionsStart();
+      await get().refresh();
+    } catch {
+      // Leave state unchanged; the caller can retry.
+    }
+  },
+
+  setQuery: (query) => set({ query }),
+  setAgentFilter: (agentFilter) => set({ agentFilter }),
+  select: (selectedId) => set({ selectedId }),
+
+  togglePin: async (id) => {
+    const before = get().sessions;
+    const target = before.find((s) => s.id === id);
+    if (!target) {
+      return;
+    }
+
+    const nextPinned = !target.pinned;
+    set({
+      sessions: before.map((s) => (s.id === id ? { ...s, pinned: nextPinned } : s)),
+    });
+
+    try {
+      await sessionsPin(id, nextPinned);
+    } catch {
+      // The optimistic flip may be wrong; resync from the backend.
+      await get().refresh();
+    }
+  },
+}));
+
+/**
+ * Pure selector splitting `sessions` into pinned (sorted by most recently
+ * ended) and history (everything else), after applying the agent filter and
+ * a case-insensitive title/project_cwd query match. Exported for tests and
+ * for the sessions panel to derive its two list sections.
+ */
+export function visibleSessions(
+  sessions: SessionSummary[],
+  query: string,
+  agentFilter: SessionAgent | "all",
+): { pinned: SessionSummary[]; history: SessionSummary[] } {
+  const q = query.trim().toLowerCase();
+
+  const filtered = sessions.filter((s) => {
+    if (agentFilter !== "all" && s.agent !== agentFilter) {
+      return false;
+    }
+    if (q === "") {
+      return true;
+    }
+    return s.title.toLowerCase().includes(q) || s.project_cwd.toLowerCase().includes(q);
+  });
+
+  const pinned = filtered.filter((s) => s.pinned).sort((a, b) => b.ended_at - a.ended_at);
+  const history = filtered.filter((s) => !s.pinned);
+
+  return { pinned, history };
+}

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -33,6 +33,11 @@ const GitGraphTabContent = lazy(() =>
 const DiffTabContent = lazy(() =>
   import("@/modules/diff/DiffTabContent").then((m) => ({ default: m.DiffTabContent })),
 );
+const SessionsTabContent = lazy(() =>
+  import("@/modules/sessions/SessionsTabContent").then((m) => ({
+    default: m.SessionsTabContent,
+  })),
+);
 import { LauncherPanel } from "@/components/LauncherPanel";
 import { dropOverlayClassName, outerBandOverlayClassName } from "@/components/EntryDropOverlay";
 import { InfoDialog } from "@/components/InfoDialog";
@@ -159,10 +164,11 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
     : undefined;
 
   // Single-file panes reject folders; terminal/note take both. Dropping a file
-  // onto a launcher pane opens it, so a launcher accepts a file too. A diff
-  // pane is a read-only comparison with no drop action, so it accepts nothing.
+  // onto a launcher pane opens it, so a launcher accepts a file too. A diff or
+  // sessions pane is a read-only browser with no drop action, so it accepts
+  // nothing.
   function canDrop(content: PaneContent, entry: DraggedEntry): boolean {
-    if (content.kind === "diff") {
+    if (content.kind === "diff" || content.kind === "sessions") {
       return false;
     }
     if (
@@ -461,6 +467,8 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                   <GitGraphTabContent />
                 ) : pane.content.kind === "diff" ? (
                   <DiffTabContent path={pane.content.path} staged={pane.content.staged} />
+                ) : pane.content.kind === "sessions" ? (
+                  <SessionsTabContent />
                 ) : pane.content.kind === "launcher" ? (
                   <LauncherPanel
                     target={{ mode: "replacePane", tabId: tab.id, leafId: pane.id }}

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -9,8 +9,8 @@ export type SplitDirection = "row" | "col";
 
 /**
  * What a leaf pane shows: a terminal, an open file, a note, a preview, the git
- * graph, a file's uncommitted diff, or the launcher (a freshly split pane that
- * hasn't been chosen yet).
+ * graph, a file's uncommitted diff, the AI sessions browser, or the launcher
+ * (a freshly split pane that hasn't been chosen yet).
  */
 export type PaneContent =
   | { kind: "terminal"; cwd?: string; ssh?: { connectionId: string } }
@@ -19,6 +19,7 @@ export type PaneContent =
   | { kind: "preview"; url: string }
   | { kind: "git-graph" }
   | { kind: "diff"; path: string; staged: boolean }
+  | { kind: "sessions" }
   | { kind: "launcher" };
 
 export const TERMINAL_PANE: PaneContent = { kind: "terminal" };

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -10,6 +10,7 @@ import {
   GitCompare,
   GitPullRequest,
   Globe,
+  History,
   LayoutGrid,
   Pencil,
   Plus,
@@ -55,6 +56,8 @@ function tabIcon(kind: TabKind): LucideIcon {
       return GitBranch;
     case "diff":
       return GitCompare;
+    case "sessions":
+      return History;
     case "launcher":
       return LayoutGrid;
   }

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -336,6 +336,18 @@ describe("tabsStore", () => {
     expect(g2).toBe(g1);
   });
 
+  it("opens a sessions tab as a singleton, focusing the existing one", () => {
+    const s1 = useTabsStore.getState().openSessionsTab();
+    expect(activeTab().kind).toBe("sessions");
+    expect(activeTab().title).toBe("AI Sessions");
+    expect(firstLeafContent(activeTab())).toEqual({ kind: "sessions" });
+
+    const s2 = useTabsStore.getState().openSessionsTab();
+    expect(s2).toBe(s1);
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    expect(useTabsStore.getState().activeId).toBe(s1);
+  });
+
   it("does not dedupe an editor tab once it has been split", () => {
     const first = useTabsStore.getState().openEditorTab("/a/b.ts");
     useTabsStore

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -40,7 +40,15 @@ export type OpenFromSidebarResult =
   | { status: "already-connected" }
   | { status: "at-capacity" };
 
-export type TabKind = "terminal" | "editor" | "note" | "preview" | "git-graph" | "diff" | "launcher";
+export type TabKind =
+  | "terminal"
+  | "editor"
+  | "note"
+  | "preview"
+  | "git-graph"
+  | "diff"
+  | "sessions"
+  | "launcher";
 
 /**
  * A single tab. `kind` is only the tab's creation type, used for the tab-bar
@@ -84,6 +92,8 @@ interface TabsState {
   openPreviewTab: (url: string) => string;
   openGitGraphTab: () => string;
   openDiffTab: (path: string, staged: boolean) => string;
+  /** Open the AI sessions browser tab (singleton per space). */
+  openSessionsTab: () => string;
   /**
    * Open sidebar content (explorer file, note, or SSH connection). When the
    * active tab is a real working tab, this splits beside its current
@@ -592,6 +602,33 @@ export const useTabsStore = create<TabsState>()(
       kind: "git-graph",
       title: "Git Graph",
       paneTree: leaf(paneId, { kind: "git-graph" }),
+      activeLeafId: paneId,
+      paneOrder: [paneId],
+    };
+    set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
+    return id;
+  },
+
+  openSessionsTab: () => {
+    const spaceId = get().ensureSpace();
+    const existing = get().tabs.find(
+      (t) =>
+        t.kind === "sessions" &&
+        t.spaceId === spaceId &&
+        singleLeafContentEquals(t, { kind: "sessions" }),
+    );
+    if (existing) {
+      set({ activeId: existing.id });
+      return existing.id;
+    }
+    const id = nextTabId();
+    const paneId = nextPaneId();
+    const tab: Tab = {
+      id,
+      spaceId,
+      kind: "sessions",
+      title: "AI Sessions",
+      paneTree: leaf(paneId, { kind: "sessions" }),
       activeLeafId: paneId,
       paneOrder: [paneId],
     };

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-export type SidebarView = "workspaces" | "explorer" | "sourceControl" | "ai" | "notes" | "connections";
+export type SidebarView = "workspaces" | "explorer" | "sourceControl" | "ai" | "notes" | "connections" | "sessions";
 
 interface UiState {
   sidebarView: SidebarView;


### PR DESCRIPTION
## Summary

AI Sessions view (P1): a cross-agent session browser for Claude Code, Codex, and Antigravity CLI histories.

**Backend** — new `sessions_index` Rust module:
- Metadata-only SQLite index (title, timestamps, counts, tokens, pins); message bodies are re-parsed from source files on demand, so the index stays a disposable few-hundred-KB cache and transcripts are always fresh
- Three defensive parsers: Claude JSONL (uuid/parentUuid DAG main-path selection, isMeta/isSidechain filtering), Codex rollout JSONL (event stream, custom_tool_call support), Antigravity CLI trajectory SQLite (hand-rolled protobuf wire reader, no prost — the real payload shape was reverse-engineered against ~1,000 production steps and differs from what agentsview documents)
- notify-based watchers with a 500 ms debounced sync loop; watcher events are filtered to real session files, `-shm` companions are excluded from change fingerprints (a read-only SQLite open touches `-shm`, which otherwise makes every re-parse schedule the next one — a self-sustaining sync loop found during field testing)
- All parsing happens outside the index lock; `sessions_list`/`sessions_get` run on the blocking pool so the UI never waits on a sync batch

**Frontend** — new sidebar view + singleton content tab:
- Sidebar: Live section (running sessions, click jumps to the terminal pane), search, agent filter chips, pinned group, history list
- Viewer: transcript with per-role styling; assistant replies render as markdown via the shared `MarkdownView`; harness-injected turns (teammate messages, system reminders, task notifications, command envelopes) collapse behind source-labelled cards and are excluded from user message counts
- One-click resume: opens a new terminal tab at the session's cwd and runs `claude --resume` / `codex resume` (session ids are regex-guarded before shell interpolation; Antigravity resume is disabled pending CLI support)

**Dependency budget**: zero new npm packages (markdown reuses existing react-markdown stack); one new Rust crate (`rusqlite`, system SQLite on macOS, bundled only on Windows/Linux).

Design spec: `docs/superpowers/specs/2026-07-06-ai-sessions-view-design.md` (P2: dashboard with stat cards/heatmap/top sessions, delete, export; P3: project view, git correlation, FTS).

## Test plan

- [x] 286 Rust tests (parsers with fixture + real-shape coverage, index, scanner, sync incl. shm-loop regression, watch filtering) — all green
- [x] 1,255 frontend tests (store, panel, viewer incl. markdown/injected-card rendering, live sessions, resume guard) — all green
- [x] `tsc --noEmit` clean; `vite build` clean
- [x] Field-verified on real data (857 sessions): initial index 358 ms, transcript loads in ms across all three agents, watcher loop confirmed quiet, resume opens the right conversation
- [x] User acceptance: list/filter/pins, transcripts for all three agents (incl. CJK), markdown rendering, collapsed injected cards, live section
