### PR TITLE
fix: AI sessions view P3 follow-ups (CSV injection, stranded filter, project-view refresh)

### DIFF
--- a/src/modules/sessions/ProjectView.test.tsx
+++ b/src/modules/sessions/ProjectView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProjectView } from "./ProjectView";
 import { useSessionsStore } from "./lib/sessionsStore";
@@ -78,7 +78,7 @@ describe("ProjectView", () => {
     // Fire the callback the component registered — e.g. the open project's last
     // session was just deleted; the tiles/recent list must not show stale data.
     const callback = mockListen.mock.calls[0][1] as () => void;
-    callback();
+    act(() => callback());
 
     await waitFor(() =>
       expect(mockInvoke).toHaveBeenCalledWith("sessions_project_stats", { projectCwd: "/tmp/proj-a" }),

--- a/src/modules/sessions/ProjectView.test.tsx
+++ b/src/modules/sessions/ProjectView.test.tsx
@@ -3,9 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProjectView } from "./ProjectView";
 import { useSessionsStore } from "./lib/sessionsStore";
 
-const { mockInvoke, mockOpenTerminal } = vi.hoisted(() => ({
+const { mockInvoke, mockOpenTerminal, mockListen, mockUnlisten } = vi.hoisted(() => ({
   mockInvoke: vi.fn(),
   mockOpenTerminal: vi.fn(),
+  mockListen: vi.fn(),
+  mockUnlisten: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mockListen,
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -46,6 +52,8 @@ describe("ProjectView", () => {
   beforeEach(() => {
     mockInvoke.mockClear();
     mockOpenTerminal.mockClear();
+    mockListen.mockReset().mockResolvedValue(mockUnlisten);
+    mockUnlisten.mockReset();
     useSessionsStore.setState({ selectedProject: "/tmp/proj-a", selectedId: null });
   });
 
@@ -56,6 +64,32 @@ describe("ProjectView", () => {
     expect(screen.getByText("14")).toBeInTheDocument();
     expect(screen.getByText("claude-sonnet-5")).toBeInTheDocument();
     expect(screen.getByText("Fix bug")).toBeInTheDocument();
+  });
+
+  it("refetches the project's stats when a sessions-index:updated event fires", async () => {
+    render(<ProjectView />);
+    // Initial fetch on mount.
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith("sessions_project_stats", { projectCwd: "/tmp/proj-a" }),
+    );
+    await waitFor(() => expect(mockListen).toHaveBeenCalledWith("sessions-index:updated", expect.any(Function)));
+    mockInvoke.mockClear();
+
+    // Fire the callback the component registered — e.g. the open project's last
+    // session was just deleted; the tiles/recent list must not show stale data.
+    const callback = mockListen.mock.calls[0][1] as () => void;
+    callback();
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith("sessions_project_stats", { projectCwd: "/tmp/proj-a" }),
+    );
+  });
+
+  it("releases the sessions-index:updated listener on unmount", async () => {
+    const { unmount } = render(<ProjectView />);
+    await waitFor(() => expect(mockListen).toHaveBeenCalled());
+    unmount();
+    await waitFor(() => expect(mockUnlisten).toHaveBeenCalled());
   });
 
   it("opens a terminal at the project cwd when the button is clicked", async () => {

--- a/src/modules/sessions/ProjectView.tsx
+++ b/src/modules/sessions/ProjectView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSessionsStore } from "./lib/sessionsStore";
+import { onSessionsUpdated } from "./lib/sessionsBridge";
 import { sessionsProjectStats, type ProjectStats } from "./lib/projectBridge";
 import { openTerminalAt } from "./lib/openTerminalAt";
 import { AGENT_BADGE_CLASS } from "./lib/agentBadge";
@@ -49,9 +50,14 @@ export function ProjectView() {
   const selectProject = useSessionsStore((s) => s.selectProject);
   const select = useSessionsStore((s) => s.select);
   const [stats, setStats] = useState<ProjectStats>(EMPTY);
+  // Bumped by every sessions-index:updated event so the fetch effect re-runs
+  // with the current cwd — e.g. deleting this project's last session from the
+  // always-present sidebar must refresh the tiles and recent list instead of
+  // leaving stale counts and a phantom row.
+  const [refreshTick, setRefreshTick] = useState(0);
 
   useEffect(() => {
-    // `cancelled` scopes this fetch to the cwd that triggered it: switching
+    // `cancelled` scopes this fetch to the cwd/tick that triggered it: switching
     // projects (or unmounting) before it resolves must not overwrite state
     // with a stale project's stats.
     let cancelled = false;
@@ -71,7 +77,29 @@ export function ProjectView() {
     return () => {
       cancelled = true;
     };
-  }, [cwd]);
+  }, [cwd, refreshTick]);
+
+  useEffect(() => {
+    // Subscribed once for the component's lifetime. The listen subscription
+    // resolves asynchronously, so an unmount before it lands releases the
+    // listener the moment it arrives instead of leaking it (mirrors
+    // DashboardView / SessionsPanel).
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+
+    void onSessionsUpdated(() => setRefreshTick((tick) => tick + 1)).then((fn) => {
+      if (disposed) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
 
   const name = useMemo(() => cwd.split(/[/\\]/).filter(Boolean).pop() ?? cwd, [cwd]);
 

--- a/src/modules/sessions/ProjectView.tsx
+++ b/src/modules/sessions/ProjectView.tsx
@@ -57,6 +57,14 @@ export function ProjectView() {
   const [refreshTick, setRefreshTick] = useState(0);
 
   useEffect(() => {
+    // Clear stats the instant the project changes so the tiles/recent list
+    // don't flash the previous project's numbers until the new fetch lands.
+    // Scoped to `cwd` only (not refreshTick), so a background index-update
+    // refetch updates in place without blanking the screen.
+    setStats(EMPTY);
+  }, [cwd]);
+
+  useEffect(() => {
     // `cancelled` scopes this fetch to the cwd/tick that triggered it: switching
     // projects (or unmounting) before it resolves must not overwrite state
     // with a stale project's stats.

--- a/src/modules/sessions/lib/sessionsCsv.test.ts
+++ b/src/modules/sessions/lib/sessionsCsv.test.ts
@@ -51,6 +51,14 @@ describe("toSessionsCsv", () => {
     expect(row.startsWith('"\'@cmd,tail",')).toBe(true);
   });
 
+  it("guards a leading line feed that spreadsheets strip before evaluating", () => {
+    // Excel/Sheets drop a leading "\n" before parsing, exposing the "=" as a
+    // formula — so the field must be prefixed with "'". The "\n" also forces
+    // RFC-4180 quoting, giving a wrapped "'\n=SUM(A1)".
+    const csv = toSessionsCsv([s({ title: "\n=SUM(A1)" })]);
+    expect(csv.includes("\"'\n=SUM(A1)\"")).toBe(true);
+  });
+
   it("returns just the header for an empty list", () => {
     expect(toSessionsCsv([])).toBe(
       "title,agent,model,project,started_at,ended_at,messages,user_messages,output_tokens,pinned",

--- a/src/modules/sessions/lib/sessionsCsv.test.ts
+++ b/src/modules/sessions/lib/sessionsCsv.test.ts
@@ -34,6 +34,23 @@ describe("toSessionsCsv", () => {
     expect(fields[3]).toBe("/proj");
   });
 
+  it("neutralizes spreadsheet formula-injection by prefixing a leading =,+,-,@", () => {
+    // A title starting with a formula trigger would execute on open in
+    // Excel/Sheets; it must be prefixed with a single quote so it's inert text.
+    const csv = toSessionsCsv([s({ title: "=SUM(A1:A9)" })]);
+    const row = csv.split("\n")[1];
+    // Leading "=" makes the guarded value start with "'=", and the "'" alone
+    // does not force quoting, so the field is the bare prefixed string.
+    expect(row.startsWith("'=SUM(A1:A9),")).toBe(true);
+  });
+
+  it("keeps the formula guard inside RFC-4180 quoting when the field also needs quoting", () => {
+    // Leading "@" AND a comma → prefixed with "'" and wrapped in quotes.
+    const csv = toSessionsCsv([s({ title: "@cmd,tail" })]);
+    const row = csv.split("\n")[1];
+    expect(row.startsWith('"\'@cmd,tail",')).toBe(true);
+  });
+
   it("returns just the header for an empty list", () => {
     expect(toSessionsCsv([])).toBe(
       "title,agent,model,project,started_at,ended_at,messages,user_messages,output_tokens,pinned",

--- a/src/modules/sessions/lib/sessionsCsv.ts
+++ b/src/modules/sessions/lib/sessionsCsv.ts
@@ -5,10 +5,20 @@ const HEADER = [
   "messages", "user_messages", "output_tokens", "pinned",
 ] as const;
 
+/** Neutralizes CSV formula injection: a field starting with a formula trigger
+ *  (`=` `+` `-` `@`, or a leading tab/CR that some parsers strip to reveal one)
+ *  is prefixed with a single quote so a spreadsheet treats it as inert text
+ *  instead of executing it on open. */
+function guardFormula(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+}
+
 /** RFC-4180 quote: wrap in double quotes and double any inner quote when the
- *  field contains a comma, quote, CR, or LF; otherwise return it unchanged. */
+ *  field contains a comma, quote, CR, or LF; otherwise return it unchanged.
+ *  Applies the formula guard first so the escaping wraps the guarded value. */
 function csvField(value: string): string {
-  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+  const guarded = guardFormula(value);
+  return /[",\r\n]/.test(guarded) ? `"${guarded.replace(/"/g, '""')}"` : guarded;
 }
 
 /** Serializes sessions to RFC-4180 CSV: a fixed header row then one row per

--- a/src/modules/sessions/lib/sessionsCsv.ts
+++ b/src/modules/sessions/lib/sessionsCsv.ts
@@ -6,11 +6,11 @@ const HEADER = [
 ] as const;
 
 /** Neutralizes CSV formula injection: a field starting with a formula trigger
- *  (`=` `+` `-` `@`, or a leading tab/CR that some parsers strip to reveal one)
- *  is prefixed with a single quote so a spreadsheet treats it as inert text
- *  instead of executing it on open. */
+ *  (`=` `+` `-` `@`, or a leading tab/CR/LF that a spreadsheet strips to reveal
+ *  one) is prefixed with a single quote so it is treated as inert text instead
+ *  of executing on open. */
 function guardFormula(value: string): string {
-  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+  return /^[=+\-@\t\r\n]/.test(value) ? `'${value}` : value;
 }
 
 /** RFC-4180 quote: wrap in double quotes and double any inner quote when the

--- a/src/modules/sessions/lib/sessionsStore.test.ts
+++ b/src/modules/sessions/lib/sessionsStore.test.ts
@@ -130,6 +130,23 @@ describe("visibleSessions", () => {
     // null-model sessions never match a specific model.
     expect(visibleSessions(sessions, "", "all", "claude-opus-4-8").history.map((s) => s.id)).toEqual(["a"]);
   });
+
+  it("ignores a model filter for a model absent from the dataset (self-heals stranding)", () => {
+    const mk = (id: string, model: string | null) =>
+      ({ id, agent: "claude", project_cwd: "/p", title: id, started_at: 0, ended_at: 0,
+         message_count: 0, user_message_count: 0, output_tokens: null, model, file_path: "/f",
+         pinned: false }) as SessionSummary;
+    // The selected model "gpt-5.5" no longer exists in any session (its sessions
+    // were deleted). Rather than strand an empty list, the filter is ignored.
+    const sessions = [mk("a", "claude-opus-4-8"), mk("b", null)];
+    expect(visibleSessions(sessions, "", "all", "gpt-5.5").history.map((s) => s.id)).toEqual(["a", "b"]);
+
+    // But a model that DOES exist is still honored even when other filters
+    // narrow it to zero — absence-clamp must key off the raw model set, not the
+    // post-filter result.
+    const present = [mk("x", "claude-opus-4-8")];
+    expect(visibleSessions(present, "nomatch-query", "all", "claude-opus-4-8").history).toEqual([]);
+  });
 });
 
 describe("useSessionsStore", () => {

--- a/src/modules/sessions/lib/sessionsStore.ts
+++ b/src/modules/sessions/lib/sessionsStore.ts
@@ -102,11 +102,20 @@ export function visibleSessions(
 ): { pinned: SessionSummary[]; history: SessionSummary[] } {
   const q = query.trim().toLowerCase();
 
+  // Self-heal a stranded model filter: if the selected model is no longer in
+  // the dataset at all (its sessions were deleted while the sidebar — and its
+  // reset effect — was unmounted), ignore it instead of returning an empty
+  // list with no visible way back to "all". Keyed off the raw model set, so a
+  // model that still exists but is narrowed to zero by other filters is
+  // honored, not clamped.
+  const effectiveModelFilter =
+    modelFilter === "all" || sessions.some((s) => s.model === modelFilter) ? modelFilter : "all";
+
   const filtered = sessions.filter((s) => {
     if (agentFilter !== "all" && s.agent !== agentFilter) {
       return false;
     }
-    if (modelFilter !== "all" && s.model !== modelFilter) {
+    if (effectiveModelFilter !== "all" && s.model !== effectiveModelFilter) {
       return false;
     }
     if (q === "") {


### PR DESCRIPTION
## AI Sessions view — P3 follow-ups

The three non-blocking Minor findings deferred from the P3 final review (#149), now fixed. Each is TDD'd; zero new deps, no i18n changes.

### Fixes

1. **CSV formula injection** (`sessionsCsv.ts`) — a session title/project starting with `=`, `+`, `-`, `@` (or a leading tab/CR) would execute as a formula when the exported CSV is opened in Excel/Sheets. Such fields are now prefixed with a single quote so the spreadsheet treats them as inert text; the guard runs before RFC-4180 quoting so it composes with the escaping.
2. **Stranded model filter** (`sessionsStore.ts` `visibleSessions`) — when the sidebar (and its filter-reset effect) is unmounted, a model filter whose sessions all get deleted left the list/CSV empty with no visible control to clear it. `visibleSessions` now ignores a `modelFilter` that is absent from the raw dataset, so the list and the CSV export self-heal regardless of mount state. A model that still exists but is narrowed to zero by other filters is unaffected.
3. **ProjectView staleness** (`ProjectView.tsx`) — the project view fetched stats only on cwd change, so deleting the open project's last session left stale tiles and a phantom recent row that opened a blank viewer when clicked. It now subscribes to `sessions-index:updated` (same pattern as DashboardView) and refetches, releasing the listener on unmount.

### Test plan

- [x] `pnpm test` — 1342 passed (formula-prefix compose with quoting, absent-model clamp + present-but-zero honored, ProjectView refetch-on-event + unmount release)
- [x] `pnpm typecheck` clean
- [x] Adversarial review: Ready to merge (no correctness issues; the CSV guard only ever prefixes free-text columns, never the numeric ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
