### PR TITLE
fix: notification label follows a renamed tab

### DIFF
--- a/src/modules/claude-progress/lib/sessionNotifications.test.ts
+++ b/src/modules/claude-progress/lib/sessionNotifications.test.ts
@@ -1,5 +1,39 @@
 import { describe, it, expect } from "vitest";
-import { notificationForTransition } from "./sessionNotifications";
+import { notificationForTransition, resolvePaneLabel } from "./sessionNotifications";
+
+describe("resolvePaneLabel", () => {
+  it("uses the tab's own title when the user renamed it, even with a cwd", () => {
+    const label = resolvePaneLabel(
+      { renamed: true, title: "My Group" },
+      "/Users/me/projects/api",
+      undefined,
+    );
+    expect(label).toBe("My Group");
+  });
+
+  it("prefers the transcript title over the cwd when the tab is not renamed", () => {
+    const label = resolvePaneLabel(
+      { renamed: false, title: "api" },
+      "/Users/me/projects/api",
+      "Fix auth bug",
+    );
+    expect(label).toBe("Fix auth bug");
+  });
+
+  it("falls back to the cwd basename when no transcript title is known", () => {
+    const label = resolvePaneLabel(
+      { renamed: false, title: "api" },
+      "/Users/me/projects/api",
+      undefined,
+    );
+    expect(label).toBe("api");
+  });
+
+  it("uses the tab title when there is no cwd and no transcript title", () => {
+    const label = resolvePaneLabel({ renamed: false, title: "Scratch" }, null, undefined);
+    expect(label).toBe("Scratch");
+  });
+});
 
 describe("notificationForTransition", () => {
   it("notifies on entering waiting-approval from any prior state", () => {

--- a/src/modules/claude-progress/lib/sessionNotifications.test.ts
+++ b/src/modules/claude-progress/lib/sessionNotifications.test.ts
@@ -22,7 +22,7 @@ describe("resolvePaneLabel", () => {
 
   it("falls back to the cwd basename when no transcript title is known", () => {
     const label = resolvePaneLabel(
-      { renamed: false, title: "api" },
+      { renamed: false, title: "Terminal" },
       "/Users/me/projects/api",
       undefined,
     );

--- a/src/modules/claude-progress/lib/sessionNotifications.ts
+++ b/src/modules/claude-progress/lib/sessionNotifications.ts
@@ -1,10 +1,12 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import i18n from "@/i18n";
 import { useSettingsStore } from "@/stores/settingsStore";
+import type { Tab } from "@/stores/tabsStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { findPaneContent } from "@/modules/terminal/lib/terminalLayout";
 import { basename } from "@/modules/explorer/lib/paths";
 import { agentLabel } from "@/modules/workspace/lib/agentLabel";
+import { selectCardTitle } from "@/modules/workspace/lib/cardTitle";
 import { progressKey } from "./progressStore";
 import { useTitlesStore } from "@/modules/workspace/lib/titlesStore";
 import type { AgentKind } from "./codexNormalize";
@@ -41,9 +43,23 @@ export function notificationForTransition(
 }
 
 /**
- * A short label for the pane a notification is about: the session's transcript
- * title if known, else its directory name, else the tab title. Searches the
- * active space's tabs for the leaf; returns "" when it can't be located.
+ * Resolve the label shown for a pane. A user rename of the tab always wins, so
+ * the notification matches what the workspace card shows; otherwise the
+ * auto-derived name is used: the session's transcript title if known, else the
+ * cwd's directory name, else the tab's own title.
+ */
+export function resolvePaneLabel(
+  tab: Pick<Tab, "renamed" | "title">,
+  cwd: string | null,
+  transcriptTitle: string | undefined,
+): string {
+  const autoTitle = transcriptTitle ?? (cwd ? basename(cwd) : undefined);
+  return selectCardTitle(tab, autoTitle);
+}
+
+/**
+ * A short label for the pane a notification is about. Searches the active
+ * space's tabs for the leaf; returns "" when it can't be located.
  */
 function leafContextName(leafId: string, agent: AgentKind | undefined): string {
   for (const tab of useTabsStore.getState().tabs) {
@@ -52,13 +68,9 @@ function leafContextName(leafId: string, agent: AgentKind | undefined): string {
       continue;
     }
     const cwd = content.cwd ?? tab.cwd ?? null;
-    if (cwd && agent) {
-      const title = useTitlesStore.getState().titles[progressKey(cwd, agent)];
-      if (title) {
-        return title;
-      }
-    }
-    return cwd ? basename(cwd) : tab.title;
+    const transcriptTitle =
+      cwd && agent ? useTitlesStore.getState().titles[progressKey(cwd, agent)] : undefined;
+    return resolvePaneLabel(tab, cwd, transcriptTitle);
   }
   return "";
 }

--- a/src/modules/workspace/lib/cardTitle.ts
+++ b/src/modules/workspace/lib/cardTitle.ts
@@ -5,7 +5,10 @@ import type { Tab } from "@/stores/tabsStore";
  * otherwise the resolved auto title (a session's transcript title, picked by the
  * caller) is used, falling back to the tab's own title (cwd basename or default).
  */
-export function selectCardTitle(tab: Tab, autoTitle: string | undefined): string {
+export function selectCardTitle(
+  tab: Pick<Tab, "renamed" | "title">,
+  autoTitle: string | undefined,
+): string {
   if (tab.renamed) {
     return tab.title;
   }


### PR DESCRIPTION
## Summary

Desktop notifications kept showing the auto-derived pane name (transcript title or cwd basename) even after the user renamed the tab, so a renamed group tab's notification never matched its new name.

`leafContextName` resolved the label as transcript title → cwd basename → tab title, and only reached the tab title when the pane had no cwd. A terminal pane almost always has a cwd, so the user's manual rename was never used.

## Fix

- Extract `resolvePaneLabel(tab, cwd, transcriptTitle)` and route it through `selectCardTitle`, the same helper the workspace card already uses. A renamed tab (`renamed: true`) now wins over the auto-derived name, so the toast matches what the card shows.
- Non-renamed panes keep the existing order: transcript title → cwd basename → tab title.
- Widen `selectCardTitle`'s first param to `Pick<Tab, "renamed" | "title">` since it only reads those two fields.

Both the approval and finished notifications share this path, so both are fixed.

## Test plan

- [x] `pnpm test` — 1347 passed, incl. new `resolvePaneLabel` cases (renamed-wins-over-cwd, transcript-over-cwd, cwd-basename fallback, tab-title fallback)
- [x] `pnpm typecheck` — clean
- [ ] Manual: rename a tab running an agent, unfocus the window, let the agent finish / hit a permission prompt, confirm the toast shows the renamed title

Fixes #157
