### PR TITLE
docs: add sponsor badge and link to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,15 @@ cd src-tauri && cargo test      # backend Rust tests
 
 TempoTerm is licensed under the [Apache License 2.0](LICENSE).
 The TempoTerm name and logo are not licensed for use by derivative works (see [NOTICE](NOTICE)).
+
+## Support
+
+If TempoTerm saves you time, you can support its continued development. Every contribution helps keep the project moving.
+
+<div align="center">
+
+<a href="https://portaly.cc/mukiwu/support">
+  <img src="https://img.shields.io/badge/%E2%9D%A4%20Support%20TempoTerm-Portaly-ff4f64?style=for-the-badge&labelColor=1a1a1a" alt="Support TempoTerm on Portaly" height="40" />
+</a>
+
+</div>

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -152,3 +152,15 @@ pnpm build          # 构建前端
 pnpm test                       # 前端单元与集成测试（Vitest）
 cd src-tauri && cargo test      # 后端 Rust 测试
 ```
+
+## 赞助支持
+
+如果 TempoTerm 帮你省下了时间，欢迎小额赞助，支持项目持续开发
+
+<div align="center">
+
+<a href="https://portaly.cc/mukiwu/support">
+  <img src="https://img.shields.io/badge/%E2%9D%A4%20Support%20TempoTerm-Portaly-ff4f64?style=for-the-badge&labelColor=1a1a1a" alt="在 Portaly 上赞助 TempoTerm" height="40" />
+</a>
+
+</div>

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -154,3 +154,15 @@ pnpm build          # 建置前端
 pnpm test                       # 前端單元與整合測試（Vitest）
 cd src-tauri && cargo test      # 後端 Rust 測試
 ```
+
+## 贊助支持
+
+如果 TempoTerm 幫你省下了時間，歡迎小額贊助，支持專案持續開發
+
+<div align="center">
+
+<a href="https://portaly.cc/mukiwu/support">
+  <img src="https://img.shields.io/badge/%E2%9D%A4%20Support%20TempoTerm-Portaly-ff4f64?style=for-the-badge&labelColor=1a1a1a" alt="在 Portaly 上贊助 TempoTerm" height="40" />
+</a>
+
+</div>


### PR DESCRIPTION
## Summary

Adds a **Support** section with a Portaly sponsor badge to the end of all three READMEs (English, Traditional Chinese, Simplified Chinese).

- Badge: a `for-the-badge` shields.io button (`❤ Support TempoTerm · Portaly`, dark label + coral) linking to https://portaly.cc/mukiwu/support, centered to match the README's existing layout.
- The badge label is kept in English across all locales (shields.io renders CJK as tofu); only the surrounding sentence is localized.

## Verification

- Badge URL returns a valid `image/svg+xml` (HTTP 200) rendering `SUPPORT TEMPOTERM` / `PORTALY`, not a shields error badge.
- Sponsor link resolves (HTTP 200).
