### PR TITLE
feat(titlebar): Windows 自訂文字選單列與品牌標記

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -224,6 +224,7 @@ pub fn run() {
             preview_create,
             preview_navigate,
             preview_reload,
+            preview_set_bounds,
             preview_history_back,
             preview_history_forward,
             preview_close,

--- a/src-tauri/src/modules/menu.rs
+++ b/src-tauri/src/modules/menu.rs
@@ -185,6 +185,13 @@ pub fn create_new_window(app: &AppHandle) -> tauri::Result<()> {
     let builder = builder
         .title_bar_style(tauri::TitleBarStyle::Overlay)
         .hidden_title(true);
+    // Windows hides the native frame in favour of the custom React title bar
+    // (mirrors the main window's set_decorations(false) in lib.rs). Without this
+    // a secondary window keeps the OS frame AND the native menu bar, while the
+    // custom title bar renders underneath — two title bars at once. Setting it on
+    // the builder means the native frame never flashes before being removed.
+    #[cfg(target_os = "windows")]
+    let builder = builder.decorations(false);
     let win = builder.build()?;
     // window-state plugin may restore a stale size from a previous run.
     // Clamp anything below the minimum back to the default so the window

--- a/src/components/TitleBar.test.tsx
+++ b/src/components/TitleBar.test.tsx
@@ -11,21 +11,32 @@ vi.mock("@/lib/platform", () => ({
   },
 }));
 
-const { minimizeWindow, toggleMaximizeWindow, closeWindow, isWindowMaximized, onWindowResized } =
-  vi.hoisted(() => ({
-    minimizeWindow: vi.fn(),
-    toggleMaximizeWindow: vi.fn(),
-    closeWindow: vi.fn(),
-    isWindowMaximized: vi.fn(),
-    onWindowResized: vi.fn(),
-  }));
+const {
+  minimizeWindow,
+  toggleMaximizeWindow,
+  closeWindow,
+  isWindowMaximized,
+  onWindowResized,
+  emitWindowMenuEvent,
+} = vi.hoisted(() => ({
+  minimizeWindow: vi.fn(),
+  toggleMaximizeWindow: vi.fn(),
+  closeWindow: vi.fn(),
+  isWindowMaximized: vi.fn(),
+  onWindowResized: vi.fn(),
+  emitWindowMenuEvent: vi.fn(),
+}));
 vi.mock("@/lib/window", () => ({
   minimizeWindow,
   toggleMaximizeWindow,
   closeWindow,
   isWindowMaximized,
   onWindowResized,
+  emitWindowMenuEvent,
 }));
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
 
 import { TitleBar } from "./TitleBar";
 
@@ -36,6 +47,8 @@ beforeEach(() => {
   closeWindow.mockReset();
   isWindowMaximized.mockReset().mockResolvedValue(false);
   onWindowResized.mockReset().mockResolvedValue(() => {});
+  emitWindowMenuEvent.mockReset().mockResolvedValue(undefined);
+  invoke.mockReset().mockResolvedValue(undefined);
 });
 
 describe("TitleBar", () => {
@@ -67,5 +80,35 @@ describe("TitleBar", () => {
     render(<TitleBar />);
     expect(await screen.findByLabelText("Restore")).toBeInTheDocument();
     expect(screen.queryByLabelText("Maximize")).toBeNull();
+  });
+
+  it("opens the File menu and runs each action through the shared handlers", () => {
+    render(<TitleBar />);
+    fireEvent.click(screen.getByRole("button", { name: "File" }));
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /New Window/ }));
+    expect(invoke).toHaveBeenCalledWith("open_new_window");
+
+    fireEvent.click(screen.getByRole("button", { name: "File" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Close Tab/ }));
+    expect(emitWindowMenuEvent).toHaveBeenCalledWith("menu:close-tab");
+  });
+
+  it("selecting an item closes the menu", () => {
+    render(<TitleBar />);
+    fireEvent.click(screen.getByRole("button", { name: "Window" }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Close Window/ }));
+    expect(closeWindow).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("clicking the open menu button toggles it shut", () => {
+    render(<TitleBar />);
+    const fileButton = screen.getByRole("button", { name: "File" });
+    fireEvent.click(fileButton);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.click(fileButton);
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 });

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -180,7 +180,7 @@ function WindowMenuBar() {
           // Once a menu is open, hovering a sibling switches to it — standard
           // menu-bar behaviour.
           onMouseEnter={(e) => {
-            if (openId !== null) openFrom(e.currentTarget, menu.id);
+            if (openId !== null && openId !== menu.id) openFrom(e.currentTarget, menu.id);
           }}
           className={`flex h-full items-center px-3 text-[13px] transition-colors ${
             openId === menu.id
@@ -273,7 +273,7 @@ export function TitleBar() {
         data-tauri-drag-region
         className="flex h-full select-none items-center gap-1.5 pl-2.5 pr-1"
       >
-        <img src="/icon.png" alt="" className="h-4 w-4 rounded-sm" />
+        <img src="/icon.png" alt="" className="h-4 w-4 rounded-sm" draggable={false} />
         <span className="text-[13px] font-semibold text-fg">{t("appName")}</span>
       </div>
       <WindowMenuBar />

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,10 +1,14 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import { invoke } from "@tauri-apps/api/core";
 import { Minus, Square, X } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
+import { useOverlayGuard } from "@/lib/overlayGuard";
 import { IS_WINDOWS } from "@/lib/platform";
 import {
   closeWindow,
+  emitWindowMenuEvent,
   isWindowMaximized,
   minimizeWindow,
   onWindowResized,
@@ -29,12 +33,211 @@ function RestoreIcon({ size = 11 }: { size?: number }) {
   );
 }
 
+interface MenuBarItem {
+  id: string;
+  label: string;
+  /** Shortcut hint shown right-aligned (Windows Ctrl-based). */
+  shortcut?: string;
+  onSelect: () => void;
+  /** Group index; a thin divider separates consecutive groups. */
+  group?: number;
+}
+
+interface MenuBarMenu {
+  id: string;
+  label: string;
+  items: MenuBarItem[];
+}
+
+/**
+ * Text menu bar (File / Window) for the Windows title bar. The native Windows
+ * menu bar is gone because the frame is hidden (`decorations(false)`) — and even
+ * if shown it is OS-drawn and can't follow the app's theme. This self-drawn menu
+ * uses the same CSS tokens as the rest of the UI, so it recolours with the theme.
+ *
+ * Each item runs the exact same action as its macOS menu counterpart in menu.rs:
+ * New Window / Close Window act directly (invoke / closeWindow, mirroring the
+ * Rust handler's direct calls), while the frontend-driven items fire the same
+ * scoped `menu:*` event the Rust side emits, so App.tsx's existing listeners stay
+ * the single source of truth for what each action does.
+ */
+function WindowMenuBar() {
+  const { t } = useTranslation();
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null);
+  const barRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // The native preview webview floats above all DOM, so hide it while a menu is
+  // open or it would cover the dropdown (same guard ContextMenu uses).
+  useOverlayGuard(openId !== null);
+
+  const menus: MenuBarMenu[] = [
+    {
+      id: "file",
+      label: t("menuBar.file"),
+      items: [
+        {
+          id: "new-window",
+          label: t("menuBar.newWindow"),
+          shortcut: "Ctrl+N",
+          group: 0,
+          onSelect: () => void invoke("open_new_window").catch(() => {}),
+        },
+        {
+          id: "open-location",
+          label: t("menuBar.openLocation"),
+          shortcut: "Ctrl+L",
+          group: 1,
+          onSelect: () => void emitWindowMenuEvent("menu:preview-open-location"),
+        },
+        {
+          id: "setup-wizard",
+          label: t("menuBar.setupWizard"),
+          group: 2,
+          onSelect: () => void emitWindowMenuEvent("menu:rerun-setup"),
+        },
+        {
+          id: "close-tab",
+          label: t("menuBar.closeTab"),
+          shortcut: "Ctrl+W",
+          group: 3,
+          onSelect: () => void emitWindowMenuEvent("menu:close-tab"),
+        },
+      ],
+    },
+    {
+      id: "window",
+      label: t("menuBar.window"),
+      items: [
+        {
+          id: "cycle-pane",
+          label: t("menuBar.cyclePane"),
+          shortcut: "Ctrl+`",
+          onSelect: () => void emitWindowMenuEvent("menu:focus-next-pane"),
+        },
+        {
+          id: "close-window",
+          label: t("menuBar.closeWindow"),
+          shortcut: "Ctrl+Shift+W",
+          onSelect: () => void closeWindow(),
+        },
+      ],
+    },
+  ];
+
+  // Close on outside pointer / Escape / resize. The menu-bar buttons count as
+  // "inside", so clicking the open button falls through to its own onClick
+  // (which toggles it shut) instead of this handler racing to reopen it.
+  useEffect(() => {
+    if (openId === null) return;
+    function onPointerDown(event: MouseEvent) {
+      const target = event.target as Node;
+      if (barRef.current?.contains(target) || menuRef.current?.contains(target)) {
+        return;
+      }
+      setOpenId(null);
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpenId(null);
+    }
+    function onResize() {
+      setOpenId(null);
+    }
+    document.addEventListener("mousedown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    window.addEventListener("resize", onResize, true);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("resize", onResize, true);
+    };
+  }, [openId]);
+
+  function openFrom(el: HTMLElement, id: string) {
+    const rect = el.getBoundingClientRect();
+    setAnchor({ x: rect.left, y: rect.bottom });
+    setOpenId(id);
+  }
+
+  const activeMenu = menus.find((m) => m.id === openId) ?? null;
+
+  return (
+    <div ref={barRef} className="flex h-full items-center">
+      {menus.map((menu) => (
+        <button
+          key={menu.id}
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={openId === menu.id}
+          onClick={(e) => {
+            if (openId === menu.id) {
+              setOpenId(null);
+            } else {
+              openFrom(e.currentTarget, menu.id);
+            }
+          }}
+          // Once a menu is open, hovering a sibling switches to it — standard
+          // menu-bar behaviour.
+          onMouseEnter={(e) => {
+            if (openId !== null) openFrom(e.currentTarget, menu.id);
+          }}
+          className={`flex h-full items-center px-3 text-[13px] transition-colors ${
+            openId === menu.id
+              ? "bg-bg-elevated text-fg"
+              : "text-fg-muted hover:bg-bg-elevated hover:text-fg"
+          }`}
+        >
+          {menu.label}
+        </button>
+      ))}
+      {activeMenu &&
+        anchor &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            style={{ position: "fixed", left: anchor.x, top: anchor.y }}
+            className="z-[200] min-w-[220px] overflow-hidden rounded-md border border-border-strong bg-bg-elevated py-1 text-[13px] shadow-lg"
+          >
+            {activeMenu.items.map((item, index) => {
+              const previous = activeMenu.items[index - 1];
+              const newGroup =
+                previous !== undefined && (previous.group ?? 0) !== (item.group ?? 0);
+              return (
+                <div key={item.id}>
+                  {newGroup && <div className="my-1 h-px bg-border" />}
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setOpenId(null);
+                      item.onSelect();
+                    }}
+                    className="flex w-full items-center gap-6 px-3 py-1.5 text-left text-fg-muted transition-colors hover:bg-bg hover:text-fg"
+                  >
+                    <span className="truncate">{item.label}</span>
+                    {item.shortcut && (
+                      <span className="ml-auto text-[11px] text-fg-subtle">{item.shortcut}</span>
+                    )}
+                  </button>
+                </div>
+              );
+            })}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}
+
 /**
  * Custom title bar for Windows, where the native frame is hidden
- * (`decorations(false)`). A draggable region fills the left, and the
- * minimize / maximize-restore / close controls sit on the right — kept in a
- * separate, non-draggable element so clicks aren't swallowed by the drag
- * region. Renders nothing on macOS, which keeps its native overlay title bar.
+ * (`decorations(false)`). A self-drawn text menu bar sits on the left, a
+ * draggable region fills the middle, and the minimize / maximize-restore / close
+ * controls sit on the right — each control group is kept non-draggable so clicks
+ * aren't swallowed by the drag region. Renders nothing on macOS, which keeps its
+ * native overlay title bar (and native menu).
  */
 export function TitleBar() {
   const { t } = useTranslation();
@@ -64,6 +267,16 @@ export function TitleBar() {
 
   return (
     <div className="flex h-8 shrink-0 items-center border-b border-border bg-bg-inset">
+      {/* Brand mark. Kept a drag region so the window can be moved from here;
+          the img/span aren't interactive, so dragging still works. */}
+      <div
+        data-tauri-drag-region
+        className="flex h-full select-none items-center gap-1.5 pl-2.5 pr-1"
+      >
+        <img src="/icon.png" alt="" className="h-4 w-4 rounded-sm" />
+        <span className="text-[13px] font-semibold text-fg">{t("appName")}</span>
+      </div>
+      <WindowMenuBar />
       <div data-tauri-drag-region className="h-full flex-1" />
       <div className="flex h-full shrink-0 items-center">
         <Tooltip label={t("titleBar.minimize")} side="bottom">

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -90,6 +90,16 @@
     "restore": "Restore",
     "close": "Close"
   },
+  "menuBar": {
+    "file": "File",
+    "window": "Window",
+    "newWindow": "New Window",
+    "openLocation": "Open Location",
+    "setupWizard": "Setup Wizard",
+    "closeTab": "Close Tab",
+    "cyclePane": "Cycle Pane",
+    "closeWindow": "Close Window"
+  },
   "actions": {
     "newTab": "New Tab",
     "closeTab": "Close Tab",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -90,6 +90,16 @@
     "restore": "還原",
     "close": "關閉"
   },
+  "menuBar": {
+    "file": "檔案",
+    "window": "視窗",
+    "newWindow": "開新視窗",
+    "openLocation": "開啟位址列",
+    "setupWizard": "設定精靈",
+    "closeTab": "關閉分頁",
+    "cyclePane": "切換面板",
+    "closeWindow": "關閉視窗"
+  },
   "actions": {
     "newTab": "新增分頁",
     "closeTab": "關閉分頁",

--- a/src/lib/window.ts
+++ b/src/lib/window.ts
@@ -1,5 +1,5 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { UnlistenFn } from "@tauri-apps/api/event";
+import { emitTo, type UnlistenFn } from "@tauri-apps/api/event";
 import type { StateStorage } from "zustand/middleware";
 
 /**
@@ -35,6 +35,18 @@ export function closeWindow(): Promise<void> {
 /** Whether the window is currently maximized (drives the maximize/restore icon). */
 export function isWindowMaximized(): Promise<boolean> {
   return getCurrentWindow().isMaximized();
+}
+
+/**
+ * Fire a `menu:*` event to this window's own webview, mirroring exactly what the
+ * native menu does on macOS (Rust `win.emit_to(win.label(), event)` in menu.rs).
+ * Used by the Windows custom title-bar menu so a menu-bar click runs the same
+ * frontend handler as the macOS menu item and the Ctrl+key shortcut — one source
+ * of truth for each action's behaviour. Scoped to this window's label so a click
+ * never triggers the action in another open window.
+ */
+export function emitWindowMenuEvent(event: string): Promise<void> {
+  return emitTo(getCurrentWindow().label, event);
 }
 
 /** Subscribe to window resize events; returns an unlisten function. */


### PR DESCRIPTION
接續 #172。Windows 隱藏原生框架（`decorations(false)`）後連原生選單列也一起消失，`File`／`Window` 選單無從點選。本 PR 在自訂 TitleBar 內做一個**自足的文字選單列**，並修正次要視窗仍出現原生選單列的問題。

## 內容

### 1. `WindowMenuBar`（自訂文字選單列）
- Portal 下拉 + `overlayGuard`（開啟時隱藏會浮在最上層的原生預覽 webview）+ outside-click／`Esc`／resize 關閉；hover 可在已開啟的選單間切換。
- 用 app 的 CSS token 繪製，會**跟隨主題**（原生選單做不到）。
- 每個項目對應 `menu.rs` 的動作：`New Window`／`Close Window` 直接呼叫（`invoke` / `closeWindow`），其餘透過新的 `emitWindowMenuEvent` 發出與 macOS 選單相同的 scoped `menu:*` 事件——`App.tsx` 既有 listener 仍是每個動作的唯一行為來源。
- **不改動共用的 `ContextMenu`**，避免影響其 17 個呼叫端。

### 2. 左上角品牌標記
`icon.png` + **TempoTerm**（`t("appName")`），該區可拖曳移動視窗。

### 3. 修正次要視窗殘留原生選單列
`create_new_window` 在 Windows 上一併 `decorations(false)`，否則新視窗會保留原生框架＋原生選單列，自訂 TitleBar 擠在旁邊（兩條標題列）。

### 4. i18n 與測試
新增 `menuBar.*` 翻譯鍵（en / zh-Hant）與 TitleBar 選單列測試。

## 驗證
- `cargo check` **零警告** ✅（此 PR 由 Windows 機器實跑，實編 `#[cfg(windows)]` 分支）
- `tsc --noEmit` ✅
- `vitest` 全套 **1389 測試通過** ✅

> [!NOTE]
> 本 PR 另含一個獨立 commit `fix(preview): 註冊遺漏的 preview_set_bounds command`——該 command 有定義、前端也呼叫，卻漏了註冊進 `generate_handler!`，導致原生預覽 webview 的定位/縮放 invoke 一直靜默失敗（#163／#171 的原子性 bounds 修復實際未生效）。順手一併修復，並消除當前的兩個 Rust 警告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)