### PR TITLE
fix(preview): register preview_set_bounds in the invoke handler

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -224,6 +224,7 @@ pub fn run() {
             preview_create,
             preview_navigate,
             preview_reload,
+            preview_set_bounds,
             preview_history_back,
             preview_history_forward,
             preview_close,

--- a/src-tauri/src/modules/pty/shell.rs
+++ b/src-tauri/src/modules/pty/shell.rs
@@ -248,6 +248,11 @@ pub fn login_args(shell: &str) -> Vec<String> {
 /// path as a percent-encoded `file://` URI, which keeps spaces and non-ASCII
 /// (e.g. CJK folder names) unambiguous. The env marker makes the wrap
 /// idempotent if the snippet is ever sourced twice.
+// The windows-integration helpers below are only called from the
+// Windows-gated block in session.rs, but their logic is platform-neutral on
+// purpose so the unit tests exercise the Windows behavior on any host. Keep
+// them compiled everywhere and just silence the dead-code lint off-Windows.
+#[cfg_attr(not(windows), allow(dead_code))]
 const POWERSHELL_OSC7_SNIPPET: &str = r#"if ($env:TEMPOTERM_OSC7 -ne '1') {
   $env:TEMPOTERM_OSC7 = '1'
   $global:__tempoTermPrompt = $function:prompt
@@ -266,6 +271,7 @@ const POWERSHELL_OSC7_SNIPPET: &str = r#"if ($env:TEMPOTERM_OSC7 -ne '1') {
 
 /// The last path component, split on both separators so a Windows path still
 /// resolves when this code is unit-tested on Unix, lowercased for matching.
+#[cfg_attr(not(windows), allow(dead_code))]
 fn shell_file_name(shell: &str) -> String {
     shell
         .rsplit(['/', '\\'])
@@ -275,6 +281,7 @@ fn shell_file_name(shell: &str) -> String {
 }
 
 /// True for Windows PowerShell (`powershell.exe`) and PowerShell 7+ (`pwsh`).
+#[cfg_attr(not(windows), allow(dead_code))]
 fn is_powershell(shell: &str) -> bool {
     matches!(
         shell_file_name(shell).trim_end_matches(".exe"),
@@ -283,11 +290,13 @@ fn is_powershell(shell: &str) -> bool {
 }
 
 /// True for `cmd.exe`, the `COMSPEC` default.
+#[cfg_attr(not(windows), allow(dead_code))]
 fn is_cmd(shell: &str) -> bool {
     shell_file_name(shell).trim_end_matches(".exe") == "cmd"
 }
 
 /// PowerShell's `-EncodedCommand` payload: base64 of the UTF-16LE script bytes.
+#[cfg_attr(not(windows), allow(dead_code))]
 fn encoded_command(script: &str) -> String {
     let bytes: Vec<u8> = script.encode_utf16().flat_map(u16::to_le_bytes).collect();
     STANDARD.encode(bytes)
@@ -298,6 +307,7 @@ fn encoded_command(script: &str) -> String {
 /// so it works under any ExecutionPolicy (a dot-sourced `.ps1` would be blocked
 /// by the client default, `Restricted`) and needs no quoting through the
 /// Windows command line. Other shells get nothing.
+#[cfg_attr(not(windows), allow(dead_code))]
 pub fn windows_integration_args(shell: &str) -> Vec<String> {
     if !is_powershell(shell) {
         return Vec::new();
@@ -315,6 +325,7 @@ pub fn windows_integration_args(shell: &str) -> Vec<String> {
 /// `$P$G`, i.e. `C:\dir>`) with an OSC 7 report does the same job. The path
 /// arrives raw — unencoded spaces and backslashes — which the frontend parser
 /// tolerates. Other shells get nothing.
+#[cfg_attr(not(windows), allow(dead_code))]
 pub fn windows_integration_env(
     shell: &str,
     current_prompt: Option<String>,


### PR DESCRIPTION
## Summary

Two things, both driven by the unused-code warnings that show up on a macOS `pnpm tauri dev`:

**1. Real bug — `preview_set_bounds` was never registered (2 warnings).**
PR #171 added the command and switched the frontend to a single atomic `invoke("preview_set_bounds", ...)` call (`useNativePreviewWebview.ts:171`), but the command was never added to `generate_handler!`. Every invoke failed with "command not found", silently, because the caller swallows errors — so the atomic position+size fix for #163 never actually ran, on any platform. This PR registers the command.

**2. False positives — 7 Windows-integration helpers in `pty/shell.rs` (7 warnings).**
`POWERSHELL_OSC7_SNIPPET`, `shell_file_name`, `is_powershell`, `is_cmd`, `encoded_command`, `windows_integration_args`, `windows_integration_env` are only called from the Windows-gated block in `session.rs:81-90`, so non-Windows builds flag them as dead. They stay compiled on every platform on purpose — the unit tests exercise the Windows behavior on any host — so they get `#[cfg_attr(not(windows), allow(dead_code))]` instead of being cfg-gated out.

## Test plan

- [x] `cargo check` — 0 warnings (was 9)
- [x] `cargo test --lib` — 333/333 pass (Windows-behavior tests in shell.rs still compiled and green on macOS)
- [x] Tauri security review: PASS — `preview_set_bounds` label resolution goes through `ensure_preview_label()` (rejects non-`preview-`-prefixed labels), no new trust surface
- [ ] Manual: open a preview pane and confirm the webview tracks pane resize/reposition (this code path was dead until now)