### PR TITLE
fix(preview): position and size the webview in one atomic call

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,7 +31,7 @@ use modules::git::{
 use modules::pr::{gh_available, pr_via_api, pr_via_gh};
 use modules::preview::{
     preview_close, preview_create, preview_history_back, preview_history_forward, preview_navigate,
-    preview_reload,
+    preview_reload, preview_set_bounds,
 };
 use modules::secrets::{
     secrets_delete_key, secrets_has_key, secrets_set_key, ssh_secret_delete, ssh_secret_set,

--- a/src-tauri/src/modules/preview.rs
+++ b/src-tauri/src/modules/preview.rs
@@ -6,7 +6,7 @@
 
 use serde::Serialize;
 use tauri::webview::WebviewBuilder;
-use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Url, WebviewUrl, Window};
+use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Rect, Url, WebviewUrl, Window};
 
 /// Prefix every preview webview label carries (see `previewWebviewLabel` in
 /// previewWebview.ts). Commands refuse any label without it, so they can never
@@ -124,6 +124,35 @@ pub async fn preview_create(
     Ok(())
 }
 
+/// Atomically move and resize the preview webview in ONE call. The rect is in
+/// unzoomed window (logical) pixels, same convention as `preview_create`.
+///
+/// This exists because the JS `setPosition` + `setSize` pair is not safe on
+/// Windows: in tauri's runtime each of the two messages does a read-modify-write
+/// of the full bounds (read current bounds, replace one half, write both back),
+/// and the write lands asynchronously (`SWP_ASYNCWINDOWPOS`). The second message
+/// can therefore read back a rect the first write has not applied yet and
+/// re-commit that stale half — in practice the webview kept its creation-time
+/// size while the position landed, leaving an L-shaped gap in the pane (#163).
+/// A single `set_bounds` carries both halves in one message, so nothing is ever
+/// read back or re-committed.
+#[tauri::command]
+pub fn preview_set_bounds(
+    app: AppHandle,
+    label: String,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+) -> Result<(), String> {
+    webview(&app, &label)?
+        .set_bounds(Rect {
+            position: LogicalPosition::new(x, y).into(),
+            size: LogicalSize::new(width, height).into(),
+        })
+        .map_err(|e| e.to_string())
+}
+
 /// Navigate the existing preview webview to a new url without recreating it, so
 /// its back/forward history survives.
 #[tauri::command]
@@ -192,5 +221,26 @@ fn parse_preview_url(url: &str) -> Result<Url, String> {
     match parsed.scheme() {
         "http" | "https" | "asset" => Ok(parsed),
         other => Err(format!("refusing to load unsupported scheme '{other}' in preview")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_guard_accepts_only_preview_labels() {
+        assert!(ensure_preview_label("preview-main-leaf1").is_ok());
+        assert!(ensure_preview_label("main").is_err());
+        assert!(ensure_preview_label("").is_err());
+    }
+
+    #[test]
+    fn preview_urls_reject_privileged_schemes() {
+        assert!(parse_preview_url("https://example.com").is_ok());
+        assert!(parse_preview_url("http://localhost:3000").is_ok());
+        assert!(parse_preview_url("asset://localhost/x").is_ok());
+        assert!(parse_preview_url("file:///etc/passwd").is_err());
+        assert!(parse_preview_url("javascript:alert(1)").is_err());
     }
 }

--- a/src/modules/preview/hooks/useNativePreviewWebview.ts
+++ b/src/modules/preview/hooks/useNativePreviewWebview.ts
@@ -3,7 +3,6 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Webview } from "@tauri-apps/api/webview";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { LogicalPosition, LogicalSize } from "@tauri-apps/api/dpi";
 import { debounce } from "@/lib/debounce";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { resolvePreviewSrc } from "../lib/resolvePreviewSrc";
@@ -161,15 +160,27 @@ export function useNativePreviewWebview({ url, leafId, visible, onNavigate, onTi
       lastRectRef.current = rect;
       // The host rect is in zoomed page pixels; the child webview lives in
       // unzoomed window pixels, so scale by the UI zoom factor.
+      //
+      // Position and size go through ONE Rust command on purpose. The JS
+      // setPosition + setSize pair is two IPC messages, and each is a
+      // read-modify-write of the full bounds inside tauri's runtime; on Windows
+      // the write lands asynchronously, so the second message could read back —
+      // and re-commit — a rect the first write had not applied yet, freezing
+      // the webview at its creation-time size with an L-shaped gap (#163).
       const z = zoomRef.current;
-      void webview.setPosition(new LogicalPosition(rect.x * z, rect.y * z)).catch(() => {});
-      void webview.setSize(new LogicalSize(rect.width * z, rect.height * z)).catch(() => {});
+      void invoke("preview_set_bounds", {
+        label,
+        x: rect.x * z,
+        y: rect.y * z,
+        width: rect.width * z,
+        height: rect.height * z,
+      }).catch(() => {});
     }
     if (!shownRef.current) {
       shownRef.current = true;
       void webview.show().catch(() => {});
     }
-  }, []);
+  }, [label]);
 
   // A zoom change keeps the host rect (page px) the same but moves/resizes its
   // on-screen footprint, so force a reposition when uiZoom changes.


### PR DESCRIPTION
## Problem

On Windows the preview pane's native webview renders smaller than its pane: content sticks to the top-left and an L-shaped white gap shows at the right/bottom (#163, with excellent measurements by @yw-chan — position exact, size short, and the two gaps unequal, which rules out any single scale factor).

## Root cause (traced through tauri-runtime-wry)

The frontend synced the webview with two separate calls, `setPosition` then `setSize`. Each becomes its own runtime message, and each message is a **read-modify-write of the full bounds**: read current bounds, replace one half, write both halves back. On Windows the write applies asynchronously (`SWP_ASYNCWINDOWPOS`), so the second message can read back a rect the first write hasn't applied yet and re-commit that stale half — the webview then keeps its creation-time (pre-layout, undersized) size while the position lands. That matches the reported symptom exactly: correct top-left, undersized, unequal gaps.

## Fix

New `preview_set_bounds` command forwarding both halves to `Webview::set_bounds` as **one** runtime message — nothing is read back, so there is nothing to interleave. The frontend `sync()` now issues this single invoke (also halving IPC traffic per rect change). The label passes the same `ensure_preview_label` guard as every other preview command.

## Verification

- `cargo check` clean; new unit tests for the label/scheme guards pass.
- `pnpm typecheck` clean; full frontend suite 1360 passed.
- macOS behavior unchanged by design (same underlying NSView frame update, now in one message). I'll smoke-test the preview pane manually before release.
- **Windows verification wanted**: I can't reproduce locally — asked the reporter to verify in #163.

Closes #163