### PR TITLE
fix: git / gh 指令改非同步，避免讀取時凍結 UI

### DIFF
--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -489,22 +489,33 @@ fn git_commits_in_range_impl(cwd: &str, since_ms: i64, until_ms: i64) -> Vec<Com
 /// during it. Always `Ok`; a non-git/remote cwd or any git failure yields an
 /// empty list rather than an error.
 #[tauri::command]
-pub fn git_commits_in_range(
+pub async fn git_commits_in_range(
     cwd: String,
     since_ms: i64,
     until_ms: i64,
 ) -> Result<Vec<CommitInfo>, String> {
-    Ok(git_commits_in_range_impl(&cwd, since_ms, until_ms))
+    tauri::async_runtime::spawn_blocking(move || git_commits_in_range_impl(&cwd, since_ms, until_ms))
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-pub fn git_resolve_repo(path: String) -> Option<String> {
-    resolve_repo(&path)
+pub async fn git_resolve_repo(path: String) -> Option<String> {
+    tauri::async_runtime::spawn_blocking(move || resolve_repo(&path))
+        .await
+        .ok()
+        .flatten()
 }
 
+// Async so the git2 status walk runs off the main GUI thread. This is what the
+// source-control panel calls on open/refresh; a slow repo would otherwise freeze
+// the whole app (same rationale as git_worktree_info). All the git commands below
+// follow this pattern for the same reason.
 #[tauri::command]
-pub fn git_status(repo_path: String) -> Result<GitStatus, String> {
-    status(&repo_path)
+pub async fn git_status(repo_path: String) -> Result<GitStatus, String> {
+    tauri::async_runtime::spawn_blocking(move || status(&repo_path))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
@@ -526,18 +537,24 @@ pub async fn git_worktree_list(path: String) -> Result<Vec<WorktreeListItem>, St
 }
 
 #[tauri::command]
-pub fn git_stage(repo_path: String, path: String) -> Result<(), String> {
-    stage(&repo_path, &path)
+pub async fn git_stage(repo_path: String, path: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || stage(&repo_path, &path))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_unstage(repo_path: String, path: String) -> Result<(), String> {
-    unstage(&repo_path, &path)
+pub async fn git_unstage(repo_path: String, path: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || unstage(&repo_path, &path))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_commit(repo_path: String, message: String) -> Result<String, String> {
-    commit(&repo_path, &message)
+pub async fn git_commit(repo_path: String, message: String) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || commit(&repo_path, &message))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 /// Run a git subcommand against `repo_path` using the system git binary. This
@@ -1109,160 +1126,239 @@ pub fn commit_range_file_diff(
 }
 
 #[tauri::command]
-pub fn git_log(repo_path: String, limit: Option<usize>) -> Result<Vec<CommitInfo>, String> {
-    log(&repo_path, limit.unwrap_or(50))
+pub async fn git_log(repo_path: String, limit: Option<usize>) -> Result<Vec<CommitInfo>, String> {
+    tauri::async_runtime::spawn_blocking(move || log(&repo_path, limit.unwrap_or(50)))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_diff(repo_path: String, staged: bool) -> Result<String, String> {
-    diff(&repo_path, staged)
+pub async fn git_diff(repo_path: String, staged: bool) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || diff(&repo_path, staged))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_file_at_rev(repo_path: String, rev: String, path: String) -> Result<String, String> {
-    file_at_rev(&repo_path, &rev, &path)
+pub async fn git_file_at_rev(
+    repo_path: String,
+    rev: String,
+    path: String,
+) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || file_at_rev(&repo_path, &rev, &path))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_restore_file(repo_path: String, path: String) -> Result<(), String> {
-    restore_file(&repo_path, &path)
+pub async fn git_restore_file(repo_path: String, path: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || restore_file(&repo_path, &path))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_push(repo_path: String) -> Result<String, String> {
-    push(&repo_path)
+pub async fn git_push(repo_path: String) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || push(&repo_path))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_fetch(repo_path: String) -> Result<(), String> {
-    fetch(&repo_path)
+pub async fn git_fetch(repo_path: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || fetch(&repo_path))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_graph_log(
+pub async fn git_graph_log(
     repo_path: String,
     limit: Option<usize>,
     skip: Option<usize>,
     options: Option<GraphOptions>,
 ) -> Result<GraphLog, String> {
-    graph_log(
-        &repo_path,
-        limit.unwrap_or(300),
-        skip.unwrap_or(0),
-        &options.unwrap_or_default(),
-    )
+    tauri::async_runtime::spawn_blocking(move || {
+        graph_log(
+            &repo_path,
+            limit.unwrap_or(300),
+            skip.unwrap_or(0),
+            &options.unwrap_or_default(),
+        )
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_branches(repo_path: String) -> Result<Vec<BranchInfo>, String> {
-    branches(&repo_path)
+pub async fn git_branches(repo_path: String) -> Result<Vec<BranchInfo>, String> {
+    tauri::async_runtime::spawn_blocking(move || branches(&repo_path))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_branch_checkout(repo_path: String, name: String) -> Result<(), String> {
-    branch_checkout(&repo_path, &name)
+pub async fn git_branch_checkout(repo_path: String, name: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || branch_checkout(&repo_path, &name))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_branch_create_at(repo_path: String, name: String, commit: String) -> Result<(), String> {
-    branch_create_at(&repo_path, &name, &commit)
+pub async fn git_branch_create_at(
+    repo_path: String,
+    name: String,
+    commit: String,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || branch_create_at(&repo_path, &name, &commit))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_branch_delete(repo_path: String, name: String, force: Option<bool>) -> Result<(), String> {
-    branch_delete(&repo_path, &name, force.unwrap_or(false))
+pub async fn git_branch_delete(
+    repo_path: String,
+    name: String,
+    force: Option<bool>,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || branch_delete(&repo_path, &name, force.unwrap_or(false)))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_tag_create(
+pub async fn git_tag_create(
     repo_path: String,
     name: String,
     commit: String,
     message: Option<String>,
 ) -> Result<(), String> {
-    tag_create(&repo_path, &name, &commit, message.as_deref())
+    tauri::async_runtime::spawn_blocking(move || {
+        tag_create(&repo_path, &name, &commit, message.as_deref())
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_tag_delete(repo_path: String, name: String) -> Result<(), String> {
-    tag_delete(&repo_path, &name)
+pub async fn git_tag_delete(repo_path: String, name: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || tag_delete(&repo_path, &name))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_merge(repo_path: String, name: String) -> Result<(), String> {
-    merge(&repo_path, &name)
+pub async fn git_merge(repo_path: String, name: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || merge(&repo_path, &name))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_revert(repo_path: String, commit: String) -> Result<(), String> {
-    revert(&repo_path, &commit)
+pub async fn git_revert(repo_path: String, commit: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || revert(&repo_path, &commit))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_cherry_pick(repo_path: String, commit: String) -> Result<(), String> {
-    cherry_pick(&repo_path, &commit)
+pub async fn git_cherry_pick(repo_path: String, commit: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || cherry_pick(&repo_path, &commit))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_reset(repo_path: String, commit: String, mode: Option<String>) -> Result<(), String> {
-    reset(&repo_path, &commit, mode.as_deref())
+pub async fn git_reset(
+    repo_path: String,
+    commit: String,
+    mode: Option<String>,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || reset(&repo_path, &commit, mode.as_deref()))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_rebase(repo_path: String, commit: String) -> Result<(), String> {
-    rebase(&repo_path, &commit)
+pub async fn git_rebase(repo_path: String, commit: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || rebase(&repo_path, &commit))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_branch_checkout_track(
+pub async fn git_branch_checkout_track(
     repo_path: String,
     local: String,
     remote_ref: String,
 ) -> Result<(), String> {
-    branch_checkout_track(&repo_path, &local, &remote_ref)
+    tauri::async_runtime::spawn_blocking(move || {
+        branch_checkout_track(&repo_path, &local, &remote_ref)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_pull(repo_path: String, remote: String, branch: String) -> Result<(), String> {
-    pull(&repo_path, &remote, &branch)
+pub async fn git_pull(repo_path: String, remote: String, branch: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || pull(&repo_path, &remote, &branch))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_push_delete(repo_path: String, remote: String, branch: String) -> Result<(), String> {
-    push_delete(&repo_path, &remote, &branch)
+pub async fn git_push_delete(
+    repo_path: String,
+    remote: String,
+    branch: String,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || push_delete(&repo_path, &remote, &branch))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_commit_details(repo_path: String, commit: String) -> Result<CommitDetails, String> {
-    commit_details(&repo_path, &commit)
+pub async fn git_commit_details(
+    repo_path: String,
+    commit: String,
+) -> Result<CommitDetails, String> {
+    tauri::async_runtime::spawn_blocking(move || commit_details(&repo_path, &commit))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_commit_file_diff(
+pub async fn git_commit_file_diff(
     repo_path: String,
     commit: String,
     file: String,
 ) -> Result<String, String> {
-    commit_file_diff(&repo_path, &commit, &file)
+    tauri::async_runtime::spawn_blocking(move || commit_file_diff(&repo_path, &commit, &file))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_commit_range_files(
+pub async fn git_commit_range_files(
     repo_path: String,
     from: String,
     to: String,
 ) -> Result<Vec<CommitFileChange>, String> {
-    commit_range_files(&repo_path, &from, &to)
+    tauri::async_runtime::spawn_blocking(move || commit_range_files(&repo_path, &from, &to))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn git_commit_range_file_diff(
+pub async fn git_commit_range_file_diff(
     repo_path: String,
     from: String,
     to: String,
     file: String,
 ) -> Result<String, String> {
-    commit_range_file_diff(&repo_path, &from, &to, &file)
+    tauri::async_runtime::spawn_blocking(move || commit_range_file_diff(&repo_path, &from, &to, &file))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[cfg(test)]

--- a/src-tauri/src/modules/pr/mod.rs
+++ b/src-tauri/src/modules/pr/mod.rs
@@ -5,6 +5,7 @@
 
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::Mutex;
 use std::time::Duration;
 
 use wait_timeout::ChildExt;
@@ -223,9 +224,8 @@ fn run_gh(mut command: Command) -> Option<std::process::Output> {
     }
 }
 
-/// Whether the `gh` CLI is available.
-#[tauri::command]
-pub fn gh_available() -> bool {
+/// Blocking probe: spawn `gh --version` and check it succeeds.
+fn gh_available_uncached() -> bool {
     let Some(gh) = find_gh() else {
         return false;
     };
@@ -236,10 +236,55 @@ pub fn gh_available() -> bool {
         .unwrap_or(false)
 }
 
-/// The PR for `branch` via the `gh` CLI, run inside `cwd`. None when gh reports
-/// no PR (a non-zero exit) or gh is missing.
+/// Sticky cache for a POSITIVE `gh` probe only. `gh_available` runs before every
+/// PR refresh, so a workspace with N cards would otherwise fork `gh` N times per
+/// focus. A negative result is deliberately NOT cached: the first probe can be a
+/// transient false-negative (a cold-start `gh --version` timeout, or `find_gh`
+/// not yet resolved), and caching that would silently disable gh for the whole
+/// session — every card — until restart. Not caching false lets it self-heal on
+/// the next call. `false` here means "no positive confirmed yet".
+static GH_AVAILABLE: Mutex<bool> = Mutex::new(false);
+
+/// Whether the `gh` CLI is available. Async so the subprocess probe runs off the
+/// main GUI thread; the positive result is cached (single-flight) so a burst of
+/// cards shares one probe, while a negative result re-probes so a transient miss
+/// recovers on its own.
 #[tauri::command]
-pub fn pr_via_gh(cwd: String, branch: Option<String>) -> Result<Option<PrInfo>, String> {
+pub async fn gh_available() -> bool {
+    tauri::async_runtime::spawn_blocking(|| gh_available_via(&GH_AVAILABLE, gh_available_uncached))
+        .await
+        .unwrap_or(false)
+}
+
+/// Read-through cache that memoizes only a positive probe. The probe runs while
+/// the lock is held, so concurrent callers share one probe instead of forking a
+/// herd; a `false` is not stored, so it re-probes next time. Generic over the
+/// cache + probe so the caching behaviour is unit-testable without spawning gh.
+fn gh_available_via(cache: &Mutex<bool>, probe: impl FnOnce() -> bool) -> bool {
+    let mut confirmed = cache.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    if *confirmed {
+        return true;
+    }
+    let available = probe();
+    if available {
+        *confirmed = true;
+    }
+    available
+}
+
+/// The PR for `branch` via the `gh` CLI, run inside `cwd`. None when gh reports
+/// no PR (a non-zero exit) or gh is missing. Async + spawn_blocking so the
+/// `gh pr view` spawn (a subprocess that also hits the GitHub API) never runs on
+/// the main GUI thread: the workspace panel fans this out across every card on
+/// focus, and a burst of synchronous spawns here froze the whole UI for seconds.
+#[tauri::command]
+pub async fn pr_via_gh(cwd: String, branch: Option<String>) -> Result<Option<PrInfo>, String> {
+    tauri::async_runtime::spawn_blocking(move || pr_via_gh_blocking(cwd, branch))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+fn pr_via_gh_blocking(cwd: String, branch: Option<String>) -> Result<Option<PrInfo>, String> {
     let mut args: Vec<&str> = vec!["pr", "view"];
     let branch = branch.unwrap_or_default();
     if !branch.is_empty() {
@@ -307,6 +352,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn gh_available_caches_positive_but_reprobes_after_false() {
+        use std::cell::Cell;
+        let cache = Mutex::new(false);
+        let calls = Cell::new(0);
+        let probe = |result: bool| {
+            calls.set(calls.get() + 1);
+            result
+        };
+        // A false result is not cached, so each call re-probes (self-heals a
+        // transient false-negative instead of disabling gh for the session).
+        assert!(!gh_available_via(&cache, || probe(false)));
+        assert!(!gh_available_via(&cache, || probe(false)));
+        assert_eq!(calls.get(), 2, "false must re-probe, not stick");
+        // The first positive is cached and sticks; later calls never re-probe.
+        assert!(gh_available_via(&cache, || probe(true)));
+        assert_eq!(calls.get(), 3);
+        assert!(gh_available_via(&cache, || panic!("cached positive must not re-probe")));
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[test]
     fn parses_ssh_remote() {
         assert_eq!(
             parse_owner_repo("git@github.com:mukiwu/tempo-term.git"),
@@ -352,7 +418,7 @@ mod tests {
     #[test]
     fn pr_via_gh_refuses_a_flag_like_branch() {
         // A branch starting with '-' must not reach gh as a positional arg.
-        assert_eq!(pr_via_gh(".".into(), Some("-x".into())), Ok(None));
+        assert_eq!(pr_via_gh_blocking(".".into(), Some("-x".into())), Ok(None));
     }
 
     #[test]


### PR DESCRIPTION
## 問題

打開**原始碼控制面板 / Git Graph**，或**側邊欄回前景刷新 PR 卡片**時，整個 App 會凍結數秒、完全無法操作（越大的 repo / 越多 commit / 越多 workspace 卡片越明顯，且只在 release build 明顯 —— 簽章後的子程序 spawn 較慢）。

## 根因

用 Safari Web Inspector 對 `tauri build --debug` 錄 Timeline：凍結期間 **CPU 幾乎為 0**、只有一串 IPC 請求 —— 主執行緒在**等 I/O**，不是運算。Network 分頁顯示是一批 `git_*` / `pr_via_gh` / `gh_available` 在排隊。

這些 `#[tauri::command]` **幾乎全是同步的**：`git/mod.rs` 的 `git_status` / `git_log` / `git_graph_log` / `git_diff` / `git_branches` / `git_commit_*` 及各種 mutation，還有 `pr/mod.rs` 的 `pr_via_gh` / `gh_available`，都在**主 GUI 執行緒**上跑 git2 / `gh` / git 子程序（真實 repo 要數百毫秒到數秒）。只有 `git_worktree_info` / `git_worktree_list` / `pr_via_api` 之前已 async。同步指令會擋住整個 IPC pipe，連 `system_stats` 與畫面重繪都被卡在後面。

## 修法

比照現有的 `git_worktree_info`，把這些指令全部改成 **`async` + `spawn_blocking`**，將工作移出主 GUI 執行緒。**內部實作函式不變**，邏輯與既有測試不受影響。

`gh_available`（每次 PR refresh 都會呼叫）改為**只快取正結果 + 單次探測（single-flight）**：探測在持鎖期間執行，一批卡片共用一次探測（不 fork herd）；而偽陰性（false）**不快取、下次重探**，所以冷啟動的暫時性 miss 會自癒，不會整個 session 停用 gh。

## 測試

- `cargo test`（含 git / pr 模組）全過（含 `gh_available` 快取行為測試：正結果會黏住、false 會重探）。
- `rg "^pub fn (git_|gh_)"` 確認已無殘留同步指令。
- 前端無需改動（`invoke` 對 sync/async 呼叫方式相同）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)