### PR TITLE
fix: submit terminal-injected commands with CR so they run on Windows

### DIFF
--- a/src/components/LauncherPanel.test.tsx
+++ b/src/components/LauncherPanel.test.tsx
@@ -20,12 +20,12 @@ describe("LauncherPanel CLI launch", () => {
     useSettingsStore.setState({ claudeFlags: "--model opus" });
     render(<LauncherPanel />);
     fireEvent.click(screen.getByText("Claude Code"));
-    expect(writeToTerminal).toHaveBeenCalledWith(expect.any(String), "claude --model opus\n");
+    expect(writeToTerminal).toHaveBeenCalledWith(expect.any(String), "claude --model opus\r");
   });
 
   it("launches Codex bare when no flags are configured", () => {
     render(<LauncherPanel />);
     fireEvent.click(screen.getByText("Codex"));
-    expect(writeToTerminal).toHaveBeenCalledWith(expect.any(String), "codex\n");
+    expect(writeToTerminal).toHaveBeenCalledWith(expect.any(String), "codex\r");
   });
 });

--- a/src/components/LauncherPanel.tsx
+++ b/src/components/LauncherPanel.tsx
@@ -126,8 +126,9 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
     // End with CR (`\r`), the byte the Enter key actually sends — PowerShell's
     // PSReadLine binds CR to AcceptLine (submit) but LF to AddLine (a `>>`
     // continuation line that never runs), so an injected LF would leave the
-    // command stranded on Windows. CR submits on macOS/Linux too.
-    const line = command.endsWith("\r") ? command : `${command}\r`;
+    // command stranded on Windows. CR submits on macOS/Linux too. Strip any
+    // trailing CR/LF first so a caller-supplied newline can't yield `\n\r`.
+    const line = `${command.replace(/[\r\n]+$/, "")}\r`;
     if (resolved.mode === "replacePane") {
       setPaneContent(resolved.tabId, resolved.leafId, { kind: "terminal" });
       writeToTerminal(resolved.leafId, line);

--- a/src/components/LauncherPanel.tsx
+++ b/src/components/LauncherPanel.tsx
@@ -123,7 +123,11 @@ export function LauncherPanel({ target }: LauncherPanelProps) {
   // The command is queued via writeToTerminal until the freshly spawned shell
   // registers, so it runs once the prompt is ready.
   function openTerminalWithCommand(command: string) {
-    const line = command.endsWith("\n") ? command : `${command}\n`;
+    // End with CR (`\r`), the byte the Enter key actually sends — PowerShell's
+    // PSReadLine binds CR to AcceptLine (submit) but LF to AddLine (a `>>`
+    // continuation line that never runs), so an injected LF would leave the
+    // command stranded on Windows. CR submits on macOS/Linux too.
+    const line = command.endsWith("\r") ? command : `${command}\r`;
     if (resolved.mode === "replacePane") {
       setPaneContent(resolved.tabId, resolved.leafId, { kind: "terminal" });
       writeToTerminal(resolved.leafId, line);

--- a/src/modules/sessions/lib/resume.test.ts
+++ b/src/modules/sessions/lib/resume.test.ts
@@ -70,7 +70,7 @@ describe("resumeSession", () => {
     // registering flushes it, proving `writeToTerminal` reached the right leaf.
     const writes: string[] = [];
     registerTerminal(tab.activeLeafId, (text) => writes.push(text));
-    expect(writes).toEqual(["claude --resume sess-1\n"]);
+    expect(writes).toEqual(["claude --resume sess-1\r"]);
     unregisterTerminal(tab.activeLeafId);
   });
 
@@ -79,7 +79,7 @@ describe("resumeSession", () => {
     const tab = useTabsStore.getState().tabs[0];
     const writes: string[] = [];
     registerTerminal(tab.activeLeafId, (text) => writes.push(text));
-    expect(writes).toEqual(["codex resume sess-2\n"]);
+    expect(writes).toEqual(["codex resume sess-2\r"]);
     unregisterTerminal(tab.activeLeafId);
   });
 });

--- a/src/modules/sessions/lib/resume.ts
+++ b/src/modules/sessions/lib/resume.ts
@@ -56,6 +56,9 @@ export function resumeSession(s: SessionSummary): boolean {
   if (!created || created.kind !== "terminal") {
     return false;
   }
-  writeToTerminal(created.activeLeafId, `${cmd}\n`);
+  // Terminate with CR (`\r`) — the byte Enter sends. Windows' PSReadLine treats
+  // LF as a `>>` continuation that never submits; `cmd` is newline-free (built
+  // from a validated id), so a bare `\r` submits it on every platform.
+  writeToTerminal(created.activeLeafId, `${cmd}\r`);
   return true;
 }

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -1192,7 +1192,9 @@ export function TerminalView({
       }
       if (shouldCdToRoot(root, last)) {
         last = root;
-        void sessionRef.current?.write(`cd ${shellQuotePath(root)}\n`);
+        // CR (`\r`), not LF — the byte Enter sends. On Windows' ConPTY a bare LF
+        // is a `>>` continuation that never runs the cd; CR submits everywhere.
+        void sessionRef.current?.write(`cd ${shellQuotePath(root)}\r`);
       }
     });
     return () => {

--- a/src/modules/terminal/lib/terminalBus.ts
+++ b/src/modules/terminal/lib/terminalBus.ts
@@ -129,8 +129,9 @@ export function runCommandInTerminal(command: string): void {
   }
 
   // CR (`\r`), not LF — the byte Enter sends. Windows' PSReadLine treats LF as
-  // a `>>` continuation (never submits); CR submits on every platform.
-  writeToTerminal(leafId, command.endsWith("\r") ? command : `${command}\r`);
+  // a `>>` continuation (never submits); CR submits on every platform. Strip any
+  // trailing CR/LF first so a caller-supplied newline can't yield `\n\r`.
+  writeToTerminal(leafId, `${command.replace(/[\r\n]+$/, "")}\r`);
 }
 
 /** Read the active terminal's scrollback as plain text, or null if there is

--- a/src/modules/terminal/lib/terminalBus.ts
+++ b/src/modules/terminal/lib/terminalBus.ts
@@ -128,7 +128,9 @@ export function runCommandInTerminal(command: string): void {
     leafId = created.activeLeafId;
   }
 
-  writeToTerminal(leafId, command.endsWith("\n") ? command : `${command}\n`);
+  // CR (`\r`), not LF — the byte Enter sends. Windows' PSReadLine treats LF as
+  // a `>>` continuation (never submits); CR submits on every platform.
+  writeToTerminal(leafId, command.endsWith("\r") ? command : `${command}\r`);
 }
 
 /** Read the active terminal's scrollback as plain text, or null if there is


### PR DESCRIPTION
## Problem

On Windows, commands that the app auto-types into a shell did not run — the shell showed the command text stranded under a `>>` continuation prompt instead of executing it:

```
PS C:\...>
>> claude --resume <id>
```

This affected every place that injects a shell command:
- the launcher (**Claude Code** / **Codex** buttons),
- the sessions **resume** button (`claude --resume <id>` / `codex resume <id>`),
- `runCommandInTerminal` (e.g. the note "run command" action),
- the explorer→shell `cd` sync.

macOS/Linux were unaffected.

## Root cause

Each site terminated the injected line with LF (`\n`). On Windows ConPTY, PSReadLine binds **CR (`\r`) to `AcceptLine`** (submit) but **LF (`\n`) to `AddLine`** (start a `>>` continuation line), so an injected LF never submits.

Manual typing worked because the Enter key travels through xterm, which emits CR. macOS/Linux only tolerated the LF because the pty line discipline (`ICRNL`) maps CR→LF on input, hiding the discrepancy.

## Changes

Terminate every injected command with `\r` instead of `\n` — the byte the Enter key actually sends and what xterm emits, so injection now matches a real Enter keypress. CR still submits on macOS/Linux via `ICRNL`.

- `LauncherPanel.tsx` (`openTerminalWithCommand`) and `terminalBus.ts` (`runCommandInTerminal`): normalize with `command.replace(/[\r\n]+$/, "") + "\r"` so a caller-supplied trailing `\n`/`\r\n` can't produce a malformed `\n\r`.
- `sessions/lib/resume.ts`: resume command ends with `\r` (the built command is newline-free).
- `terminal/TerminalView.tsx`: explorer→shell `cd` sync ends with `\r`.
- Updated `LauncherPanel.test.tsx` and `resume.test.ts` assertions.

## Test plan

- [x] `npx pnpm exec tsc --noEmit` — clean
- [x] `npx pnpm exec vitest run` — full suite green apart from a known-flaky test (`FileFinder` / git-graph, order/timing dependent) that passes in isolation and is unrelated to this change
- [x] `npx pnpm exec vitest run src/modules/sessions/lib/resume.test.ts src/components/LauncherPanel.test.tsx src/modules/terminal/lib/terminalBus.test.ts` — 12 passed
- [x] Manual (Windows release build): **Claude Code** launcher and the sessions **resume** button both now submit and run instead of stalling on a `>>` continuation line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
