### PR TITLE
fix(fonts): surface auto-detected icon font at startup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { UpdateToast } from "@/components/UpdateToast";
 import { NotifyToast } from "@/components/NotifyToast";
 import { TabsArea } from "@/components/TabsArea";
 import { useUiStore } from "@/stores/uiStore";
+import { useFontStore, shouldPrefetchFontReport } from "@/stores/fontStore";
 import { useUpdaterStore } from "@/stores/updaterStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useTabsStore, tabHasDirtyEditor } from "@/stores/tabsStore";
@@ -198,6 +199,32 @@ function App() {
   // The font report (enumerating every installed family) is loaded lazily by
   // the Fonts settings section when it opens, not at startup — the terminal's
   // default font chain already covers CJK, so a cold launch does no font work.
+  // One exception (#164): icon-font auto-detect has no static fallback list
+  // (unlike CJK), so on the very first launch ever — auto mode with no cached
+  // suggestion — the report is loaded once off the critical path, at idle.
+  // Its suggestion then persists (fontStore.cachedIconFallback), so every
+  // later launch is back to zero font work and Nerd Font glyphs still render.
+  useEffect(() => {
+    if (!shouldPrefetchFontReport(useFontStore.getState())) {
+      return;
+    }
+    let cancelled = false;
+    const run = () => {
+      if (!cancelled) {
+        void useFontStore.getState().loadReport();
+      }
+    };
+    // requestIdleCallback is missing on older WKWebView; a delayed timeout is
+    // an acceptable "idle" stand-in for a one-time prefetch.
+    if (typeof window.requestIdleCallback === "function") {
+      window.requestIdleCallback(run);
+    } else {
+      window.setTimeout(run, 2000);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Drop saved terminal scrollback for panes that no longer exist (orphans
   // left by closed tabs/panes), keeping only the panes still in the layout.

--- a/src/stores/fontStore.test.ts
+++ b/src/stores/fontStore.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FONT_STORAGE_KEY,
+  selectTerminalFontFamily,
+  shouldPrefetchFontReport,
+  useFontStore,
+} from "./fontStore";
+import { fetchFontReport, type FontReport } from "@/modules/fonts/lib/fontsBridge";
+
+vi.mock("@/modules/fonts/lib/fontsBridge", () => ({
+  fetchFontReport: vi.fn(),
+}));
+
+function report(overrides: Partial<FontReport> = {}): FontReport {
+  return {
+    fonts: [],
+    recommended_cjk: [],
+    suggested_cjk_fallback: null,
+    has_cjk_fallback: false,
+    suggested_icon_fallback: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.mocked(fetchFontReport).mockReset();
+  useFontStore.setState({
+    primaryFont: "",
+    iconFont: "",
+    cjkFallbackFont: "",
+    cachedIconFallback: "",
+    report: null,
+    loading: false,
+  });
+});
+
+// Regression tests for #164: with the icon font on auto-detect, the suggested
+// Nerd Font must reach the chain at startup (before the settings panel ever
+// loads the full report), or PUA glyphs render as tofu until the user re-picks
+// a font — on every launch.
+describe("cached icon fallback in the font chain", () => {
+  it("uses the cached suggestion before the report loads", () => {
+    useFontStore.setState({ cachedIconFallback: "MesloLGS NF" });
+    const chain = selectTerminalFontFamily(useFontStore.getState());
+    expect(chain).toContain('"MesloLGS NF"');
+  });
+
+  it("prefers a loaded report over the cache", () => {
+    useFontStore.setState({
+      cachedIconFallback: "MesloLGS NF",
+      report: report({ suggested_icon_fallback: "Hack Nerd Font Mono" }),
+    });
+    const chain = selectTerminalFontFamily(useFontStore.getState());
+    expect(chain).toContain('"Hack Nerd Font Mono"');
+    expect(chain).not.toContain('"MesloLGS NF"');
+  });
+
+  it("trusts a loaded report that found no icon font, even with a stale cache", () => {
+    useFontStore.setState({
+      cachedIconFallback: "Gone Nerd Font",
+      report: report({ suggested_icon_fallback: null }),
+    });
+    expect(selectTerminalFontFamily(useFontStore.getState())).not.toContain("Nerd");
+  });
+
+  it("is overridden by an explicit user icon font", () => {
+    useFontStore.setState({
+      iconFont: "FiraCode Nerd Font Mono",
+      cachedIconFallback: "MesloLGS NF",
+    });
+    const chain = selectTerminalFontFamily(useFontStore.getState());
+    expect(chain).toContain('"FiraCode Nerd Font Mono"');
+    expect(chain).not.toContain('"MesloLGS NF"');
+  });
+
+  it('is disabled entirely by the "none" sentinel', () => {
+    useFontStore.setState({ iconFont: "none", cachedIconFallback: "MesloLGS NF" });
+    expect(selectTerminalFontFamily(useFontStore.getState())).not.toContain("Nerd");
+    expect(selectTerminalFontFamily(useFontStore.getState())).not.toContain("MesloLGS");
+  });
+});
+
+describe("loadReport caching", () => {
+  it("persists the detected icon fallback for the next launch", async () => {
+    vi.mocked(fetchFontReport).mockResolvedValue(
+      report({ suggested_icon_fallback: "MesloLGS NF" }),
+    );
+    await useFontStore.getState().loadReport();
+    expect(useFontStore.getState().cachedIconFallback).toBe("MesloLGS NF");
+    const persisted = JSON.parse(localStorage.getItem(FONT_STORAGE_KEY) ?? "{}") as {
+      state?: { cachedIconFallback?: string };
+    };
+    expect(persisted.state?.cachedIconFallback).toBe("MesloLGS NF");
+  });
+
+  it("clears a stale cache when the report finds no icon font", async () => {
+    useFontStore.setState({ cachedIconFallback: "Gone Nerd Font" });
+    vi.mocked(fetchFontReport).mockResolvedValue(report({ suggested_icon_fallback: null }));
+    await useFontStore.getState().loadReport();
+    expect(useFontStore.getState().cachedIconFallback).toBe("");
+  });
+});
+
+describe("shouldPrefetchFontReport", () => {
+  it("asks for a prefetch only on auto mode with nothing cached or loaded", () => {
+    expect(shouldPrefetchFontReport(useFontStore.getState())).toBe(true);
+  });
+
+  it("skips the prefetch when a suggestion is already cached", () => {
+    useFontStore.setState({ cachedIconFallback: "MesloLGS NF" });
+    expect(shouldPrefetchFontReport(useFontStore.getState())).toBe(false);
+  });
+
+  it("skips the prefetch when the user chose a font or opted out", () => {
+    useFontStore.setState({ iconFont: "FiraCode Nerd Font Mono" });
+    expect(shouldPrefetchFontReport(useFontStore.getState())).toBe(false);
+    useFontStore.setState({ iconFont: "none" });
+    expect(shouldPrefetchFontReport(useFontStore.getState())).toBe(false);
+  });
+
+  it("skips the prefetch when the report is loaded or loading", () => {
+    useFontStore.setState({ report: report() });
+    expect(shouldPrefetchFontReport(useFontStore.getState())).toBe(false);
+    useFontStore.setState({ report: null, loading: true });
+    expect(shouldPrefetchFontReport(useFontStore.getState())).toBe(false);
+  });
+});

--- a/src/stores/fontStore.ts
+++ b/src/stores/fontStore.ts
@@ -19,6 +19,15 @@ interface FontState {
   iconFont: string;
   /** User-selected Traditional Chinese fallback. Empty means auto-detect. */
   cjkFallbackFont: string;
+  /**
+   * The last backend-detected icon fallback, persisted across launches. The
+   * report itself only loads when the Fonts settings section opens (or via the
+   * one-time startup prefetch, see `shouldPrefetchFontReport`), so on a cold
+   * launch this cache is what puts the detected Nerd Font into the chain —
+   * without it, auto-detect users got tofu icons until they re-picked a font
+   * every single launch (#164). Empty means no suggestion is known.
+   */
+  cachedIconFallback: string;
   fontSize: number;
   report: FontReport | null;
   loading: boolean;
@@ -44,6 +53,7 @@ export const useFontStore = create<FontState>()(
       primaryFont: "",
       iconFont: "",
       cjkFallbackFont: "",
+      cachedIconFallback: "",
       fontSize: DEFAULT_FONT_SIZE,
       report: null,
       loading: false,
@@ -61,7 +71,13 @@ export const useFontStore = create<FontState>()(
         set({ loading: true });
         try {
           const report = await fetchFontReport();
-          set({ report, loading: false });
+          // Refresh the persisted suggestion (including clearing it when the
+          // report found nothing) so the next launch starts from fresh truth.
+          set({
+            report,
+            loading: false,
+            cachedIconFallback: report.suggested_icon_fallback ?? "",
+          });
         } catch {
           set({ loading: false });
         }
@@ -73,6 +89,7 @@ export const useFontStore = create<FontState>()(
         primaryFont: state.primaryFont,
         iconFont: state.iconFont,
         cjkFallbackFont: state.cjkFallbackFont,
+        cachedIconFallback: state.cachedIconFallback,
         fontSize: state.fontSize,
       }),
     },
@@ -81,11 +98,32 @@ export const useFontStore = create<FontState>()(
 
 /** Derive the effective xterm font-family stack from the current store state. */
 export function selectTerminalFontFamily(state: FontState): string {
+  // A loaded report is authoritative (it may legitimately say "no icon font
+  // installed"); the persisted cache only stands in while the report is absent.
+  const suggestedIcon = state.report
+    ? state.report.suggested_icon_fallback
+    : state.cachedIconFallback || null;
   return terminalFontFamilyFor(
     state.primaryFont,
     state.cjkFallbackFont,
     state.report?.suggested_cjk_fallback ?? null,
     state.iconFont,
-    state.report?.suggested_icon_fallback ?? null,
+    suggestedIcon,
+  );
+}
+
+/**
+ * Whether startup should trigger the one-time idle font-report load: only when
+ * the icon font is on auto-detect AND no suggestion has ever been cached (the
+ * very first launch). Every later launch reads the cache and does no font
+ * enumeration at startup, preserving the "cold launch does no font work"
+ * design; the report still refreshes whenever the Fonts settings section opens.
+ */
+export function shouldPrefetchFontReport(state: FontState): boolean {
+  return (
+    state.iconFont === "" &&
+    state.cachedIconFallback === "" &&
+    state.report === null &&
+    !state.loading
   );
 }


### PR DESCRIPTION
## Problem

With the icon font set to auto-detect, Nerd Font / Powerline glyphs rendered as tofu on every cold launch, and recovered only after re-picking a font in Settings → Fonts — until the next restart. Root cause analysis in #164 (thanks @yw-chan for the excellent report): the suggested icon fallback comes from the font report, which is only loaded when the Fonts settings section mounts, so at startup the chain has no PUA-capable family.

## Fix

Rather than a static frontend list (which would miss non-curated Nerd Fonts that the backend's name heuristic catches) or enumerating fonts on every launch (which the cold-launch design deliberately avoids):

- Persist the backend suggestion as `cachedIconFallback` in the fontStore whenever a report loads (including clearing it when detection finds nothing).
- `selectTerminalFontFamily` falls back to the cache while the report is absent; a loaded report stays authoritative.
- On the very first launch only (auto mode, nothing cached), load the report once via `requestIdleCallback`, off the startup critical path. Every later launch reads the cache and does zero font work at startup.

A stale cache (font uninstalled since) is harmless — the browser skips missing families — and self-corrects the next time detection runs.

## Tests

- 11 new tests in `src/stores/fontStore.test.ts`: cache in the chain, report-over-cache precedence, explicit/none override, persistence through `loadReport`, and the prefetch gate.
- `pnpm typecheck` clean, full suite 1371 passed.

Closes #164