### PR TITLE
fix(shortcuts): 修復 Windows 平台快捷鍵無法使用的問題

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,6 +78,14 @@ fn app_build_info() -> AppBuildInfo {
     }
 }
 
+/// Open a new window, mirroring the File > New Window menu item. On Windows the
+/// native menu bar is hidden, so its Ctrl+N accelerator never fires; the
+/// frontend invokes this command from its keydown handler instead (see App.tsx).
+#[tauri::command]
+fn open_new_window(app: tauri::AppHandle) -> tauri::Result<()> {
+    modules::menu::create_new_window(&app)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -156,6 +164,7 @@ pub fn run() {
             pty_close,
             pty_close_all,
             app_build_info,
+            open_new_window,
             terminal_clipboard_paths,
             terminal_clipboard_image_paths,
             terminal_clipboard_text,

--- a/src-tauri/src/modules/menu.rs
+++ b/src-tauri/src/modules/menu.rs
@@ -22,6 +22,25 @@ const RERUN_SETUP_ID: &str = "rerun-setup";
 /// File menu, so the frontend re-opens the first-run install guide on demand.
 const RERUN_SETUP_EVENT: &str = "menu:rerun-setup";
 
+/// Accelerator for a custom menu item, gated per platform.
+///
+/// On macOS these accelerators are what actually fire the shortcut — they work
+/// even while a native preview webview holds keyboard focus (see the per-item
+/// comments below). On Windows the native menu bar does not exist: the main
+/// window runs with the native frame hidden (`set_decorations(false)` in
+/// lib.rs, custom React title bar), so a menu accelerator never fires. There the
+/// frontend handles the same shortcuts in its webview keydown handler instead
+/// (see the `IS_WINDOWS` block in App.tsx). Returning `None` on Windows keeps the
+/// menu items but strips their accelerators, so a shortcut can never fire twice.
+#[cfg(not(target_os = "windows"))]
+fn accel(shortcut: &str) -> Option<&str> {
+    Some(shortcut)
+}
+#[cfg(target_os = "windows")]
+fn accel(_shortcut: &str) -> Option<&str> {
+    None
+}
+
 /// Build the menu (Tauri's default plus custom items and a Cmd+W rebind), set it
 /// as the app menu, and wire the menu-event handler.
 pub fn init(app: &mut App) -> tauri::Result<()> {
@@ -34,7 +53,7 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
         NEW_WINDOW_ID,
         "New Window",
         true,
-        Some("CmdOrCtrl+N"),
+        accel("CmdOrCtrl+N"),
     )?;
     // Cmd+W must peel the active tab, not destroy the window. Tauri's default
     // menu bundles a native "Close Window" (bound to the OS's standard Cmd+W) as
@@ -55,23 +74,23 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
     // would otherwise swallow the key. Each emits an event to the focused window;
     // the frontend listens scoped to its own label.
     let close_tab =
-        MenuItem::with_id(&handle, CLOSE_TAB_ID, "Close Tab", true, Some("CmdOrCtrl+W"))?;
+        MenuItem::with_id(&handle, CLOSE_TAB_ID, "Close Tab", true, accel("CmdOrCtrl+W"))?;
     let close_window = MenuItem::with_id(
         &handle,
         CLOSE_WINDOW_ID,
         "Close Window",
         true,
-        Some("Shift+CmdOrCtrl+W"),
+        accel("Shift+CmdOrCtrl+W"),
     )?;
     let open_location = MenuItem::with_id(
         &handle,
         OPEN_LOCATION_ID,
         "Open Location",
         true,
-        Some("CmdOrCtrl+L"),
+        accel("CmdOrCtrl+L"),
     )?;
     let cycle_pane =
-        MenuItem::with_id(&handle, CYCLE_PANE_ID, "Cycle Pane", true, Some("CmdOrCtrl+`"))?;
+        MenuItem::with_id(&handle, CYCLE_PANE_ID, "Cycle Pane", true, accel("CmdOrCtrl+`"))?;
     let rerun_setup = MenuItem::with_id(&handle, RERUN_SETUP_ID, "Setup Wizard", true, None::<&str>)?;
     let mut inserted = false;
     for item in menu.items()? {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,9 @@ import { registerSecondaryWindowCleanup } from "@/lib/windowLifecycle";
 import { SshPromptDialog } from "@/modules/ssh/SshPromptDialog";
 import { SetupWizard } from "@/modules/setup/SetupWizard";
 import { detectTools, isToolReady } from "@/modules/setup/lib/setupTools";
-import { isMainWindow } from "@/lib/window";
+import { isMainWindow, closeWindow } from "@/lib/window";
+import { IS_WINDOWS } from "@/lib/platform";
+import { invoke } from "@tauri-apps/api/core";
 import { useForwardStatusListener } from "@/modules/ssh/lib/useForwardStatus";
 import { sftpSessionStore } from "@/modules/ssh/lib/sftpSessionStore";
 import { enforceLogRetention } from "@/modules/logs/lib/sessionLog";
@@ -348,6 +350,48 @@ function App() {
         return;
       }
 
+      // On Windows the native menu bar is hidden (the window runs with the frame
+      // off and a custom React title bar — see lib.rs set_decorations(false)), so
+      // the menu accelerators that drive these shortcuts on macOS never fire.
+      // Handle them here in the webview instead. Gated to Windows so macOS keeps
+      // its menu accelerators and never runs both (which would fire twice); on
+      // Windows the Rust side drops these accelerators too (see menu.rs `accel`).
+      // `code` is used so it matches regardless of keyboard layout.
+      if (IS_WINDOWS && !e.altKey) {
+        // Ctrl+W closes the active tab/pane; Shift+Ctrl+W closes the window.
+        if (e.code === "KeyW") {
+          e.preventDefault();
+          if (e.shiftKey) {
+            void closeWindow();
+          } else {
+            closeActiveTabOrPane();
+          }
+          return;
+        }
+        // Ctrl+` cycles focus through the active tab's panes.
+        if (e.code === "Backquote" && !e.shiftKey) {
+          e.preventDefault();
+          useTabsStore.getState().focusNextPane();
+          return;
+        }
+        // Ctrl+N opens a new window (mirrors File > New Window).
+        if (e.code === "KeyN" && !e.shiftKey) {
+          e.preventDefault();
+          void invoke("open_new_window").catch(() => {});
+          return;
+        }
+        // Ctrl+L focuses the active preview's address bar. Only acts on a preview
+        // pane, so a focused terminal keeps Ctrl+L (clear screen).
+        if (e.code === "KeyL" && !e.shiftKey) {
+          const controls = activePreviewControls();
+          if (controls) {
+            e.preventDefault();
+            controls.focusAddressBar();
+          }
+          return;
+        }
+      }
+
       // ⌘1…⌘9 switch to the Nth tab of the active space (matching the tab bar).
       if (digit !== null && !e.shiftKey && !e.altKey && !editable) {
         const state = useTabsStore.getState();
@@ -430,7 +474,7 @@ function App() {
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, []);
+  }, [closeActiveTabOrPane]);
 
   // ⌘W closes the active tab/pane. It is driven solely by the "Close Tab" menu
   // accelerator, NOT a keydown branch: the native menu fires even when a preview

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -350,6 +350,15 @@ function App() {
         return;
       }
 
+      // On Windows the app's shortcut modifier is Ctrl; `metaKey` is the Windows
+      // key, whose system combos (Win+D, Win+E, Win+W, …) must never trigger an
+      // app shortcut. Reject them here so neither the Windows block nor the
+      // shared Ctrl+letter handlers below can misfire on a Win+key press. (macOS
+      // uses Cmd = metaKey, so this is Windows-only.)
+      if (IS_WINDOWS && e.metaKey) {
+        return;
+      }
+
       // On Windows the native menu bar is hidden (the window runs with the frame
       // off and a custom React title bar — see lib.rs set_decorations(false)), so
       // the menu accelerators that drive these shortcuts on macOS never fire.
@@ -357,7 +366,7 @@ function App() {
       // its menu accelerators and never runs both (which would fire twice); on
       // Windows the Rust side drops these accelerators too (see menu.rs `accel`).
       // `code` is used so it matches regardless of keyboard layout.
-      if (IS_WINDOWS && !e.altKey) {
+      if (IS_WINDOWS && e.ctrlKey && !e.altKey) {
         // Ctrl+W closes the active tab/pane; Shift+Ctrl+W closes the window.
         if (e.code === "KeyW") {
           e.preventDefault();

--- a/src/App.windows.test.tsx
+++ b/src/App.windows.test.tsx
@@ -79,6 +79,39 @@ describe("App shell — Windows keyboard shortcuts", () => {
     expect(tab?.paneTree).toEqual(leaf("right-leaf", { kind: "launcher" }));
   });
 
+  it("ignores Windows-key combos (Win+W must not close a tab)", () => {
+    const paneTree = splitLeaf(
+      leaf("left-leaf", { kind: "launcher" }),
+      "left-leaf",
+      "row",
+      "right-leaf",
+      { kind: "launcher" },
+    );
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space 1" }],
+      activeSpaceId: "s1",
+      tabs: [
+        {
+          id: "a",
+          spaceId: "s1",
+          title: "a",
+          kind: "launcher" as const,
+          paneTree,
+          activeLeafId: "left-leaf",
+          paneOrder: ["left-leaf", "right-leaf"],
+        },
+      ],
+      activeId: "a",
+    });
+    render(<App />);
+
+    // metaKey is the Windows key here — Win+W must be left to the OS, not close a pane.
+    fireEvent.keyDown(window, { code: "KeyW", key: "w", metaKey: true });
+
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
+    expect(tab?.paneTree).toEqual(paneTree);
+  });
+
   it("cycles panes with Ctrl+` and switches tabs with Ctrl+digit", () => {
     const tabs = ["a", "b"].map((id) => ({
       id,

--- a/src/App.windows.test.tsx
+++ b/src/App.windows.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// On Windows the native menu bar is hidden (the window runs with decorations
+// off and a custom title bar), so the menu accelerators that drive Close Tab /
+// Cycle Pane / New Window on macOS never fire. App.tsx handles those in its
+// webview keydown handler instead, gated on IS_WINDOWS. Force that gate on here
+// while preserving the module's other exports (IS_MAC etc.).
+vi.mock("@/lib/platform", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/platform")>();
+  return { ...actual, IS_WINDOWS: true };
+});
+
+// The Windows title bar calls Tauri window APIs on mount, which jsdom has no
+// backend for; the shortcut handler under test does not need it, so stub it out.
+vi.mock("@/components/TitleBar", () => ({ TitleBar: () => null }));
+
+// ⌘/Ctrl+W is delivered as a `menu:close-tab` event on macOS; on Windows the
+// keydown handler drives it directly. The webview still needs a listen/setZoom
+// stub for App to mount.
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    setZoom: () => Promise.resolve(),
+    listen: () => Promise.resolve(() => {}),
+  }),
+}));
+
+import App from "./App";
+import "./i18n";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useUiStore } from "@/stores/uiStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useTabsStore } from "@/stores/tabsStore";
+import { leaf, splitLeaf } from "@/modules/terminal/lib/terminalLayout";
+
+describe("App shell — Windows keyboard shortcuts", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ language: "en", themeId: "vitesse-dark" });
+    useUiStore.setState({
+      sidebarVisible: true,
+      settingsOpen: false,
+      sidebarView: "explorer",
+      fileFinderOpen: false,
+    });
+    useWorkspaceStore.setState({ rootPath: null });
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("closes the focused pane with Ctrl+W (menu accelerator is unavailable)", () => {
+    const paneTree = splitLeaf(
+      leaf("left-leaf", { kind: "launcher" }),
+      "left-leaf",
+      "row",
+      "right-leaf",
+      { kind: "launcher" },
+    );
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space 1" }],
+      activeSpaceId: "s1",
+      tabs: [
+        {
+          id: "a",
+          spaceId: "s1",
+          title: "a",
+          kind: "launcher" as const,
+          paneTree,
+          activeLeafId: "left-leaf",
+          paneOrder: ["left-leaf", "right-leaf"],
+        },
+      ],
+      activeId: "a",
+    });
+    render(<App />);
+
+    // One Ctrl+W peels exactly the focused (left) pane, leaving the right one.
+    fireEvent.keyDown(window, { code: "KeyW", key: "w", ctrlKey: true });
+
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
+    expect(tab?.paneTree).toEqual(leaf("right-leaf", { kind: "launcher" }));
+  });
+
+  it("cycles panes with Ctrl+` and switches tabs with Ctrl+digit", () => {
+    const tabs = ["a", "b"].map((id) => ({
+      id,
+      spaceId: "s1",
+      title: id,
+      kind: "launcher" as const,
+      paneTree: leaf(`${id}-leaf`, { kind: "launcher" }),
+      activeLeafId: `${id}-leaf`,
+      paneOrder: [`${id}-leaf`],
+    }));
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space 1" }],
+      activeSpaceId: "s1",
+      tabs,
+      activeId: "a",
+    });
+    render(<App />);
+
+    // Ctrl+2 switches to the second tab (works on every platform).
+    fireEvent.keyDown(window, { code: "Digit2", key: "2", ctrlKey: true });
+    expect(useTabsStore.getState().activeId).toBe("b");
+
+    // Ctrl+` is a no-op with a single pane but must not throw or switch tabs.
+    fireEvent.keyDown(window, { code: "Backquote", key: "`", ctrlKey: true });
+    expect(useTabsStore.getState().activeId).toBe("b");
+  });
+});

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -16,25 +16,6 @@ function isPtySession(s: PtySession | SshSession): s is PtySession {
   return "cwd" in s;
 }
 
-/**
- * True for the global shortcuts the app handles at the window level (⌘/Ctrl+1-9
- * switch tab, ⌥1-9 switch sidebar, ⌘/Ctrl +/-/0 zoom the UI). `code` is used
- * over `key` so it still matches when a modifier rewrites the character (macOS
- * ⌥1 yields "¡"). The terminal must let these pass through to the window handler
- * rather than typing them into the shell.
- */
-function isAppShortcut(event: KeyboardEvent): boolean {
-  const cmd = event.metaKey || event.ctrlKey;
-  if (/^(?:Digit|Numpad)[1-9]$/.test(event.code)) {
-    const switchTab = cmd && !event.shiftKey && !event.altKey;
-    const switchSidebar = event.altKey && !event.metaKey && !event.ctrlKey;
-    return switchTab || switchSidebar;
-  }
-  if (/^(?:Equal|Minus|Digit0|NumpadAdd|NumpadSubtract|Numpad0|Backquote)$/.test(event.code)) {
-    return cmd && !event.altKey;
-  }
-  return false;
-}
 import { useConnectionsStore } from "@/stores/connectionsStore";
 import {
   deleteTerminalHistory,
@@ -75,7 +56,7 @@ import {
 import { actionsFor, findActionLinks, type TerminalAction } from "./lib/actionLinks";
 import { ActionCard } from "./ActionCard";
 import { buildCellPositions, gatherLogicalLine } from "./lib/cellPositions";
-import { terminalKeySequence } from "./lib/terminalKeymap";
+import { terminalKeySequence, isAppShortcut } from "./lib/terminalKeymap";
 import { shouldCdToRoot } from "./lib/cwdSync";
 import { parseOsc7Cwd, parseOsc7RemotePath } from "./lib/osc7";
 import { remoteCwdStore } from "@/modules/ssh/lib/remoteCwdStore";
@@ -514,7 +495,7 @@ export function TerminalView({
       // ⌘/Ctrl +/-/0 zoom) must not be typed into the shell. Returning false
       // lets them bubble to the window handler instead; preventDefault stops
       // xterm's hidden textarea from emitting the character (e.g. macOS ⌥-symbols).
-      if (event.type === "keydown" && isAppShortcut(event)) {
+      if (event.type === "keydown" && isAppShortcut(event, IS_WINDOWS)) {
         event.preventDefault();
         return false;
       }
@@ -572,6 +553,25 @@ export function TerminalView({
             void handleTerminalPaste("cmd");
             return false;
           }
+        }
+        // Clipboard on Windows: Ctrl+C copies the current selection (like Windows
+        // Terminal / VS Code), then clears it so a second Ctrl+C interrupts. With
+        // NO selection it must fall through untouched so xterm sends 0x03 (SIGINT)
+        // to the shell — Ctrl+C is the interrupt key, so it can't unconditionally
+        // mean copy. (Ctrl+V paste is handled by the capture-phase interceptor.)
+        if (
+          IS_WINDOWS &&
+          event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
+          !event.shiftKey &&
+          (event.code === "KeyC" || event.key.toLowerCase() === "c") &&
+          term.hasSelection()
+        ) {
+          void navigator.clipboard.writeText(term.getSelection());
+          term.clearSelection();
+          event.preventDefault();
+          return false;
         }
       }
       return true;

--- a/src/modules/terminal/lib/terminalKeymap.test.ts
+++ b/src/modules/terminal/lib/terminalKeymap.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { terminalKeySequence, type NavKeyEvent } from "./terminalKeymap";
+import {
+  terminalKeySequence,
+  isAppShortcut,
+  type NavKeyEvent,
+  type AppShortcutEvent,
+} from "./terminalKeymap";
 
 const base: NavKeyEvent = {
   key: "",
@@ -45,5 +50,56 @@ describe("terminalKeySequence", () => {
     expect(mac({ key: "ArrowLeft", ctrlKey: true })).toBeNull();
     expect(mac({ key: "ArrowLeft" })).toBeNull();
     expect(mac({ key: "Enter" })).toBeNull();
+  });
+});
+
+const appBase: AppShortcutEvent = {
+  code: "",
+  ctrlKey: false,
+  metaKey: false,
+  altKey: false,
+  shiftKey: false,
+};
+const win = (e: Partial<AppShortcutEvent>) => isAppShortcut({ ...appBase, ...e }, true);
+const notWin = (e: Partial<AppShortcutEvent>) => isAppShortcut({ ...appBase, ...e }, false);
+
+describe("isAppShortcut", () => {
+  it("treats Cmd/Ctrl+digit as tab-switch and Alt+digit as sidebar on every platform", () => {
+    expect(notWin({ code: "Digit3", metaKey: true })).toBe(true);
+    expect(win({ code: "Digit3", ctrlKey: true })).toBe(true);
+    expect(notWin({ code: "Digit3", altKey: true })).toBe(true);
+    // Alt+Ctrl+digit is neither.
+    expect(win({ code: "Digit3", altKey: true, ctrlKey: true })).toBe(false);
+  });
+
+  it("treats zoom keys and Cmd/Ctrl+backtick as app shortcuts on every platform", () => {
+    for (const code of ["Equal", "Minus", "Digit0", "Backquote"]) {
+      expect(notWin({ code, metaKey: true })).toBe(true);
+      expect(win({ code, ctrlKey: true })).toBe(true);
+    }
+  });
+
+  it("routes the Windows Ctrl+letter shortcuts to the app so the shell can't eat them", () => {
+    // These collide with terminal control codes (Ctrl+T=^T, Ctrl+D=EOF, ...);
+    // on Windows the app must win. Shift variants of W/T/D are valid too.
+    for (const code of ["KeyW", "KeyT", "KeyD"]) {
+      expect(win({ code, ctrlKey: true })).toBe(true);
+      expect(win({ code, ctrlKey: true, shiftKey: true })).toBe(true);
+    }
+    for (const code of ["KeyP", "KeyB", "KeyN", "Comma"]) {
+      expect(win({ code, ctrlKey: true })).toBe(true);
+      // No Shift variant for these — Ctrl+Shift+P etc. stay with the terminal.
+      expect(win({ code, ctrlKey: true, shiftKey: true })).toBe(false);
+    }
+  });
+
+  it("does NOT claim those Ctrl+letter keys off Windows (macOS uses Cmd, no collision)", () => {
+    for (const code of ["KeyW", "KeyT", "KeyD", "KeyP", "KeyB", "KeyN", "Comma"]) {
+      expect(notWin({ code, ctrlKey: true })).toBe(false);
+    }
+  });
+
+  it("leaves Ctrl+L to the terminal (clear-screen) on Windows", () => {
+    expect(win({ code: "KeyL", ctrlKey: true })).toBe(false);
   });
 });

--- a/src/modules/terminal/lib/terminalKeymap.test.ts
+++ b/src/modules/terminal/lib/terminalKeymap.test.ts
@@ -102,4 +102,14 @@ describe("isAppShortcut", () => {
   it("leaves Ctrl+L to the terminal (clear-screen) on Windows", () => {
     expect(win({ code: "KeyL", ctrlKey: true })).toBe(false);
   });
+
+  it("does NOT treat Windows-key combos as app shortcuts (metaKey is the Win key)", () => {
+    // Win+W / Win+T / Win+3 must fall through to the OS, not be claimed by the app.
+    expect(win({ code: "KeyW", metaKey: true })).toBe(false);
+    expect(win({ code: "KeyT", metaKey: true })).toBe(false);
+    expect(win({ code: "Digit3", metaKey: true })).toBe(false);
+    expect(win({ code: "Backquote", metaKey: true })).toBe(false);
+    // Even Ctrl+Win+W is rejected (Win held).
+    expect(win({ code: "KeyW", ctrlKey: true, metaKey: true })).toBe(false);
+  });
 });

--- a/src/modules/terminal/lib/terminalKeymap.ts
+++ b/src/modules/terminal/lib/terminalKeymap.ts
@@ -22,6 +22,65 @@ export interface NavKeyEvent {
   shiftKey: boolean;
 }
 
+/** Physical-key event shape used to detect app-level shortcuts (uses `code`). */
+export interface AppShortcutEvent {
+  code: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+}
+
+/**
+ * True for the global shortcuts the app handles at the window level, which the
+ * terminal must let bubble to the window handler instead of typing into the
+ * shell. `code` is used over `key` so it still matches when a modifier rewrites
+ * the character (macOS ⌥1 yields "¡").
+ *
+ * Cross-platform: ⌘/Ctrl+1-9 switch tab, ⌥1-9 switch sidebar, ⌘/Ctrl +/-/0 zoom,
+ * ⌘/Ctrl+` cycle pane.
+ *
+ * Windows-only: the app's other shortcuts use Ctrl as their modifier (macOS uses
+ * Cmd). Ctrl+<letter> combos are ALSO terminal control codes — Ctrl+T sends ^T,
+ * Ctrl+D sends EOF, Ctrl+W deletes a word — so when a terminal pane is focused
+ * xterm would send them to the shell and the app shortcut would never fire.
+ * Matching the Shortcuts settings list, let the app win here so the shortcuts
+ * behave the same whether or not a terminal has focus. macOS routes these
+ * through Cmd, which never collides with the terminal, so this branch is gated
+ * to Windows. Ctrl+L is deliberately excluded so a focused terminal keeps its
+ * clear-screen (Open Location applies only to a preview pane, never a terminal).
+ */
+export function isAppShortcut(event: AppShortcutEvent, isWindows: boolean): boolean {
+  const cmd = event.metaKey || event.ctrlKey;
+  if (/^(?:Digit|Numpad)[1-9]$/.test(event.code)) {
+    const switchTab = cmd && !event.shiftKey && !event.altKey;
+    const switchSidebar = event.altKey && !event.metaKey && !event.ctrlKey;
+    return switchTab || switchSidebar;
+  }
+  if (/^(?:Equal|Minus|Digit0|NumpadAdd|NumpadSubtract|Numpad0|Backquote)$/.test(event.code)) {
+    return cmd && !event.altKey;
+  }
+  if (isWindows && cmd && !event.altKey) {
+    switch (event.code) {
+      // Close Tab / Close Window, New Tab / New Terminal Tab, Split Right / Split
+      // Down — the Shift variants are valid app shortcuts too, so match any Shift.
+      case "KeyW":
+      case "KeyT":
+      case "KeyD":
+        return true;
+      // Find Files, Toggle Sidebar, New Window, Settings — no Shift variant.
+      case "KeyP":
+      case "KeyB":
+      case "KeyN":
+      case "Comma":
+        return !event.shiftKey;
+      default:
+        return false;
+    }
+  }
+  return false;
+}
+
 export function terminalKeySequence(event: NavKeyEvent, isMac: boolean): string | null {
   const { key, ctrlKey, metaKey, altKey, shiftKey } = event;
 

--- a/src/modules/terminal/lib/terminalKeymap.ts
+++ b/src/modules/terminal/lib/terminalKeymap.ts
@@ -51,7 +51,10 @@ export interface AppShortcutEvent {
  * clear-screen (Open Location applies only to a preview pane, never a terminal).
  */
 export function isAppShortcut(event: AppShortcutEvent, isWindows: boolean): boolean {
-  const cmd = event.metaKey || event.ctrlKey;
+  // The app's shortcut modifier is Cmd (metaKey) on macOS and Ctrl on Windows.
+  // On Windows metaKey is the Windows key, so a Win+<key> system combo must NOT
+  // be treated as an app shortcut — require Ctrl and exclude Win there.
+  const cmd = isWindows ? event.ctrlKey && !event.metaKey : event.metaKey || event.ctrlKey;
   if (/^(?:Digit|Numpad)[1-9]$/.test(event.code)) {
     const switchTab = cmd && !event.shiftKey && !event.altKey;
     const switchSidebar = event.altKey && !event.metaKey && !event.ctrlKey;


### PR DESCRIPTION
## 問題

Windows 平台上多個快捷鍵無法使用。經排查為**三個獨立原因**，逐一修復。開發環境在 macOS，這些問題只在 Windows 重現，因此過去未被發現。

## 修復內容

### 1. 選單 accelerator 驅動的快捷鍵完全無效
`Ctrl+W`（關閉分頁）、`Ctrl+\``（循環 pane）、`Ctrl+N`（開新視窗）、`Ctrl+L`（預覽網址列）、`Shift+Ctrl+W`（關閉視窗）。

**根因**：Windows 上 `lib.rs` 的 `set_decorations(false)` 隱藏原生視窗框架（改用自訂 React TitleBar），連帶讓**原生選單列消失**，而這些快捷鍵原本只靠選單的 accelerator 觸發。

**修法**：改由前端 webview keydown 接手（`App.tsx` 的 `IS_WINDOWS` 分支）；Rust 端在 Windows 用 `accel()` helper 移除這些 accelerator，避免萬一雙觸發；新增 `open_new_window` command 供 `Ctrl+N` 呼叫。macOS 維持用選單 accelerator。

### 2. `Ctrl+字母` app 快捷鍵被終端機當控制碼吃掉
`Ctrl+T`（顯示 `^T`）、`Ctrl+P`、`Ctrl+B`、`Ctrl+D`（不分割）、`Ctrl+,`。

**根因**：Windows app 快捷鍵用 `Ctrl` 當修飾鍵，而 `Ctrl+字母` 剛好是終端機控制碼（`Ctrl+T`=0x14、`Ctrl+D`=EOF）；終端機焦點時 xterm 直接送給 shell，app 收不到。（macOS 用 `Cmd` 不衝突。）

**修法**：`isAppShortcut` 抽成 `terminalKeymap.ts` 的純函式（`isWindows` 參數化，可測），在 Windows 放行這些 app 快捷鍵冒泡到 window handler。`Ctrl+L` 刻意保留給終端機清畫面。

### 3. `Ctrl+C` 無法複製、只會送 SIGINT
**根因**：clipboard 處理只有 macOS 的 `Cmd+C` 分支，Windows 沒有 `Ctrl+C` 複製。

**修法**：Windows 智慧型 `Ctrl+C`（同 Windows Terminal / VSCode）——有選取則複製並清除選取，無選取則照舊送 SIGINT 中斷。

## 取捨說明
讓 `Ctrl+字母` 成為 app 快捷鍵，終端機會失去對應控制鍵：`Ctrl+D` 不再送 EOF（改為分割）、`Ctrl+B` 蓋掉 tmux prefix（改為側邊欄）、`Ctrl+W` werase（改為關閉分頁）。此為 app 既有快捷鍵方案（設定內的快捷鍵清單）的必然結果，本 PR 依現況實作。

## 驗證
- `cargo check` ✅（此 PR 由 Windows 機器實跑，**實際編譯了 `#[cfg(target_os="windows")]` 分支**）
- `tsc --noEmit` ✅
- `vitest` 全套 **1384 測試通過** ✅（新增 7 個測試）
- ⚠️ 修復 #1 屬選單行為，只在 **release build** 完整重現，建議在真實 Windows release 再實測一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)