### PR TITLE
docs(skills): add windows-tauri development guardrails skill

### DIFF
--- a/.claude/skills/windows-tauri/SKILL.md
+++ b/.claude/skills/windows-tauri/SKILL.md
@@ -49,7 +49,7 @@ Copy the established helper shape (`src-tauri/src/modules/git/mod.rs:545`, `src-
 ```rust
 use std::process::Command;
 
-fn spawn_thing() -> Command {
+fn spawn_thing(exe: &str) -> Command {
     let mut command = Command::new(exe);
     #[cfg(windows)]
     {

--- a/.claude/skills/windows-tauri/SKILL.md
+++ b/.claude/skills/windows-tauri/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: windows-tauri
+description: Use when writing or reviewing code in this Tauri app that can behave differently on Windows — spawning a subprocess (git/gh/any Command), path handling, cfg-gated platform APIs, the pty/terminal, clipboard, ssh, line endings, or a new native crate — and before cutting a release. The dev box is macOS, so Windows regressions do not surface locally; they only show in the Windows CI build or on a user's machine. Encodes the Windows pitfalls this repo has actually shipped and fixed.
+---
+
+# Windows × Tauri guardrails (tempo-term)
+
+Development happens on macOS. Windows is built only by `.github/workflows/windows-build.yml` (on a `windows-latest` runner) and run by users. That gap is why every Windows bug in this repo's history reached a release: it compiled and ran fine on the mac, and nobody exercised Windows until CI or a user did.
+
+This skill is the checklist that closes the gap. Read it before touching any of the surfaces below, and run the pre-flight list before a release.
+
+## Pre-flight checklist
+
+Apply while writing, not after. Each line links to the detailed rule.
+
+- [ ] **Spawning a process?** Set `CREATE_NO_WINDOW` on Windows, or a console flashes and each call costs ~100ms in a release build. [→](#1-every-subprocess-spawn-needs-create_no_window)
+- [ ] **Resolving an executable on disk?** Windows binaries are `gh.exe`/`.cmd`/`.bat`, home is `USERPROFILE`, install dirs differ. [→](#2-executable-resolution-differs-on-windows)
+- [ ] **A subprocess with no timeout?** A hung `gh`/`git` blocks the caller thread forever; add a timeout. [→](#3-give-external-commands-a-timeout)
+- [ ] **Injecting a command into a pty?** Terminate with `\r`, not `\n`, or ConPTY leaves it on a `>>` continuation line. [→](#4-inject-pty-commands-with-cr-not-lf)
+- [ ] **Building a path that bash will run?** Use forward slashes; never inject a bare `.sh`; quote Windows paths with double quotes. [→](#5-paths-forward-slashes-for-bash-double-quotes-for-shells)
+- [ ] **A `#[cfg(unix)]` API or a new native crate?** It must still compile on Windows. Provide a Windows arm or cfg-gate cleanly. [→](#6-unix-only-apis-and-native-crates-must-still-build-on-windows)
+- [ ] **Reaching into `/proc`, `lsof`, a unix socket, pty foreground?** No Windows backend exists; skip the feature there or return a clean `None`. [→](#7-no-windows-backend-skip-do-not-crash-or-spin)
+- [ ] **Frontend behavior gated on platform?** Route Windows through `IS_WINDOWS`, do not leave it `IS_MAC`-only. [→](#8-frontend-gate-on-is_windows-not-just-is_mac)
+- [ ] **Release?** Windows CI is the compile gate; `latest.json` notes get re-patched; functional test on a real Windows host. [→](#release-checklist-windows)
+
+## Failure catalog (what this repo has actually hit)
+
+| Symptom on Windows | Root cause | Rule | Shipped fix |
+|---|---|---|---|
+| Black console flashes on every git/gh call; UI stalls | Release build owns no console (`windows_subsystem = "windows"`); a spawn without `CREATE_NO_WINDOW` allocates one | Set `CREATE_NO_WINDOW` on every `Command` | #82, #105 |
+| "PATH 上找不到 gh CLI" although `gh` is installed | Searched for bare `gh`; Windows binary is `gh.exe`; used `HOME` and macOS install dirs | Append `.exe`/`.cmd`/`.bat`, use `USERPROFILE`, Windows install dirs | #89 |
+| Launcher command sits under a `>>` prompt, never runs | ConPTY/PSReadLine binds CR to submit, LF to continuation; we injected LF | Terminate injected commands with `\r` | #160 |
+| Status hook never fires / spams "Open With" dialog | bash escapes `\`; a bare `.sh` under cmd triggers ShellExecute picker | Forward-slash paths; do not inject a bare `.sh` on Windows | #76, #155 (open) |
+| `cargo build` fails on a stock Windows box | `aws-lc-sys` (via russh default `aws-lc-rs`) needs NASM | Use russh `ring` backend | #75 |
+| Windows release fails to compile (E0599) once SSH landed | `AgentClient::connect_env` is `#[cfg(unix)]` | Windows arm: `connect_named_pipe` / `connect_pageant` | #52, #54 |
+| Terminal paste does nothing | Native paste suppressed everywhere; smart-paste mac-only; backend empty off mac | Route `Ctrl+V` via `IS_WINDOWS`; read clipboard with `clipboard-win` | #75 |
+| cwd tracking dead / 1.2s poll fires empty IPC every terminal | `pty_cwd` has no Windows backend (`/proc`, `lsof` absent) | Skip the poll on Windows, or use OSC 7 shell integration | #105, #115 |
+| Updater "更新內容" dialog empty after a release | Windows CI `tauri-action` rewrites `latest.json` and wipes `notes` | Re-patch notes post-build from `CHANGELOG-NEXT.md` | #43 |
+| Diff-open lag only in the release build | Same console-flash spawn cost, per git subprocess | `CREATE_NO_WINDOW` (see row 1) | #82 |
+
+---
+
+## 1. Every subprocess spawn needs `CREATE_NO_WINDOW`
+
+A release build sets `windows_subsystem = "windows"` (`src-tauri/src/main.rs:2`) and owns no console, so Windows allocates a fresh console for every child process spawned without the flag: a visible window flash plus ~100ms per call. `tauri dev` owns a console, so this **never reproduces in dev** — only in a release build or on a user's machine.
+
+Copy the established helper shape (`src-tauri/src/modules/git/mod.rs:545`, `src-tauri/src/modules/pr/mod.rs:185`):
+
+```rust
+use std::process::Command;
+
+fn spawn_thing() -> Command {
+    let mut command = Command::new(exe);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    command
+}
+```
+
+Rule: **any** new `Command` that shells out (git, gh, a formatter, anything) routes through a helper that sets this flag. A no-op on Unix and on debug builds; mandatory in the Windows release.
+
+## 2. Executable resolution differs on Windows
+
+`find_gh()` searched for a file literally named `gh`; on Windows the binary is `gh.exe`, so it never matched (#89). Three separate assumptions break:
+
+- **Extension**: probe `gh`, then `gh.exe`, `gh.cmd`, `gh.bat` on Windows. See `exe_names()` in `src-tauri/src/modules/pr/mod.rs`.
+- **Home var**: Windows usually has no `HOME`; fall back to `USERPROFILE`.
+- **Install dirs**: not `/opt/homebrew/bin`; use `Program Files\GitHub CLI`, chocolatey, scoop shims.
+
+Parameterize the platform (`windows: bool`) so both arms are unit-testable on the mac CI runner, rather than hiding the Windows path behind `#[cfg]` where it never gets exercised locally.
+
+## 3. Give external commands a timeout
+
+`Command::output()` has no timeout. A hung `gh` (network stall, an interactive auth prompt) blocks the calling thread forever, and on a poll timer those pile up (#105). Wrap spawns that can hang with a timeout (this repo uses the `wait-timeout` crate — see `run_gh` in `src-tauri/src/modules/pr/mod.rs`, 5s kill).
+
+## 4. Inject pty commands with CR, not LF
+
+On Windows ConPTY, PSReadLine binds **CR (`\r`) to `AcceptLine`** (submit) and **LF (`\n`) to `AddLine`** (a `>>` continuation line). An injected `\n` never runs the command (#160). macOS/Linux tolerate `\n` only because the pty line discipline (`ICRNL`) maps CR→LF on input, hiding the bug.
+
+Rule: any code that auto-types a command into a pane (`runCommandInTerminal`, launcher command injection) terminates with `\r`. CR is what a real Enter key sends and what xterm emits, so it submits on all three platforms.
+
+## 5. Paths: forward slashes for bash, double quotes for shells
+
+- **bash escapes `\`.** A Windows backslash path handed to anything Claude Code / git-bash runs collapses (`C:\Users\...` → `C:Users...`). Store and compare paths in a single forward-slash form; git-bash accepts them. See `normalize()` in `src-tauri/src/modules/claude_status_hook/mod.rs`.
+- **Never inject a bare `.sh` command on Windows.** cmd cannot execute a `.sh` path and pops the "Open With" picker on every hook event (#155, still open). If a shell script must run, name the interpreter explicitly (`bash -c "..."` / the git-bash `bash.exe`), or ship a `.cmd`/`.ps1`/native shim.
+- **Quote paths with double quotes**, accepted by cmd, PowerShell, and git-bash. POSIX single quotes are wrong on Windows (#75).
+
+## 6. Unix-only APIs and native crates must still build on Windows
+
+The dev box **cannot cross-compile** the Windows bundle — `git2`, `font-kit`, `portable-pty`, and crypto crates all pull native code, so only `windows-build.yml` on a Windows runner catches a break. Two recurring traps:
+
+- **A `#[cfg(unix)]` API used unconditionally fails to compile on Windows (E0599).** `AgentClient::connect_env` (unix socket) needed a Windows arm (`connect_named_pipe` / `connect_pageant`) and the shared loop extracted into a generic helper (#52, #54). When an API has no Windows form, cfg-gate it and provide a Windows path or a clean error — do not leave the call unconditional.
+- **A new native crate may need a Windows toolchain.** `aws-lc-sys` needs NASM; switching russh to its `ring` backend removed that so `cargo build` works on a stock Windows MSVC setup (#75). Before adding a crate with a `-sys` dependency, check its Windows build requirements.
+
+If you touch anything a Windows build compiles, kick `windows-build.yml` (`workflow_dispatch`) and confirm it is green before merging — it is the only compile gate you have.
+
+## 7. No Windows backend: skip, do not crash or spin
+
+Some capabilities have no Windows implementation and must degrade cleanly, not error or busy-loop:
+
+- **pty foreground process**: `portable-pty` exposes none on Windows, so detecting that `claude`/`codex` is running (for image auto-attach) is mac/Linux only (#75).
+- **process cwd**: no `/proc`, no `lsof`, so `read_process_cwd` returns `None`. The frontend must not keep polling `pty_cwd` every 1.2s per terminal into a dead backend — guard the poll off on Windows (#105), or drive cwd from OSC 7 shell integration instead (#115).
+
+Rule: when a feature's backend is a no-op on Windows, gate the frontend caller too, so it does not fire pointless IPC or show a broken control.
+
+## 8. Frontend: gate on `IS_WINDOWS`, not just `IS_MAC`
+
+Platform branches written as "mac vs everything else" silently break Windows. Terminal paste was suppressed on all platforms and the smart-paste shortcut was `IS_MAC`-only, so Windows had no paste at all (#75). Window decorations are native on Windows and need a custom `TitleBar` (#67). Use `IS_WINDOWS` from `src/lib/platform.ts` and give Windows its own explicit branch.
+
+---
+
+## Release checklist (Windows)
+
+The release is two-phase: `scripts/release.sh` runs on the mac (build, notarize, `latest.json`, `gh release create` with the `v*` tag), and the tag push triggers `windows-build.yml`, which builds on Windows, uploads `.exe`/`.msi`, and merges the `windows-x86_64` platform into `latest.json`.
+
+- [ ] **Windows CI is green.** It is the only thing that compiles the Windows target; a red build means the release ships no working Windows binary.
+- [ ] **The tagged commit still has a populated `CHANGELOG-NEXT.md`.** `windows-build.yml` re-patches `latest.json`'s `notes` from the changelog at the tagged commit. If the changelog was already archived/emptied, notes (macOS included) get wiped (#43). Do not point the tag at a master HEAD whose changelog was cleared.
+- [ ] **Do not hand-patch `latest.json` before CI finishes** — `tauri-action` rewrites it mid-run and would clobber your patch. Patch only after CI, via `node scripts/patchManifestNotes.mjs <manifest> <changelog>` then `gh release upload --clobber`.
+- [ ] **Functional-test on a real Windows host.** CI proves it compiles and bundles, not that it works. The recurring gap in this repo's PRs is the unchecked "Windows real verification" box. Use the CI artifact from the branch to smoke-test paste, launcher, terminal cwd, and the updater dialog.
+
+## How to actually verify on Windows
+
+- **Dev never shows console-flash / spawn-cost bugs** — a debug build owns a console. Reproduce these only in a **release** build (or the CI artifact).
+- No Windows box? Push the branch and run `windows-build.yml` via `workflow_dispatch`; download the artifact to test.
+- Keep platform logic in **pure functions parameterized by `windows: bool`** (see `pr/mod.rs`) so the Windows path has real unit tests that run on the mac, instead of `#[cfg(windows)]` code that is never executed until a user hits it.


### PR DESCRIPTION
## Summary

Adds a `windows-tauri` skill that encodes the Windows pitfalls this repo has actually shipped and fixed. Development happens on macOS, so Windows regressions never surface locally — every Windows bug in the issue/PR history reached a release because it compiled and ran fine on the mac and nobody exercised Windows until CI or a user did. The skill is the checklist that closes that gap.

## What it covers

Built by mining every Windows-tagged issue and PR:

- **Console-flash subprocess spawns** — release build owns no console, so a `Command` without `CREATE_NO_WINDOW` flashes one and costs ~100ms/call (#82, #105)
- **Executable resolution** — `gh.exe`/`.cmd`/`.bat`, `USERPROFILE`, Windows install dirs (#89)
- **Command timeouts** — a hung `gh`/`git` blocks the caller thread (#105)
- **CR vs LF pty injection** — ConPTY submits on `\r`, LF makes a `>>` continuation line (#160)
- **Path handling** — forward slashes for bash, never inject a bare `.sh`, double-quote paths (#76, #155)
- **Build/compile** — `aws-lc-sys` NASM vs `ring`; `#[cfg(unix)]` APIs that fail to compile on Windows; native crates only build in CI (#75, #52, #54)
- **Missing Windows backends** — pty foreground / cwd have none; skip cleanly (#105, #115)
- **Frontend platform gating** — `IS_WINDOWS`, not `IS_MAC`-only (#75, #67)
- **Release** — Windows CI is the compile gate; `latest.json` notes get re-patched; functional-test on a real Windows host (#43)

Structure: a pre-flight checklist, a symptom → root cause → rule → shipped-PR catalog, per-category detail with in-repo `file:line` references, and a Windows release checklist.

## Note on scope

Only the skill is in this PR. The related CLAUDE.md update (a "Tauri 開發流程" section pointing at `/plan`, `/tauri-check`, `/tauri-review`, `/tauri-perf`, `/tauri-audit`, and this skill) and a local pre-commit hook nudge were applied on the dev machine, but `CLAUDE.md` and `.claude/hooks/` are gitignored in this repo, so they stay local by design.

## Test plan

- [x] Skill registers and is discoverable (`windows-tauri` appears in the skill list)
- [x] Every claim traces to a real merged PR / open issue in this repo
- [x] `file:line` references verified against the current tree
