### PR TITLE
perf(sessions): 歷史對話列表改用虛擬化，解決開啟時卡頓

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@lezer/highlight": "^1.2.3",
+    "@tanstack/react-virtual": "^3.14.5",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-notification": "^2.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
+      '@tanstack/react-virtual':
+        specifier: ^3.14.5
+        version: 3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.0
@@ -1013,6 +1016,15 @@ packages:
     resolution: {integrity: sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/react-virtual@3.14.5':
+    resolution: {integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.3':
+    resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
 
   '@tauri-apps/api@2.11.0':
     resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
@@ -3405,6 +3417,14 @@ snapshots:
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
       vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@tanstack/react-virtual@3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/virtual-core@3.17.3': {}
 
   '@tauri-apps/api@2.11.0': {}
 

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -8,6 +8,10 @@ interface ConfirmDialogProps {
   cancelLabel: string;
   onConfirm: () => void;
   onCancel: () => void;
+  /** Shown in red under the message when a confirm attempt failed, so the
+   *  dialog can stay open and report the error in place rather than the caller
+   *  surfacing it elsewhere. */
+  error?: string;
 }
 
 export function ConfirmDialog({
@@ -17,6 +21,7 @@ export function ConfirmDialog({
   cancelLabel,
   onConfirm,
   onCancel,
+  error,
 }: ConfirmDialogProps) {
   // Mounted only while open, so guard unconditionally to hide the preview webview.
   useOverlayGuard(true);
@@ -38,7 +43,10 @@ export function ConfirmDialog({
         <div className="border-b border-border px-4 py-3">
           <span className="text-sm font-semibold text-fg">{title}</span>
         </div>
-        <div className="px-4 py-4 text-sm text-fg-muted">{message}</div>
+        <div className="px-4 py-4 text-sm text-fg-muted">
+          {message}
+          {error && <p className="mt-2 text-danger/90">{error}</p>}
+        </div>
         <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
           <button
             type="button"

--- a/src/modules/sessions/SessionsPanel.test.tsx
+++ b/src/modules/sessions/SessionsPanel.test.tsx
@@ -450,11 +450,13 @@ describe("SessionsPanel", () => {
     expect(useSessionsStore.getState().selectedId).toBe("a");
   });
 
-  it("clears the delete error line when a new delete attempt starts", async () => {
+  it("clears the delete error when a new delete attempt starts", async () => {
     seedSessions([session({ id: "a", title: "Deploy script" })]);
     await renderSettled();
     deleteFailure.current = true;
 
+    // The delete confirmation is panel-level (shared, above the virtualized
+    // rows), so a failed attempt keeps the dialog open with an inline error.
     fireEvent.click(screen.getByRole("button", { name: "sessions.delete" }));
     await act(async () => {
       fireEvent.click(
@@ -464,7 +466,8 @@ describe("SessionsPanel", () => {
     });
     expect(screen.getByText("sessions.deleteError")).toBeInTheDocument();
 
-    // Re-opening the confirm dialog starts a fresh attempt: stale error gone.
+    // Dismiss, then start a fresh attempt from the row: the stale error is gone.
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "actions.cancel" }));
     fireEvent.click(screen.getByRole("button", { name: "sessions.delete" }));
 
     expect(screen.queryByText("sessions.deleteError")).not.toBeInTheDocument();

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { History, LayoutDashboard, Pin, PinOff, Play, Search, Trash2 } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -139,7 +140,7 @@ function SessionRow({ session, selected }: SessionRowProps) {
   }
 
   return (
-    <li className="group">
+    <div className="group">
       <div className="flex items-center">
         <button
           type="button"
@@ -267,7 +268,65 @@ function SessionRow({ session, selected }: SessionRowProps) {
           onCancel={() => setConfirmingDelete(false)}
         />
       )}
-    </li>
+    </div>
+  );
+}
+
+/** Fixed row height (px) for the virtualized history list. The two-line row
+ *  (title + meta) plus its vertical padding is a constant height, so a fixed
+ *  size lets the virtualizer skip per-row measurement entirely. */
+const HISTORY_ROW_HEIGHT = 48;
+
+/** The indexed history list, virtualized. The user's transcript index can hold
+ *  tens of thousands of sessions; rendering every row into the DOM froze the
+ *  whole app for seconds on open (huge style-recalc + layout). This renders
+ *  only the rows in view. It shares the panel's single scroll container (passed
+ *  in as `scrollEl`) rather than owning its own, so the Live and pinned
+ *  sections above it scroll together with the history; `scrollMargin` accounts
+ *  for their height so item offsets line up. */
+function HistoryList({
+  sessions,
+  selectedId,
+  scrollEl,
+}: {
+  sessions: SessionSummary[];
+  selectedId: string | null;
+  scrollEl: HTMLDivElement | null;
+}) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: sessions.length,
+    getScrollElement: () => scrollEl,
+    estimateSize: () => HISTORY_ROW_HEIGHT,
+    overscan: 12,
+    getItemKey: (index) => sessions[index].id,
+    scrollMargin: listRef.current?.offsetTop ?? 0,
+  });
+
+  const items = virtualizer.getVirtualItems();
+
+  return (
+    <div ref={listRef} style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+      {items.map((item) => {
+        const session = sessions[item.index];
+        return (
+          <div
+            key={item.key}
+            data-index={item.index}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              height: HISTORY_ROW_HEIGHT,
+              transform: `translateY(${item.start - virtualizer.options.scrollMargin}px)`,
+            }}
+          >
+            <SessionRow session={session} selected={session.id === selectedId} />
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -284,6 +343,11 @@ export function SessionsPanel() {
   const setModelFilter = useSessionsStore((s) => s.setModelFilter);
   const select = useSessionsStore((s) => s.select);
   const openSessionsTab = useTabsStore((s) => s.openSessionsTab);
+  // The virtualized history list reads its viewport from this scroll
+  // container. It lives in state (not a ref) so setting it on mount triggers a
+  // re-render, which is what lets the virtualizer pick up the element and
+  // compute its first visible range.
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
     void useSessionsStore.getState().start();
@@ -403,7 +467,7 @@ export function SessionsPanel() {
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto py-1">
+      <div ref={setScrollEl} className="relative min-h-0 flex-1 overflow-y-auto py-1">
         <LiveSection />
 
         {!loaded ? (
@@ -423,7 +487,7 @@ export function SessionsPanel() {
                 <div className="px-3 py-1 text-[11px] font-semibold uppercase text-fg-subtle">
                   {t("sessions.pinned")}
                 </div>
-                <ul>
+                <div>
                   {pinned.map((session) => (
                     <SessionRow
                       key={session.id}
@@ -431,18 +495,10 @@ export function SessionsPanel() {
                       selected={session.id === selectedId}
                     />
                   ))}
-                </ul>
+                </div>
               </div>
             )}
-            <ul>
-              {history.map((session) => (
-                <SessionRow
-                  key={session.id}
-                  session={session}
-                  selected={session.id === selectedId}
-                />
-              ))}
-            </ul>
+            <HistoryList sessions={history} selectedId={selectedId} scrollEl={scrollEl} />
           </>
         )}
       </div>

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { History, LayoutDashboard, Pin, PinOff, Play, Search, Trash2 } from "lucide-react";
@@ -294,13 +294,26 @@ function HistoryList({
   scrollEl: HTMLDivElement | null;
 }) {
   const listRef = useRef<HTMLDivElement>(null);
+  // The list starts below the Live and pinned sections, so its offset from the
+  // scroll container's top is the virtualizer's scrollMargin. A ref's
+  // offsetTop can't be read during render (it's null on the first pass, and
+  // ref changes don't re-render), so measure it in a layout effect and store
+  // it in state. Running on every commit — guarded to only set state when the
+  // value actually changed — keeps it correct when the sections above grow or
+  // shrink (Live sessions start/stop, a pin is toggled) without a dependency
+  // list that would miss those layout shifts.
+  const [scrollMargin, setScrollMargin] = useState(0);
+  useLayoutEffect(() => {
+    const top = listRef.current?.offsetTop ?? 0;
+    setScrollMargin((prev) => (prev === top ? prev : top));
+  });
   const virtualizer = useVirtualizer({
     count: sessions.length,
     getScrollElement: () => scrollEl,
     estimateSize: () => HISTORY_ROW_HEIGHT,
     overscan: 12,
     getItemKey: (index) => sessions[index].id,
-    scrollMargin: listRef.current?.offsetTop ?? 0,
+    scrollMargin,
   });
 
   const items = virtualizer.getVirtualItems();

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -102,19 +102,20 @@ function LiveSection() {
 interface SessionRowProps {
   session: SessionSummary;
   selected: boolean;
+  /** Asks the panel to open its shared, panel-level delete confirmation for
+   *  this session. Deletion is handled above the virtualized rows so the modal
+   *  isn't trapped by a row's `transform` (which would become the containing
+   *  block for its `position: fixed`) and doesn't vanish when the row scrolls
+   *  out of the render window. */
+  onRequestDelete: (session: SessionSummary) => void;
 }
 
-function SessionRow({ session, selected }: SessionRowProps) {
+function SessionRow({ session, selected, onRequestDelete }: SessionRowProps) {
   const { t } = useTranslation();
   const select = useSessionsStore((s) => s.select);
   const selectProject = useSessionsStore((s) => s.selectProject);
   const togglePin = useSessionsStore((s) => s.togglePin);
   const openSessionsTab = useTabsStore((s) => s.openSessionsTab);
-  const [confirmingDelete, setConfirmingDelete] = useState(false);
-  // Delete is destructive (even if recoverable from the Trash), so a failure
-  // must never pass silently: this renders an error line under the row until
-  // the next delete attempt replaces it.
-  const [deleteError, setDeleteError] = useState(false);
   const pinLabel = t(session.pinned ? "sessions.unpin" : "sessions.pin");
   const resumeLabel = t("sessions.resume");
   const deleteLabel = t("sessions.delete");
@@ -123,24 +124,8 @@ function SessionRow({ session, selected }: SessionRowProps) {
   // instead, since there's space there for the explanation.
   const canResume = resumeCommand(session.agent, session.id) !== null;
 
-  // Trashing is recoverable (never a permanent delete), but it still touches
-  // real files on disk, so it goes through the shared ConfirmDialog rather
-  // than firing on click like pin/resume do.
-  async function handleDelete() {
-    setConfirmingDelete(false);
-    try {
-      await sessionsDelete(session.id);
-    } catch {
-      setDeleteError(true);
-      return;
-    }
-    if (selected) {
-      select(null);
-    }
-  }
-
   return (
-    <div className="group">
+    <div role="listitem" className="group">
       <div className="flex items-center">
         <button
           type="button"
@@ -242,9 +227,7 @@ function SessionRow({ session, selected }: SessionRowProps) {
               aria-label={deleteLabel}
               onClick={(e) => {
                 e.stopPropagation();
-                // A fresh attempt supersedes any stale error from the last one.
-                setDeleteError(false);
-                setConfirmingDelete(true);
+                onRequestDelete(session);
               }}
               className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-danger"
             >
@@ -253,21 +236,6 @@ function SessionRow({ session, selected }: SessionRowProps) {
           </Tooltip>
         </div>
       </div>
-
-      {deleteError && (
-        <p className="px-3 pb-1 text-xs text-danger/80">{t("sessions.deleteError")}</p>
-      )}
-
-      {confirmingDelete && (
-        <ConfirmDialog
-          title={deleteLabel}
-          message={t("sessions.deleteConfirm")}
-          confirmLabel={deleteLabel}
-          cancelLabel={t("actions.cancel")}
-          onConfirm={() => void handleDelete()}
-          onCancel={() => setConfirmingDelete(false)}
-        />
-      )}
     </div>
   );
 }
@@ -288,25 +256,41 @@ function HistoryList({
   sessions,
   selectedId,
   scrollEl,
+  contentEl,
+  onRequestDelete,
 }: {
   sessions: SessionSummary[];
   selectedId: string | null;
   scrollEl: HTMLDivElement | null;
+  /** The scroll container's inner content wrapper (Live + pinned + this list).
+   *  Observed for resize so `scrollMargin` re-measures when the sections above
+   *  change height — e.g. a Live session starts/ends. Those sections are
+   *  sibling subtrees that re-render on their own store updates without
+   *  re-rendering this component, so a plain layout effect would miss the
+   *  shift and only self-correct on the next scroll. */
+  contentEl: HTMLElement | null;
+  onRequestDelete: (session: SessionSummary) => void;
 }) {
   const listRef = useRef<HTMLDivElement>(null);
   // The list starts below the Live and pinned sections, so its offset from the
-  // scroll container's top is the virtualizer's scrollMargin. A ref's
-  // offsetTop can't be read during render (it's null on the first pass, and
-  // ref changes don't re-render), so measure it in a layout effect and store
-  // it in state. Running on every commit — guarded to only set state when the
-  // value actually changed — keeps it correct when the sections above grow or
-  // shrink (Live sessions start/stop, a pin is toggled) without a dependency
-  // list that would miss those layout shifts.
+  // scroll container's top is the virtualizer's scrollMargin. A ref's offsetTop
+  // can't be read during render, so measure it in a layout effect (on mount and
+  // whenever the content wrapper resizes), guarded to only set state on a real
+  // change.
   const [scrollMargin, setScrollMargin] = useState(0);
   useLayoutEffect(() => {
-    const top = listRef.current?.offsetTop ?? 0;
-    setScrollMargin((prev) => (prev === top ? prev : top));
-  });
+    const measure = () => {
+      const top = listRef.current?.offsetTop ?? 0;
+      setScrollMargin((prev) => (prev === top ? prev : top));
+    };
+    measure();
+    if (!contentEl) {
+      return;
+    }
+    const observer = new ResizeObserver(measure);
+    observer.observe(contentEl);
+    return () => observer.disconnect();
+  }, [contentEl]);
   const virtualizer = useVirtualizer({
     count: sessions.length,
     getScrollElement: () => scrollEl,
@@ -319,7 +303,11 @@ function HistoryList({
   const items = virtualizer.getVirtualItems();
 
   return (
-    <div ref={listRef} style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+    <div
+      ref={listRef}
+      role="list"
+      style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+    >
       {items.map((item) => {
         const session = sessions[item.index];
         return (
@@ -335,7 +323,11 @@ function HistoryList({
               transform: `translateY(${item.start - virtualizer.options.scrollMargin}px)`,
             }}
           >
-            <SessionRow session={session} selected={session.id === selectedId} />
+            <SessionRow
+              session={session}
+              selected={session.id === selectedId}
+              onRequestDelete={onRequestDelete}
+            />
           </div>
         );
       })}
@@ -361,6 +353,38 @@ export function SessionsPanel() {
   // re-render, which is what lets the virtualizer pick up the element and
   // compute its first visible range.
   const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  // The scroll container's inner content wrapper, handed to HistoryList so it
+  // can observe height changes above the list. In state (not a ref) so the
+  // observer effect re-runs once the element mounts.
+  const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
+  // Delete confirmation is owned here, above the virtualized rows, rather than
+  // inside each row: a row's `transform` would trap the modal's `position:
+  // fixed`, and the row can unmount mid-dialog as it scrolls out of the render
+  // window. `deleteFailed` keeps the dialog open with an inline error.
+  const [pendingDelete, setPendingDelete] = useState<SessionSummary | null>(null);
+  const [deleteFailed, setDeleteFailed] = useState(false);
+
+  const requestDelete = (session: SessionSummary) => {
+    setDeleteFailed(false);
+    setPendingDelete(session);
+  };
+
+  async function confirmDelete() {
+    const target = pendingDelete;
+    if (!target) {
+      return;
+    }
+    try {
+      await sessionsDelete(target.id);
+    } catch {
+      setDeleteFailed(true);
+      return;
+    }
+    setPendingDelete(null);
+    if (selectedId === target.id) {
+      select(null);
+    }
+  }
 
   useEffect(() => {
     void useSessionsStore.getState().start();
@@ -481,40 +505,61 @@ export function SessionsPanel() {
       </div>
 
       <div ref={setScrollEl} className="relative min-h-0 flex-1 overflow-y-auto py-1">
-        <LiveSection />
+        <div ref={setContentEl}>
+          <LiveSection />
 
-        {!loaded ? (
-          <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
-            <History size={28} className="text-fg-subtle" />
-            <p className="text-xs text-fg-subtle">{t("sessions.indexing")}</p>
-          </div>
-        ) : isEmpty ? (
-          <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
-            <History size={28} className="text-fg-subtle" />
-            <p className="text-xs text-fg-subtle">{t("sessions.empty")}</p>
-          </div>
-        ) : (
-          <>
-            {pinned.length > 0 && (
-              <div>
-                <div className="px-3 py-1 text-[11px] font-semibold uppercase text-fg-subtle">
-                  {t("sessions.pinned")}
-                </div>
+          {!loaded ? (
+            <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+              <History size={28} className="text-fg-subtle" />
+              <p className="text-xs text-fg-subtle">{t("sessions.indexing")}</p>
+            </div>
+          ) : isEmpty ? (
+            <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+              <History size={28} className="text-fg-subtle" />
+              <p className="text-xs text-fg-subtle">{t("sessions.empty")}</p>
+            </div>
+          ) : (
+            <>
+              {pinned.length > 0 && (
                 <div>
-                  {pinned.map((session) => (
-                    <SessionRow
-                      key={session.id}
-                      session={session}
-                      selected={session.id === selectedId}
-                    />
-                  ))}
+                  <div className="px-3 py-1 text-[11px] font-semibold uppercase text-fg-subtle">
+                    {t("sessions.pinned")}
+                  </div>
+                  <div role="list">
+                    {pinned.map((session) => (
+                      <SessionRow
+                        key={session.id}
+                        session={session}
+                        selected={session.id === selectedId}
+                        onRequestDelete={requestDelete}
+                      />
+                    ))}
+                  </div>
                 </div>
-              </div>
-            )}
-            <HistoryList sessions={history} selectedId={selectedId} scrollEl={scrollEl} />
-          </>
-        )}
+              )}
+              <HistoryList
+                sessions={history}
+                selectedId={selectedId}
+                scrollEl={scrollEl}
+                contentEl={contentEl}
+                onRequestDelete={requestDelete}
+              />
+            </>
+          )}
+        </div>
       </div>
+
+      {pendingDelete && (
+        <ConfirmDialog
+          title={t("sessions.delete")}
+          message={t("sessions.deleteConfirm")}
+          confirmLabel={t("sessions.delete")}
+          cancelLabel={t("actions.cancel")}
+          error={deleteFailed ? t("sessions.deleteError") : undefined}
+          onConfirm={() => void confirmDelete()}
+          onCancel={() => setPendingDelete(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -39,6 +39,26 @@ if (typeof HTMLElement.prototype.scrollIntoView === "undefined") {
   HTMLElement.prototype.scrollIntoView = () => {};
 }
 
+// jsdom performs no layout, so offsetWidth/offsetHeight are always 0.
+// @tanstack/react-virtual (the sessions history list) reads its scroll
+// element's viewport from offsetHeight on mount and, seeing 0, renders zero
+// rows — seeded rows then never appear under test. Report a fixed non-zero
+// viewport so the virtualizer has a window to fill. Row heights come from the
+// virtualizer's fixed estimate (it does not measure individual rows), so a
+// uniform stub here does not distort them.
+Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+  configurable: true,
+  get() {
+    return 800;
+  },
+});
+Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+  configurable: true,
+  get() {
+    return 300;
+  },
+});
+
 if (typeof window.matchMedia === "undefined") {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
     matches: false,


### PR DESCRIPTION
## 問題

當累積大量 session（跨 Claude / Codex / Antigravity 可達上萬筆）時，點開歷史對話面板整個 app 會卡頓數秒。

用 Web Inspector Timeline 追下來，`sessions_list` IPC 回傳約 7.25MB，接著 `renderRows` 觸發 **Styles Recalculated ~2.03s + Layout ~1.22s** 的凍結 —— 根因是歷史列表 `history.map()` 一次把每一列都 render 進 DOM（無虛擬化、無上限）。

## 修法

改用 `@tanstack/react-virtual`，只渲染可視範圍的列：

- 新增虛擬化的 `HistoryList`，共用面板既有的單一捲動容器（Live / pinned 與 history 一起捲動），以 `scrollMargin` 對齊位移。
- 列高固定 `48px`（兩行的標題＋中繼資訊為固定高度），省掉逐列量測。
- 捲動容器改用 `state` 持有（而非 ref），掛載後觸發一次 re-render 讓 virtualizer 取得視窗尺寸 —— tanstack 官方建議寫法。
- `SessionRow` 根節點 `li` → `div`（脫離 `ul` 後 `li` 會冒出項目符號），pinned 容器一併調整。

## 測試

- `src/test/setup.ts` 補上 `offsetWidth/offsetHeight` stub —— jsdom 無版面計算，否則 virtualizer 以為視窗高度 0、不渲染任何列。
- 全套件通過：**1348 tests passed**，`pnpm typecheck` 乾淨。

## 備註

後端 `sessions_list` 的 7.25MB / ~6.8s IPC 傳輸仍在（已用 `spawn_blocking` 不卡主執行緒），本 PR 只解前端渲染凍結。若要再壓傳輸時間，後續可做後端分頁。

🤖 Generated with [Claude Code](https://claude.com/claude-code)