### PR TITLE
feat(setup): 首次啟動的工具安裝引導精靈

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ use modules::sessions_index::{
     sessions_delete, sessions_export, sessions_get, sessions_index_start, sessions_list, sessions_pin,
     sessions_project_stats, sessions_stats, SessionsIndexState,
 };
+use modules::setup::{detect_tools, install_tool};
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -264,7 +265,9 @@ pub fn run() {
             sessions_stats,
             sessions_project_stats,
             sessions_delete,
-            sessions_export
+            sessions_export,
+            detect_tools,
+            install_tool
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/menu.rs
+++ b/src-tauri/src/modules/menu.rs
@@ -17,6 +17,10 @@ const CYCLE_PANE_ID: &str = "cycle-pane";
 /// the same reason as Open Location: a focused native preview webview would
 /// otherwise swallow the key before the app webview's handler sees it.
 const CYCLE_PANE_EVENT: &str = "menu:focus-next-pane";
+const RERUN_SETUP_ID: &str = "rerun-setup";
+/// Emitted to the focused window when the user picks "Setup Wizard" from the
+/// File menu, so the frontend re-opens the first-run install guide on demand.
+const RERUN_SETUP_EVENT: &str = "menu:rerun-setup";
 
 /// Build the menu (Tauri's default plus custom items and a Cmd+W rebind), set it
 /// as the app menu, and wire the menu-event handler.
@@ -68,6 +72,7 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
     )?;
     let cycle_pane =
         MenuItem::with_id(&handle, CYCLE_PANE_ID, "Cycle Pane", true, Some("CmdOrCtrl+`"))?;
+    let rerun_setup = MenuItem::with_id(&handle, RERUN_SETUP_ID, "Setup Wizard", true, None::<&str>)?;
     let mut inserted = false;
     for item in menu.items()? {
         let MenuItemKind::Submenu(submenu) = item else {
@@ -86,6 +91,8 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
                 submenu.insert(&new_window, 0)?;
                 submenu.insert(&PredefinedMenuItem::separator(&handle)?, 1)?;
                 submenu.append(&open_location)?;
+                submenu.append(&PredefinedMenuItem::separator(&handle)?)?;
+                submenu.append(&rerun_setup)?;
                 submenu.append(&PredefinedMenuItem::separator(&handle)?)?;
                 submenu.append(&close_tab)?;
                 inserted = true;
@@ -127,6 +134,12 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
             // active pane; a bare emit() would cycle panes in every window.
             if let Some(win) = app.get_focused_window() {
                 let _ = win.emit_to(win.label(), CYCLE_PANE_EVENT, ());
+            }
+        } else if event.id() == RERUN_SETUP_ID {
+            // Target the focused window's label so only its frontend re-opens the
+            // setup wizard; a bare emit() would open it in every window.
+            if let Some(win) = app.get_focused_window() {
+                let _ = win.emit_to(win.label(), RERUN_SETUP_EVENT, ());
             }
         }
     });

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -19,5 +19,6 @@ pub mod pty;
 pub mod secrets;
 pub mod session_log;
 pub mod sessions_index;
+pub mod setup;
 pub mod sysmon;
 pub mod terminal_history;

--- a/src-tauri/src/modules/setup/mod.rs
+++ b/src-tauri/src/modules/setup/mod.rs
@@ -5,10 +5,18 @@
 //! one-line change; version comparison is a pure function for easy testing.
 
 use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use serde::Serialize;
 use tauri::ipc::Channel;
+use wait_timeout::ChildExt;
+
+/// Ceiling on a single `<tool> --version` probe. A hung binary (a stalled
+/// mount, an interactive prompt) must not freeze detection — bound the wait and
+/// treat a timeout as "not installed". Detection runs ~6 probes on first launch.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A single tool the wizard knows how to detect and install. The install
 /// commands are the raw shell strings run per platform; an empty string means
@@ -70,7 +78,10 @@ const TOOLS: &[ToolSpec] = &[
         bin: "antigravity",
         min_version: None,
         mac_install: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
-        windows_install: "curl -fsSL https://antigravity.google/cli/install.cmd -o install.cmd && install.cmd && del install.cmd",
+        // Write the installer to an absolute TEMP path (the GUI process CWD is
+        // often read-only) and clean up unconditionally with `&` — `&&` would
+        // skip `del` whenever curl fails, leaving the file behind.
+        windows_install: "curl -fsSL https://antigravity.google/cli/install.cmd -o \"%TEMP%\\ag_install.cmd\" & call \"%TEMP%\\ag_install.cmd\" & del \"%TEMP%\\ag_install.cmd\"",
     },
 ];
 
@@ -141,14 +152,125 @@ pub fn meets_min(version: &str, min: &str) -> bool {
     true
 }
 
-/// Run `<bin> --version` and return its combined output, or None if the binary
-/// is absent or errors out.
-fn probe_version(bin: &str) -> Option<String> {
-    let output = Command::new(bin)
+/// Candidate file names for an executable. Windows binaries carry an extension
+/// (`node.exe`) and npm/antigravity ship `.cmd`/`.bat` shims — a bare `claude`
+/// file never exists on disk there (#89) — so probe every common extension;
+/// elsewhere the stem itself is the only candidate. Pure for testing.
+fn exe_names(stem: &str, windows: bool) -> Vec<String> {
+    if windows {
+        [".exe", ".cmd", ".bat"]
+            .iter()
+            .map(|ext| format!("{stem}{ext}"))
+            .collect()
+    } else {
+        vec![stem.to_string()]
+    }
+}
+
+/// Directories to search for a CLI, in priority order: PATH first, then the
+/// common install locations a GUI launch's minimal PATH omits (Homebrew/npm on
+/// macOS; Program Files, chocolatey, scoop and the npm prefix on Windows). Pure
+/// so both platform arms are unit-tested on the macOS CI runner.
+fn search_dirs(
+    path_env: Option<&str>,
+    home: Option<&str>,
+    appdata: Option<&str>,
+    windows: bool,
+) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = match path_env {
+        Some(path) => std::env::split_paths(path).collect(),
+        None => Vec::new(),
+    };
+    if windows {
+        for extra in [
+            r"C:\Program Files\nodejs",
+            r"C:\Program Files\Git\cmd",
+            r"C:\Program Files\GitHub CLI",
+            r"C:\Program Files (x86)\GitHub CLI",
+            r"C:\ProgramData\chocolatey\bin",
+        ] {
+            dirs.push(PathBuf::from(extra));
+        }
+        // npm installs global shims (claude.cmd, codex.cmd) under %APPDATA%\npm.
+        if let Some(appdata) = appdata {
+            dirs.push(PathBuf::from(appdata).join("npm"));
+        }
+        if let Some(home) = home {
+            dirs.push(PathBuf::from(home).join("scoop").join("shims"));
+        }
+    } else {
+        for extra in ["/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin"] {
+            dirs.push(PathBuf::from(extra));
+        }
+        if let Some(home) = home {
+            // npm --prefix bins, antigravity's installer dir, and pipx-style bins.
+            dirs.push(PathBuf::from(home).join(".local").join("bin"));
+            dirs.push(PathBuf::from(home).join(".antigravity").join("bin"));
+        }
+    }
+    dirs
+}
+
+/// Absolute path to `stem`'s executable, or None when it isn't installed.
+/// Resolving to an absolute path (never spawning a bare name) both finds the
+/// Windows `.exe`/`.cmd` forms and avoids the `CreateProcess` CWD-search hijack,
+/// where a planted same-named binary in a writable working dir would run instead.
+fn find_tool(stem: &str) -> Option<PathBuf> {
+    let path_env = std::env::var("PATH").ok();
+    let home = std::env::var("HOME")
+        .ok()
+        .or_else(|| std::env::var("USERPROFILE").ok());
+    let appdata = std::env::var("APPDATA").ok();
+    let windows = cfg!(windows);
+    let names = exe_names(stem, windows);
+    for dir in search_dirs(path_env.as_deref(), home.as_deref(), appdata.as_deref(), windows) {
+        for name in &names {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Build a `Command` with the console suppressed on Windows. A release build has
+/// no console of its own (windows_subsystem = "windows"), so an un-flagged spawn
+/// allocates a fresh console that flashes a window — detection alone spawns one
+/// probe per tool. A no-op on Unix and on debug builds. See git::run_git / pr.
+fn tool_command(exe: &std::path::Path) -> Command {
+    #[cfg_attr(not(windows), allow(unused_mut))]
+    let mut command = Command::new(exe);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    command
+}
+
+/// Resolve and run `<tool> --version`, returning the parsed version or None if
+/// the tool is absent, errors, or outruns PROBE_TIMEOUT (killed so a hung binary
+/// never lingers). Reads output only after the process exits — `--version` is a
+/// few bytes, well under the pipe buffer, so this cannot deadlock.
+fn probe_version(stem: &str) -> Option<String> {
+    let exe = find_tool(stem)?;
+    let mut child = tool_command(&exe)
         .arg("--version")
         .stdin(Stdio::null())
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .ok()?;
+    let output = match child.wait_timeout(PROBE_TIMEOUT) {
+        Ok(Some(_)) => child.wait_with_output().ok()?,
+        Ok(None) | Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+    };
     if !output.status.success() && output.stdout.is_empty() {
         return None;
     }
@@ -157,32 +279,6 @@ fn probe_version(bin: &str) -> Option<String> {
         text = String::from_utf8_lossy(&output.stderr).into_owned();
     }
     parse_version(&text)
-}
-
-/// Whether a command is resolvable on PATH.
-fn command_exists(bin: &str) -> bool {
-    let (finder, arg) = if cfg!(target_os = "windows") {
-        ("where", bin)
-    } else {
-        ("command", bin)
-    };
-    // `command -v` is a shell builtin, so route it through the shell on unix.
-    if cfg!(target_os = "windows") {
-        Command::new(finder)
-            .arg(arg)
-            .stdin(Stdio::null())
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
-    } else {
-        Command::new("sh")
-            .arg("-c")
-            .arg(format!("command -v {bin}"))
-            .stdin(Stdio::null())
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
-    }
 }
 
 /// The install command string for `spec` on the current OS ("" when none).
@@ -226,8 +322,9 @@ fn detect_tools_blocking() -> DetectResult {
 
     DetectResult {
         tools,
-        brew: command_exists("brew"),
-        winget: command_exists("winget"),
+        // Pure filesystem resolution — no subprocess, so no console flash.
+        brew: find_tool("brew").is_some(),
+        winget: find_tool("winget").is_some(),
     }
 }
 
@@ -250,25 +347,34 @@ pub async fn install_tool(id: String, on_output: Channel<String>) -> Result<i32,
         .map_err(|e| e.to_string())?
 }
 
+/// Run one install command, streaming its output over `on_output`. The shell
+/// merges stderr into stdout (`2>&1`) so a single reader captures everything in
+/// order; the child's own stderr pipe is therefore closed (`Stdio::null()`).
+///
+/// Note: the install cannot be cancelled from the UI — closing the wizard leaves
+/// the spawned process (npm/brew/winget) running to completion in the background.
 fn run_install(cmd: &str, on_output: &Channel<String>) -> Result<i32, String> {
-    let mut child = if cfg!(target_os = "windows") {
-        Command::new("cmd")
-            .arg("/C")
-            .arg(format!("{cmd} 2>&1"))
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
+    // Run from a writable directory: the GUI process CWD is often read-only
+    // (install dir / System32), which breaks installers that write to CWD (e.g.
+    // antigravity's downloaded .cmd). CREATE_NO_WINDOW keeps a release build from
+    // flashing a console for the shell it spawns.
+    let temp = std::env::temp_dir();
+    let mut builder = if cfg!(target_os = "windows") {
+        let mut c = tool_command(std::path::Path::new("cmd"));
+        c.arg("/C").arg(format!("{cmd} 2>&1"));
+        c
     } else {
-        Command::new("sh")
-            .arg("-c")
-            .arg(format!("{cmd} 2>&1"))
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-    }
-    .map_err(|e| format!("failed to start install: {e}"))?;
+        let mut c = tool_command(std::path::Path::new("sh"));
+        c.arg("-c").arg(format!("{cmd} 2>&1"));
+        c
+    };
+    let mut child = builder
+        .current_dir(temp)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("failed to start install: {e}"))?;
 
     if let Some(stdout) = child.stdout.take() {
         let reader = BufReader::new(stdout);
@@ -316,5 +422,48 @@ mod tests {
         assert!(meets_min("2", "2.0"));
         assert!(meets_min("2.0", "2"));
         assert!(!meets_min("garbage", "2.0"));
+    }
+
+    #[test]
+    fn exe_names_appends_windows_extensions_only_on_windows() {
+        // #89: npm ships claude.cmd, so probing a bare `claude` never matches on
+        // Windows — the .cmd/.exe/.bat forms must be tried.
+        assert_eq!(exe_names("claude", false), vec!["claude".to_string()]);
+        let win = exe_names("claude", true);
+        assert!(win.contains(&"claude.exe".to_string()));
+        assert!(win.contains(&"claude.cmd".to_string()));
+        assert!(win.contains(&"claude.bat".to_string()));
+        assert!(!win.contains(&"claude".to_string()));
+    }
+
+    #[test]
+    fn search_dirs_prepends_path_then_platform_locations() {
+        // NB: std::env::split_paths uses the *host* separator, so a Windows-style
+        // PATH can't be split correctly on the macOS test runner — assert only
+        // the platform extras for the Windows arm, and PATH order on the Unix arm.
+        let home = r"C:\Users\me";
+        let appdata = r"C:\Users\me\AppData\Roaming";
+        let win = search_dirs(None, Some(home), Some(appdata), true);
+        // Static install dirs are literals; joined dirs are built the same way so
+        // the assertion is separator-agnostic (join uses `/` on the macOS runner).
+        assert!(win.contains(&PathBuf::from(r"C:\Program Files\nodejs")));
+        // npm global shims live under %APPDATA%\npm.
+        assert!(win.contains(&PathBuf::from(appdata).join("npm")));
+        assert!(win.contains(&PathBuf::from(home).join("scoop").join("shims")));
+
+        let unix = search_dirs(Some("/usr/bin"), Some("/home/me"), None, false);
+        assert_eq!(unix.first(), Some(&PathBuf::from("/usr/bin")));
+        assert!(unix.contains(&PathBuf::from("/opt/homebrew/bin")));
+        assert!(unix.contains(&PathBuf::from("/home/me/.antigravity/bin")));
+    }
+
+    #[test]
+    fn search_dirs_works_without_a_path_or_home() {
+        // A GUI launch can hand us no PATH and no HOME; resolution must still
+        // return the platform install dirs rather than panic on None.
+        let unix = search_dirs(None, None, None, false);
+        assert!(unix.contains(&PathBuf::from("/usr/local/bin")));
+        let win = search_dirs(None, None, None, true);
+        assert!(win.contains(&PathBuf::from(r"C:\ProgramData\chocolatey\bin")));
     }
 }

--- a/src-tauri/src/modules/setup/mod.rs
+++ b/src-tauri/src/modules/setup/mod.rs
@@ -1,0 +1,320 @@
+//! First-run setup wizard backend: detects the CLI tools a Vibe Coding user
+//! needs (node, git, gh, claude, codex, antigravity) plus the platform package
+//! managers, and installs the missing ones with live output streamed to the
+//! wizard. The tool registry is data-driven so adding or tweaking a tool is a
+//! one-line change; version comparison is a pure function for easy testing.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+
+use serde::Serialize;
+use tauri::ipc::Channel;
+
+/// A single tool the wizard knows how to detect and install. The install
+/// commands are the raw shell strings run per platform; an empty string means
+/// "no automated install, guide the user to the official page instead".
+struct ToolSpec {
+    /// Stable id shared with the frontend registry.
+    id: &'static str,
+    /// The binary to probe with `<bin> --version`.
+    bin: &'static str,
+    /// Minimum acceptable major.minor, or None when any version is fine.
+    min_version: Option<&'static str>,
+    /// Install command on macOS (run via `sh -c`).
+    mac_install: &'static str,
+    /// Install command on Windows (run via `cmd /C`).
+    windows_install: &'static str,
+}
+
+/// The tool registry. Keep in sync with the frontend `setup/lib/registry.ts`.
+const TOOLS: &[ToolSpec] = &[
+    ToolSpec {
+        id: "node",
+        bin: "node",
+        min_version: Some("18"),
+        mac_install: "brew install node",
+        windows_install: "winget install -e --id OpenJS.NodeJS --accept-package-agreements --accept-source-agreements",
+    },
+    ToolSpec {
+        id: "git",
+        bin: "git",
+        min_version: Some("2.30"),
+        mac_install: "brew install git",
+        windows_install: "winget install -e --id Git.Git --accept-package-agreements --accept-source-agreements",
+    },
+    ToolSpec {
+        id: "gh",
+        bin: "gh",
+        min_version: Some("2.0"),
+        mac_install: "brew install gh",
+        windows_install: "winget install -e --id GitHub.cli --accept-package-agreements --accept-source-agreements",
+    },
+    ToolSpec {
+        id: "claude",
+        bin: "claude",
+        min_version: None,
+        mac_install: "npm install -g @anthropic-ai/claude-code",
+        windows_install: "npm install -g @anthropic-ai/claude-code",
+    },
+    ToolSpec {
+        id: "codex",
+        bin: "codex",
+        min_version: None,
+        mac_install: "npm install -g @openai/codex",
+        windows_install: "npm install -g @openai/codex",
+    },
+    ToolSpec {
+        // Official installer scripts from https://antigravity.google/cli.
+        // macOS/Linux uses the bash installer; Windows uses the CMD installer.
+        id: "antigravity",
+        bin: "antigravity",
+        min_version: None,
+        mac_install: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+        windows_install: "curl -fsSL https://antigravity.google/cli/install.cmd -o install.cmd && install.cmd && del install.cmd",
+    },
+];
+
+/// Detection result for one tool, returned to the wizard.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolStatus {
+    pub id: String,
+    pub installed: bool,
+    pub version: Option<String>,
+    pub meets_min: bool,
+    /// Whether this tool has an automated install command on the current OS.
+    pub installable: bool,
+}
+
+/// The whole detection payload: per-tool status plus package-manager presence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DetectResult {
+    pub tools: Vec<ToolStatus>,
+    /// Homebrew present (macOS package manager).
+    pub brew: bool,
+    /// winget present (Windows package manager).
+    pub winget: bool,
+}
+
+/// Pull the first dotted numeric token out of a `--version` line, e.g.
+/// "git version 2.50.1 (Apple Git-155)" -> "2.50.1", "v22.14.0" -> "22.14.0".
+pub fn parse_version(output: &str) -> Option<String> {
+    let bytes = output.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_digit() || bytes[i] == b'.') {
+                i += 1;
+            }
+            // Trim a trailing dot so "1." never slips through.
+            let token = output[start..i].trim_end_matches('.');
+            if token.chars().any(|c| c.is_ascii_digit()) {
+                return Some(token.to_string());
+            }
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+/// Compare a detected version against a minimum, component by component. A
+/// missing component counts as 0 (so "2" satisfies min "2.0"). Non-numeric
+/// input fails closed (returns false).
+pub fn meets_min(version: &str, min: &str) -> bool {
+    let parse = |s: &str| -> Option<Vec<u64>> {
+        s.split('.').map(|p| p.parse::<u64>().ok()).collect()
+    };
+    let (Some(have), Some(need)) = (parse(version), parse(min)) else {
+        return false;
+    };
+    let len = have.len().max(need.len());
+    for idx in 0..len {
+        let h = have.get(idx).copied().unwrap_or(0);
+        let n = need.get(idx).copied().unwrap_or(0);
+        if h != n {
+            return h > n;
+        }
+    }
+    true
+}
+
+/// Run `<bin> --version` and return its combined output, or None if the binary
+/// is absent or errors out.
+fn probe_version(bin: &str) -> Option<String> {
+    let output = Command::new(bin)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        return None;
+    }
+    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+    if text.trim().is_empty() {
+        text = String::from_utf8_lossy(&output.stderr).into_owned();
+    }
+    parse_version(&text)
+}
+
+/// Whether a command is resolvable on PATH.
+fn command_exists(bin: &str) -> bool {
+    let (finder, arg) = if cfg!(target_os = "windows") {
+        ("where", bin)
+    } else {
+        ("command", bin)
+    };
+    // `command -v` is a shell builtin, so route it through the shell on unix.
+    if cfg!(target_os = "windows") {
+        Command::new(finder)
+            .arg(arg)
+            .stdin(Stdio::null())
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    } else {
+        Command::new("sh")
+            .arg("-c")
+            .arg(format!("command -v {bin}"))
+            .stdin(Stdio::null())
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+}
+
+/// The install command string for `spec` on the current OS ("" when none).
+fn install_command(spec: &ToolSpec) -> &'static str {
+    if cfg!(target_os = "windows") {
+        spec.windows_install
+    } else {
+        spec.mac_install
+    }
+}
+
+/// Detect all tools and the package managers. Runs the blocking probes on a
+/// worker thread so the GUI thread never stalls (same reasoning as sysmon).
+#[tauri::command]
+pub async fn detect_tools() -> Result<DetectResult, String> {
+    tauri::async_runtime::spawn_blocking(detect_tools_blocking)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+fn detect_tools_blocking() -> DetectResult {
+    let tools = TOOLS
+        .iter()
+        .map(|spec| {
+            let version = probe_version(spec.bin);
+            let installed = version.is_some();
+            let meets_min = match (&version, spec.min_version) {
+                (Some(v), Some(min)) => meets_min(v, min),
+                (Some(_), None) => true,
+                (None, _) => false,
+            };
+            ToolStatus {
+                id: spec.id.to_string(),
+                installed,
+                version,
+                meets_min,
+                installable: !install_command(spec).is_empty(),
+            }
+        })
+        .collect();
+
+    DetectResult {
+        tools,
+        brew: command_exists("brew"),
+        winget: command_exists("winget"),
+    }
+}
+
+/// Install one tool by id, streaming combined stdout/stderr to `on_output`
+/// line by line. Returns the process exit code (0 = success). stderr is merged
+/// into stdout via the shell so a single reader captures everything in order.
+#[tauri::command]
+pub async fn install_tool(id: String, on_output: Channel<String>) -> Result<i32, String> {
+    let spec = TOOLS
+        .iter()
+        .find(|s| s.id == id)
+        .ok_or_else(|| format!("unknown tool: {id}"))?;
+    let cmd = install_command(spec);
+    if cmd.is_empty() {
+        return Err(format!("no automated install for {id}"));
+    }
+    let cmd = cmd.to_string();
+    tauri::async_runtime::spawn_blocking(move || run_install(&cmd, &on_output))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+fn run_install(cmd: &str, on_output: &Channel<String>) -> Result<i32, String> {
+    let mut child = if cfg!(target_os = "windows") {
+        Command::new("cmd")
+            .arg("/C")
+            .arg(format!("{cmd} 2>&1"))
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    } else {
+        Command::new("sh")
+            .arg("-c")
+            .arg(format!("{cmd} 2>&1"))
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    }
+    .map_err(|e| format!("failed to start install: {e}"))?;
+
+    if let Some(stdout) = child.stdout.take() {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            match line {
+                Ok(text) => {
+                    let _ = on_output.send(text);
+                }
+                Err(_) => break,
+            }
+        }
+    }
+
+    let status = child.wait().map_err(|e| e.to_string())?;
+    Ok(status.code().unwrap_or(-1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_common_version_formats() {
+        assert_eq!(parse_version("v22.14.0").as_deref(), Some("22.14.0"));
+        assert_eq!(
+            parse_version("git version 2.50.1 (Apple Git-155)").as_deref(),
+            Some("2.50.1")
+        );
+        assert_eq!(
+            parse_version("gh version 2.86.0 (2026-01-21)").as_deref(),
+            Some("2.86.0")
+        );
+        assert_eq!(parse_version("2.1.195 (Claude Code)").as_deref(), Some("2.1.195"));
+        assert_eq!(parse_version("codex-cli 0.137.0").as_deref(), Some("0.137.0"));
+        assert_eq!(parse_version("no numbers here"), None);
+    }
+
+    #[test]
+    fn version_comparison() {
+        assert!(meets_min("22.14.0", "18"));
+        assert!(meets_min("18.0.0", "18"));
+        assert!(!meets_min("16.20.0", "18"));
+        assert!(meets_min("2.50.1", "2.30"));
+        assert!(!meets_min("2.29.0", "2.30"));
+        assert!(meets_min("2", "2.0"));
+        assert!(meets_min("2.0", "2"));
+        assert!(!meets_min("garbage", "2.0"));
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,8 @@ import { ensureNotificationPermission } from "@/modules/claude-progress/lib/noti
 import { useWatchNotes } from "@/modules/notes/lib/useWatchNotes";
 import { registerSecondaryWindowCleanup } from "@/lib/windowLifecycle";
 import { SshPromptDialog } from "@/modules/ssh/SshPromptDialog";
+import { SetupWizard } from "@/modules/setup/SetupWizard";
+import { isMainWindow } from "@/lib/window";
 import { useForwardStatusListener } from "@/modules/ssh/lib/useForwardStatus";
 import { sftpSessionStore } from "@/modules/ssh/lib/sftpSessionStore";
 import { enforceLogRetention } from "@/modules/logs/lib/sessionLog";
@@ -122,6 +124,8 @@ function App() {
   const uiZoom = useSettingsStore((s) => s.uiZoom);
   const sidebarVisible = useUiStore((s) => s.sidebarVisible);
   const settingsOpen = useUiStore((s) => s.settingsOpen);
+  const setupWizardOpen = useUiStore((s) => s.setupWizardOpen);
+  const setSetupWizardOpen = useUiStore((s) => s.setSetupWizardOpen);
   const fileFinderOpen = useUiStore((s) => s.fileFinderOpen);
   const setFileFinderOpen = useUiStore((s) => s.setFileFinderOpen);
   const rootPath = useWorkspaceStore((s) => s.rootPath);
@@ -425,6 +429,21 @@ function App() {
     [],
   );
 
+  // Re-open the setup wizard from the File menu (works in any window).
+  useEffect(
+    () => listenWebview("menu:rerun-setup", () => setSetupWizardOpen(true)),
+    [setSetupWizardOpen],
+  );
+
+  // Auto-open the setup wizard on the very first launch. Gated to the main
+  // window: secondary windows use isolated in-memory storage, so their
+  // onboardingCompleted is always false and would otherwise re-trigger it.
+  useEffect(() => {
+    if (isMainWindow() && !useSettingsStore.getState().onboardingCompleted) {
+      setSetupWizardOpen(true);
+    }
+  }, [setSetupWizardOpen]);
+
   return (
     <div className="flex h-screen w-screen flex-col overflow-hidden bg-bg text-fg">
       <TitleBar />
@@ -450,6 +469,7 @@ function App() {
 
       <StatusBar />
       {settingsOpen && <SettingsModal />}
+      {setupWizardOpen && <SetupWizard />}
       {fileFinderOpen && canSearchRoot(rootPath) && (
         <FileFinder root={rootPath} onClose={() => setFileFinderOpen(false)} />
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { useWatchNotes } from "@/modules/notes/lib/useWatchNotes";
 import { registerSecondaryWindowCleanup } from "@/lib/windowLifecycle";
 import { SshPromptDialog } from "@/modules/ssh/SshPromptDialog";
 import { SetupWizard } from "@/modules/setup/SetupWizard";
+import { detectTools, isToolReady } from "@/modules/setup/lib/setupTools";
 import { isMainWindow } from "@/lib/window";
 import { useForwardStatusListener } from "@/modules/ssh/lib/useForwardStatus";
 import { sftpSessionStore } from "@/modules/ssh/lib/sftpSessionStore";
@@ -438,10 +439,30 @@ function App() {
   // Auto-open the setup wizard on the very first launch. Gated to the main
   // window: secondary windows use isolated in-memory storage, so their
   // onboardingCompleted is always false and would otherwise re-trigger it.
+  // If every tool is already installed (e.g. an existing user upgrading to the
+  // version that adds this flag), silently mark onboarding done instead of
+  // interrupting them. Detection failure falls back to showing the wizard.
   useEffect(() => {
-    if (isMainWindow() && !useSettingsStore.getState().onboardingCompleted) {
-      setSetupWizardOpen(true);
+    if (!isMainWindow() || useSettingsStore.getState().onboardingCompleted) {
+      return;
     }
+    let cancelled = false;
+    void detectTools()
+      .then((res) => {
+        if (cancelled) return;
+        const allReady = res.tools.length > 0 && res.tools.every(isToolReady);
+        if (allReady) {
+          useSettingsStore.getState().setOnboardingCompleted(true);
+        } else {
+          setSetupWizardOpen(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setSetupWizardOpen(true);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [setSetupWizardOpen]);
 
   return (

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -7,6 +7,7 @@ import enAi from "./locales/en/ai.json";
 import enNotes from "./locales/en/notes.json";
 import enPreview from "./locales/en/preview.json";
 import enGitGraph from "./locales/en/gitGraph.json";
+import enOnboarding from "./locales/en/onboarding.json";
 import zhHantCommon from "./locales/zh-Hant/common.json";
 import zhHantSettings from "./locales/zh-Hant/settings.json";
 import zhHantExplorer from "./locales/zh-Hant/explorer.json";
@@ -16,6 +17,7 @@ import zhHantAi from "./locales/zh-Hant/ai.json";
 import zhHantNotes from "./locales/zh-Hant/notes.json";
 import zhHantPreview from "./locales/zh-Hant/preview.json";
 import zhHantGitGraph from "./locales/zh-Hant/gitGraph.json";
+import zhHantOnboarding from "./locales/zh-Hant/onboarding.json";
 
 export const SUPPORTED_LANGUAGES = ["en", "zh-Hant"] as const;
 
@@ -33,6 +35,7 @@ export const NAMESPACES = [
   "notes",
   "preview",
   "gitGraph",
+  "onboarding",
 ] as const;
 
 export const DEFAULT_NAMESPACE = "common";
@@ -48,6 +51,7 @@ export const resources = {
     notes: enNotes,
     preview: enPreview,
     gitGraph: enGitGraph,
+    onboarding: enOnboarding,
   },
   "zh-Hant": {
     common: zhHantCommon,
@@ -59,6 +63,7 @@ export const resources = {
     notes: zhHantNotes,
     preview: zhHantPreview,
     gitGraph: zhHantGitGraph,
+    onboarding: zhHantOnboarding,
   },
 } as const;
 

--- a/src/i18n/locales/en/onboarding.json
+++ b/src/i18n/locales/en/onboarding.json
@@ -1,0 +1,40 @@
+{
+  "title": "Set up your Vibe Coding tools",
+  "subtitle": "TempoTerm can install the command-line tools you need. Existing ones are detected automatically — install the rest, or skip and do it later.",
+  "stepLabel": "Step {{current}} of {{total}}",
+  "tools": {
+    "node": "Node.js",
+    "git": "Git",
+    "gh": "GitHub CLI",
+    "claude": "Claude Code CLI",
+    "codex": "Codex CLI",
+    "antigravity": "Antigravity CLI"
+  },
+  "desc": {
+    "node": "The JavaScript runtime that powers most Vibe Coding CLIs. It ships with npm, the package manager used to install Claude Code and Codex.",
+    "git": "The version control system for tracking changes and collaborating. Almost every project and AI coding workflow depends on it.",
+    "gh": "GitHub's official command-line tool. Lets you create pull requests, review issues and manage repositories without leaving the terminal.",
+    "claude": "Anthropic's agentic coding assistant in your terminal. Reads, edits and runs your codebase from natural-language instructions.",
+    "codex": "OpenAI's command-line coding agent. An alternative AI pair-programmer that works directly in your terminal.",
+    "antigravity": "Google's Antigravity CLI. Build, debug and ship from your terminal — describe what you need and it handles the rest."
+  },
+  "status": {
+    "checking": "Checking…",
+    "missing": "Not installed",
+    "outdated": "Version too old",
+    "ready": "Installed",
+    "installing": "Installing…",
+    "failed": "Install failed"
+  },
+  "actions": {
+    "install": "Install",
+    "update": "Update",
+    "download": "Download page",
+    "back": "Back",
+    "next": "Skip / Next",
+    "nextReady": "Next",
+    "skipAll": "Skip setup",
+    "finish": "Finish",
+    "done": "Done"
+  }
+}

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -50,7 +50,8 @@
     "bundleId": "Bundle ID",
     "sourceCode": "Source code",
     "viewOnGitHub": "View on GitHub",
-    "reportIssue": "Report an issue"
+    "reportIssue": "Report an issue",
+    "setupWizard": "Setup wizard"
   },
   "update": {
     "available": "Update available: v{{version}}",

--- a/src/i18n/locales/zh-Hant/onboarding.json
+++ b/src/i18n/locales/zh-Hant/onboarding.json
@@ -1,0 +1,40 @@
+{
+  "title": "設定你的 Vibe Coding 工具",
+  "subtitle": "TempoTerm 可以幫你安裝所需的命令列工具。已安裝的會自動偵測，缺少的可以直接安裝，或先跳過稍後再裝。",
+  "stepLabel": "第 {{current}} / {{total}} 步",
+  "tools": {
+    "node": "Node.js",
+    "git": "Git",
+    "gh": "GitHub CLI",
+    "claude": "Claude Code CLI",
+    "codex": "Codex CLI",
+    "antigravity": "Antigravity CLI"
+  },
+  "desc": {
+    "node": "驅動大多數 Vibe Coding CLI 的 JavaScript 執行環境，內建 npm 套件管理器，Claude Code 與 Codex 都靠它安裝。",
+    "git": "追蹤程式碼變更與協作的版本控制系統。幾乎每個專案與 AI 開發流程都仰賴它。",
+    "gh": "GitHub 官方命令列工具。不用離開終端機就能建立 Pull Request、檢視 Issue、管理儲存庫。",
+    "claude": "Anthropic 的終端機 AI 開發助理。能依自然語言指示讀取、修改並執行你的程式碼。",
+    "codex": "OpenAI 的命令列開發代理。另一個直接在終端機運作的 AI 結對程式夥伴。",
+    "antigravity": "Google 的 Antigravity CLI。在終端機裡建置、除錯與交付——說出你的需求，其餘交給它處理。"
+  },
+  "status": {
+    "checking": "偵測中…",
+    "missing": "尚未安裝",
+    "outdated": "版本過舊",
+    "ready": "已安裝",
+    "installing": "安裝中…",
+    "failed": "安裝失敗"
+  },
+  "actions": {
+    "install": "安裝",
+    "update": "更新",
+    "download": "下載頁面",
+    "back": "上一步",
+    "next": "略過／下一步",
+    "nextReady": "下一步",
+    "skipAll": "略過設定",
+    "finish": "完成",
+    "done": "完成"
+  }
+}

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -50,7 +50,8 @@
     "bundleId": "套件識別碼",
     "sourceCode": "原始碼",
     "viewOnGitHub": "在 GitHub 查看",
-    "reportIssue": "回報問題"
+    "reportIssue": "回報問題",
+    "setupWizard": "安裝引導"
   },
   "update": {
     "available": "有新版本 v{{version}}",

--- a/src/modules/settings/AboutSettingsSection.tsx
+++ b/src/modules/settings/AboutSettingsSection.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { ExternalLink, GitBranch, RefreshCw } from "lucide-react";
+import { ExternalLink, GitBranch, RefreshCw, Wand2 } from "lucide-react";
 import { useUpdaterStore } from "@/stores/updaterStore";
+import { useUiStore } from "@/stores/uiStore";
 import { appBuildInfo, osLabel, type AppBuildInfo } from "./buildInfo";
 
 const REPO_URL = "https://github.com/mukiwu/tempo-term";
@@ -25,6 +26,8 @@ export function AboutSettingsSection() {
   const updaterStatus = useUpdaterStore((s) => s.status);
   const updaterError = useUpdaterStore((s) => s.errorMessage);
   const checkManually = useUpdaterStore((s) => s.checkManually);
+  const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
+  const setSetupWizardOpen = useUiStore((s) => s.setSetupWizardOpen);
 
   useEffect(() => {
     let active = true;
@@ -113,6 +116,17 @@ export function AboutSettingsSection() {
         >
           <ExternalLink size={14} />
           {t("about.viewOnGitHub")}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setSettingsOpen(false);
+            setSetupWizardOpen(true);
+          }}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border px-3.5 py-2 text-sm text-fg transition-colors hover:border-border-strong"
+        >
+          <Wand2 size={14} />
+          {t("about.setupWizard")}
         </button>
         <button
           type="button"

--- a/src/modules/setup/SetupWizard.tsx
+++ b/src/modules/setup/SetupWizard.tsx
@@ -54,7 +54,16 @@ export function SetupWizard() {
   const [installing, setInstalling] = useState<ToolId | null>(null);
   const [failed, setFailed] = useState<Set<ToolId>>(new Set());
   const [logLines, setLogLines] = useState<string[]>([]);
-  const logEndRef = useRef<HTMLDivElement | null>(null);
+  const logBoxRef = useRef<HTMLDivElement | null>(null);
+  // Guards against setState after unmount: install streams and detection resolve
+  // asynchronously and can land after the user closes the wizard mid-run.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const total = TOOL_REGISTRY.length;
   const meta = TOOL_REGISTRY[step];
@@ -68,7 +77,10 @@ export function SetupWizard() {
 
   const refresh = useCallback(async () => {
     try {
-      setDetection(await detectTools());
+      const result = await detectTools();
+      if (mountedRef.current) {
+        setDetection(result);
+      }
     } catch {
       // Detection failure leaves the step in its "checking" phase; the user can
       // still skip forward. Nothing actionable to surface here.
@@ -79,14 +91,31 @@ export function SetupWizard() {
     void refresh();
   }, [refresh]);
 
+  // Keep the newest line in view by scrolling the log container itself, rather
+  // than scrollIntoView (which would also scroll the whole modal/page).
   useEffect(() => {
-    logEndRef.current?.scrollIntoView({ block: "end" });
+    const box = logBoxRef.current;
+    if (box) {
+      box.scrollTop = box.scrollHeight;
+    }
   }, [logLines]);
 
   const close = useCallback(() => {
     setOnboardingCompleted(true);
     setSetupWizardOpen(false);
   }, [setOnboardingCompleted, setSetupWizardOpen]);
+
+  // Esc closes the wizard (unless an install is mid-flight, to avoid orphaning
+  // a running process silently). Mirrors ConfirmDialog's accessibility.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !installing) {
+        close();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [close, installing]);
 
   const goNext = useCallback(() => {
     if (isLast) {
@@ -116,9 +145,14 @@ export function SetupWizard() {
       });
       let code = -1;
       try {
-        code = await installTool(id, (line) => setLogLines((prev) => [...prev, line]));
+        code = await installTool(id, (line) => {
+          if (mountedRef.current) setLogLines((prev) => [...prev, line]);
+        });
       } catch (err) {
-        setLogLines((prev) => [...prev, String(err)]);
+        if (mountedRef.current) setLogLines((prev) => [...prev, String(err)]);
+      }
+      if (!mountedRef.current) {
+        return;
       }
       if (code !== 0) {
         setFailed((prev) => new Set(prev).add(id));
@@ -168,13 +202,15 @@ export function SetupWizard() {
           <p className="mt-2 text-sm leading-relaxed text-fg-muted">{t(`desc.${meta.name}`)}</p>
 
           {logLines.length > 0 ? (
-            <div className="mt-4 max-h-44 overflow-y-auto rounded-lg border border-border bg-black/40 p-2.5 font-mono text-[11px] leading-relaxed text-fg-muted">
+            <div
+              ref={logBoxRef}
+              className="mt-4 max-h-44 overflow-y-auto rounded-lg border border-border bg-black/40 p-2.5 font-mono text-[11px] leading-relaxed text-fg-muted"
+            >
               {logLines.map((line, i) => (
                 <div key={i} className="whitespace-pre-wrap break-all">
                   {line}
                 </div>
               ))}
-              <div ref={logEndRef} />
             </div>
           ) : null}
         </div>

--- a/src/modules/setup/SetupWizard.tsx
+++ b/src/modules/setup/SetupWizard.tsx
@@ -1,0 +1,326 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { Check } from "lucide-react";
+import { useOverlayGuard } from "@/lib/overlayGuard";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useUiStore } from "@/stores/uiStore";
+import {
+  detectTools,
+  installTool,
+  isToolReady,
+  TOOL_REGISTRY,
+  type DetectResult,
+  type ToolId,
+  type ToolStatus,
+} from "@/modules/setup/lib/setupTools";
+
+/** Per-tool UI phase driving the status pill and controls. */
+type RowPhase = "checking" | "missing" | "outdated" | "ready" | "installing" | "failed";
+
+function phaseFor(status: ToolStatus | undefined, installing: boolean, failed: boolean): RowPhase {
+  if (!status) {
+    return "checking";
+  }
+  if (installing) {
+    return "installing";
+  }
+  if (isToolReady(status)) {
+    return "ready";
+  }
+  if (failed) {
+    return "failed";
+  }
+  if (status.installed && !status.meetsMin) {
+    return "outdated";
+  }
+  return "missing";
+}
+
+/**
+ * First-run setup wizard, presented one tool per step. Each step explains what
+ * the tool does and lets the user install it or skip to the next one. A stepper
+ * across the top shows overall progress. Dismissing the wizard (skip or finish)
+ * marks onboarding complete so it never auto-opens again.
+ */
+export function SetupWizard() {
+  useOverlayGuard(true);
+  const { t } = useTranslation("onboarding");
+  const setSetupWizardOpen = useUiStore((s) => s.setSetupWizardOpen);
+  const setOnboardingCompleted = useSettingsStore((s) => s.setOnboardingCompleted);
+
+  const [detection, setDetection] = useState<DetectResult | null>(null);
+  const [step, setStep] = useState(0);
+  const [installing, setInstalling] = useState<ToolId | null>(null);
+  const [failed, setFailed] = useState<Set<ToolId>>(new Set());
+  const [logLines, setLogLines] = useState<string[]>([]);
+  const logEndRef = useRef<HTMLDivElement | null>(null);
+
+  const total = TOOL_REGISTRY.length;
+  const meta = TOOL_REGISTRY[step];
+  const statusById = new Map<ToolId, ToolStatus>();
+  for (const s of detection?.tools ?? []) {
+    statusById.set(s.id, s);
+  }
+  const status = statusById.get(meta.id);
+  const phase = phaseFor(status, installing === meta.id, failed.has(meta.id));
+  const isLast = step === total - 1;
+
+  const refresh = useCallback(async () => {
+    try {
+      setDetection(await detectTools());
+    } catch {
+      // Detection failure leaves the step in its "checking" phase; the user can
+      // still skip forward. Nothing actionable to surface here.
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ block: "end" });
+  }, [logLines]);
+
+  const close = useCallback(() => {
+    setOnboardingCompleted(true);
+    setSetupWizardOpen(false);
+  }, [setOnboardingCompleted, setSetupWizardOpen]);
+
+  const goNext = useCallback(() => {
+    if (isLast) {
+      close();
+      return;
+    }
+    setLogLines([]);
+    setStep((s) => Math.min(total - 1, s + 1));
+  }, [isLast, close, total]);
+
+  const goBack = useCallback(() => {
+    setLogLines([]);
+    setStep((s) => Math.max(0, s - 1));
+  }, []);
+
+  const runInstall = useCallback(
+    async (id: ToolId) => {
+      if (installing) {
+        return;
+      }
+      setInstalling(id);
+      setLogLines([]);
+      setFailed((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      let code = -1;
+      try {
+        code = await installTool(id, (line) => setLogLines((prev) => [...prev, line]));
+      } catch (err) {
+        setLogLines((prev) => [...prev, String(err)]);
+      }
+      if (code !== 0) {
+        setFailed((prev) => new Set(prev).add(id));
+      }
+      setInstalling(null);
+      await refresh();
+    },
+    [installing, refresh],
+  );
+
+  const busy = installing !== null;
+
+  return (
+    <div onPointerDown={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+      <div className="fixed inset-0 z-[95] bg-black/60" />
+      <div className="fixed left-1/2 top-1/2 z-[100] flex max-h-[88vh] w-[560px] max-w-[94vw] -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border bg-bg-elevated shadow-2xl">
+        {/* Header + stepper */}
+        <div className="border-b border-border px-6 pb-4 pt-5">
+          <h2 className="text-base font-semibold text-fg">{t("title")}</h2>
+          <p className="mt-0.5 text-xs text-fg-subtle">
+            {t("stepLabel", { current: step + 1, total })}
+          </p>
+          <Stepper
+            current={step}
+            statuses={TOOL_REGISTRY.map((m) => ({
+              phase: phaseFor(statusById.get(m.id), installing === m.id, failed.has(m.id)),
+              label: t(`tools.${m.name}`),
+            }))}
+            onJump={(i) => {
+              if (!busy) {
+                setLogLines([]);
+                setStep(i);
+              }
+            }}
+          />
+        </div>
+
+        {/* Current tool */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          <div className="flex items-center gap-2">
+            <h3 className="text-lg font-semibold text-fg">{t(`tools.${meta.name}`)}</h3>
+            {status?.version ? (
+              <span className="text-xs text-fg-subtle">v{status.version}</span>
+            ) : null}
+            <StatusPill phase={phase} t={t} />
+          </div>
+          <p className="mt-2 text-sm leading-relaxed text-fg-muted">{t(`desc.${meta.name}`)}</p>
+
+          {logLines.length > 0 ? (
+            <div className="mt-4 max-h-44 overflow-y-auto rounded-lg border border-border bg-black/40 p-2.5 font-mono text-[11px] leading-relaxed text-fg-muted">
+              {logLines.map((line, i) => (
+                <div key={i} className="whitespace-pre-wrap break-all">
+                  {line}
+                </div>
+              ))}
+              <div ref={logEndRef} />
+            </div>
+          ) : null}
+        </div>
+
+        {/* Footer / navigation */}
+        <div className="flex items-center justify-between gap-2 border-t border-border px-6 py-3">
+          <button
+            type="button"
+            onClick={close}
+            disabled={busy}
+            className="text-xs text-fg-subtle transition-colors hover:text-fg disabled:opacity-50"
+          >
+            {t("actions.skipAll")}
+          </button>
+          <div className="flex items-center gap-2">
+            {step > 0 ? (
+              <button
+                type="button"
+                onClick={goBack}
+                disabled={busy}
+                className="rounded-md px-3 py-1.5 text-xs text-fg-muted hover:bg-bg-inset disabled:opacity-50"
+              >
+                {t("actions.back")}
+              </button>
+            ) : null}
+            {phase !== "ready" ? (
+              <ActionButton
+                phase={phase}
+                installable={status?.installable ?? false}
+                disabled={busy}
+                onInstall={() => void runInstall(meta.id)}
+                onOpenUrl={() => void openUrl(meta.url)}
+                t={t}
+              />
+            ) : null}
+            <button
+              type="button"
+              onClick={goNext}
+              disabled={busy}
+              className="rounded-md bg-accent px-4 py-1.5 text-xs font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+            >
+              {isLast
+                ? phase === "ready"
+                  ? t("actions.done")
+                  : t("actions.finish")
+                : phase === "ready"
+                  ? t("actions.nextReady")
+                  : t("actions.next")}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** The progress rail: one node per tool, with the current one highlighted and
+ *  ready ones checked. Nodes are clickable to jump between steps. */
+function Stepper({
+  current,
+  statuses,
+  onJump,
+}: {
+  current: number;
+  statuses: { phase: RowPhase; label: string }[];
+  onJump: (index: number) => void;
+}) {
+  return (
+    <div className="mt-4 flex items-center">
+      {statuses.map((s, i) => {
+        const isCurrent = i === current;
+        const done = s.phase === "ready";
+        return (
+          <div key={i} className="flex flex-1 items-center last:flex-none">
+            <button
+              type="button"
+              onClick={() => onJump(i)}
+              title={s.label}
+              className={[
+                "flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-[11px] font-medium transition-colors",
+                isCurrent
+                  ? "border-accent bg-accent text-white"
+                  : done
+                    ? "border-success bg-success/15 text-success"
+                    : "border-border bg-bg-inset text-fg-subtle hover:border-border-strong",
+              ].join(" ")}
+            >
+              {done && !isCurrent ? <Check size={13} /> : i + 1}
+            </button>
+            {i < statuses.length - 1 ? (
+              <div className={`mx-1 h-px flex-1 ${i < current ? "bg-accent/60" : "bg-border"}`} />
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function StatusPill({ phase, t }: { phase: RowPhase; t: (k: string) => string }) {
+  const map: Record<RowPhase, { key: string; cls: string }> = {
+    checking: { key: "status.checking", cls: "text-fg-subtle" },
+    missing: { key: "status.missing", cls: "border border-border text-fg-muted" },
+    outdated: { key: "status.outdated", cls: "border border-warning/40 text-warning" },
+    ready: { key: "status.ready", cls: "border border-success/40 text-success" },
+    installing: { key: "status.installing", cls: "border border-accent/40 text-accent" },
+    failed: { key: "status.failed", cls: "border border-danger/40 text-danger" },
+  };
+  const { key, cls } = map[phase];
+  return <span className={`ml-auto rounded-full px-2 py-0.5 text-[11px] ${cls}`}>{t(key)}</span>;
+}
+
+function ActionButton({
+  phase,
+  installable,
+  disabled,
+  onInstall,
+  onOpenUrl,
+  t,
+}: {
+  phase: RowPhase;
+  installable: boolean;
+  disabled: boolean;
+  onInstall: () => void;
+  onOpenUrl: () => void;
+  t: (k: string) => string;
+}) {
+  if (installable) {
+    return (
+      <button
+        type="button"
+        onClick={onInstall}
+        disabled={disabled}
+        className="rounded-md border border-accent px-3 py-1.5 text-xs font-medium text-accent hover:bg-accent/10 disabled:opacity-50"
+      >
+        {phase === "outdated" ? t("actions.update") : t("actions.install")}
+      </button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onOpenUrl}
+      className="rounded-md border border-border px-3 py-1.5 text-xs text-fg-muted hover:bg-bg-inset"
+    >
+      {t("actions.download")}
+    </button>
+  );
+}

--- a/src/modules/setup/lib/setupTools.test.ts
+++ b/src/modules/setup/lib/setupTools.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke,
+  Channel: class {
+    onmessage: ((m: unknown) => void) | null = null;
+  },
+}));
+
+import {
+  detectTools,
+  installTool,
+  isToolReady,
+  TOOL_REGISTRY,
+  type ToolStatus,
+} from "./setupTools";
+
+beforeEach(() => {
+  invoke.mockReset();
+});
+
+function status(overrides: Partial<ToolStatus>): ToolStatus {
+  return {
+    id: "node",
+    installed: true,
+    version: "22.0.0",
+    meetsMin: true,
+    installable: true,
+    ...overrides,
+  };
+}
+
+describe("isToolReady", () => {
+  it("is ready only when installed and meeting the minimum version", () => {
+    expect(isToolReady(status({}))).toBe(true);
+    expect(isToolReady(status({ installed: false, meetsMin: false }))).toBe(false);
+    expect(isToolReady(status({ installed: true, meetsMin: false }))).toBe(false);
+  });
+});
+
+describe("TOOL_REGISTRY", () => {
+  it("lists all six tools with unique ids and official urls", () => {
+    const ids = TOOL_REGISTRY.map((t) => t.id);
+    expect(ids).toEqual(["node", "git", "gh", "claude", "codex", "antigravity"]);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(TOOL_REGISTRY.every((t) => t.url.startsWith("https://"))).toBe(true);
+  });
+});
+
+describe("detectTools / installTool bridge", () => {
+  it("detectTools invokes the detect_tools command", async () => {
+    invoke.mockResolvedValueOnce({ tools: [], brew: true, winget: false });
+    await detectTools();
+    expect(invoke.mock.calls[0][0]).toBe("detect_tools");
+  });
+
+  it("installTool passes the id and a Channel wired to onOutput", async () => {
+    invoke.mockResolvedValueOnce(0);
+    const lines: string[] = [];
+    await installTool("git", (line) => lines.push(line));
+
+    const call = invoke.mock.calls.find(([cmd]) => cmd === "install_tool");
+    const args = call?.[1] as { id: string; onOutput: { onmessage: (m: string) => void } };
+    expect(args.id).toBe("git");
+    args.onOutput.onmessage("cloning…");
+    expect(lines).toEqual(["cloning…"]);
+  });
+});

--- a/src/modules/setup/lib/setupTools.ts
+++ b/src/modules/setup/lib/setupTools.ts
@@ -1,0 +1,63 @@
+import { Channel, invoke } from "@tauri-apps/api/core";
+
+/** Stable ids, kept in sync with the backend registry in modules/setup/mod.rs. */
+export type ToolId = "node" | "git" | "gh" | "claude" | "codex" | "antigravity";
+
+/** Per-tool detection result returned by the `detect_tools` command. */
+export interface ToolStatus {
+  id: ToolId;
+  installed: boolean;
+  version: string | null;
+  meetsMin: boolean;
+  /** Whether the current OS has an automated install command for this tool. */
+  installable: boolean;
+}
+
+/** Full detection payload: per-tool status plus package-manager presence. */
+export interface DetectResult {
+  tools: ToolStatus[];
+  brew: boolean;
+  winget: boolean;
+}
+
+/** Display metadata for each tool, in the order shown in the wizard. */
+export interface ToolMeta {
+  id: ToolId;
+  /** i18n key suffix under the `onboarding.tools` namespace. */
+  name: string;
+  /** Official page users can open when there is no automated install. */
+  url: string;
+}
+
+/**
+ * Display registry. The actual detect/install commands live in the Rust
+ * backend; this only drives labels, ordering and the "official page" links.
+ */
+export const TOOL_REGISTRY: ToolMeta[] = [
+  { id: "node", name: "node", url: "https://nodejs.org/" },
+  { id: "git", name: "git", url: "https://git-scm.com/" },
+  { id: "gh", name: "gh", url: "https://cli.github.com/" },
+  { id: "claude", name: "claude", url: "https://docs.claude.com/en/docs/claude-code" },
+  { id: "codex", name: "codex", url: "https://github.com/openai/codex" },
+  { id: "antigravity", name: "antigravity", url: "https://antigravity.google/cli" },
+];
+
+/** Run backend detection for every tool. */
+export function detectTools(): Promise<DetectResult> {
+  return invoke<DetectResult>("detect_tools");
+}
+
+/**
+ * Install one tool, streaming combined stdout/stderr to `onOutput` line by line.
+ * Resolves with the process exit code (0 = success).
+ */
+export function installTool(id: ToolId, onOutput: (line: string) => void): Promise<number> {
+  const channel = new Channel<string>();
+  channel.onmessage = (line) => onOutput(line);
+  return invoke<number>("install_tool", { id, onOutput: channel });
+}
+
+/** Whether a tool counts as ready: installed and meeting its minimum version. */
+export function isToolReady(status: ToolStatus): boolean {
+  return status.installed && status.meetsMin;
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -73,6 +73,12 @@ interface SettingsState {
   uiZoom: number;
   /** Port monitor lists every listening port instead of only the current user's. */
   showAllPorts: boolean;
+  /**
+   * Whether the first-run setup wizard has been dismissed (skipped or finished).
+   * Persisted so the wizard only auto-opens on the very first launch.
+   */
+  onboardingCompleted: boolean;
+  setOnboardingCompleted: (value: boolean) => void;
   setShowAllPorts: (value: boolean) => void;
   setLanguage: (language: SupportedLanguage) => void;
   setThemeId: (themeId: string) => void;
@@ -138,6 +144,8 @@ export const useSettingsStore = create<SettingsState>()(
       actionLinksEnabled: true,
       uiZoom: DEFAULT_UI_ZOOM,
       showAllPorts: false,
+      onboardingCompleted: false,
+      setOnboardingCompleted: (value) => set({ onboardingCompleted: value }),
       setLanguage: (language) => set({ language }),
       setThemeId: (themeId) => set({ themeId }),
       setTerminalPadding: (padding) => set({ terminalPadding: clampPadding(padding) }),

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -6,6 +6,9 @@ interface UiState {
   sidebarView: SidebarView;
   sidebarVisible: boolean;
   settingsOpen: boolean;
+  /** First-run setup wizard visibility. Opened automatically on first launch and
+   *  re-openable from the File menu or the Settings About tab. */
+  setupWizardOpen: boolean;
   terminalOpen: boolean;
   fileFinderOpen: boolean;
   portsPanelOpen: boolean;
@@ -20,6 +23,7 @@ interface UiState {
   selectSidebar: (view: SidebarView) => void;
   toggleSidebar: () => void;
   setSettingsOpen: (open: boolean) => void;
+  setSetupWizardOpen: (open: boolean) => void;
   setTerminalOpen: (open: boolean) => void;
   toggleTerminal: () => void;
   setFileFinderOpen: (open: boolean) => void;
@@ -37,6 +41,7 @@ export const useUiStore = create<UiState>((set) => ({
   sidebarView: "workspaces",
   sidebarVisible: true,
   settingsOpen: false,
+  setupWizardOpen: false,
   terminalOpen: true,
   fileFinderOpen: false,
   portsPanelOpen: false,
@@ -46,6 +51,7 @@ export const useUiStore = create<UiState>((set) => ({
 
   toggleSidebar: () => set((state) => ({ sidebarVisible: !state.sidebarVisible })),
   setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
+  setSetupWizardOpen: (setupWizardOpen) => set({ setupWizardOpen }),
   setTerminalOpen: (terminalOpen) => set({ terminalOpen }),
   toggleTerminal: () => set((state) => ({ terminalOpen: !state.terminalOpen })),
   setFileFinderOpen: (fileFinderOpen) => set({ fileFinderOpen }),


### PR DESCRIPTION
## 摘要
第一次啟動時自動跳出設定精靈，逐步引導使用者安裝 Vibe Coding 所需的命令列工具：**node、git、gh、claude、codex、antigravity**。一次一個工具、附用途說明，可選擇安裝或略過，上方 stepper 顯示目前進度。關閉後寫入 `onboardingCompleted` 旗標，第二次啟動不再自動出現；可從 File 選單或設定「關於」分頁重新開啟。

## 內容
- **後端 `modules/setup`**：`detect_tools` 偵測安裝狀態與版本、`install_tool` 以 Tauri Channel 串流安裝輸出；data-driven registry；版本比對為純函式並附單元測試。
- **跨平台安裝**：Mac 用 Homebrew、Windows 用 winget、CLI 類用 npm；antigravity 用官方 `install.sh` / `install.cmd`。
- **前端 `SetupWizard`**：逐步流程 UI + stepper 進度；i18n 新增 `onboarding` namespace（en / zh-Hant）。
- **入口**：首次啟動自動開（限主視窗）、File 選單「Setup Wizard」、設定「關於」分頁按鈕。

## 已知限制
- Mac 若缺 Homebrew 需 sudo 互動安裝，目前未自動 bootstrap（`detect_tools` 已回報 brew/winget 是否存在）。

## 驗證
- `pnpm typecheck` ✅
- `cargo test`（setup 版本比對純函式）✅
- `pnpm test` 164 檔 / 1359 測試全過 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)