### PR TITLE
feat: AI sessions view (P3) — project view, git correlation, model filter, CSV

### DIFF
--- a/docs/superpowers/plans/2026-07-07-ai-sessions-view-p3.md
+++ b/docs/superpowers/plans/2026-07-07-ai-sessions-view-p3.md
@@ -1,0 +1,1129 @@
+# AI Sessions View P3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a project-view screen, session↔git-commit correlation, a model filter, and CSV export to the AI Sessions view, reusing P1/P2 patterns.
+
+**Architecture:** One new backend aggregate command (`sessions_project_stats`) and one new git command (`git_commits_in_range`) on the existing Rust modules; a third main-area screen routed off a new `selectedProject` store field; a model filter mirroring the existing agent filter; and a pure-frontend CSV builder wired to a filter-aware save dialog.
+
+**Tech Stack:** Tauri 2 (Rust, rusqlite), React 19 + zustand + Tailwind v4, vitest + cargo test. Work in the dev worktree `/Users/muki/Documents/01.project/tempo-term-dev`, branch `feat/ai-sessions-p3` (already checked out, based on master c08c9df).
+
+## Global Constraints
+
+- Zero new npm packages, zero new Rust crates. Git reuses `src-tauri/src/modules/git/mod.rs`; CSV is hand-built; project view and model filter are hand-rolled UI over existing stores.
+- Commit messages / PR / issues / code comments / review replies in English; user-facing conversation in Traditional Chinese.
+- All user-visible strings go through i18next in BOTH `src/i18n/locales/en/common.json` and `src/i18n/locales/zh-Hant/common.json`.
+- Every change goes through the PR (branch `feat/ai-sessions-p3`), never a direct push to master.
+- Conventional-commit messages; no AI attribution.
+- Serde field names are snake_case and must match the TS bridge types verbatim (no mapping layer).
+- ⚠️ `CommitInfo.timestamp` is epoch **seconds** (`%ct`); session `started_at`/`ended_at` are epoch **milliseconds**. Convert ms→seconds (`ms / 1000`) before passing to git.
+- Everything degrades quietly: unknown project → zeroed stats; non-git/remote/failed cwd → empty commit list (section hidden); empty CSV → header-only file; cancelled save dialog → no-op. Git is read-only.
+
+---
+
+## File Structure
+
+**Backend**
+- `src-tauri/src/modules/sessions_index/stats.rs` — add `ProjectStats` struct + `Index::project_stats(cwd)` method + tests (Task 1).
+- `src-tauri/src/modules/sessions_index/mod.rs` — add `sessions_project_stats` command wrapper (Task 1).
+- `src-tauri/src/modules/git/mod.rs` — add `git_commits_in_range` command + tests (Task 3).
+- `src-tauri/src/lib.rs` — register both new commands in the invoke handler (Tasks 1, 3).
+
+**Frontend**
+- `src/modules/sessions/lib/projectBridge.ts` (new) — `ProjectStats` type + `sessionsProjectStats(cwd)` wrapper (Task 1).
+- `src/modules/sessions/lib/sessionsStore.ts` — add `selectedProject`/`selectProject`, `modelFilter`/`setModelFilter`, extend `visibleSessions` (Tasks 2, 4).
+- `src/modules/sessions/ProjectView.tsx` (new) + `.test.tsx` — the third screen (Task 2).
+- `src/modules/sessions/lib/openTerminalAt.ts` (new) + `.test.ts` — open a terminal tab at a cwd (Task 2).
+- `src/modules/sessions/SessionsTabContent.tsx` — add the project-view routing branch (Task 2).
+- `src/modules/sessions/SessionsPanel.tsx` — clickable project name → `selectProject`; model filter dropdown (Tasks 2, 4).
+- `src/modules/sessions/DashboardView.tsx` — clickable project on Top Sessions rows; CSV export button (Tasks 2, 5).
+- `src/modules/source-control/lib/gitBridge.ts` — add `gitCommitsInRange(cwd, sinceMs, untilMs)` wrapper (Task 3).
+- `src/modules/sessions/lib/gitCorrelation.ts` (new) is NOT needed — the viewer calls `gitCommitsInRange` directly.
+- `src/modules/sessions/lib/sessionsCsv.ts` (new) + `.test.ts` — `toSessionsCsv(sessions)` (Task 5).
+- `src/lib/dialog.ts` — add an optional `filters` param to `saveFile` (Task 5).
+- Both locale files — new keys under `sessions.project.*`, `sessions.commits.*`, `sessions.modelFilterAll`, `sessions.dashboard.exportCsv` (Tasks 2-5).
+
+---
+
+## Task 1: `sessions_project_stats` backend command
+
+**Files:**
+- Modify: `src-tauri/src/modules/sessions_index/stats.rs` (add `ProjectStats`, `Index::project_stats`, tests)
+- Modify: `src-tauri/src/modules/sessions_index/mod.rs` (add command wrapper)
+- Modify: `src-tauri/src/lib.rs:60` (import) and `:262` (handler list)
+- Create: `src/modules/sessions/lib/projectBridge.ts` (TS type + wrapper)
+
+**Interfaces:**
+- Consumes: existing `Index`, `SessionSummary` (types.rs), `stats::empty_stats` pattern, the `sessions_stats` command shape (mod.rs:333-350).
+- Produces:
+  - Rust `ProjectStats { project_cwd: String, sessions: i64, messages: i64, output_tokens: i64, active_days: i64, top_model: Option<String>, first_at: i64, last_at: i64, recent: Vec<SessionSummary> }`
+  - Rust command `sessions_project_stats(state, project_cwd: String) -> Result<ProjectStats, String>`
+  - TS `ProjectStats` (same fields, snake_case) + `sessionsProjectStats(projectCwd: string): Promise<ProjectStats>` invoking `"sessions_project_stats"` with `{ projectCwd }`.
+
+- [ ] **Step 1: Write the failing Rust test**
+
+Add to the `#[cfg(test)] mod tests` in `stats.rs` (the `seeded_index` fixture has proj-a with s1 today + s3 40d ago, proj-b with s2 3d ago):
+
+```rust
+#[test]
+fn project_stats_aggregates_only_that_project() {
+    let index = seeded_index("proj-stats");
+    let ps = index.project_stats("/tmp/proj-a");
+    // proj-a = s1 (10 msg, 100 tok, sonnet-5, today) + s3 (4 msg, 0 tok, 40d ago).
+    assert_eq!(ps.project_cwd, "/tmp/proj-a");
+    assert_eq!(ps.sessions, 2);
+    assert_eq!(ps.messages, 14);
+    assert_eq!(ps.output_tokens, 100);
+    assert_eq!(ps.active_days, 2);
+    assert_eq!(ps.top_model.as_deref(), Some("claude-sonnet-5"));
+    // recent is newest-first by ended_at; both fixture sessions share ended_at,
+    // so just assert membership and count.
+    assert_eq!(ps.recent.len(), 2);
+    assert!(ps.recent.iter().all(|s| s.project_cwd == "/tmp/proj-a"));
+}
+
+#[test]
+fn project_stats_is_zeroed_for_an_unknown_project() {
+    let index = seeded_index("proj-stats-none");
+    let ps = index.project_stats("/tmp/does-not-exist");
+    assert_eq!(ps.sessions, 0);
+    assert_eq!(ps.messages, 0);
+    assert_eq!(ps.output_tokens, 0);
+    assert_eq!(ps.active_days, 0);
+    assert_eq!(ps.top_model, None);
+    assert_eq!(ps.first_at, 0);
+    assert_eq!(ps.last_at, 0);
+    assert!(ps.recent.is_empty());
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd src-tauri && cargo test sessions_index::stats::tests::project_stats 2>&1 | tail -20`
+Expected: FAIL — `no method named project_stats` / `cannot find type ProjectStats`.
+
+- [ ] **Step 3: Add the `ProjectStats` struct and `Index::project_stats`**
+
+In `stats.rs`, near the other serde structs, add (import `SessionSummary` if not already in scope — it lives in `super::types`):
+
+```rust
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProjectStats {
+    pub project_cwd: String,
+    pub sessions: i64,
+    pub messages: i64,
+    pub output_tokens: i64,
+    pub active_days: i64,
+    /// Model used in the most sessions in this project (ties by model name),
+    /// or None when no session here recorded a model.
+    pub top_model: Option<String>,
+    pub first_at: i64,
+    pub last_at: i64,
+    /// This project's sessions, newest first (capped at 50).
+    pub recent: Vec<SessionSummary>,
+}
+```
+
+Add the method to the same `impl Index` block that holds `stats`:
+
+```rust
+/// Per-project aggregates + this project's recent sessions. Filtered to
+/// `project_cwd = ?1`. An unknown project yields zeroed counts and an empty
+/// `recent` — never an error.
+pub fn project_stats(&self, project_cwd: &str) -> ProjectStats {
+    let (sessions, messages, output_tokens, first_at, last_at) = self
+        .conn
+        .query_row(
+            "SELECT COUNT(*), COALESCE(SUM(message_count),0), COALESCE(SUM(output_tokens),0),
+                    COALESCE(MIN(started_at),0), COALESCE(MAX(ended_at),0)
+             FROM sessions WHERE project_cwd = ?1",
+            params![project_cwd],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )
+        .unwrap_or((0, 0, 0, 0, 0));
+
+    let active_days = self
+        .conn
+        .query_row(
+            "SELECT COUNT(DISTINCT a.date) FROM activity a
+             JOIN sessions s ON s.id = a.session_id WHERE s.project_cwd = ?1",
+            params![project_cwd],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    let top_model = self
+        .conn
+        .query_row(
+            "SELECT model FROM sessions WHERE project_cwd = ?1 AND model IS NOT NULL
+             GROUP BY model ORDER BY COUNT(*) DESC, model ASC LIMIT 1",
+            params![project_cwd],
+            |r| r.get(0),
+        )
+        .ok();
+
+    let recent = self.list_for_project(project_cwd);
+
+    ProjectStats {
+        project_cwd: project_cwd.to_string(),
+        sessions,
+        messages,
+        output_tokens,
+        active_days,
+        top_model,
+        first_at,
+        last_at,
+        recent,
+    }
+}
+```
+
+Add a helper next to `Index::list()` in `index.rs` (mirror `list()`'s row mapping exactly — reuse its `SELECT` column list and `row_to_summary`/closure; the existing `list()` is at index.rs:140):
+
+```rust
+/// This project's sessions, newest first, capped at 50. Same row shape as
+/// `list()`, filtered to one `project_cwd`.
+pub fn list_for_project(&self, project_cwd: &str) -> Vec<SessionSummary> {
+    // Copy list()'s SELECT column order and row mapping; add
+    // `WHERE project_cwd = ?1 ORDER BY ended_at DESC LIMIT 50`.
+    // (Fill in with list()'s exact SELECT + mapping closure.)
+    let mut stmt = match self.conn.prepare(
+        "SELECT <same columns as list()> FROM sessions
+         WHERE project_cwd = ?1 ORDER BY ended_at DESC LIMIT 50",
+    ) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let rows = match stmt.query_map(params![project_cwd], /* same closure as list() */) {
+        Ok(r) => r,
+        Err(_) => return Vec::new(),
+    };
+    rows.filter_map(Result::ok).collect()
+}
+```
+
+Note for implementer: open `index.rs:140` (`list()`), copy its exact `SELECT` column list and its row→`SessionSummary` mapping closure into `list_for_project` verbatim, changing only the `WHERE`/`ORDER BY`/`LIMIT`. Do not invent a new column order.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd src-tauri && cargo test sessions_index::stats::tests::project_stats 2>&1 | tail -20`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Add the command wrapper**
+
+In `mod.rs`, mirror `sessions_stats` (mod.rs:333):
+
+```rust
+/// Per-project aggregates + recent sessions for the project view. Offloaded to
+/// a blocking pool thread like `sessions_stats`. Zeroed stats (never an error)
+/// before the index has started or for an unknown project.
+#[tauri::command]
+pub async fn sessions_project_stats(
+    state: State<'_, SessionsIndexState>,
+    project_cwd: String,
+) -> Result<stats::ProjectStats, String> {
+    let index = {
+        let guard = state.inner.lock().unwrap();
+        guard.as_ref().map(|inner| Arc::clone(&inner.index))
+    };
+    let Some(index) = index else {
+        return Ok(stats::ProjectStats {
+            project_cwd,
+            sessions: 0,
+            messages: 0,
+            output_tokens: 0,
+            active_days: 0,
+            top_model: None,
+            first_at: 0,
+            last_at: 0,
+            recent: Vec::new(),
+        });
+    };
+    tauri::async_runtime::spawn_blocking(move || index.lock().unwrap().project_stats(&project_cwd))
+        .await
+        .map_err(|e| e.to_string())
+}
+```
+
+- [ ] **Step 6: Register the command in `lib.rs`**
+
+At `lib.rs:60` add `sessions_project_stats` to the `use` list from the module (next to `sessions_stats`). At the handler list (`lib.rs:262`, next to `sessions_stats,`) add `sessions_project_stats,`.
+
+- [ ] **Step 7: Create the frontend bridge**
+
+Create `src/modules/sessions/lib/projectBridge.ts`:
+
+```ts
+import { invoke } from "@tauri-apps/api/core";
+import type { SessionSummary } from "./sessionsBridge";
+
+/** Per-project aggregates + recent sessions for the project view. Field names
+ *  mirror the Rust `ProjectStats` serde output exactly. */
+export interface ProjectStats {
+  project_cwd: string;
+  sessions: number;
+  messages: number;
+  output_tokens: number;
+  active_days: number;
+  top_model: string | null;
+  first_at: number;
+  last_at: number;
+  recent: SessionSummary[];
+}
+
+/** Aggregates for one project. Zeroed (never rejects) for an unknown project. */
+export function sessionsProjectStats(projectCwd: string): Promise<ProjectStats> {
+  return invoke<ProjectStats>("sessions_project_stats", { projectCwd });
+}
+```
+
+- [ ] **Step 8: Typecheck and build**
+
+Run: `pnpm typecheck 2>&1 | tail -3 && cd src-tauri && cargo test sessions_index 2>&1 | grep "test result" | head -1`
+Expected: typecheck clean; all sessions_index tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src-tauri/src/modules/sessions_index/stats.rs src-tauri/src/modules/sessions_index/index.rs src-tauri/src/modules/sessions_index/mod.rs src-tauri/src/lib.rs src/modules/sessions/lib/projectBridge.ts
+git commit -m "feat(sessions): add sessions_project_stats command for the project view"
+```
+
+---
+
+## Task 2: Project view screen + store + routing + clickable project names
+
+**Files:**
+- Modify: `src/modules/sessions/lib/sessionsStore.ts` (add `selectedProject`/`selectProject`; `select`/`selectProject` clear each other)
+- Create: `src/modules/sessions/lib/openTerminalAt.ts` + `src/modules/sessions/lib/openTerminalAt.test.ts`
+- Create: `src/modules/sessions/ProjectView.tsx` + `src/modules/sessions/ProjectView.test.tsx`
+- Modify: `src/modules/sessions/SessionsTabContent.tsx:158` (route project view first)
+- Modify: `src/modules/sessions/SessionsPanel.tsx` (project basename → `selectProject`)
+- Modify: `src/modules/sessions/DashboardView.tsx` (Top Sessions project → `selectProject`)
+- Modify: both locale files (`sessions.project.*`)
+
+**Interfaces:**
+- Consumes: `sessionsProjectStats` (Task 1), `useSessionsStore`, `useTabsStore.getState().newTerminalTab(cwd)` (tabsStore.ts:436).
+- Produces:
+  - store: `selectedProject: string | null`, `selectProject(cwd: string | null)` (sets `selectedProject`, clears `selectedId`); `select(id)` also clears `selectedProject`.
+  - `openTerminalAt(cwd: string): string` — creates a terminal tab at cwd, returns its tabId.
+  - `<ProjectView />` — reads `selectedProject`, fetches stats, renders tiles + back + open-terminal + recent list.
+
+- [ ] **Step 1: Write the failing store test**
+
+Add to `src/modules/sessions/lib/sessionsStore.test.ts`:
+
+```ts
+it("selectProject sets the project and clears any selected session", () => {
+  useSessionsStore.setState({ selectedId: "s1", selectedProject: null });
+  useSessionsStore.getState().selectProject("/tmp/proj-a");
+  expect(useSessionsStore.getState().selectedProject).toBe("/tmp/proj-a");
+  expect(useSessionsStore.getState().selectedId).toBeNull();
+});
+
+it("select clears any selected project", () => {
+  useSessionsStore.setState({ selectedProject: "/tmp/proj-a", selectedId: null });
+  useSessionsStore.getState().select("s2");
+  expect(useSessionsStore.getState().selectedId).toBe("s2");
+  expect(useSessionsStore.getState().selectedProject).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm vitest run src/modules/sessions/lib/sessionsStore.test.ts 2>&1 | tail -15`
+Expected: FAIL — `selectProject` is not a function / `selectedProject` undefined.
+
+- [ ] **Step 3: Extend the store**
+
+In `sessionsStore.ts`: add `selectedProject: string | null` to the interface and initial state (`selectedProject: null`), add `selectProject` to the interface, and update the actions:
+
+```ts
+  select: (selectedId) => set({ selectedId, selectedProject: null }),
+  selectProject: (selectedProject) => set({ selectedProject, selectedId: null }),
+```
+
+Add `selectProject: (cwd: string | null) => void;` to the `SessionsState` interface.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm vitest run src/modules/sessions/lib/sessionsStore.test.ts 2>&1 | tail -8`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing openTerminalAt test**
+
+Create `src/modules/sessions/lib/openTerminalAt.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { openTerminalAt } from "./openTerminalAt";
+import { useTabsStore } from "@/stores/tabsStore";
+
+describe("openTerminalAt", () => {
+  it("creates a terminal tab at the given cwd and returns its id", () => {
+    const newTerminalTab = vi.fn().mockReturnValue("tab-9");
+    vi.spyOn(useTabsStore, "getState").mockReturnValue({ newTerminalTab } as never);
+
+    const id = openTerminalAt("/tmp/proj-a");
+
+    expect(newTerminalTab).toHaveBeenCalledWith("/tmp/proj-a");
+    expect(id).toBe("tab-9");
+  });
+});
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `pnpm vitest run src/modules/sessions/lib/openTerminalAt.test.ts 2>&1 | tail -12`
+Expected: FAIL — module not found.
+
+- [ ] **Step 7: Implement openTerminalAt**
+
+Create `src/modules/sessions/lib/openTerminalAt.ts`:
+
+```ts
+import { useTabsStore } from "@/stores/tabsStore";
+
+/** Opens a new terminal tab rooted at `cwd` (e.g. the project view's
+ *  "open a terminal here"). Returns the created tab's id. */
+export function openTerminalAt(cwd: string): string {
+  return useTabsStore.getState().newTerminalTab(cwd);
+}
+```
+
+- [ ] **Step 8: Run to verify it passes**
+
+Run: `pnpm vitest run src/modules/sessions/lib/openTerminalAt.test.ts 2>&1 | tail -6`
+Expected: PASS.
+
+- [ ] **Step 9: Write the failing ProjectView test**
+
+Create `src/modules/sessions/ProjectView.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectView } from "./ProjectView";
+import { useSessionsStore } from "./lib/sessionsStore";
+
+const { mockInvoke, mockOpenTerminal } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+  mockOpenTerminal: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: Record<string, unknown>) => {
+    mockInvoke(cmd, args);
+    if (cmd === "sessions_project_stats") {
+      return Promise.resolve({
+        project_cwd: "/tmp/proj-a",
+        sessions: 2,
+        messages: 14,
+        output_tokens: 100,
+        active_days: 2,
+        top_model: "claude-sonnet-5",
+        first_at: 1000,
+        last_at: 2000,
+        recent: [
+          { id: "s1", agent: "claude", project_cwd: "/tmp/proj-a", title: "Fix bug",
+            started_at: 1000, ended_at: 2000, message_count: 10, user_message_count: 5,
+            output_tokens: 100, model: "claude-sonnet-5", file_path: "/f/s1.jsonl", pinned: false },
+        ],
+      });
+    }
+    return Promise.resolve(undefined);
+  },
+}));
+
+vi.mock("./lib/openTerminalAt", () => ({ openTerminalAt: mockOpenTerminal }));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string, o?: Record<string, unknown>) =>
+    o?.count !== undefined ? `${k}:${o.count}` : k, i18n: { language: "en" } }),
+}));
+
+describe("ProjectView", () => {
+  beforeEach(() => {
+    mockInvoke.mockClear();
+    mockOpenTerminal.mockClear();
+    useSessionsStore.setState({ selectedProject: "/tmp/proj-a", selectedId: null });
+  });
+
+  it("fetches and renders the project's aggregates and recent sessions", async () => {
+    render(<ProjectView />);
+    expect(mockInvoke).toHaveBeenCalledWith("sessions_project_stats", { projectCwd: "/tmp/proj-a" });
+    await waitFor(() => expect(screen.getByText("2")).toBeInTheDocument());
+    expect(screen.getByText("14")).toBeInTheDocument();
+    expect(screen.getByText("claude-sonnet-5")).toBeInTheDocument();
+    expect(screen.getByText("Fix bug")).toBeInTheDocument();
+  });
+
+  it("opens a terminal at the project cwd when the button is clicked", async () => {
+    render(<ProjectView />);
+    await waitFor(() => expect(screen.getByText("2")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "sessions.project.openTerminal" }));
+    expect(mockOpenTerminal).toHaveBeenCalledWith("/tmp/proj-a");
+  });
+
+  it("returns to the dashboard when back is clicked", async () => {
+    render(<ProjectView />);
+    await waitFor(() => expect(screen.getByText("2")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "sessions.project.back" }));
+    expect(useSessionsStore.getState().selectedProject).toBeNull();
+  });
+
+  it("selects a recent session into the viewer when its row is clicked", async () => {
+    render(<ProjectView />);
+    await waitFor(() => expect(screen.getByText("Fix bug")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Fix bug"));
+    expect(useSessionsStore.getState().selectedId).toBe("s1");
+  });
+});
+```
+
+- [ ] **Step 10: Run to verify it fails**
+
+Run: `pnpm vitest run src/modules/sessions/ProjectView.test.tsx 2>&1 | tail -12`
+Expected: FAIL — module not found.
+
+- [ ] **Step 11: Implement ProjectView**
+
+Create `src/modules/sessions/ProjectView.tsx`. Model the tiles on `DashboardView`'s `StatCard` look (border, big value); reuse `basename` from the project path for the header. Key structure:
+
+```tsx
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSessionsStore } from "./lib/sessionsStore";
+import { sessionsProjectStats, type ProjectStats } from "./lib/projectBridge";
+import { openTerminalAt } from "./lib/openTerminalAt";
+import { AGENT_BADGE_CLASS } from "./lib/agentBadge";
+
+const EMPTY: ProjectStats = {
+  project_cwd: "", sessions: 0, messages: 0, output_tokens: 0, active_days: 0,
+  top_model: null, first_at: 0, last_at: 0, recent: [],
+};
+
+export function ProjectView() {
+  const { t } = useTranslation();
+  const cwd = useSessionsStore((s) => s.selectedProject) ?? "";
+  const selectProject = useSessionsStore((s) => s.selectProject);
+  const select = useSessionsStore((s) => s.select);
+  const [stats, setStats] = useState<ProjectStats>(EMPTY);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!cwd) return;
+    sessionsProjectStats(cwd).then((next) => { if (!cancelled) setStats(next); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [cwd]);
+
+  const name = useMemo(() => cwd.split("/").filter(Boolean).pop() ?? cwd, [cwd]);
+
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <div className="flex items-center gap-2">
+        <button type="button" onClick={() => selectProject(null)}
+          className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-elevated hover:text-fg">
+          {t("sessions.project.back")}
+        </button>
+        <h1 className="min-w-0 flex-1 truncate text-lg font-semibold text-fg">{name}</h1>
+        <button type="button" onClick={() => openTerminalAt(cwd)}
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-elevated hover:text-fg">
+          {t("sessions.project.openTerminal")}
+        </button>
+      </div>
+      <p className="mt-0.5 truncate text-xs text-fg-subtle">{cwd}</p>
+
+      <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-5">
+        <Tile label={t("sessions.project.sessions")} value={stats.sessions.toLocaleString()} />
+        <Tile label={t("sessions.project.messages")} value={stats.messages.toLocaleString()} />
+        <Tile label={t("sessions.project.tokens")} value={stats.output_tokens.toLocaleString()} />
+        <Tile label={t("sessions.project.activeDays")} value={stats.active_days.toLocaleString()} />
+        <Tile label={t("sessions.project.topModel")} value={stats.top_model ?? "—"} />
+      </div>
+
+      <h2 className="mt-6 text-[11px] font-semibold uppercase tracking-wide text-fg-subtle">
+        {t("sessions.project.recent")}
+      </h2>
+      <ul className="mt-2">
+        {stats.recent.map((s) => (
+          <li key={s.id}>
+            <button type="button" onClick={() => select(s.id)}
+              className="flex w-full min-w-0 items-center justify-between gap-2 rounded px-2 py-1.5 text-left hover:bg-bg-elevated">
+              <span className="min-w-0 truncate text-sm text-fg">{s.title}</span>
+              <span className={`shrink-0 text-[10px] font-medium uppercase ${AGENT_BADGE_CLASS[s.agent]}`}>
+                {t(`sessions.agents.${s.agent}`)}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Tile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-0.5 rounded-lg border border-border bg-bg px-3.5 py-3">
+      <div className="truncate text-[20px] font-bold leading-none tabular-nums text-fg">{value}</div>
+      <div className="mt-1 text-[11px] text-fg-subtle">{label}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 12: Run to verify it passes**
+
+Run: `pnpm vitest run src/modules/sessions/ProjectView.test.tsx 2>&1 | tail -8`
+Expected: PASS (4 tests).
+
+- [ ] **Step 13: Route the project view in SessionsTabContent**
+
+In `SessionsTabContent.tsx`, read `selectedProject` from the store (add to the existing `useSessionsStore` selectors) and add a branch **before** the `if (!selectedId)` at line 158:
+
+```tsx
+  if (selectedProject) {
+    return <ProjectView />;
+  }
+  if (!selectedId) {
+    return <DashboardView />;
+  }
+```
+
+Import `ProjectView` at the top.
+
+- [ ] **Step 14: Make project names clickable in the sidebar and dashboard**
+
+In `SessionsPanel.tsx`, the row renders the project basename as text; wrap it in a click that calls `selectProject(s.project_cwd)` and `stopPropagation()` so it doesn't also select the session. In `DashboardView.tsx`'s `TopSessionRow`, make the `project_cwd` line a nested button calling `selectProject(session.project_cwd)` with `stopPropagation()`. Add `selectProject` from the store in both. (Keep the row's own click behavior intact.)
+
+- [ ] **Step 15: Add i18n keys**
+
+Add to both `en/common.json` and `zh-Hant/common.json` under `sessions.project`:
+- en: `{ "back": "Back", "openTerminal": "Open terminal here", "sessions": "Sessions", "messages": "Messages", "tokens": "Output tokens", "activeDays": "Active days", "topModel": "Top model", "recent": "Recent sessions" }`
+- zh-Hant: `{ "back": "返回", "openTerminal": "在此開新終端", "sessions": "對話數", "messages": "訊息數", "tokens": "輸出 token", "activeDays": "活躍天數", "topModel": "最常用 model", "recent": "最近對話" }`
+
+- [ ] **Step 16: Typecheck + run sessions tests**
+
+Run: `pnpm typecheck 2>&1 | tail -3 && pnpm vitest run src/modules/sessions 2>&1 | grep -E "Tests |×" | tail -3`
+Expected: typecheck clean; all sessions tests pass.
+
+- [ ] **Step 17: Commit**
+
+```bash
+git add src/modules/sessions/ src/i18n/locales/en/common.json src/i18n/locales/zh-Hant/common.json
+git commit -m "feat(sessions): add project view screen reached by clicking a project name"
+```
+
+---
+
+## Task 3: Session ↔ git commit correlation
+
+**Files:**
+- Modify: `src-tauri/src/modules/git/mod.rs` (add `git_commits_in_range` command + tests)
+- Modify: `src-tauri/src/lib.rs` (register the command)
+- Modify: `src/modules/source-control/lib/gitBridge.ts` (add `gitCommitsInRange` wrapper)
+- Modify: `src/modules/sessions/SessionsTabContent.tsx` (viewer commit section)
+- Modify: both locale files (`sessions.commits.*`)
+
+**Interfaces:**
+- Consumes: `run_git` (git/mod.rs:499), `parse_commit_info` (git/mod.rs:411), `CommitInfo`.
+- Produces:
+  - Rust command `git_commits_in_range(cwd: String, since_ms: i64, until_ms: i64) -> Result<Vec<CommitInfo>, String>` — always `Ok`, empty on any non-git/remote/failure.
+  - TS `gitCommitsInRange(cwd: string, sinceMs: number, untilMs: number): Promise<CommitInfo[]>` invoking `"git_commits_in_range"` with `{ cwd, sinceMs, untilMs }`.
+
+- [ ] **Step 1: Write the failing Rust tests**
+
+Add to the `#[cfg(test)] mod tests` in `git/mod.rs` (create a real temp repo with two commits; use `run_git` to init/commit or `std::process::Command`). Helper sketch:
+
+```rust
+#[test]
+fn commits_in_range_returns_empty_for_a_non_git_dir() {
+    let dir = std::env::temp_dir().join(format!("tt-git-nonrepo-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let out = git_commits_in_range_impl(dir.to_str().unwrap(), 0, i64::MAX);
+    assert!(out.is_empty());
+}
+
+#[test]
+fn commits_in_range_rejects_a_remote_looking_cwd() {
+    let out = git_commits_in_range_impl("ssh://host/repo", 0, i64::MAX);
+    assert!(out.is_empty());
+}
+
+#[test]
+fn commits_in_range_filters_by_the_time_window() {
+    // Build a temp repo, commit twice with controlled author dates via
+    // GIT_AUTHOR_DATE/GIT_COMMITTER_DATE (epoch seconds). One commit at t=1000s,
+    // one at t=5000s. A window of [900s, 2000s] in MILLISECONDS = [900_000, 2_000_000].
+    let repo = make_temp_repo_with_commits(); // helper: returns path, commits at 1000s and 5000s
+    let out = git_commits_in_range_impl(&repo, 900_000, 2_000_000);
+    assert_eq!(out.len(), 1, "only the t=1000s commit is inside the window");
+}
+```
+
+Implementer note: factor the logic into a plain `fn git_commits_in_range_impl(cwd: &str, since_ms: i64, until_ms: i64) -> Vec<CommitInfo>` so tests call it without the Tauri command wrapper. `make_temp_repo_with_commits` uses `git init`, sets `user.email`/`user.name` locally, and commits with `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` set to `@1000 +0000` / `@5000 +0000`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd src-tauri && cargo test git::tests::commits_in_range 2>&1 | tail -20`
+Expected: FAIL — `git_commits_in_range_impl` not found.
+
+- [ ] **Step 3: Implement the impl + command**
+
+In `git/mod.rs`:
+
+```rust
+/// Commits authored in `[since_ms, until_ms]` (epoch MILLISECONDS) in the git
+/// work tree at `cwd`. Empty for an empty/remote (`://`) `cwd`, a non-git dir,
+/// or any git failure — a missing/odd repo simply shows no commits, never an
+/// error. Session↔code correlation for the transcript viewer.
+fn git_commits_in_range_impl(cwd: &str, since_ms: i64, until_ms: i64) -> Vec<CommitInfo> {
+    if cwd.is_empty() || cwd.contains("://") || ensure_not_flag(cwd).is_err() {
+        return Vec::new();
+    }
+    // Must be a git work tree.
+    match run_git(cwd, &["rev-parse", "--is-inside-work-tree"]) {
+        Ok(out) if out.trim() == "true" => {}
+        _ => return Vec::new(),
+    }
+    // git wants seconds; sessions carry milliseconds.
+    let since = (since_ms / 1000).to_string();
+    let until = (until_ms / 1000).to_string();
+    let args = [
+        "log",
+        "--date-order",
+        &format!("--since={since}"),
+        &format!("--until={until}"),
+        "--pretty=format:%h\u{241f}%p\u{241f}%an\u{241f}%ct\u{241f}%s",
+        "--max-count=100",
+    ];
+    match run_git(cwd, &args) {
+        Ok(out) => out.lines().filter_map(parse_commit_info).collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[tauri::command]
+pub fn git_commits_in_range(cwd: String, since_ms: i64, until_ms: i64) -> Result<Vec<CommitInfo>, String> {
+    Ok(git_commits_in_range_impl(&cwd, since_ms, until_ms))
+}
+```
+
+Note: match the exact separator byte and `parse_commit_info` signature used by the existing `log` (git/mod.rs:429-452); if `parse_commit_info` returns `Option<CommitInfo>` use `filter_map`, if `Result` adapt accordingly. Copy the `--pretty=format` string verbatim from `log`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd src-tauri && cargo test git::tests::commits_in_range 2>&1 | tail -20`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Register the command**
+
+In `lib.rs`, add `git_commits_in_range` to the git imports and to the handler list next to `git_log`.
+
+- [ ] **Step 6: Add the frontend bridge + failing viewer test**
+
+In `gitBridge.ts` add:
+
+```ts
+/** Commits authored in [sinceMs, untilMs] in the git work tree at `cwd`.
+ *  Empty for a non-git / remote / failed cwd. Timestamps are epoch ms. */
+export function gitCommitsInRange(cwd: string, sinceMs: number, untilMs: number): Promise<CommitInfo[]> {
+  return invoke<CommitInfo[]>("git_commits_in_range", { cwd, sinceMs, untilMs });
+}
+```
+
+Add to `SessionsTabContent.test.tsx` a test: when `git_commits_in_range` resolves with one commit, the viewer shows its summary; when it resolves empty, no commits header appears. (Extend the existing invoke mock to answer `git_commits_in_range`.)
+
+```tsx
+it("shows a commits section listing commits made during the session", async () => {
+  // arrange: select a session, make git_commits_in_range resolve to one commit
+  // assert: screen.getByText("<commit summary>") present, and the header
+  //         screen.getByText("sessions.commits.title") present
+});
+
+it("hides the commits section entirely when there are no commits", async () => {
+  // git_commits_in_range resolves []; assert queryByText("sessions.commits.title") is null
+});
+```
+
+- [ ] **Step 7: Run to verify it fails**
+
+Run: `pnpm vitest run src/modules/sessions/SessionsTabContent.test.tsx 2>&1 | tail -12`
+Expected: FAIL — commits section not rendered.
+
+- [ ] **Step 8: Render the commit section in the viewer**
+
+In `SessionsTabContent.tsx`, after the transcript render, add an effect that fetches commits for the selected session and a section that only renders when the list is non-empty:
+
+```tsx
+const [commits, setCommits] = useState<CommitInfo[]>([]);
+useEffect(() => {
+  let cancelled = false;
+  if (!session) { setCommits([]); return; }
+  gitCommitsInRange(session.project_cwd, session.started_at, session.ended_at)
+    .then((c) => { if (!cancelled) setCommits(c); })
+    .catch(() => { if (!cancelled) setCommits([]); });
+  return () => { cancelled = true; };
+}, [session?.id]);
+```
+
+```tsx
+{commits.length > 0 && (
+  <section className="mt-4 border-t border-border pt-3">
+    <h2 className="text-[11px] font-semibold uppercase tracking-wide text-fg-subtle">
+      {t("sessions.commits.title")}
+    </h2>
+    <ul className="mt-2 flex flex-col gap-1">
+      {commits.map((c) => (
+        <li key={c.id} className="flex items-baseline gap-2 text-xs">
+          <span className="shrink-0 font-mono text-fg-subtle">{c.id}</span>
+          <span className="min-w-0 flex-1 truncate text-fg">{c.summary}</span>
+          <span className="shrink-0 text-fg-subtle">{c.author}</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}
+```
+
+Import `gitCommitsInRange` and the `CommitInfo` type from `gitBridge`. Place the section where the viewer's scroll area holds the transcript (after the message list, inside the same scroll container).
+
+- [ ] **Step 9: Add i18n + run to verify it passes**
+
+Add `sessions.commits.title` — en `"Commits during this session"`, zh-Hant `"這次對話期間的 commit"`.
+Run: `pnpm vitest run src/modules/sessions/SessionsTabContent.test.tsx 2>&1 | tail -8`
+Expected: PASS.
+
+- [ ] **Step 10: Typecheck + Rust build**
+
+Run: `pnpm typecheck 2>&1 | tail -3 && cd src-tauri && cargo test git 2>&1 | grep "test result" | head -1`
+Expected: clean.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src-tauri/src/modules/git/mod.rs src-tauri/src/lib.rs src/modules/source-control/lib/gitBridge.ts src/modules/sessions/SessionsTabContent.tsx src/modules/sessions/SessionsTabContent.test.tsx src/i18n/locales/en/common.json src/i18n/locales/zh-Hant/common.json
+git commit -m "feat(sessions): correlate a session with the git commits made during it"
+```
+
+---
+
+## Task 4: Model filter
+
+**Files:**
+- Modify: `src/modules/sessions/lib/sessionsStore.ts` (`modelFilter`/`setModelFilter`; extend `visibleSessions`)
+- Modify: `src/modules/sessions/lib/sessionsStore.test.ts`
+- Modify: `src/modules/sessions/SessionsPanel.tsx` (model dropdown)
+- Modify: both locale files (`sessions.modelFilterAll`)
+
+**Interfaces:**
+- Consumes: `SessionSummary.model`, existing `Combobox` (`src/components/Combobox.tsx`) or the agent-chip control style.
+- Produces:
+  - store: `modelFilter: string` (`"all"` default), `setModelFilter(model: string)`.
+  - `visibleSessions(sessions, query, agentFilter, modelFilter)` — fourth arg; `"all"` passes everything, otherwise exact `s.model === modelFilter` (a `null`-model session shows only under `"all"`).
+
+- [ ] **Step 1: Write the failing selector test**
+
+Add to `sessionsStore.test.ts`:
+
+```ts
+it("visibleSessions filters by exact model, with 'all' passing everything", () => {
+  const mk = (id: string, model: string | null) =>
+    ({ id, agent: "claude", project_cwd: "/p", title: id, started_at: 0, ended_at: 0,
+       message_count: 0, user_message_count: 0, output_tokens: null, model, file_path: "/f",
+       pinned: false }) as SessionSummary;
+  const sessions = [mk("a", "claude-opus-4-8"), mk("b", "gpt-5.5"), mk("c", null)];
+
+  expect(visibleSessions(sessions, "", "all", "all").history.map((s) => s.id)).toEqual(["a", "b", "c"]);
+  expect(visibleSessions(sessions, "", "all", "gpt-5.5").history.map((s) => s.id)).toEqual(["b"]);
+  // null-model sessions never match a specific model.
+  expect(visibleSessions(sessions, "", "all", "claude-opus-4-8").history.map((s) => s.id)).toEqual(["a"]);
+});
+```
+
+Update the existing `visibleSessions` call sites in this test file to pass `"all"` as the fourth arg.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm vitest run src/modules/sessions/lib/sessionsStore.test.ts 2>&1 | tail -12`
+Expected: FAIL — `visibleSessions` takes 3 args / wrong result.
+
+- [ ] **Step 3: Extend the store + selector**
+
+In `sessionsStore.ts`: add `modelFilter: string` to the interface + initial state (`modelFilter: "all"`), add `setModelFilter: (model: string) => void;` and `setModelFilter: (modelFilter) => set({ modelFilter }),`. Extend the selector:
+
+```ts
+export function visibleSessions(
+  sessions: SessionSummary[],
+  query: string,
+  agentFilter: SessionAgent | "all",
+  modelFilter: string,
+): { pinned: SessionSummary[]; history: SessionSummary[] } {
+  const q = query.trim().toLowerCase();
+  const filtered = sessions.filter((s) => {
+    if (agentFilter !== "all" && s.agent !== agentFilter) return false;
+    if (modelFilter !== "all" && s.model !== modelFilter) return false;
+    if (q === "") return true;
+    return s.title.toLowerCase().includes(q) || s.project_cwd.toLowerCase().includes(q);
+  });
+  const pinned = filtered.filter((s) => s.pinned).sort((a, b) => b.ended_at - a.ended_at);
+  const history = filtered.filter((s) => !s.pinned);
+  return { pinned, history };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm vitest run src/modules/sessions/lib/sessionsStore.test.ts 2>&1 | tail -8`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the sidebar dropdown**
+
+In `SessionsPanel.tsx`: read `modelFilter`/`setModelFilter` from the store and update the `visibleSessions(...)` call to pass `modelFilter`. Derive the option list from the loaded sessions:
+
+```tsx
+const modelOptions = useMemo(() => {
+  const set = new Set<string>();
+  for (const s of sessions) if (s.model) set.add(s.model);
+  return ["all", ...[...set].sort()];
+}, [sessions]);
+```
+
+Render a compact dropdown near the agent chips. Use the shared `Combobox` (`src/components/Combobox.tsx`) per the project convention, mapping `"all"` to the label `t("sessions.modelFilterAll")` and every other option to its raw model id. On change call `setModelFilter(value)`. Only render the dropdown when `modelOptions.length > 1` (i.e. at least one model exists).
+
+- [ ] **Step 6: Add i18n + typecheck + tests**
+
+Add `sessions.modelFilterAll` — en `"All models"`, zh-Hant `"所有 model"`.
+Run: `pnpm typecheck 2>&1 | tail -3 && pnpm vitest run src/modules/sessions 2>&1 | grep -E "Tests |×" | tail -3`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/modules/sessions/ src/i18n/locales/en/common.json src/i18n/locales/zh-Hant/common.json
+git commit -m "feat(sessions): add a sidebar model filter for the session list"
+```
+
+---
+
+## Task 5: CSV export
+
+**Files:**
+- Create: `src/modules/sessions/lib/sessionsCsv.ts` + `.test.ts`
+- Modify: `src/lib/dialog.ts` (optional `filters` param on `saveFile`)
+- Modify: `src/modules/sessions/DashboardView.tsx` (Export CSV button)
+- Modify: both locale files (`sessions.dashboard.exportCsv`)
+
+**Interfaces:**
+- Consumes: `SessionSummary`, `visibleSessions` (Task 4), `saveFile`, `fsWriteFile`.
+- Produces: `toSessionsCsv(sessions: SessionSummary[]): string`.
+
+- [ ] **Step 1: Write the failing CSV test**
+
+Create `src/modules/sessions/lib/sessionsCsv.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { toSessionsCsv } from "./sessionsCsv";
+import type { SessionSummary } from "./sessionsBridge";
+
+const s = (o: Partial<SessionSummary>): SessionSummary => ({
+  id: "id", agent: "claude", project_cwd: "/p", title: "t", started_at: 0, ended_at: 0,
+  message_count: 0, user_message_count: 0, output_tokens: null, model: null,
+  file_path: "/f", pinned: false, ...o,
+});
+
+describe("toSessionsCsv", () => {
+  it("writes a header row plus one row per session in field order", () => {
+    const csv = toSessionsCsv([s({ title: "Fix bug", agent: "codex", model: "gpt-5.5", message_count: 12 })]);
+    const [header, row] = csv.split("\n");
+    expect(header).toBe("title,agent,model,project,started_at,ended_at,messages,user_messages,output_tokens,pinned");
+    expect(row.startsWith("Fix bug,codex,gpt-5.5,/p,")).toBe(true);
+    expect(row.endsWith(",12,0,,false")).toBe(true); // null output_tokens → empty field
+  });
+
+  it("quotes and escapes fields containing commas, quotes, or newlines", () => {
+    const csv = toSessionsCsv([s({ title: 'a,"b"\nc' })]);
+    const row = csv.split("\n").slice(1).join("\n"); // field itself contains a newline
+    expect(row.startsWith('"a,""b""\nc",claude,')).toBe(true);
+  });
+
+  it("returns just the header for an empty list", () => {
+    expect(toSessionsCsv([])).toBe(
+      "title,agent,model,project,started_at,ended_at,messages,user_messages,output_tokens,pinned",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm vitest run src/modules/sessions/lib/sessionsCsv.test.ts 2>&1 | tail -12`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement toSessionsCsv**
+
+Create `src/modules/sessions/lib/sessionsCsv.ts`:
+
+```ts
+import type { SessionSummary } from "./sessionsBridge";
+
+const HEADER = [
+  "title", "agent", "model", "project", "started_at", "ended_at",
+  "messages", "user_messages", "output_tokens", "pinned",
+] as const;
+
+/** RFC-4180 quote: wrap in double quotes and double any inner quote when the
+ *  field contains a comma, quote, CR, or LF; otherwise return it unchanged. */
+function csvField(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/** Serializes sessions to RFC-4180 CSV: a fixed header row then one row per
+ *  session. A null `output_tokens`/`model` becomes an empty field. Timestamps
+ *  are the raw epoch-ms numbers (stable, spreadsheet-parseable). */
+export function toSessionsCsv(sessions: SessionSummary[]): string {
+  const rows = sessions.map((s) =>
+    [
+      s.title,
+      s.agent,
+      s.model ?? "",
+      s.project_cwd,
+      String(s.started_at),
+      String(s.ended_at),
+      String(s.message_count),
+      String(s.user_message_count),
+      s.output_tokens === null ? "" : String(s.output_tokens),
+      String(s.pinned),
+    ]
+      .map(csvField)
+      .join(","),
+  );
+  return [HEADER.join(","), ...rows].join("\n");
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm vitest run src/modules/sessions/lib/sessionsCsv.test.ts 2>&1 | tail -8`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Add a `filters` param to saveFile**
+
+In `src/lib/dialog.ts`, change `saveFile` to accept optional filters (default keeps Markdown):
+
+```ts
+export async function saveFile(
+  defaultPath: string,
+  filters: { name: string; extensions: string[] }[] = [{ name: "Markdown", extensions: ["md"] }],
+): Promise<string | null> {
+  const result = await save({ defaultPath, filters });
+  return typeof result === "string" ? result : null;
+}
+```
+
+(The existing Markdown export call is unchanged — it omits the second arg.)
+
+- [ ] **Step 6: Wire the dashboard Export CSV button**
+
+In `DashboardView.tsx`, read the loaded `sessions` and the filters (`query`, `agentFilter`, `modelFilter`) from `useSessionsStore`, and add a top-right button. Its handler:
+
+```tsx
+async function handleExportCsv() {
+  const { pinned, history } = visibleSessions(sessions, query, agentFilter, modelFilter);
+  const csv = toSessionsCsv([...pinned, ...history]);
+  const path = await saveFile("ai-sessions.csv", [{ name: "CSV", extensions: ["csv"] }]);
+  if (path === null) return;
+  await fsWriteFile(path, csv);
+}
+```
+
+Import `visibleSessions` from `./lib/sessionsStore`, `toSessionsCsv` from `./lib/sessionsCsv`, `saveFile` from `@/lib/dialog`, `fsWriteFile` from `@/modules/explorer/lib/fsBridge`. Place the button in the dashboard header row (next to the range chips), labelled `t("sessions.dashboard.exportCsv")`.
+
+- [ ] **Step 7: Add a failing dashboard test for the button**
+
+Add to `DashboardView.test.tsx` (mock `@/lib/dialog` `saveFile` → a path, and `@/modules/explorer/lib/fsBridge` `fsWriteFile`; seed the store `sessions`):
+
+```tsx
+it("exports the filtered session list as CSV via saveFile + fsWriteFile", async () => {
+  // seed useSessionsStore.setState({ sessions: [oneSession], query:"", agentFilter:"all", modelFilter:"all" })
+  // render, click getByRole("button", { name: "sessions.dashboard.exportCsv" })
+  // await: expect(mockSaveFile).toHaveBeenCalledWith("ai-sessions.csv", [{ name: "CSV", extensions: ["csv"] }])
+  // expect(mockFsWriteFile).toHaveBeenCalledWith("/path.csv", expect.stringContaining("title,agent,model"))
+});
+```
+
+- [ ] **Step 8: Run to verify the whole task passes**
+
+Run: `pnpm vitest run src/modules/sessions/DashboardView.test.tsx src/modules/sessions/lib/sessionsCsv.test.ts 2>&1 | grep -E "Tests |×" | tail -3`
+Expected: PASS.
+
+- [ ] **Step 9: Add i18n + typecheck**
+
+Add `sessions.dashboard.exportCsv` — en `"Export CSV"`, zh-Hant `"匯出 CSV"`.
+Run: `pnpm typecheck 2>&1 | tail -3`
+Expected: clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/modules/sessions/ src/lib/dialog.ts src/i18n/locales/en/common.json src/i18n/locales/zh-Hant/common.json
+git commit -m "feat(sessions): export the filtered session list as CSV from the dashboard"
+```
+
+---
+
+## Task 6: Verification + PR
+
+**Files:** none (verification + PR only)
+
+- [ ] **Step 1: Full frontend suite + typecheck**
+
+Run: `pnpm typecheck 2>&1 | tail -3 && pnpm test 2>&1 | grep -E "Tests " | tail -1`
+Expected: typecheck clean; all frontend tests pass.
+
+- [ ] **Step 2: Full Rust suite**
+
+Run: `cd src-tauri && cargo test 2>&1 | grep "test result" | tail -5`
+Expected: all suites pass (sessions_index + git).
+
+- [ ] **Step 3: Build + relaunch for manual check**
+
+Run:
+```bash
+export TAURI_SIGNING_PRIVATE_KEY="$(cat ~/.tauri/tempo-term.key)" TAURI_SIGNING_PRIVATE_KEY_PASSWORD=""
+pnpm tauri build 2>&1 | grep -E "Finished 1 updater|error running bundle" | tail -1
+pkill -f "TempoTerm.app/Contents/MacOS/tempo-term" 2>/dev/null; sleep 1
+rm -rf ~/Library/Caches/com.tempoterm.desktop ~/Library/WebKit/com.tempoterm.desktop 2>/dev/null
+nohup ./src-tauri/target/release/bundle/macos/TempoTerm.app/Contents/MacOS/tempo-term >/tmp/app-p3.log 2>&1 &
+```
+Manual: click a project name → project view; open terminal here; a session with local git commits shows the commits section; model filter narrows the list; Export CSV writes a file.
+
+- [ ] **Step 4: Final whole-branch review**
+
+Dispatch a `code-reviewer` on the diff `git merge-base origin/master HEAD..HEAD`. Fix Critical/Important findings.
+
+- [ ] **Step 5: Push + open PR**
+
+```bash
+git push -u origin feat/ai-sessions-p3
+MILESTONE=$(gh api repos/mukiwu/tempo-term/milestones --jq '.[0].title')
+gh pr create --title "feat: AI sessions view (P3) — project view, git correlation, model filter, CSV" --body "<summary + test plan>"
+PR=$(gh pr view --json number --jq .number)
+gh pr edit "$PR" --add-label enhancement --milestone "$MILESTONE" --add-assignee mukiwu
+```
+
+- [ ] **Step 6: Track Gemini review**
+
+After the PR opens, fetch `gh api repos/mukiwu/tempo-term/pulls/$PR/reviews` and `.../comments`; triage high/medium/low; fix or reply in English.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Project view (T1 backend + T2 frontend), git correlation (T3), model filter (T4), CSV export (T5), verification/PR (T6) — every spec section maps to a task. Non-goals (FTS, remote git, commit→graph jump, per-project charts) are correctly absent.
+
+**Placeholder scan:** `list_for_project` (T1 Step 3) intentionally defers to `list()`'s exact SELECT/mapping with an explicit implementer note (the real column list lives in index.rs:140 and must be copied verbatim, not invented) — this is a "copy the existing pattern" instruction, not a vague placeholder. The T3 repo-fixture helper and two component-test bodies (T3 Step 6, T5 Step 7) are described by their asserts rather than fully written; every other step carries complete code.
+
+**Type consistency:** `ProjectStats` fields match between Rust (T1 Step 3), the command (T1 Step 5), and TS (T1 Step 7). `visibleSessions` gains a 4th `modelFilter` arg consistently across T4 (definition) and T5 (call site). `selectProject`/`select` mutual-clear defined in T2 and relied on in T2's routing. `gitCommitsInRange(cwd, sinceMs, untilMs)` matches the Rust `git_commits_in_range(cwd, since_ms, until_ms)`.

--- a/docs/superpowers/specs/2026-07-07-ai-sessions-view-p3-design.md
+++ b/docs/superpowers/specs/2026-07-07-ai-sessions-view-p3-design.md
@@ -1,0 +1,204 @@
+# AI sessions view P3 (project view, git correlation, model filter, CSV) (v1)
+
+Status: approved design, ready for planning
+Date: 2026-07-07
+Branch: feat/ai-sessions-p3 (based on master c08c9df — P1 #147 + P2 #148 both merged)
+
+## Problem
+
+The AI Sessions view (P1 browse, P2 dashboard/delete/export) has no way to look
+at one project's history, no link between a conversation and the code it
+produced, no way to narrow the list by model, and no spreadsheet-friendly
+export. P3 adds those, all reusing existing patterns. Full-text search over
+message content is explicitly out of scope (a later phase).
+
+## Goals
+
+- **Project view**: a third main-area screen showing one project's aggregate
+  stats and recent sessions, reached by clicking a project name, with a
+  one-click "open a terminal here".
+- **Session ↔ git commit correlation**: in the transcript viewer, a section
+  listing the local git commits made in that project during the session's time
+  window. Absent (whole section hidden) for non-git / remote / no-commit cases.
+- **Model filter**: a sidebar dropdown that narrows the session list to one
+  model, alongside the existing agent chips.
+- **CSV export**: a dashboard button that exports the currently-filtered
+  session list as CSV.
+
+## Non-goals (v1)
+
+- Full-text search over message bodies (needs FTS5 / stored bodies — deferred).
+- Git correlation for remote (SSH) or non-git working directories — those hide
+  the section rather than erroring.
+- Clicking a commit to jump into the git-graph view (P3 shows commits read-only;
+  a jump is a later nicety).
+- Per-project heatmap / charts in the project view (v1 is stat tiles + a
+  recent-sessions list; charts can follow).
+
+## Verified facts (recon, in the dev worktree)
+
+- **git module** `src-tauri/src/modules/git/mod.rs`: `CommitInfo` (mod.rs:23-31)
+  = `{ id (short hash), summary, author, timestamp: i64, parents: Vec<String> }`.
+  ⚠️ `timestamp` is epoch **seconds** (`%ct`), but sessions' `started_at`/
+  `ended_at` are epoch **milliseconds** — convert (ms/1000) before passing to
+  git or comparing. `run_git(repo_path, args)` (mod.rs:46-ish / 499) is the
+  `git -C <repo_path> …` primitive; `parse_commit_info` (mod.rs:411) parses the
+  `%h␟%p␟%an␟%ct␟%s` line format; `ensure_not_flag` (mod.rs:527) guards
+  positional args. **No** `--since/--until` support exists — a new command adds
+  it. Frontend git bridge: `src/modules/source-control/lib/gitBridge.ts`.
+- **sessions_index** `src-tauri/src/modules/sessions_index/`: schema
+  `sessions(id, agent, project_cwd, title, started_at, ended_at, message_count,
+  user_message_count, output_tokens, model, file_path, …)` (index.rs:51-75) +
+  `activity(session_id, date, hour, messages, user_messages, output_tokens)`.
+  Commands registered in `lib.rs`. `SessionSummary` types.rs:36-49 /
+  `sessionsBridge.ts:13-26` — `model` is already present (`Option<String>` /
+  `string | null`).
+- **Sessions tab routing** `SessionsTabContent.tsx:158-160`: two screens keyed
+  off store `selectedId` (`null` → `DashboardView`, set → transcript viewer).
+  Single `"sessions"` TabKind; no new kind needed for a third screen.
+- **sessions store** `sessionsStore.ts`: `{ sessions, loaded, query, agentFilter,
+  selectedId }` + `visibleSessions(sessions, query, agentFilter)` selector
+  (:84, predicate :91). Model list must be derived client-side from
+  `sessions[].model` (no backend distinct-models query; `range_models` drops
+  null-model sessions so it's not a clean filter source).
+- **Export/save** `saveFile(defaultPath)` (`src/lib/dialog.ts:18`) currently
+  hardcodes a Markdown filter; CSV needs a filter param or a sibling helper.
+  `fsWriteFile(path, contents)` (`src/modules/explorer/lib/fsBridge.ts:42`).
+- **Open terminal at cwd**: `useTabsStore.getState().newTerminalTab(cwd)`
+  (tabsStore.ts:436) returns a tabId; to also run a command, mirror
+  `resumeSession` (`resume.ts:49-61`): create tab, read back `activeLeafId`,
+  `writeToTerminal(leafId, cmd + "\n")` (`terminalBus.ts`).
+
+## Architecture
+
+### A. Project view (Task 1 backend, Task 2 frontend)
+
+**Backend** — new command `sessions_project_stats(project_cwd: String) ->
+ProjectStats` on the index (mirrors `sessions_stats`'s async + spawn_blocking
+shape; empty/unknown project ⇒ zeroed stats, never Err):
+
+```rust
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProjectStats {
+    pub project_cwd: String,
+    pub sessions: i64,
+    pub messages: i64,
+    pub output_tokens: i64,
+    pub active_days: i64,
+    /// Most-used model (by session count) in this project, or None.
+    pub top_model: Option<String>,
+    pub first_at: i64,   // earliest started_at (ms), 0 when none
+    pub last_at: i64,    // latest ended_at (ms), 0 when none
+    /// The project's own sessions, newest first (reuses SessionSummary).
+    pub recent: Vec<SessionSummary>,
+}
+```
+
+Aggregates are `SUM`/`COUNT` over `sessions`/`activity` filtered to
+`project_cwd = ?1`. `recent` is `SELECT … WHERE project_cwd=?1 ORDER BY
+ended_at DESC LIMIT 50`.
+
+**Frontend** — a third screen. Add `selectedProject: string | null` +
+`selectProject(cwd | null)` to `sessionsStore`. `SessionsTabContent` routing
+gains a branch **above** the existing two: `selectedProject` set → render
+`ProjectView`; else the current `selectedId` split. Selecting a session or the
+dashboard clears `selectedProject`; opening the project view clears
+`selectedId`. Project names become clickable (`selectProject(cwd)`) in: sidebar
+rows (the project basename), the dashboard's Top Sessions rows, and the
+transcript viewer's header path. `ProjectView` fetches
+`sessionsProjectStats(cwd)` on mount, renders stat tiles (sessions / messages /
+output tokens / active days / top model) + a "back" button + an "open terminal
+here" button (`newTerminalTab(cwd)`) + a recent-sessions list (row click →
+`select(id)` into the viewer).
+
+### B. Git commit correlation (Task 3)
+
+**Backend** — new command `sessions_git_commits(cwd: String, since_ms: i64,
+until_ms: i64) -> Vec<CommitInfo>`:
+- Return `[]` immediately if `cwd` is empty, looks remote (`parseRemoteUri`
+  concerns are frontend; backend: reject a `cwd` containing `://`), or isn't a
+  git work tree (`git -C <cwd> rev-parse --is-inside-work-tree` fails/≠ "true").
+- Else run `git -C <cwd> log --since=<since_s> --until=<until_s>
+  --pretty=format:%h␟%p␟%an␟%ct␟%s --max-count=100` (convert ms→seconds for the
+  date bounds), parse each line with `parse_commit_info`. Any git failure ⇒
+  `[]` (never an error — a missing/odd repo just shows no commits).
+- Guard `cwd` with the existing arg-safety approach; the since/until values are
+  numeric strings we format ourselves, not user input.
+
+**Frontend** — in the transcript viewer, after the transcript, a "commits
+during this session" section: call `sessionsGitCommits(session.project_cwd,
+session.started_at, session.ended_at)` in an effect (cancel stale like the
+transcript fetch). Render nothing (no header, no empty state) when the result
+is empty — the whole block only appears when there are commits. Each row: short
+hash (mono), subject (truncate), author + relative date.
+
+### C. Model filter (Task 4)
+
+Add `modelFilter: string | "all"` + `setModelFilter` to `sessionsStore`, and
+extend `visibleSessions` to a fourth argument, filtering `s.model === modelFilter`
+(exact match; `"all"` passes everything; a session with `model === null` only
+shows under `"all"`). The sidebar (`SessionsPanel`) renders a compact model
+dropdown (a `<Combobox>` per the project's dropdown convention, or a native-free
+control matching the agent chips) whose options are the distinct non-null
+`sessions[].model` values (sorted) plus "all". Deriving the list client-side
+means no backend change.
+
+### D. CSV export (Task 5)
+
+Pure frontend. A `toSessionsCsv(sessions: SessionSummary[]): string` helper
+(unit-tested) builds RFC-4180 CSV: header row `title,agent,model,project,
+started_at,ended_at,messages,user_messages,output_tokens,pinned` then one row
+per session, with proper quoting (wrap fields containing `,` `"` or newlines in
+double quotes, escape `"`→`""`), timestamps as ISO-8601 local. A dashboard
+top-right "Export CSV" button exports the **currently filtered** list
+(`visibleSessions(...)` flattened: pinned + history) via a `saveFile` variant
+that offers a `.csv` filter, then `fsWriteFile`. `saveFile` gains an optional
+`filters` param (default keeps today's Markdown behavior) so both exporters
+share it.
+
+## Error handling
+
+Everything degrades quietly: project stats on an unknown cwd → zeros; git
+commits on a non-repo/remote/failed cwd → empty (section hidden); CSV of an
+empty list → header-only file; a cancelled save dialog → no-op. Git is read-only
+(`log`/`rev-parse`); no writes to the repo. All new IPC follows the module's
+existing async + spawn_blocking + defensive-parse conventions.
+
+## Testing (TDD)
+
+- Rust: `sessions_project_stats` aggregation (fixture with 2 projects — counts,
+  top_model, first/last, recent ordering, empty project → zeros);
+  `sessions_git_commits` — a real temp git repo with commits inside/outside the
+  window (since/until filtering, ms→s conversion), a non-git dir → `[]`, a
+  `cwd` with `://` → `[]`.
+- Frontend: `visibleSessions` model-filter cases (exact match, "all", null
+  model); `toSessionsCsv` (quoting, escaping, empty list, field order);
+  component tests — project name click routes to ProjectView; ProjectView renders
+  tiles + recent list + fires open-terminal; the viewer's commit section renders
+  on non-empty and is absent on empty; the CSV button calls saveFile + fsWriteFile
+  with the filtered rows.
+
+## Phasing (one PR)
+
+| Task | Scope |
+|---|---|
+| T1 | `sessions_project_stats` command + ProjectStats type + Rust tests |
+| T2 | ProjectView screen + store `selectedProject`/`selectProject` + routing + clickable project names + open-terminal |
+| T3 | `sessions_git_commits` command (+ tests) + viewer commit section |
+| T4 | model filter (store + visibleSessions + sidebar dropdown) |
+| T5 | CSV export (`toSessionsCsv` + `saveFile` filter param + dashboard button) |
+| T6 | verification + PR |
+
+## Dependency budget
+
+Zero new npm packages, zero new Rust crates. Git reuses the existing module;
+CSV is hand-built; the project view and model filter are hand-rolled UI over
+existing stores.
+
+## Open questions (resolved)
+
+- Project view entry: click a project name (not a separate projects list). ✓
+- Git correlation scope: local git only; non-git/remote/no-commit → hide the
+  section. ✓
+- Model filter home: sidebar, beside the agent chips. ✓
+- CSV content: the currently-filtered session list. ✓

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,7 +57,7 @@ use modules::ports::{kill_port_process, list_ports, PortsState};
 use modules::editor_watch::{editor_watch_set, EditorWatchState};
 use modules::sessions_index::{
     sessions_delete, sessions_export, sessions_get, sessions_index_start, sessions_list, sessions_pin,
-    sessions_stats, SessionsIndexState,
+    sessions_project_stats, sessions_stats, SessionsIndexState,
 };
 
 #[derive(serde::Serialize)]
@@ -260,6 +260,7 @@ pub fn run() {
             sessions_get,
             sessions_pin,
             sessions_stats,
+            sessions_project_stats,
             sessions_delete,
             sessions_export
         ])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,10 +22,11 @@ use modules::clipboard::{
 use modules::git::{
     git_branch_checkout, git_branch_checkout_track, git_branch_create_at, git_branch_delete,
     git_branches, git_cherry_pick, git_commit, git_commit_details, git_commit_file_diff,
-    git_commit_range_file_diff, git_commit_range_files, git_diff, git_fetch, git_file_at_rev,
-    git_graph_log, git_log, git_merge, git_pull, git_push, git_push_delete, git_rebase, git_reset,
-    git_resolve_repo, git_restore_file, git_revert, git_stage, git_status, git_tag_create,
-    git_tag_delete, git_unstage, git_worktree_info, git_worktree_list,
+    git_commit_range_file_diff, git_commit_range_files, git_commits_in_range, git_diff,
+    git_fetch, git_file_at_rev, git_graph_log, git_log, git_merge, git_pull, git_push,
+    git_push_delete, git_rebase, git_reset, git_resolve_repo, git_restore_file, git_revert,
+    git_stage, git_status, git_tag_create, git_tag_delete, git_unstage, git_worktree_info,
+    git_worktree_list,
 };
 use modules::pr::{gh_available, pr_via_api, pr_via_gh};
 use modules::preview::{
@@ -179,6 +180,7 @@ pub fn run() {
             git_unstage,
             git_commit,
             git_log,
+            git_commits_in_range,
             git_diff,
             git_file_at_rev,
             git_restore_file,

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -451,6 +451,52 @@ pub fn log(repo_path: &str, limit: usize) -> Result<Vec<CommitInfo>, String> {
     Ok(stdout.lines().filter_map(parse_commit_info).collect())
 }
 
+/// Commits authored in `[since_ms, until_ms]` (epoch MILLISECONDS) in the git
+/// work tree at `cwd`. Empty for an empty/remote (`://`) `cwd`, a non-git dir,
+/// or any git failure — a missing/odd repo simply shows no commits, never an
+/// error. Session↔code correlation for the transcript viewer.
+fn git_commits_in_range_impl(cwd: &str, since_ms: i64, until_ms: i64) -> Vec<CommitInfo> {
+    if cwd.is_empty() || cwd.contains("://") || ensure_not_flag(cwd).is_err() {
+        return Vec::new();
+    }
+    // Must be a git work tree.
+    match run_git(cwd, &["rev-parse", "--is-inside-work-tree"]) {
+        Ok(out) if out.trim() == "true" => {}
+        _ => return Vec::new(),
+    }
+    // git wants seconds; sessions carry milliseconds. `@<seconds> +0000` is
+    // the same absolute-epoch form git itself writes for GIT_AUTHOR_DATE — a
+    // bare number is parsed by approxidate as a relative offset, not an
+    // epoch timestamp, so the "@" + explicit offset is required here.
+    let since = since_ms / 1000;
+    let until = until_ms / 1000;
+    let args = [
+        "log",
+        "--date-order",
+        &format!("--since=@{since} +0000"),
+        &format!("--until=@{until} +0000"),
+        "--pretty=format:%h%x1f%p%x1f%an%x1f%ct%x1f%s",
+        "--max-count=100",
+    ];
+    match run_git(cwd, &args) {
+        Ok(out) => out.lines().filter_map(parse_commit_info).collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Commits authored in `[since_ms, until_ms]` (epoch milliseconds) in the git
+/// work tree at `cwd`, for correlating a viewed session with the commits made
+/// during it. Always `Ok`; a non-git/remote cwd or any git failure yields an
+/// empty list rather than an error.
+#[tauri::command]
+pub fn git_commits_in_range(
+    cwd: String,
+    since_ms: i64,
+    until_ms: i64,
+) -> Result<Vec<CommitInfo>, String> {
+    Ok(git_commits_in_range_impl(&cwd, since_ms, until_ms))
+}
+
 #[tauri::command]
 pub fn git_resolve_repo(path: String) -> Option<String> {
     resolve_repo(&path)
@@ -1953,5 +1999,59 @@ mod tests {
     fn parse_name_status_blank_is_none() {
         assert_eq!(parse_name_status_line(""), None);
         assert_eq!(parse_name_status_line("   "), None);
+    }
+
+    #[test]
+    fn commits_in_range_returns_empty_for_a_non_git_dir() {
+        let dir = temp_repo_dir("commits-range-nonrepo");
+        let out = git_commits_in_range_impl(&dir.to_string_lossy(), 0, i64::MAX);
+        assert!(out.is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn commits_in_range_rejects_a_remote_looking_cwd() {
+        let out = git_commits_in_range_impl("ssh://host/repo", 0, i64::MAX);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn commits_in_range_filters_by_the_time_window() {
+        let dir = temp_repo_dir("commits-range-window");
+        let path = dir.to_string_lossy().to_string();
+        run_git(&path, &["init", "-b", "main"]).unwrap();
+        run_git(&path, &["config", "user.email", "t@t.dev"]).unwrap();
+        run_git(&path, &["config", "user.name", "Tester"]).unwrap();
+
+        // Two commits with controlled author/committer dates (epoch seconds):
+        // one at t=1000s, one at t=5000s.
+        std::fs::write(dir.join("a.txt"), "one").unwrap();
+        run_git(&path, &["add", "."]).unwrap();
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(&path)
+            .args(["commit", "-m", "first"])
+            .env("GIT_AUTHOR_DATE", "@1000 +0000")
+            .env("GIT_COMMITTER_DATE", "@1000 +0000")
+            .output()
+            .unwrap();
+
+        std::fs::write(dir.join("a.txt"), "two").unwrap();
+        run_git(&path, &["add", "."]).unwrap();
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(&path)
+            .args(["commit", "-m", "second"])
+            .env("GIT_AUTHOR_DATE", "@5000 +0000")
+            .env("GIT_COMMITTER_DATE", "@5000 +0000")
+            .output()
+            .unwrap();
+
+        // A window of [900s, 2000s] expressed in milliseconds.
+        let out = git_commits_in_range_impl(&path, 900_000, 2_000_000);
+        assert_eq!(out.len(), 1, "only the t=1000s commit is inside the window");
+        assert_eq!(out[0].summary, "first");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/modules/sessions_index/index.rs
+++ b/src-tauri/src/modules/sessions_index/index.rs
@@ -170,6 +170,41 @@ impl Index {
         }
     }
 
+    /// This project's sessions, newest first, capped at 50. Same row shape as
+    /// `list()`, filtered to one `project_cwd`.
+    pub fn list_for_project(&self, project_cwd: &str) -> Vec<SessionSummary> {
+        let mut stmt = match self.conn.prepare(
+            "SELECT s.id,s.agent,s.project_cwd,s.title,s.started_at,s.ended_at,
+                    s.message_count,s.user_message_count,s.output_tokens,s.model,s.file_path,
+                    (p.session_id IS NOT NULL) AS pinned
+             FROM sessions s LEFT JOIN pins p ON p.session_id = s.id
+             WHERE s.project_cwd = ?1 ORDER BY s.ended_at DESC LIMIT 50",
+        ) {
+            Ok(stmt) => stmt,
+            Err(_) => return Vec::new(),
+        };
+        let rows = stmt.query_map(params![project_cwd], |r| {
+            Ok(SessionSummary {
+                id: r.get(0)?,
+                agent: r.get(1)?,
+                project_cwd: r.get(2)?,
+                title: r.get(3)?,
+                started_at: r.get(4)?,
+                ended_at: r.get(5)?,
+                message_count: r.get(6)?,
+                user_message_count: r.get(7)?,
+                output_tokens: r.get(8)?,
+                model: r.get(9)?,
+                file_path: r.get(10)?,
+                pinned: r.get(11)?,
+            })
+        });
+        match rows {
+            Ok(iter) => iter.flatten().collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
     pub fn set_pinned(&self, id: &str, pinned: bool) -> Result<(), String> {
         let sql = if pinned {
             "INSERT OR IGNORE INTO pins(session_id) VALUES(?1)"

--- a/src-tauri/src/modules/sessions_index/mod.rs
+++ b/src-tauri/src/modules/sessions_index/mod.rs
@@ -343,3 +343,33 @@ pub async fn sessions_stats(state: State<'_, SessionsIndexState>, days: Option<i
         .await
         .map_err(|e| e.to_string())
 }
+
+/// Per-project aggregates + recent sessions for the project view. Offloaded to
+/// a blocking pool thread like `sessions_stats`. Zeroed stats (never an error)
+/// before the index has started or for an unknown project.
+#[tauri::command]
+pub async fn sessions_project_stats(
+    state: State<'_, SessionsIndexState>,
+    project_cwd: String,
+) -> Result<stats::ProjectStats, String> {
+    let index = {
+        let guard = state.inner.lock().unwrap();
+        guard.as_ref().map(|inner| Arc::clone(&inner.index))
+    };
+    let Some(index) = index else {
+        return Ok(stats::ProjectStats {
+            project_cwd,
+            sessions: 0,
+            messages: 0,
+            output_tokens: 0,
+            active_days: 0,
+            top_model: None,
+            first_at: 0,
+            last_at: 0,
+            recent: Vec::new(),
+        });
+    };
+    tauri::async_runtime::spawn_blocking(move || index.lock().unwrap().project_stats(&project_cwd))
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/modules/sessions_index/stats.rs
+++ b/src-tauri/src/modules/sessions_index/stats.rs
@@ -8,6 +8,7 @@ use chrono::{Duration, Local};
 use rusqlite::{params, Connection, Row};
 
 use super::index::Index;
+use super::types::SessionSummary;
 
 /// Everything the dashboard renders in one round trip.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -77,6 +78,24 @@ pub struct WeeklyAgentRow {
 pub struct ModelTokens {
     pub model: String,
     pub output_tokens: i64,
+}
+
+/// Per-project aggregates + this project's recent sessions, for the project
+/// view. Filtered to `project_cwd = ?1`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProjectStats {
+    pub project_cwd: String,
+    pub sessions: i64,
+    pub messages: i64,
+    pub output_tokens: i64,
+    pub active_days: i64,
+    /// Model used in the most sessions in this project (ties by model name),
+    /// or None when no session here recorded a model.
+    pub top_model: Option<String>,
+    pub first_at: i64,
+    pub last_at: i64,
+    /// This project's sessions, newest first (capped at 50).
+    pub recent: Vec<SessionSummary>,
 }
 
 /// Zeroed stats for an empty (or not-yet-started) index. Never `Err`.
@@ -348,6 +367,56 @@ impl Index {
 
         rows
     }
+
+    /// Per-project aggregates + this project's recent sessions. Filtered to
+    /// `project_cwd = ?1`. An unknown project yields zeroed counts and an empty
+    /// `recent` — never an error.
+    pub fn project_stats(&self, project_cwd: &str) -> ProjectStats {
+        let (sessions, messages, output_tokens, first_at, last_at) = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*), COALESCE(SUM(message_count),0), COALESCE(SUM(output_tokens),0),
+                        COALESCE(MIN(started_at),0), COALESCE(MAX(ended_at),0)
+                 FROM sessions WHERE project_cwd = ?1",
+                params![project_cwd],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+            )
+            .unwrap_or((0, 0, 0, 0, 0));
+
+        let active_days = self
+            .conn
+            .query_row(
+                "SELECT COUNT(DISTINCT a.date) FROM activity a
+                 JOIN sessions s ON s.id = a.session_id WHERE s.project_cwd = ?1",
+                params![project_cwd],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+
+        let top_model = self
+            .conn
+            .query_row(
+                "SELECT model FROM sessions WHERE project_cwd = ?1 AND model IS NOT NULL
+                 GROUP BY model ORDER BY COUNT(*) DESC, model ASC LIMIT 1",
+                params![project_cwd],
+                |r| r.get(0),
+            )
+            .ok();
+
+        let recent = self.list_for_project(project_cwd);
+
+        ProjectStats {
+            project_cwd: project_cwd.to_string(),
+            sessions,
+            messages,
+            output_tokens,
+            active_days,
+            top_model,
+            first_at,
+            last_at,
+            recent,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -565,5 +634,36 @@ mod tests {
         assert_eq!(codex.messages, 6);
         assert_eq!(codex.output_tokens, 0);
         assert!(codex.models.is_empty()); // model was None
+    }
+
+    #[test]
+    fn project_stats_aggregates_only_that_project() {
+        let index = seeded_index("proj-stats");
+        let ps = index.project_stats("/tmp/proj-a");
+        // proj-a = s1 (10 msg, 100 tok, sonnet-5, today) + s3 (4 msg, 0 tok, 40d ago).
+        assert_eq!(ps.project_cwd, "/tmp/proj-a");
+        assert_eq!(ps.sessions, 2);
+        assert_eq!(ps.messages, 14);
+        assert_eq!(ps.output_tokens, 100);
+        assert_eq!(ps.active_days, 2);
+        assert_eq!(ps.top_model.as_deref(), Some("claude-sonnet-5"));
+        // recent is newest-first by ended_at; both fixture sessions share ended_at,
+        // so just assert membership and count.
+        assert_eq!(ps.recent.len(), 2);
+        assert!(ps.recent.iter().all(|s| s.project_cwd == "/tmp/proj-a"));
+    }
+
+    #[test]
+    fn project_stats_is_zeroed_for_an_unknown_project() {
+        let index = seeded_index("proj-stats-none");
+        let ps = index.project_stats("/tmp/does-not-exist");
+        assert_eq!(ps.sessions, 0);
+        assert_eq!(ps.messages, 0);
+        assert_eq!(ps.output_tokens, 0);
+        assert_eq!(ps.active_days, 0);
+        assert_eq!(ps.top_model, None);
+        assert_eq!(ps.first_at, 0);
+        assert_eq!(ps.last_at, 0);
+        assert!(ps.recent.is_empty());
     }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -262,6 +262,7 @@
     "pinned": "Pinned",
     "searchPlaceholder": "Search sessions…",
     "all": "All",
+    "modelFilterAll": "All models",
     "empty": "No sessions found",
     "messages": "{{count}} msgs",
     "resume": "Resume",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -339,6 +339,16 @@
       "modelsTitle": "Model usage",
       "modelsEmpty": "No model data in this range",
       "modelsOthers": "Others"
+    },
+    "project": {
+      "back": "Back",
+      "openTerminal": "Open terminal here",
+      "sessions": "Sessions",
+      "messages": "Messages",
+      "tokens": "Output tokens",
+      "activeDays": "Active days",
+      "topModel": "Top model",
+      "recent": "Recent sessions"
     }
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -276,6 +276,9 @@
     "deleteError": "Could not move the files to the Trash",
     "export": "Export",
     "exportError": "Could not export the transcript",
+    "commits": {
+      "title": "Commits during this session"
+    },
     "agents": {
       "claude": "Claude",
       "codex": "Codex",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -263,6 +263,7 @@
     "searchPlaceholder": "Search sessions…",
     "all": "All",
     "modelFilterAll": "All models",
+    "modelFilterLabel": "Filter by model",
     "empty": "No sessions found",
     "messages": "{{count}} msgs",
     "resume": "Resume",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -310,6 +310,7 @@
       "range90": "90d",
       "range365": "1y",
       "rangeAll": "All",
+      "exportCsv": "Export CSV",
       "cards": {
         "sessions": "Sessions",
         "messages": "Messages",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -339,6 +339,16 @@
       "modelsTitle": "Model 使用量",
       "modelsEmpty": "此範圍沒有 model 資料",
       "modelsOthers": "其他"
+    },
+    "project": {
+      "back": "返回",
+      "openTerminal": "在此開新終端",
+      "sessions": "對話數",
+      "messages": "訊息數",
+      "tokens": "輸出 token",
+      "activeDays": "活躍天數",
+      "topModel": "最常用 model",
+      "recent": "最近對話"
     }
   }
 }

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -263,6 +263,7 @@
     "searchPlaceholder": "搜尋對話…",
     "all": "全部",
     "modelFilterAll": "所有 model",
+    "modelFilterLabel": "以 model 篩選",
     "empty": "沒有符合的對話",
     "messages": "{{count}} 則訊息",
     "resume": "接續對話",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -276,6 +276,9 @@
     "deleteError": "無法把檔案丟到垃圾桶",
     "export": "匯出",
     "exportError": "無法匯出對話記錄",
+    "commits": {
+      "title": "這次對話期間的 commit"
+    },
     "agents": {
       "claude": "Claude",
       "codex": "Codex",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -310,6 +310,7 @@
       "range90": "90 天",
       "range365": "1 年",
       "rangeAll": "全部",
+      "exportCsv": "匯出 CSV",
       "cards": {
         "sessions": "對話數",
         "messages": "訊息數",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -262,6 +262,7 @@
     "pinned": "已釘選",
     "searchPlaceholder": "搜尋對話…",
     "all": "全部",
+    "modelFilterAll": "所有 model",
     "empty": "沒有符合的對話",
     "messages": "{{count}} 則訊息",
     "resume": "接續對話",

--- a/src/lib/dialog.ts
+++ b/src/lib/dialog.ts
@@ -12,10 +12,15 @@ export async function pickFile(): Promise<string | null> {
   return typeof result === "string" ? result : null;
 }
 
-/** Prompt the user to pick a save location for a Markdown file, pre-filled
- *  with `defaultPath` (typically a suggested filename). Returns null if
- *  cancelled — the caller should treat that as a no-op, not an error. */
-export async function saveFile(defaultPath: string): Promise<string | null> {
-  const result = await save({ defaultPath, filters: [{ name: "Markdown", extensions: ["md"] }] });
+/** Prompt the user to pick a save location for a file, pre-filled with
+ *  `defaultPath` (typically a suggested filename). `filters` defaults to
+ *  Markdown for the transcript export; callers exporting another format
+ *  (e.g. CSV) pass their own. Returns null if cancelled — the caller should
+ *  treat that as a no-op, not an error. */
+export async function saveFile(
+  defaultPath: string,
+  filters: { name: string; extensions: string[] }[] = [{ name: "Markdown", extensions: ["md"] }],
+): Promise<string | null> {
+  const result = await save({ defaultPath, filters });
   return typeof result === "string" ? result : null;
 }

--- a/src/modules/sessions/DashboardView.test.tsx
+++ b/src/modules/sessions/DashboardView.test.tsx
@@ -2,14 +2,18 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DashboardView } from "./DashboardView";
 import { useSessionsStore } from "./lib/sessionsStore";
+import type { SessionSummary } from "./lib/sessionsBridge";
 import type { SessionsStats } from "./lib/statsBridge";
 
 // vi.mock is hoisted to the top of the file, so mocks must be created with
 // vi.hoisted() to be accessible inside the factory callbacks.
-const { mockInvoke, mockListen, mockUnlisten, statsFixture } = vi.hoisted(() => ({
+const { mockInvoke, mockListen, mockUnlisten, mockSaveFile, mockFsWriteFile, statsFixture } = vi.hoisted(() => ({
   mockInvoke: vi.fn(),
   mockListen: vi.fn(),
   mockUnlisten: vi.fn(),
+  // Backs the CSV export button's save dialog + file write.
+  mockSaveFile: vi.fn(),
+  mockFsWriteFile: vi.fn(),
   // Backs the "sessions_stats" invoke response, seeded per test.
   statsFixture: { current: null as unknown },
 }));
@@ -26,6 +30,14 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: mockListen,
+}));
+
+vi.mock("@/lib/dialog", () => ({
+  saveFile: mockSaveFile,
+}));
+
+vi.mock("@/modules/explorer/lib/fsBridge", () => ({
+  fsWriteFile: mockFsWriteFile,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -72,17 +84,38 @@ function stats(overrides: Partial<SessionsStats> = {}): SessionsStats {
   };
 }
 
+function session(overrides: Partial<SessionSummary>): SessionSummary {
+  return {
+    id: "id",
+    agent: "claude",
+    project_cwd: "/p",
+    title: "t",
+    started_at: 0,
+    ended_at: 0,
+    message_count: 0,
+    user_message_count: 0,
+    output_tokens: null,
+    model: null,
+    file_path: "/f",
+    pinned: false,
+    ...overrides,
+  };
+}
+
 describe("DashboardView", () => {
   beforeEach(() => {
     mockInvoke.mockReset();
     mockListen.mockReset().mockResolvedValue(mockUnlisten);
     mockUnlisten.mockReset();
+    mockSaveFile.mockReset();
+    mockFsWriteFile.mockReset().mockResolvedValue(undefined);
     statsFixture.current = stats();
     useSessionsStore.setState({
       sessions: [],
       loaded: false,
       query: "",
       agentFilter: "all",
+      modelFilter: "all",
       selectedId: null,
     });
   });
@@ -272,5 +305,27 @@ describe("DashboardView", () => {
     resolveListen(mockUnlisten);
 
     await waitFor(() => expect(mockUnlisten).toHaveBeenCalled());
+  });
+
+  it("exports the filtered session list as CSV via saveFile + fsWriteFile", async () => {
+    useSessionsStore.setState({
+      sessions: [session({ id: "a", title: "Fix bug", agent: "codex", model: "gpt-5.5" })],
+      query: "",
+      agentFilter: "all",
+      modelFilter: "all",
+    });
+    mockSaveFile.mockResolvedValue("/path.csv");
+
+    render(<DashboardView />);
+    await waitFor(() => expect(screen.getByText("12")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "sessions.dashboard.exportCsv" }));
+
+    await waitFor(() =>
+      expect(mockSaveFile).toHaveBeenCalledWith("ai-sessions.csv", [{ name: "CSV", extensions: ["csv"] }]),
+    );
+    await waitFor(() =>
+      expect(mockFsWriteFile).toHaveBeenCalledWith("/path.csv", expect.stringContaining("title,agent,model")),
+    );
   });
 });

--- a/src/modules/sessions/DashboardView.test.tsx
+++ b/src/modules/sessions/DashboardView.test.tsx
@@ -307,11 +307,17 @@ describe("DashboardView", () => {
     await waitFor(() => expect(mockUnlisten).toHaveBeenCalled());
   });
 
-  it("exports the filtered session list as CSV via saveFile + fsWriteFile", async () => {
+  it("exports only the filtered session list as CSV via saveFile + fsWriteFile", async () => {
+    // Two sessions that only the agent filter distinguishes: with
+    // agentFilter:"codex" the export must include the kept row and exclude
+    // the other one, proving it serializes the filtered list, not raw `sessions`.
     useSessionsStore.setState({
-      sessions: [session({ id: "a", title: "Fix bug", agent: "codex", model: "gpt-5.5" })],
+      sessions: [
+        session({ id: "a", title: "Keep me", agent: "codex", model: "gpt-5.5" }),
+        session({ id: "b", title: "Drop me", agent: "claude", model: "claude-sonnet-5" }),
+      ],
       query: "",
-      agentFilter: "all",
+      agentFilter: "codex",
       modelFilter: "all",
     });
     mockSaveFile.mockResolvedValue("/path.csv");
@@ -324,8 +330,10 @@ describe("DashboardView", () => {
     await waitFor(() =>
       expect(mockSaveFile).toHaveBeenCalledWith("ai-sessions.csv", [{ name: "CSV", extensions: ["csv"] }]),
     );
-    await waitFor(() =>
-      expect(mockFsWriteFile).toHaveBeenCalledWith("/path.csv", expect.stringContaining("title,agent,model")),
-    );
+    await waitFor(() => expect(mockFsWriteFile).toHaveBeenCalledWith("/path.csv", expect.any(String)));
+
+    const csv = mockFsWriteFile.mock.calls[0][1] as string;
+    expect(csv).toContain("Keep me");
+    expect(csv).not.toContain("Drop me");
   });
 });

--- a/src/modules/sessions/DashboardView.test.tsx
+++ b/src/modules/sessions/DashboardView.test.tsx
@@ -132,6 +132,29 @@ describe("DashboardView", () => {
     expect(useSessionsStore.getState().selectedId).toBe("s1");
   });
 
+  it("clicks a top-sessions row's project name to open the project view without selecting the session", async () => {
+    render(<DashboardView />);
+    await waitFor(() => expect(screen.getByText("Fix flaky test")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("/repo/app"));
+
+    expect(useSessionsStore.getState().selectedProject).toBe("/repo/app");
+    // The row's own onSelect(session.id) must not have fired.
+    expect(useSessionsStore.getState().selectedId).toBe(null);
+  });
+
+  it("renders no clickable project element when a top-sessions row's project_cwd is empty", async () => {
+    statsFixture.current = stats({
+      top_by_messages: [
+        { id: "s1", agent: "claude", title: "Fix flaky test", project_cwd: "", value: 42 },
+      ],
+    });
+    render(<DashboardView />);
+
+    await waitFor(() => expect(screen.getByText("Fix flaky test")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "" })).not.toBeInTheDocument();
+  });
+
   it("renders the weekly digest with per-agent sessions/messages/tokens", async () => {
     render(<DashboardView />);
 

--- a/src/modules/sessions/DashboardView.tsx
+++ b/src/modules/sessions/DashboardView.tsx
@@ -8,7 +8,10 @@ import {
   type TopSession,
 } from "./lib/statsBridge";
 import { Tooltip } from "@/components/Tooltip";
-import { useSessionsStore } from "./lib/sessionsStore";
+import { useSessionsStore, visibleSessions } from "./lib/sessionsStore";
+import { toSessionsCsv } from "./lib/sessionsCsv";
+import { saveFile } from "@/lib/dialog";
+import { fsWriteFile } from "@/modules/explorer/lib/fsBridge";
 import { AGENT_BADGE_CLASS } from "./lib/agentBadge";
 import { heatmapLevel, heatmapMax, heatmapMonthLabels, heatmapWeeks } from "./lib/heatmap";
 import { estimateOutputCost } from "./lib/cost";
@@ -208,6 +211,10 @@ export function DashboardView() {
   const { t, i18n } = useTranslation();
   const select = useSessionsStore((s) => s.select);
   const selectProject = useSessionsStore((s) => s.selectProject);
+  const sessions = useSessionsStore((s) => s.sessions);
+  const query = useSessionsStore((s) => s.query);
+  const agentFilter = useSessionsStore((s) => s.agentFilter);
+  const modelFilter = useSessionsStore((s) => s.modelFilter);
   const [range, setRange] = useState<RangeDays>(365);
   const [stats, setStats] = useState<SessionsStats>(EMPTY_STATS);
   const [topTab, setTopTab] = useState<"messages" | "tokens">("messages");
@@ -290,24 +297,46 @@ export function DashboardView() {
     return Array.from({ length: 7 }, (_, row) => fmt.format(new Date(2026, 2, 1 + row)));
   }, [locale]);
 
+  // Exports exactly the sessions currently visible under the active
+  // search/agent/model filters (not the full unfiltered index), mirroring
+  // what the sessions panel itself shows.
+  async function handleExportCsv() {
+    const { pinned, history } = visibleSessions(sessions, query, agentFilter, modelFilter);
+    const csv = toSessionsCsv([...pinned, ...history]);
+    const path = await saveFile("ai-sessions.csv", [{ name: "CSV", extensions: ["csv"] }]);
+    if (path === null) {
+      return;
+    }
+    await fsWriteFile(path, csv);
+  }
+
   return (
     <div className="h-full overflow-y-auto bg-bg-inset p-4">
       <div className="flex items-center justify-between">
         <h1 className="text-sm font-semibold text-fg">{t("sessions.dashboard.title")}</h1>
-        <div className="flex items-center gap-1">
-          {RANGE_OPTIONS.map((opt) => (
-            <button
-              key={String(opt.key)}
-              type="button"
-              aria-pressed={range === opt.key}
-              onClick={() => setRange(opt.key)}
-              className={`rounded px-2 py-0.5 text-[11px] transition-colors ${
-                range === opt.key ? "bg-bg-elevated text-fg" : "text-fg-subtle hover:text-fg"
-              }`}
-            >
-              {t(opt.labelKey)}
-            </button>
-          ))}
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1">
+            {RANGE_OPTIONS.map((opt) => (
+              <button
+                key={String(opt.key)}
+                type="button"
+                aria-pressed={range === opt.key}
+                onClick={() => setRange(opt.key)}
+                className={`rounded px-2 py-0.5 text-[11px] transition-colors ${
+                  range === opt.key ? "bg-bg-elevated text-fg" : "text-fg-subtle hover:text-fg"
+                }`}
+              >
+                {t(opt.labelKey)}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleExportCsv()}
+            className="rounded border border-border px-2 py-0.5 text-[11px] text-fg-subtle transition-colors hover:text-fg"
+          >
+            {t("sessions.dashboard.exportCsv")}
+          </button>
         </div>
       </div>
 

--- a/src/modules/sessions/DashboardView.tsx
+++ b/src/modules/sessions/DashboardView.tsx
@@ -136,9 +136,10 @@ function StatCard({
 interface TopSessionRowProps {
   session: TopSession;
   onSelect: (id: string) => void;
+  onSelectProject: (cwd: string) => void;
 }
 
-function TopSessionRow({ session, onSelect }: TopSessionRowProps) {
+function TopSessionRow({ session, onSelect, onSelectProject }: TopSessionRowProps) {
   const { t } = useTranslation();
   return (
     <li>
@@ -156,7 +157,29 @@ function TopSessionRow({ session, onSelect }: TopSessionRowProps) {
               {t(`sessions.agents.${session.agent}`)}
             </span>
           </div>
-          <p className="truncate text-xs text-fg-subtle">{session.project_cwd}</p>
+          {/* Nested inside the row's own select-session button, so a click
+              here must stop propagation or it would also select the session;
+              role="button" + a keydown handler keep it reachable from the
+              keyboard despite not being a real <button> (which can't nest
+              inside another button). */}
+          <p
+            role="button"
+            tabIndex={0}
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelectProject(session.project_cwd);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.stopPropagation();
+                onSelectProject(session.project_cwd);
+              }
+            }}
+            className="truncate text-xs text-fg-subtle hover:text-fg hover:underline"
+          >
+            {session.project_cwd}
+          </p>
         </div>
         {/* Token counts easily reach 6-7 digits; group them for readability. */}
         <span className="shrink-0 text-xs text-fg-subtle">{session.value.toLocaleString()}</span>
@@ -176,6 +199,7 @@ function TopSessionRow({ session, onSelect }: TopSessionRowProps) {
 export function DashboardView() {
   const { t, i18n } = useTranslation();
   const select = useSessionsStore((s) => s.select);
+  const selectProject = useSessionsStore((s) => s.selectProject);
   const [range, setRange] = useState<RangeDays>(365);
   const [stats, setStats] = useState<SessionsStats>(EMPTY_STATS);
   const [topTab, setTopTab] = useState<"messages" | "tokens">("messages");
@@ -433,7 +457,12 @@ export function DashboardView() {
           </div>
           <ul className="mt-2">
             {topSessions.map((session) => (
-              <TopSessionRow key={session.id} session={session} onSelect={select} />
+              <TopSessionRow
+                key={session.id}
+                session={session}
+                onSelect={select}
+                onSelectProject={selectProject}
+              />
             ))}
           </ul>
         </div>

--- a/src/modules/sessions/DashboardView.tsx
+++ b/src/modules/sessions/DashboardView.tsx
@@ -161,25 +161,33 @@ function TopSessionRow({ session, onSelect, onSelectProject }: TopSessionRowProp
               here must stop propagation or it would also select the session;
               role="button" + a keydown handler keep it reachable from the
               keyboard despite not being a real <button> (which can't nest
-              inside another button). */}
-          <p
-            role="button"
-            tabIndex={0}
-            onClick={(e) => {
-              e.stopPropagation();
-              onSelectProject(session.project_cwd);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
+              inside another button). An empty cwd has nothing to route to
+              (onSelectProject("") would fall through to the dashboard), so
+              it's skipped entirely rather than rendered as a no-op link. */}
+          {session.project_cwd && (
+            <p
+              role="button"
+              tabIndex={0}
+              onClick={(e) => {
                 e.stopPropagation();
-                onSelectProject(session.project_cwd);
-              }
-            }}
-            className="truncate text-xs text-fg-subtle hover:text-fg hover:underline"
-          >
-            {session.project_cwd}
-          </p>
+                if (session.project_cwd) {
+                  onSelectProject(session.project_cwd);
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (session.project_cwd) {
+                    onSelectProject(session.project_cwd);
+                  }
+                }
+              }}
+              className="truncate text-xs text-fg-subtle hover:text-fg hover:underline"
+            >
+              {session.project_cwd}
+            </p>
+          )}
         </div>
         {/* Token counts easily reach 6-7 digits; group them for readability. */}
         <span className="shrink-0 text-xs text-fg-subtle">{session.value.toLocaleString()}</span>

--- a/src/modules/sessions/ProjectView.test.tsx
+++ b/src/modules/sessions/ProjectView.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectView } from "./ProjectView";
+import { useSessionsStore } from "./lib/sessionsStore";
+
+const { mockInvoke, mockOpenTerminal } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+  mockOpenTerminal: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: Record<string, unknown>) => {
+    mockInvoke(cmd, args);
+    if (cmd === "sessions_project_stats") {
+      return Promise.resolve({
+        project_cwd: "/tmp/proj-a",
+        sessions: 2,
+        messages: 14,
+        output_tokens: 100,
+        // Deliberately distinct from `sessions` (2) — DashboardView.test.tsx
+        // follows the same convention (distinct mock numbers per stat) so
+        // `screen.getByText("2")` below resolves to a single element.
+        active_days: 5,
+        top_model: "claude-sonnet-5",
+        first_at: 1000,
+        last_at: 2000,
+        recent: [
+          { id: "s1", agent: "claude", project_cwd: "/tmp/proj-a", title: "Fix bug",
+            started_at: 1000, ended_at: 2000, message_count: 10, user_message_count: 5,
+            output_tokens: 100, model: "claude-sonnet-5", file_path: "/f/s1.jsonl", pinned: false },
+        ],
+      });
+    }
+    return Promise.resolve(undefined);
+  },
+}));
+
+vi.mock("./lib/openTerminalAt", () => ({ openTerminalAt: mockOpenTerminal }));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string, o?: Record<string, unknown>) =>
+    o?.count !== undefined ? `${k}:${o.count}` : k, i18n: { language: "en" } }),
+}));
+
+describe("ProjectView", () => {
+  beforeEach(() => {
+    mockInvoke.mockClear();
+    mockOpenTerminal.mockClear();
+    useSessionsStore.setState({ selectedProject: "/tmp/proj-a", selectedId: null });
+  });
+
+  it("fetches and renders the project's aggregates and recent sessions", async () => {
+    render(<ProjectView />);
+    expect(mockInvoke).toHaveBeenCalledWith("sessions_project_stats", { projectCwd: "/tmp/proj-a" });
+    await waitFor(() => expect(screen.getByText("2")).toBeInTheDocument());
+    expect(screen.getByText("14")).toBeInTheDocument();
+    expect(screen.getByText("claude-sonnet-5")).toBeInTheDocument();
+    expect(screen.getByText("Fix bug")).toBeInTheDocument();
+  });
+
+  it("opens a terminal at the project cwd when the button is clicked", async () => {
+    render(<ProjectView />);
+    await waitFor(() => expect(screen.getByText("2")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "sessions.project.openTerminal" }));
+    expect(mockOpenTerminal).toHaveBeenCalledWith("/tmp/proj-a");
+  });
+
+  it("returns to the dashboard when back is clicked", async () => {
+    render(<ProjectView />);
+    await waitFor(() => expect(screen.getByText("2")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "sessions.project.back" }));
+    expect(useSessionsStore.getState().selectedProject).toBeNull();
+  });
+
+  it("selects a recent session into the viewer when its row is clicked", async () => {
+    render(<ProjectView />);
+    await waitFor(() => expect(screen.getByText("Fix bug")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Fix bug"));
+    expect(useSessionsStore.getState().selectedId).toBe("s1");
+  });
+});

--- a/src/modules/sessions/ProjectView.tsx
+++ b/src/modules/sessions/ProjectView.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSessionsStore } from "./lib/sessionsStore";
+import { sessionsProjectStats, type ProjectStats } from "./lib/projectBridge";
+import { openTerminalAt } from "./lib/openTerminalAt";
+import { AGENT_BADGE_CLASS } from "./lib/agentBadge";
+
+const EMPTY: ProjectStats = {
+  project_cwd: "",
+  sessions: 0,
+  messages: 0,
+  output_tokens: 0,
+  active_days: 0,
+  top_model: null,
+  first_at: 0,
+  last_at: 0,
+  recent: [],
+};
+
+/** A summary tile: a big value and a label. Mirrors DashboardView's
+ *  `StatCard` look (border, big tabular-nums value) for a consistent feel
+ *  between the two stats screens. */
+interface TileProps {
+  label: string;
+  value: string;
+}
+
+function Tile({ label, value }: TileProps) {
+  return (
+    <div className="flex flex-col gap-0.5 rounded-lg border border-border bg-bg px-3.5 py-3">
+      <div className="truncate text-[20px] font-bold leading-none tabular-nums text-fg">{value}</div>
+      <div className="mt-1 text-[11px] text-fg-subtle">{label}</div>
+    </div>
+  );
+}
+
+/**
+ * Main-area screen for a single project's aggregates, reached by clicking a
+ * project name in the sidebar or the dashboard's Top Sessions list. Fetches
+ * `sessions_project_stats` whenever `selectedProject` changes, shows summary
+ * tiles plus the project's recent sessions, and offers a shortcut to open a
+ * terminal rooted at the project's cwd. Mutually exclusive with the
+ * transcript viewer and the dashboard — see `sessionsStore`'s
+ * `selectProject`/`select`.
+ */
+export function ProjectView() {
+  const { t } = useTranslation();
+  const cwd = useSessionsStore((s) => s.selectedProject) ?? "";
+  const selectProject = useSessionsStore((s) => s.selectProject);
+  const select = useSessionsStore((s) => s.select);
+  const [stats, setStats] = useState<ProjectStats>(EMPTY);
+
+  useEffect(() => {
+    // `cancelled` scopes this fetch to the cwd that triggered it: switching
+    // projects (or unmounting) before it resolves must not overwrite state
+    // with a stale project's stats.
+    let cancelled = false;
+    if (!cwd) {
+      return;
+    }
+    sessionsProjectStats(cwd)
+      .then((next) => {
+        if (!cancelled) {
+          setStats(next);
+        }
+      })
+      .catch(() => {
+        // The command never rejects in practice; swallow defensively rather
+        // than leave an unhandled rejection.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cwd]);
+
+  const name = useMemo(() => cwd.split(/[/\\]/).filter(Boolean).pop() ?? cwd, [cwd]);
+
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => selectProject(null)}
+          className="rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-elevated hover:text-fg"
+        >
+          {t("sessions.project.back")}
+        </button>
+        <h1 className="min-w-0 flex-1 truncate text-lg font-semibold text-fg">{name}</h1>
+        <button
+          type="button"
+          onClick={() => openTerminalAt(cwd)}
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-fg-subtle hover:bg-bg-elevated hover:text-fg"
+        >
+          {t("sessions.project.openTerminal")}
+        </button>
+      </div>
+      <p className="mt-0.5 truncate text-xs text-fg-subtle">{cwd}</p>
+
+      <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-5">
+        <Tile label={t("sessions.project.sessions")} value={stats.sessions.toLocaleString()} />
+        <Tile label={t("sessions.project.messages")} value={stats.messages.toLocaleString()} />
+        <Tile label={t("sessions.project.tokens")} value={stats.output_tokens.toLocaleString()} />
+        <Tile label={t("sessions.project.activeDays")} value={stats.active_days.toLocaleString()} />
+        <Tile label={t("sessions.project.topModel")} value={stats.top_model ?? "—"} />
+      </div>
+
+      <h2 className="mt-6 text-[11px] font-semibold uppercase tracking-wide text-fg-subtle">
+        {t("sessions.project.recent")}
+      </h2>
+      <ul className="mt-2">
+        {stats.recent.map((s) => (
+          <li key={s.id}>
+            <button
+              type="button"
+              onClick={() => select(s.id)}
+              className="flex w-full min-w-0 items-center justify-between gap-2 rounded px-2 py-1.5 text-left hover:bg-bg-elevated"
+            >
+              <span className="min-w-0 truncate text-sm text-fg">{s.title}</span>
+              <span className={`shrink-0 text-[10px] font-medium uppercase ${AGENT_BADGE_CLASS[s.agent]}`}>
+                {t(`sessions.agents.${s.agent}`)}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/modules/sessions/SessionsPanel.test.tsx
+++ b/src/modules/sessions/SessionsPanel.test.tsx
@@ -251,6 +251,41 @@ describe("SessionsPanel", () => {
     expect(tabs[0].cwd).toBe("/repo/app");
   });
 
+  it("clicks the project name to open the project view without selecting the session", async () => {
+    seedSessions([
+      session({ id: "a", title: "Deploy script", project_cwd: "/Users/muki/tempo-term" }),
+    ]);
+    await renderSettled();
+
+    fireEvent.click(screen.getByText("tempo-term"));
+
+    expect(useSessionsStore.getState().selectedProject).toBe("/Users/muki/tempo-term");
+    // The row's own select(id) must not have fired.
+    expect(useSessionsStore.getState().selectedId).toBe(null);
+  });
+
+  it("activates the project name via keyboard without selecting the session", async () => {
+    seedSessions([
+      session({ id: "a", title: "Deploy script", project_cwd: "/Users/muki/tempo-term" }),
+    ]);
+    await renderSettled();
+
+    fireEvent.keyDown(screen.getByText("tempo-term"), { key: "Enter" });
+
+    expect(useSessionsStore.getState().selectedProject).toBe("/Users/muki/tempo-term");
+    expect(useSessionsStore.getState().selectedId).toBe(null);
+  });
+
+  it("renders no clickable project element when project_cwd is empty", async () => {
+    seedSessions([session({ id: "a", title: "Deploy script", project_cwd: "" })]);
+    await renderSettled();
+
+    expect(screen.queryByRole("button", { name: "" })).not.toBeInTheDocument();
+    // basename("") falls back to "" too, so there's simply nothing to click;
+    // the rest of the meta line (time · message count) still renders.
+    expect(screen.getByText(/sessions\.messages:0/)).toBeInTheDocument();
+  });
+
   it("hides the resume button on rows for agents with no supported resume command", async () => {
     seedSessions([session({ id: "a", agent: "antigravity" })]);
     await renderSettled();

--- a/src/modules/sessions/SessionsPanel.test.tsx
+++ b/src/modules/sessions/SessionsPanel.test.tsx
@@ -98,6 +98,7 @@ describe("SessionsPanel", () => {
       loaded: false,
       query: "",
       agentFilter: "all",
+      modelFilter: "all",
       selectedId: null,
     });
     useTabsStore.setState({ spaces: [], activeSpaceId: null, tabs: [], activeId: null });
@@ -180,6 +181,28 @@ describe("SessionsPanel", () => {
 
     expect(screen.getByText("Codex session")).toBeInTheDocument();
     expect(screen.queryByText("Claude session")).not.toBeInTheDocument();
+  });
+
+  it("resets a stale model filter to \"all\" once its model drops out of the option list", async () => {
+    seedSessions([
+      session({ id: "a", title: "GPT session", model: "gpt-5.5" }),
+      session({ id: "b", title: "No-model session", model: null }),
+    ]);
+    await renderSettled();
+    act(() => {
+      useSessionsStore.setState({ modelFilter: "gpt-5.5" });
+    });
+
+    // Simulate a refresh (e.g. the session was deleted or re-indexed) that
+    // drops the only session carrying "gpt-5.5" out of the list, so the
+    // filter no longer matches any option.
+    act(() => {
+      useSessionsStore.setState({
+        sessions: [session({ id: "b", title: "No-model session", model: null })],
+      });
+    });
+
+    expect(useSessionsStore.getState().modelFilter).toBe("all");
   });
 
   it("selects a session on row click", async () => {

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -318,6 +318,18 @@ export function SessionsPanel() {
     return ["all", ...[...set].sort()];
   }, [sessions]);
 
+  // A selected model can drop out of the option list (its only session got
+  // deleted or a refresh reshuffled the data). Once that happens the dropdown
+  // that would let the user pick "all" again is hidden too (see the
+  // `modelOptions.length > 1` gate below), so the list would otherwise be
+  // stranded empty with no on-screen way back. Reset instead of leaving it
+  // dangling.
+  useEffect(() => {
+    if (modelFilter !== "all" && !modelOptions.includes(modelFilter)) {
+      setModelFilter("all");
+    }
+  }, [modelOptions, modelFilter, setModelFilter]);
+
   // Combobox takes a flat string list where the option string doubles as its
   // own label (see GitGraphToolbar's branch picker for the same pattern), so
   // "all" is displayed as its translated label and mapped back on change.
@@ -383,7 +395,7 @@ export function SessionsPanel() {
               value={modelComboboxValue}
               options={modelComboboxOptions}
               onChange={(v) => setModelFilter(v === modelFilterAllLabel ? "all" : v)}
-              ariaLabel={modelFilterAllLabel}
+              ariaLabel={t("sessions.modelFilterLabel")}
               size="sm"
               className="ml-auto w-32"
             />

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -167,28 +167,40 @@ function SessionRow({ session, selected }: SessionRowProps) {
                   here must stop propagation or it would also select the
                   session; role="button" + a keydown handler keep it reachable
                   from the keyboard despite not being a real <button> (which
-                  can't nest inside another button). */}
-              <span
-                role="button"
-                tabIndex={0}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  selectProject(session.project_cwd);
-                  openSessionsTab();
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    selectProject(session.project_cwd);
-                    openSessionsTab();
-                  }
-                }}
-                className="hover:text-fg hover:underline"
-              >
-                {basename(session.project_cwd)}
-              </span>{" "}
-              · {formatRelativeTime(session.ended_at, t)} ·{" "}
+                  can't nest inside another button). An empty cwd has nothing
+                  to route to (selectProject("") would fall through to the
+                  dashboard), so it's skipped entirely rather than rendered as
+                  a no-op link. */}
+              {session.project_cwd && (
+                <>
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (session.project_cwd) {
+                        selectProject(session.project_cwd);
+                        openSessionsTab();
+                      }
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        if (session.project_cwd) {
+                          selectProject(session.project_cwd);
+                          openSessionsTab();
+                        }
+                      }
+                    }}
+                    className="hover:text-fg hover:underline"
+                  >
+                    {basename(session.project_cwd)}
+                  </span>{" "}
+                  ·{" "}
+                </>
+              )}
+              {formatRelativeTime(session.ended_at, t)} ·{" "}
               {t("sessions.messages", { count: session.message_count })}
             </div>
           </div>

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { History, LayoutDashboard, Pin, PinOff, Play, Search, Trash2 } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Combobox } from "@/components/Combobox";
 import { useTabsStore } from "@/stores/tabsStore";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
 import { onSessionsUpdated, type SessionAgent, type SessionSummary } from "./lib/sessionsBridge";
@@ -276,9 +277,11 @@ export function SessionsPanel() {
   const loaded = useSessionsStore((s) => s.loaded);
   const query = useSessionsStore((s) => s.query);
   const agentFilter = useSessionsStore((s) => s.agentFilter);
+  const modelFilter = useSessionsStore((s) => s.modelFilter);
   const selectedId = useSessionsStore((s) => s.selectedId);
   const setQuery = useSessionsStore((s) => s.setQuery);
   const setAgentFilter = useSessionsStore((s) => s.setAgentFilter);
+  const setModelFilter = useSessionsStore((s) => s.setModelFilter);
   const select = useSessionsStore((s) => s.select);
   const openSessionsTab = useTabsStore((s) => s.openSessionsTab);
 
@@ -307,7 +310,22 @@ export function SessionsPanel() {
     };
   }, []);
 
-  const { pinned, history } = visibleSessions(sessions, query, agentFilter);
+  // Distinct non-null models seen across the loaded sessions, "all" first.
+  // The dropdown is only worth showing once there's actually a choice to make.
+  const modelOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const s of sessions) if (s.model) set.add(s.model);
+    return ["all", ...[...set].sort()];
+  }, [sessions]);
+
+  // Combobox takes a flat string list where the option string doubles as its
+  // own label (see GitGraphToolbar's branch picker for the same pattern), so
+  // "all" is displayed as its translated label and mapped back on change.
+  const modelFilterAllLabel = t("sessions.modelFilterAll");
+  const modelComboboxOptions = modelOptions.map((m) => (m === "all" ? modelFilterAllLabel : m));
+  const modelComboboxValue = modelFilter === "all" ? modelFilterAllLabel : modelFilter;
+
+  const { pinned, history } = visibleSessions(sessions, query, agentFilter, modelFilter);
   const isEmpty = pinned.length === 0 && history.length === 0;
 
   return (
@@ -360,6 +378,16 @@ export function SessionsPanel() {
               {key === "all" ? t("sessions.all") : t(`sessions.agents.${key}`)}
             </button>
           ))}
+          {modelOptions.length > 1 && (
+            <Combobox
+              value={modelComboboxValue}
+              options={modelComboboxOptions}
+              onChange={(v) => setModelFilter(v === modelFilterAllLabel ? "all" : v)}
+              ariaLabel={modelFilterAllLabel}
+              size="sm"
+              className="ml-auto w-32"
+            />
+          )}
         </div>
       </div>
 

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -105,6 +105,7 @@ interface SessionRowProps {
 function SessionRow({ session, selected }: SessionRowProps) {
   const { t } = useTranslation();
   const select = useSessionsStore((s) => s.select);
+  const selectProject = useSessionsStore((s) => s.selectProject);
   const togglePin = useSessionsStore((s) => s.togglePin);
   const openSessionsTab = useTabsStore((s) => s.openSessionsTab);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -162,7 +163,32 @@ function SessionRow({ session, selected }: SessionRowProps) {
               </span>
             </div>
             <div className="truncate text-xs text-fg-subtle">
-              {basename(session.project_cwd)} · {formatRelativeTime(session.ended_at, t)} ·{" "}
+              {/* Nested inside the row's own select-session button, so a click
+                  here must stop propagation or it would also select the
+                  session; role="button" + a keydown handler keep it reachable
+                  from the keyboard despite not being a real <button> (which
+                  can't nest inside another button). */}
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  selectProject(session.project_cwd);
+                  openSessionsTab();
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    selectProject(session.project_cwd);
+                    openSessionsTab();
+                  }
+                }}
+                className="hover:text-fg hover:underline"
+              >
+                {basename(session.project_cwd)}
+              </span>{" "}
+              · {formatRelativeTime(session.ended_at, t)} ·{" "}
               {t("sessions.messages", { count: session.message_count })}
             </div>
           </div>

--- a/src/modules/sessions/SessionsTabContent.test.tsx
+++ b/src/modules/sessions/SessionsTabContent.test.tsx
@@ -5,6 +5,7 @@ import { useSessionsStore } from "./lib/sessionsStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import type { SessionSummary, TranscriptMessage } from "./lib/sessionsBridge";
 import type { SessionsStats } from "./lib/statsBridge";
+import type { CommitInfo } from "@/modules/source-control/lib/gitBridge";
 
 // vi.mock is hoisted to the top of the file, so mocks must be created with
 // vi.hoisted() to be accessible inside the factory callbacks.
@@ -19,6 +20,7 @@ const {
   deleteFailure,
   exportFailure,
   exportMarkdown,
+  commitsFixture,
 } = vi.hoisted(() => ({
   mockInvoke: vi.fn(),
   mockListen: vi.fn(),
@@ -38,10 +40,12 @@ const {
   // When set, "sessions_export" rejects — for the failure-surfacing tests.
   exportFailure: { current: false },
   exportMarkdown: { current: "# Fix flaky test\n\nsome content\n" },
+  // Backs the "git_commits_in_range" invoke response for the commits section.
+  commitsFixture: { current: [] as CommitInfo[] },
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: (cmd: string, args?: { id?: string }) => {
+  invoke: (cmd: string, args?: { id?: string; cwd?: string; sinceMs?: number; untilMs?: number }) => {
     mockInvoke(cmd, args);
     if (cmd === "sessions_get" && args?.id) {
       return transcripts.get(args.id) ?? Promise.resolve([]);
@@ -56,6 +60,9 @@ vi.mock("@tauri-apps/api/core", () => ({
       return exportFailure.current
         ? Promise.reject(new Error("export failed"))
         : Promise.resolve(exportMarkdown.current);
+    }
+    if (cmd === "git_commits_in_range") {
+      return Promise.resolve(commitsFixture.current);
     }
     return Promise.resolve(undefined);
   },
@@ -142,6 +149,7 @@ describe("SessionsTabContent", () => {
     deleteFailure.current = false;
     exportFailure.current = false;
     exportMarkdown.current = "# Fix flaky test\n\nsome content\n";
+    commitsFixture.current = [];
     useSessionsStore.setState({
       sessions: [],
       loaded: false,
@@ -503,5 +511,38 @@ describe("SessionsTabContent", () => {
     await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith("sessions_get", { id: "a" }));
 
     expect(screen.getByRole("button", { name: "sessions.resume" })).toBeDisabled();
+  });
+
+  it("shows a commits section listing commits made during the session", async () => {
+    const target = session({ id: "a", project_cwd: "/repo/app", started_at: 1000, ended_at: 2000 });
+    useSessionsStore.setState({ sessions: [target], selectedId: "a" });
+    transcripts.set("a", Promise.resolve([]));
+    commitsFixture.current = [
+      { id: "abc1234", summary: "Fix flaky test", author: "Tester", timestamp: 1500, parents: [] },
+    ];
+
+    render(<SessionsTabContent />);
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith("git_commits_in_range", {
+        cwd: "/repo/app",
+        sinceMs: 1000,
+        untilMs: 2000,
+      }),
+    );
+    await waitFor(() => expect(screen.getByText("sessions.commits.title")).toBeInTheDocument());
+    expect(screen.getByText("Fix flaky test")).toBeInTheDocument();
+  });
+
+  it("hides the commits section entirely when there are no commits", async () => {
+    const target = session({ id: "a" });
+    useSessionsStore.setState({ sessions: [target], selectedId: "a" });
+    transcripts.set("a", Promise.resolve([]));
+    commitsFixture.current = [];
+
+    render(<SessionsTabContent />);
+
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith("sessions_get", { id: "a" }));
+    expect(screen.queryByText("sessions.commits.title")).not.toBeInTheDocument();
   });
 });

--- a/src/modules/sessions/SessionsTabContent.tsx
+++ b/src/modules/sessions/SessionsTabContent.tsx
@@ -9,6 +9,7 @@ import { fsWriteFile } from "@/modules/explorer/lib/fsBridge";
 import { sessionsGet, type TranscriptMessage } from "./lib/sessionsBridge";
 import { useSessionsStore } from "./lib/sessionsStore";
 import { sessionsDelete, sessionsExport } from "./lib/statsBridge";
+import { gitCommitsInRange, type CommitInfo } from "@/modules/source-control/lib/gitBridge";
 import { formatRelativeTime } from "./lib/relativeTime";
 import { AGENT_BADGE_CLASS } from "./lib/agentBadge";
 import { resumeCommand, resumeSession } from "./lib/resume";
@@ -101,6 +102,8 @@ export function SessionsTabContent() {
   const togglePin = useSessionsStore((s) => s.togglePin);
   const select = useSessionsStore((s) => s.select);
 
+  const session = sessions.find((s) => s.id === selectedId) ?? null;
+
   const [transcript, setTranscript] = useState<TranscriptMessage[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -113,6 +116,11 @@ export function SessionsTabContent() {
   // Same treatment for export: a failed render or a failed disk write both
   // surface here rather than silently doing nothing.
   const [exportError, setExportError] = useState(false);
+  // Commits made during the session's time window, for the correlation
+  // section below the transcript. Empty (and hidden) when the cwd isn't a
+  // git repo, or the fetch fails — same "quietly show nothing" contract as
+  // `git_commits_in_range` itself.
+  const [commits, setCommits] = useState<CommitInfo[]>([]);
 
   useEffect(() => {
     if (!selectedId) {
@@ -157,14 +165,35 @@ export function SessionsTabContent() {
     };
   }, [selectedId]);
 
+  useEffect(() => {
+    let cancelled = false;
+    if (!session) {
+      setCommits([]);
+      return;
+    }
+    gitCommitsInRange(session.project_cwd, session.started_at, session.ended_at)
+      .then((c) => {
+        if (!cancelled) {
+          setCommits(c);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCommits([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.id]);
+
   if (selectedProject) {
     return <ProjectView />;
   }
   if (!selectedId) {
     return <DashboardView />;
   }
-
-  const session = sessions.find((s) => s.id === selectedId) ?? null;
 
   // The header only ever shows the currently selected session, so a
   // successful delete always clears the selection and falls back to the
@@ -321,6 +350,22 @@ export function SessionsTabContent() {
             <TranscriptEntry key={index} message={message} />
           ))}
         </div>
+        {commits.length > 0 && (
+          <section className="mt-4 border-t border-border pt-3">
+            <h2 className="text-[11px] font-semibold uppercase tracking-wide text-fg-subtle">
+              {t("sessions.commits.title")}
+            </h2>
+            <ul className="mt-2 flex flex-col gap-1">
+              {commits.map((c) => (
+                <li key={c.id} className="flex items-baseline gap-2 text-xs">
+                  <span className="shrink-0 font-mono text-fg-subtle">{c.id}</span>
+                  <span className="min-w-0 flex-1 truncate text-fg">{c.summary}</span>
+                  <span className="shrink-0 text-fg-subtle">{c.author}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/src/modules/sessions/SessionsTabContent.tsx
+++ b/src/modules/sessions/SessionsTabContent.tsx
@@ -185,8 +185,10 @@ export function SessionsTabContent() {
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session?.id]);
+    // Re-fetch when any input to the query changes, not just the session id:
+    // an active session's `ended_at` grows as new messages arrive, so the
+    // commit window must widen with it to pick up commits made mid-session.
+  }, [session?.id, session?.project_cwd, session?.started_at, session?.ended_at]);
 
   if (selectedProject) {
     return <ProjectView />;

--- a/src/modules/sessions/SessionsTabContent.tsx
+++ b/src/modules/sessions/SessionsTabContent.tsx
@@ -14,6 +14,7 @@ import { AGENT_BADGE_CLASS } from "./lib/agentBadge";
 import { resumeCommand, resumeSession } from "./lib/resume";
 import { slugifyTitle } from "./lib/slug";
 import { DashboardView } from "./DashboardView";
+import { ProjectView } from "./ProjectView";
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -96,6 +97,7 @@ export function SessionsTabContent() {
   const { t } = useTranslation();
   const sessions = useSessionsStore((s) => s.sessions);
   const selectedId = useSessionsStore((s) => s.selectedId);
+  const selectedProject = useSessionsStore((s) => s.selectedProject);
   const togglePin = useSessionsStore((s) => s.togglePin);
   const select = useSessionsStore((s) => s.select);
 
@@ -155,6 +157,9 @@ export function SessionsTabContent() {
     };
   }, [selectedId]);
 
+  if (selectedProject) {
+    return <ProjectView />;
+  }
   if (!selectedId) {
     return <DashboardView />;
   }

--- a/src/modules/sessions/lib/openTerminalAt.test.ts
+++ b/src/modules/sessions/lib/openTerminalAt.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from "vitest";
+import { openTerminalAt } from "./openTerminalAt";
+import { useTabsStore } from "@/stores/tabsStore";
+
+describe("openTerminalAt", () => {
+  it("creates a terminal tab at the given cwd and returns its id", () => {
+    const newTerminalTab = vi.fn().mockReturnValue("tab-9");
+    vi.spyOn(useTabsStore, "getState").mockReturnValue({ newTerminalTab } as never);
+
+    const id = openTerminalAt("/tmp/proj-a");
+
+    expect(newTerminalTab).toHaveBeenCalledWith("/tmp/proj-a");
+    expect(id).toBe("tab-9");
+  });
+});

--- a/src/modules/sessions/lib/openTerminalAt.ts
+++ b/src/modules/sessions/lib/openTerminalAt.ts
@@ -1,0 +1,7 @@
+import { useTabsStore } from "@/stores/tabsStore";
+
+/** Opens a new terminal tab rooted at `cwd` (e.g. the project view's
+ *  "open a terminal here"). Returns the created tab's id. */
+export function openTerminalAt(cwd: string): string {
+  return useTabsStore.getState().newTerminalTab(cwd);
+}

--- a/src/modules/sessions/lib/projectBridge.ts
+++ b/src/modules/sessions/lib/projectBridge.ts
@@ -1,0 +1,21 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { SessionSummary } from "./sessionsBridge";
+
+/** Per-project aggregates + recent sessions for the project view. Field names
+ *  mirror the Rust `ProjectStats` serde output exactly. */
+export interface ProjectStats {
+  project_cwd: string;
+  sessions: number;
+  messages: number;
+  output_tokens: number;
+  active_days: number;
+  top_model: string | null;
+  first_at: number;
+  last_at: number;
+  recent: SessionSummary[];
+}
+
+/** Aggregates for one project. Zeroed (never rejects) for an unknown project. */
+export function sessionsProjectStats(projectCwd: string): Promise<ProjectStats> {
+  return invoke<ProjectStats>("sessions_project_stats", { projectCwd });
+}

--- a/src/modules/sessions/lib/sessionsCsv.test.ts
+++ b/src/modules/sessions/lib/sessionsCsv.test.ts
@@ -23,6 +23,17 @@ describe("toSessionsCsv", () => {
     expect(row.startsWith('"a,""b""\nc",claude,')).toBe(true);
   });
 
+  it("emits an empty model field for a null model", () => {
+    const csv = toSessionsCsv([s({ agent: "codex", model: null, project_cwd: "/proj" })]);
+    const row = csv.split("\n")[1];
+    const fields = row.split(",");
+    // Header order is title,agent,model,project,... — model is index 2, and
+    // must be empty (the `s.model ?? ""` branch), not the literal "null".
+    expect(fields[1]).toBe("codex");
+    expect(fields[2]).toBe("");
+    expect(fields[3]).toBe("/proj");
+  });
+
   it("returns just the header for an empty list", () => {
     expect(toSessionsCsv([])).toBe(
       "title,agent,model,project,started_at,ended_at,messages,user_messages,output_tokens,pinned",

--- a/src/modules/sessions/lib/sessionsCsv.test.ts
+++ b/src/modules/sessions/lib/sessionsCsv.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { toSessionsCsv } from "./sessionsCsv";
+import type { SessionSummary } from "./sessionsBridge";
+
+const s = (o: Partial<SessionSummary>): SessionSummary => ({
+  id: "id", agent: "claude", project_cwd: "/p", title: "t", started_at: 0, ended_at: 0,
+  message_count: 0, user_message_count: 0, output_tokens: null, model: null,
+  file_path: "/f", pinned: false, ...o,
+});
+
+describe("toSessionsCsv", () => {
+  it("writes a header row plus one row per session in field order", () => {
+    const csv = toSessionsCsv([s({ title: "Fix bug", agent: "codex", model: "gpt-5.5", message_count: 12 })]);
+    const [header, row] = csv.split("\n");
+    expect(header).toBe("title,agent,model,project,started_at,ended_at,messages,user_messages,output_tokens,pinned");
+    expect(row.startsWith("Fix bug,codex,gpt-5.5,/p,")).toBe(true);
+    expect(row.endsWith(",12,0,,false")).toBe(true); // null output_tokens → empty field
+  });
+
+  it("quotes and escapes fields containing commas, quotes, or newlines", () => {
+    const csv = toSessionsCsv([s({ title: 'a,"b"\nc' })]);
+    const row = csv.split("\n").slice(1).join("\n"); // field itself contains a newline
+    expect(row.startsWith('"a,""b""\nc",claude,')).toBe(true);
+  });
+
+  it("returns just the header for an empty list", () => {
+    expect(toSessionsCsv([])).toBe(
+      "title,agent,model,project,started_at,ended_at,messages,user_messages,output_tokens,pinned",
+    );
+  });
+});

--- a/src/modules/sessions/lib/sessionsCsv.ts
+++ b/src/modules/sessions/lib/sessionsCsv.ts
@@ -1,0 +1,35 @@
+import type { SessionSummary } from "./sessionsBridge";
+
+const HEADER = [
+  "title", "agent", "model", "project", "started_at", "ended_at",
+  "messages", "user_messages", "output_tokens", "pinned",
+] as const;
+
+/** RFC-4180 quote: wrap in double quotes and double any inner quote when the
+ *  field contains a comma, quote, CR, or LF; otherwise return it unchanged. */
+function csvField(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/** Serializes sessions to RFC-4180 CSV: a fixed header row then one row per
+ *  session. A null `output_tokens`/`model` becomes an empty field. Timestamps
+ *  are the raw epoch-ms numbers (stable, spreadsheet-parseable). */
+export function toSessionsCsv(sessions: SessionSummary[]): string {
+  const rows = sessions.map((s) =>
+    [
+      s.title,
+      s.agent,
+      s.model ?? "",
+      s.project_cwd,
+      String(s.started_at),
+      String(s.ended_at),
+      String(s.message_count),
+      String(s.user_message_count),
+      s.output_tokens === null ? "" : String(s.output_tokens),
+      String(s.pinned),
+    ]
+      .map(csvField)
+      .join(","),
+  );
+  return [HEADER.join(","), ...rows].join("\n");
+}

--- a/src/modules/sessions/lib/sessionsStore.test.ts
+++ b/src/modules/sessions/lib/sessionsStore.test.ts
@@ -25,7 +25,7 @@ describe("visibleSessions", () => {
     const a = session({ id: "a", pinned: true, ended_at: 1 });
     const b = session({ id: "b", pinned: false, ended_at: 2 });
 
-    const { pinned, history } = visibleSessions([a, b], "", "all");
+    const { pinned, history } = visibleSessions([a, b], "", "all", "all");
 
     expect(pinned).toEqual([a]);
     expect(history).toEqual([b]);
@@ -35,7 +35,7 @@ describe("visibleSessions", () => {
     const older = session({ id: "older", pinned: true, ended_at: 100 });
     const newer = session({ id: "newer", pinned: true, ended_at: 200 });
 
-    const { pinned } = visibleSessions([older, newer], "", "all");
+    const { pinned } = visibleSessions([older, newer], "", "all", "all");
 
     expect(pinned.map((s) => s.id)).toEqual(["newer", "older"]);
   });
@@ -44,7 +44,7 @@ describe("visibleSessions", () => {
     const pinnedSession = session({ id: "p", pinned: true, ended_at: 50 });
     const historySession = session({ id: "h", pinned: false, ended_at: 10 });
 
-    const { history } = visibleSessions([pinnedSession, historySession], "", "all");
+    const { history } = visibleSessions([pinnedSession, historySession], "", "all", "all");
 
     expect(history).toEqual([historySession]);
   });
@@ -53,7 +53,7 @@ describe("visibleSessions", () => {
     const claude = session({ id: "c", agent: "claude" });
     const codex = session({ id: "x", agent: "codex" });
 
-    const { history } = visibleSessions([claude, codex], "", "codex");
+    const { history } = visibleSessions([claude, codex], "", "codex", "all");
 
     expect(history).toEqual([codex]);
   });
@@ -62,7 +62,7 @@ describe("visibleSessions", () => {
     const claude = session({ id: "c", agent: "claude" });
     const codex = session({ id: "x", agent: "codex" });
 
-    const { history } = visibleSessions([claude, codex], "", "all");
+    const { history } = visibleSessions([claude, codex], "", "all", "all");
 
     expect(history.map((s) => s.id)).toEqual(["c", "x"]);
   });
@@ -71,7 +71,7 @@ describe("visibleSessions", () => {
     const match = session({ id: "m", title: "Refactor Auth Flow" });
     const noMatch = session({ id: "n", title: "Unrelated" });
 
-    const { history } = visibleSessions([match, noMatch], "refactor", "all");
+    const { history } = visibleSessions([match, noMatch], "refactor", "all", "all");
 
     expect(history).toEqual([match]);
   });
@@ -80,7 +80,7 @@ describe("visibleSessions", () => {
     const match = session({ id: "m", title: "x", project_cwd: "/Users/muki/Tempo-Term" });
     const noMatch = session({ id: "n", title: "y", project_cwd: "/Users/muki/other" });
 
-    const { history } = visibleSessions([match, noMatch], "tempo-term", "all");
+    const { history } = visibleSessions([match, noMatch], "tempo-term", "all", "all");
 
     expect(history).toEqual([match]);
   });
@@ -94,6 +94,7 @@ describe("visibleSessions", () => {
       [claudeMatch, codexMatch, claudeNoMatch],
       "deploy",
       "claude",
+      "all",
     );
 
     expect(history).toEqual([claudeMatch]);
@@ -102,7 +103,7 @@ describe("visibleSessions", () => {
   it("returns empty arrays when nothing matches", () => {
     const s = session({ id: "s", title: "foo" });
 
-    const { pinned, history } = visibleSessions([s], "nomatch", "all");
+    const { pinned, history } = visibleSessions([s], "nomatch", "all", "all");
 
     expect(pinned).toEqual([]);
     expect(history).toEqual([]);
@@ -112,9 +113,22 @@ describe("visibleSessions", () => {
     const pinnedMatch = session({ id: "pm", pinned: true, title: "release notes" });
     const pinnedNoMatch = session({ id: "pn", pinned: true, title: "unrelated" });
 
-    const { pinned } = visibleSessions([pinnedMatch, pinnedNoMatch], "release", "all");
+    const { pinned } = visibleSessions([pinnedMatch, pinnedNoMatch], "release", "all", "all");
 
     expect(pinned).toEqual([pinnedMatch]);
+  });
+
+  it("visibleSessions filters by exact model, with 'all' passing everything", () => {
+    const mk = (id: string, model: string | null) =>
+      ({ id, agent: "claude", project_cwd: "/p", title: id, started_at: 0, ended_at: 0,
+         message_count: 0, user_message_count: 0, output_tokens: null, model, file_path: "/f",
+         pinned: false }) as SessionSummary;
+    const sessions = [mk("a", "claude-opus-4-8"), mk("b", "gpt-5.5"), mk("c", null)];
+
+    expect(visibleSessions(sessions, "", "all", "all").history.map((s) => s.id)).toEqual(["a", "b", "c"]);
+    expect(visibleSessions(sessions, "", "all", "gpt-5.5").history.map((s) => s.id)).toEqual(["b"]);
+    // null-model sessions never match a specific model.
+    expect(visibleSessions(sessions, "", "all", "claude-opus-4-8").history.map((s) => s.id)).toEqual(["a"]);
   });
 });
 

--- a/src/modules/sessions/lib/sessionsStore.test.ts
+++ b/src/modules/sessions/lib/sessionsStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { visibleSessions } from "./sessionsStore";
+import { useSessionsStore, visibleSessions } from "./sessionsStore";
 import type { SessionSummary } from "./sessionsBridge";
 
 function session(overrides: Partial<SessionSummary>): SessionSummary {
@@ -115,5 +115,21 @@ describe("visibleSessions", () => {
     const { pinned } = visibleSessions([pinnedMatch, pinnedNoMatch], "release", "all");
 
     expect(pinned).toEqual([pinnedMatch]);
+  });
+});
+
+describe("useSessionsStore", () => {
+  it("selectProject sets the project and clears any selected session", () => {
+    useSessionsStore.setState({ selectedId: "s1", selectedProject: null });
+    useSessionsStore.getState().selectProject("/tmp/proj-a");
+    expect(useSessionsStore.getState().selectedProject).toBe("/tmp/proj-a");
+    expect(useSessionsStore.getState().selectedId).toBeNull();
+  });
+
+  it("select clears any selected project", () => {
+    useSessionsStore.setState({ selectedProject: "/tmp/proj-a", selectedId: null });
+    useSessionsStore.getState().select("s2");
+    expect(useSessionsStore.getState().selectedId).toBe("s2");
+    expect(useSessionsStore.getState().selectedProject).toBeNull();
   });
 });

--- a/src/modules/sessions/lib/sessionsStore.ts
+++ b/src/modules/sessions/lib/sessionsStore.ts
@@ -12,6 +12,7 @@ interface SessionsState {
   loaded: boolean;
   query: string;
   agentFilter: SessionAgent | "all";
+  modelFilter: string;
   selectedId: string | null;
   /** The project cwd shown by the project view, or `null` when it's not
    *  open. Mutually exclusive with `selectedId` — selecting one clears the
@@ -24,6 +25,7 @@ interface SessionsState {
   start: () => Promise<void>;
   setQuery: (query: string) => void;
   setAgentFilter: (filter: SessionAgent | "all") => void;
+  setModelFilter: (model: string) => void;
   select: (id: string | null) => void;
   selectProject: (cwd: string | null) => void;
   /** Flips a session's pinned state optimistically, then persists it;
@@ -36,6 +38,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
   loaded: false,
   query: "",
   agentFilter: "all",
+  modelFilter: "all",
   selectedId: null,
   selectedProject: null,
 
@@ -59,6 +62,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
 
   setQuery: (query) => set({ query }),
   setAgentFilter: (agentFilter) => set({ agentFilter }),
+  setModelFilter: (modelFilter) => set({ modelFilter }),
   select: (selectedId) => set({ selectedId, selectedProject: null }),
   selectProject: (selectedProject) => set({ selectedProject, selectedId: null }),
 
@@ -85,19 +89,24 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
 
 /**
  * Pure selector splitting `sessions` into pinned (sorted by most recently
- * ended) and history (everything else), after applying the agent filter and
- * a case-insensitive title/project_cwd query match. Exported for tests and
- * for the sessions panel to derive its two list sections.
+ * ended) and history (everything else), after applying the agent filter, the
+ * model filter, and a case-insensitive title/project_cwd query match.
+ * Exported for tests and for the sessions panel to derive its two list
+ * sections.
  */
 export function visibleSessions(
   sessions: SessionSummary[],
   query: string,
   agentFilter: SessionAgent | "all",
+  modelFilter: string,
 ): { pinned: SessionSummary[]; history: SessionSummary[] } {
   const q = query.trim().toLowerCase();
 
   const filtered = sessions.filter((s) => {
     if (agentFilter !== "all" && s.agent !== agentFilter) {
+      return false;
+    }
+    if (modelFilter !== "all" && s.model !== modelFilter) {
       return false;
     }
     if (q === "") {

--- a/src/modules/sessions/lib/sessionsStore.ts
+++ b/src/modules/sessions/lib/sessionsStore.ts
@@ -13,6 +13,11 @@ interface SessionsState {
   query: string;
   agentFilter: SessionAgent | "all";
   selectedId: string | null;
+  /** The project cwd shown by the project view, or `null` when it's not
+   *  open. Mutually exclusive with `selectedId` — selecting one clears the
+   *  other, since the main area shows exactly one of dashboard / project
+   *  view / session transcript at a time. */
+  selectedProject: string | null;
   /** Reloads `sessions` from the index. Leaves state unchanged on error. */
   refresh: () => Promise<void>;
   /** Starts the backend index (idempotent), then refreshes. */
@@ -20,6 +25,7 @@ interface SessionsState {
   setQuery: (query: string) => void;
   setAgentFilter: (filter: SessionAgent | "all") => void;
   select: (id: string | null) => void;
+  selectProject: (cwd: string | null) => void;
   /** Flips a session's pinned state optimistically, then persists it;
    *  re-syncs from the backend if the write fails. */
   togglePin: (id: string) => Promise<void>;
@@ -31,6 +37,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
   query: "",
   agentFilter: "all",
   selectedId: null,
+  selectedProject: null,
 
   refresh: async () => {
     try {
@@ -52,7 +59,8 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
 
   setQuery: (query) => set({ query }),
   setAgentFilter: (agentFilter) => set({ agentFilter }),
-  select: (selectedId) => set({ selectedId }),
+  select: (selectedId) => set({ selectedId, selectedProject: null }),
+  selectProject: (selectedProject) => set({ selectedProject, selectedId: null }),
 
   togglePin: async (id) => {
     const before = get().sessions;

--- a/src/modules/source-control/lib/gitBridge.ts
+++ b/src/modules/source-control/lib/gitBridge.ts
@@ -45,6 +45,12 @@ export function gitLog(repoPath: string, limit?: number): Promise<CommitInfo[]> 
   return invoke<CommitInfo[]>("git_log", { repoPath, limit });
 }
 
+/** Commits authored in [sinceMs, untilMs] in the git work tree at `cwd`.
+ *  Empty for a non-git / remote / failed cwd. Timestamps are epoch ms. */
+export function gitCommitsInRange(cwd: string, sinceMs: number, untilMs: number): Promise<CommitInfo[]> {
+  return invoke<CommitInfo[]>("git_commits_in_range", { cwd, sinceMs, untilMs });
+}
+
 export function gitDiff(repoPath: string, staged: boolean): Promise<string> {
   return invoke<string>("git_diff", { repoPath, staged });
 }

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -491,6 +491,21 @@ describe("tabsStore", () => {
     expect(firstLeafContent(activeTab())).toEqual({ kind: "terminal", cwd: "/work/dir" });
   });
 
+  it("seeds the requested cwd onto the pane content so it wins over the explorer root", () => {
+    // "Open terminal here" (project view) needs the requested cwd as the pane's
+    // OWN cwd: resolveTerminalCwd ranks paneCwd above the explorer root, so a
+    // bare tab-level cwd would be overridden whenever a folder is open.
+    useTabsStore.getState().newTerminalTab("/a/proj");
+    const leafId = activeTab().activeLeafId;
+    expect(findPaneContent(activeTab().paneTree, leafId)).toEqual({ kind: "terminal", cwd: "/a/proj" });
+  });
+
+  it("leaves the pane cwd unset for a plain new terminal", () => {
+    useTabsStore.getState().newTerminalTab();
+    const leafId = activeTab().activeLeafId;
+    expect(findPaneContent(activeTab().paneTree, leafId)).toEqual({ kind: "terminal" });
+  });
+
   it("leaves a non-terminal pane untouched", () => {
     const id = useTabsStore.getState().openEditorTab("/a/b.ts");
     const leafId = activeTab().activeLeafId;

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -443,7 +443,11 @@ export const useTabsStore = create<TabsState>()(
       spaceId,
       kind: "terminal",
       title: cwd ? basename(cwd) : `Terminal ${count}`,
-      paneTree: leaf(paneId, { kind: "terminal" }),
+      // Seed the requested cwd onto the pane content, not just the tab. The
+      // pane's own cwd is the highest-precedence spawn location
+      // (resolveTerminalCwd ranks paneCwd above the explorer root), so
+      // "open terminal here" lands in the project even when a folder is open.
+      paneTree: leaf(paneId, cwd ? { kind: "terminal", cwd } : { kind: "terminal" }),
       activeLeafId: paneId,
       paneOrder: [paneId],
       cwd,


### PR DESCRIPTION
## AI Sessions view — P3

Third phase of the AI Sessions view (after P1 browse #147 and P2 dashboard/delete/export #148). Adds a project-focused screen, a session↔code link, list filtering by model, and a spreadsheet export. Full-text search over message bodies is intentionally out of scope (a later phase).

### What's new

- **Project view** — click a project name (in a sidebar session row or a dashboard Top Sessions row) to open a per-project screen: aggregate tiles (sessions, messages, output tokens, active days, top model), a recent-sessions list, and a one-click "open a terminal here" rooted at that project.
- **Session ↔ git commit correlation** — the transcript viewer shows the local git commits made during that session's time window. Hidden entirely for non-git / remote (SSH) / no-commit working directories.
- **Model filter** — a sidebar dropdown narrows the session list to one model (options derived from the indexed sessions); it resets to "all" if the selected model disappears.
- **CSV export** — a dashboard button exports the currently filtered session list as RFC-4180 CSV.

### Backend

- New `sessions_project_stats(project_cwd)` command (per-project aggregates + recent sessions, reusing `SessionSummary`).
- New `git_commits_in_range(cwd, since_ms, until_ms)` command on the git module: converts session milliseconds to git's seconds, guards non-git/remote cwds, and degrades to an empty list on any failure (never errors).
- Zero new npm packages, zero new Rust crates — git reuses the existing module, CSV is hand-built, the new UI is hand-rolled over existing stores.

### Extra fix (field-reported during review)

- **`fix(terminal)`**: "open a terminal here" (and the explorer's "Open in Terminal") spawned at the open explorer root instead of the requested directory, because `newTerminalTab` put the cwd only on the tab, which `resolveTerminalCwd` ranks below the explorer root. The requested cwd is now seeded onto the pane content (highest precedence).

### Test plan

- [x] `cargo test` — 325 passed (project_stats aggregation + git time-window incl. the ms→s conversion end-to-end + non-git/remote guards)
- [x] `pnpm test` — 1335 passed (model-filter semantics, select/selectProject exclusivity, CSV quoting/null/empty + filtered-list proof, project-link click/keyboard/empty-cwd, stranded-filter reset, commits section present/absent, terminal-cwd precedence)
- [x] `pnpm typecheck` clean
- [x] Manual: project name → project view; open terminal here cd's into the project; a session with local commits shows the commits section; model filter narrows the list; Export CSV writes the filtered rows

### Known follow-ups (non-blocking, from the final review)

- ProjectView doesn't subscribe to `sessions-index:updated`, so its tiles can show stale counts until you leave and re-enter.
- If the sidebar is switched away (SessionsPanel unmounts) while a model filter is active, the stranded-filter reset can't run, so Export CSV may serialize a header-only file.
- `toSessionsCsv` doesn't guard against spreadsheet formula injection (a title starting with `=`/`+`/`-`/`@`). Low risk for a single-user local tool exporting one's own transcript titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
