### PR TITLE
fix(status-hook): Windows 上不再注入裸 .sh，停止 OpenWith 對話框轟炸 (#155)

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -4,8 +4,12 @@
 
 ### fix
 
+- 修復 Windows 上狀態 hook 反覆彈出「挑選應用程式」對話框的問題；由於 OSC→PTY 狀態機制在 Windows 無法運作，改為不再注入 hook，並自動清除舊版留下的設定 (#155)
+
 ## English
 
 ### feat
 
 ### fix
+
+- Stop the status hook from spamming the Windows "Open With" dialog: the OSC→PTY status mechanism does not work on Windows, so we no longer inject the hook there and clean up any entries an older build left behind (#155)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -152,6 +152,22 @@ pub fn run() {
                 }
             }
             modules::menu::init(app)?;
+            // Windows: the status hooks' install command is cleanup-only (#155,
+            // since a bare `.sh` hook command pops the "Open With" dialog on
+            // every event there). But the only launch-time caller of install is
+            // gated on the user's `claudeStatusTracking` setting (see App.tsx) —
+            // a user who flipped that off to work around the dialog storm would
+            // otherwise never get cleaned up. Run cleanup here instead,
+            // independent of any frontend setting, on every launch. Both
+            // uninstall fns are already best-effort and idempotent (a no-op
+            // rewrite is skipped internally — see PR #176 review Fix 3), so a
+            // direct cfg-gated call needs no extra wrapper.
+            #[cfg(target_os = "windows")]
+            {
+                let handle = app.handle().clone();
+                let _ = claude_status_hook_uninstall(handle.clone());
+                let _ = codex_status_hook_uninstall(handle);
+            }
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/modules/claude_status_hook/mod.rs
+++ b/src-tauri/src/modules/claude_status_hook/mod.rs
@@ -10,7 +10,9 @@ use tauri::{AppHandle, Manager};
 
 use crate::modules::claude_progress::config_base_dir;
 
-/// The hook script body, embedded so install can write it to disk.
+/// The hook script body, embedded so install can write it to disk. Unused on
+/// Windows, where install is cleanup-only and never writes the script (#155).
+#[cfg_attr(windows, allow(dead_code))]
 pub const HOOK_SCRIPT: &str = include_str!("status-hook.sh");
 
 /// (Claude Code hook event, status argument) pairs we install. The argument is
@@ -31,6 +33,7 @@ const EVENTS: &[(&str, &str)] = &[
     ("SessionEnd", "end"),
 ];
 
+#[cfg_attr(windows, allow(dead_code))]
 fn our_command(script_path: &str, state: &str) -> String {
     format!("{script_path} {state}")
 }
@@ -48,7 +51,9 @@ fn normalize(s: &str) -> String {
 }
 
 /// Add our hook entry to each event without disturbing the user's own hooks.
-/// Idempotent: re-running never duplicates our entries.
+/// Idempotent: re-running never duplicates our entries. Unused on Windows, where
+/// install is cleanup-only and never merges our entries in (#155).
+#[cfg_attr(windows, allow(dead_code))]
 pub fn merge_hook_settings(mut existing: Value, script_path: &str, events: &[(&str, &str)]) -> Value {
     if !existing.is_object() {
         existing = json!({});
@@ -158,31 +163,43 @@ fn write_settings(settings_path: &PathBuf, value: &Value) -> Result<(), String> 
 }
 
 /// Write the hook script and register its entries in settings.json. Idempotent.
+///
+/// On Windows this is a cleanup-only no-op: the status mechanism (walk the
+/// process ancestry to the PTY and write an OSC to `/dev/$tty`) has no Windows
+/// backend, and Claude Code runs `command` hooks through cmd, which cannot
+/// execute a bare forward-slash `.sh` path — it pops the Windows "Open With"
+/// picker on every hook event (#155). Since install runs on every launch when
+/// tracking is enabled, we instead strip any entries an older build wrote so
+/// affected users recover automatically.
 #[tauri::command]
 pub fn claude_status_hook_install(app: AppHandle) -> Result<(), String> {
-    let (script_path, settings_path) = paths(&app)?;
-    if let Some(dir) = script_path.parent() {
-        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
-    }
-    std::fs::write(&script_path, HOOK_SCRIPT).map_err(|e| e.to_string())?;
-    #[cfg(unix)]
+    #[cfg(windows)]
     {
+        return claude_status_hook_uninstall(app);
+    }
+    #[cfg(not(windows))]
+    {
+        let (script_path, settings_path) = paths(&app)?;
+        if let Some(dir) = script_path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        std::fs::write(&script_path, HOOK_SCRIPT).map_err(|e| e.to_string())?;
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
             .map_err(|e| e.to_string())?;
+        let script_str = script_path.to_str().ok_or("script path is not valid UTF-8")?;
+        // Canonicalize to forward slashes so the command has one stable form (see
+        // `normalize`); a no-op on Unix, but keeps install/remove symmetric.
+        let script_str = normalize(script_str);
+        let script_str = script_str.as_str();
+        // Remove our existing entries first, then merge fresh. This migrates installs
+        // from older versions whose command arguments differed (e.g. Notification
+        // used to pass "waiting-approval") or whose path used backslashes; a plain
+        // merge would leave those stale entries behind alongside the new ones.
+        let cleaned = remove_hook_settings(read_settings(&settings_path)?, script_str, EVENTS);
+        let merged = merge_hook_settings(cleaned, script_str, EVENTS);
+        write_settings(&settings_path, &merged)
     }
-    let script_str = script_path.to_str().ok_or("script path is not valid UTF-8")?;
-    // Canonicalize to forward slashes so the command bash runs is valid on Windows
-    // and has one stable form (see `normalize`).
-    let script_str = normalize(script_str);
-    let script_str = script_str.as_str();
-    // Remove our existing entries first, then merge fresh. This migrates installs
-    // from older versions whose command arguments differed (e.g. Notification
-    // used to pass "waiting-approval") or whose path used backslashes; a plain
-    // merge would leave those stale entries behind alongside the new ones.
-    let cleaned = remove_hook_settings(read_settings(&settings_path)?, script_str, EVENTS);
-    let merged = merge_hook_settings(cleaned, script_str, EVENTS);
-    write_settings(&settings_path, &merged)
 }
 
 /// Remove our settings.json entries and delete the hook script.

--- a/src-tauri/src/modules/claude_status_hook/mod.rs
+++ b/src-tauri/src/modules/claude_status_hook/mod.rs
@@ -46,7 +46,9 @@ fn our_command(script_path: &str, state: &str) -> String {
 /// forward-slash form. Applied unconditionally: Unix paths never contain a
 /// backslash, so this is effectively a no-op there, and keeping it
 /// platform-agnostic lets the dedup logic be tested on any CI runner.
-fn normalize(s: &str) -> String {
+/// `pub(crate)`: `codex_status_hook` mirrors this same normalize-before-match
+/// step for its own hooks.json cleanup (see #155 follow-up).
+pub(crate) fn normalize(s: &str) -> String {
     s.replace('\\', "/")
 }
 
@@ -202,21 +204,38 @@ pub fn claude_status_hook_install(app: AppHandle) -> Result<(), String> {
     }
 }
 
-/// Remove our settings.json entries and delete the hook script.
+/// Remove our entries from the settings file at `settings_path`, skipping the
+/// rewrite entirely when nothing changed. `raw_script_path` need not be
+/// pre-normalized: it is normalized internally (see `normalize`) before
+/// matching, so entries are found regardless of which slash style
+/// `script_path.to_str()` produced (e.g. an old Windows build's backslash
+/// path) — PR #176 review Fix 1. Only rewrites when an entry was actually
+/// removed, so a file with nothing of ours in it (the common case on every
+/// launch) is never touched — no re-sorted keys, no race with Claude Code's
+/// own writes — PR #176 review Fix 3. A missing file is a no-op, so
+/// uninstalling never creates an empty `{}` file for a user with no settings.
+fn cleanup_settings(settings_path: &PathBuf, raw_script_path: &str) -> Result<(), String> {
+    if !settings_path.exists() {
+        return Ok(());
+    }
+    let script_path = normalize(raw_script_path);
+    let existing = read_settings(settings_path)?;
+    let cleaned = remove_hook_settings(existing.clone(), &script_path, EVENTS);
+    if cleaned != existing {
+        write_settings(settings_path, &cleaned)?;
+    }
+    Ok(())
+}
+
+/// Remove our settings.json entries and delete the hook script. Also called
+/// (via `crate::modules::claude_status_hook::claude_status_hook_uninstall`)
+/// from `lib.rs`'s `.setup()` on Windows, independent of the user's
+/// `claudeStatusTracking` setting (see #155 follow-up, Fix 2).
 #[tauri::command]
 pub fn claude_status_hook_uninstall(app: AppHandle) -> Result<(), String> {
     let (script_path, settings_path) = paths(&app)?;
     let script_str = script_path.to_str().ok_or("script path is not valid UTF-8")?;
-    // Match on the same forward-slash form install wrote (see `normalize`), so we
-    // also clean up entries left by older backslash installs.
-    let script_str = normalize(script_str);
-    let script_str = script_str.as_str();
-    // Only rewrite settings.json if it already exists, so uninstalling never
-    // creates an empty `{}` file for a user who has no settings.
-    if settings_path.exists() {
-        let cleaned = remove_hook_settings(read_settings(&settings_path)?, script_str, EVENTS);
-        write_settings(&settings_path, &cleaned)?;
-    }
+    cleanup_settings(&settings_path, script_str)?;
     let _ = std::fs::remove_file(&script_path);
     if let Some(dir) = script_path.parent() {
         let _ = std::fs::remove_dir(dir); // best-effort, only succeeds when empty
@@ -284,6 +303,49 @@ mod tests {
         let other = json!({ "hooks": { "PreToolUse": [{ "hooks": [{ "type": "command", "command": "user" }] }] } });
         let cleaned = remove_hook_settings(other.clone(), "/p/status-hook.sh", EVENTS);
         assert_eq!(cleaned, other);
+    }
+
+    fn temp_dir_for(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-claude-hook-cleanup-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    // --- cleanup_settings: PR #176 review findings ---------------------------
+
+    #[test]
+    fn cleanup_settings_skips_rewrite_when_nothing_to_remove() {
+        // Fix 3: a settings.json with no tempo-term entries must come out
+        // byte-identical, including key order. serde_json has no preserve_order
+        // feature, so any unconditional rewrite would re-sort these keys
+        // alphabetically even though nothing changed — that's the bug.
+        let dir = temp_dir_for("noop");
+        let settings_path = dir.join("settings.json");
+        let original = "{\n  \"zeta\": 1,\n  \"alpha\": 2\n}\n";
+        std::fs::write(&settings_path, original).unwrap();
+
+        cleanup_settings(&settings_path, "/p/status-hook.sh").unwrap();
+
+        let after = std::fs::read_to_string(&settings_path).unwrap();
+        assert_eq!(after, original, "file with nothing to remove must be left byte-identical");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cleanup_settings_rewrites_when_an_entry_is_actually_removed() {
+        let dir = temp_dir_for("changed");
+        let settings_path = dir.join("settings.json");
+        let merged = merge_hook_settings(json!({}), "/p/status-hook.sh", EVENTS);
+        std::fs::write(&settings_path, serde_json::to_string_pretty(&merged).unwrap()).unwrap();
+
+        cleanup_settings(&settings_path, "/p/status-hook.sh").unwrap();
+
+        let after: Value = serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        assert!(after.get("hooks").is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/modules/codex_status_hook/mod.rs
+++ b/src-tauri/src/modules/codex_status_hook/mod.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 use toml_edit::{DocumentMut, Item, Table, value};
 
-use crate::modules::claude_status_hook::remove_hook_settings;
+use crate::modules::claude_status_hook::{normalize, remove_hook_settings};
 // Only the non-Windows install path merges our entries and writes the script;
 // on Windows install is cleanup-only (#155), so these would be unused there.
 #[cfg(not(windows))]
@@ -108,17 +108,41 @@ pub fn codex_status_hook_install(app: AppHandle) -> Result<(), String> {
     }
 }
 
+/// Remove our entries from `hooks_path`, skipping the rewrite entirely when
+/// nothing changed. `raw_script_path` need not be pre-normalized: it is
+/// normalized internally (see `normalize`) before matching, mirroring
+/// `claude_status_hook`'s `cleanup_settings`. Without this, `remove_hook_settings`
+/// only normalizes the *stored* side, so a raw backslash needle (as
+/// `script_path.to_str()` yields on Windows) never matches, and the delegated
+/// cleanup silently removes zero entries — PR #176 review Fix 1. Only rewrites
+/// when an entry was actually removed, so a hooks.json with nothing of ours in
+/// it (the common case on every launch) is left untouched — PR #176 review
+/// Fix 3. A missing file is a no-op.
+fn cleanup_hooks_json(hooks_path: &PathBuf, raw_script_path: &str) -> Result<(), String> {
+    if !hooks_path.exists() {
+        return Ok(());
+    }
+    let script_path = normalize(raw_script_path);
+    let existing = read_json(hooks_path)?;
+    let cleaned = remove_hook_settings(existing.clone(), &script_path, CODEX_EVENTS);
+    if cleaned != existing {
+        let text = serde_json::to_string_pretty(&cleaned).map_err(|e| e.to_string())? + "\n";
+        write_atomic(hooks_path, &text)?;
+    }
+    Ok(())
+}
+
+/// Also called (via
+/// `crate::modules::codex_status_hook::codex_status_hook_uninstall`) from
+/// `lib.rs`'s `.setup()` on Windows, independent of the user's
+/// `claudeStatusTracking` setting (see #155 follow-up, Fix 2).
 #[tauri::command]
 pub fn codex_status_hook_uninstall(app: AppHandle) -> Result<(), String> {
     let (script_path, hooks_path, _config_path) = codex_paths(&app)?;
     let script_str = script_path.to_str().ok_or("script path is not valid UTF-8")?;
     // Leave `[features] hooks = true` in config.toml: it is shared infra other
     // tools (e.g. CodeIsland) rely on. Only remove our hooks.json entries + script.
-    if hooks_path.exists() {
-        let cleaned = remove_hook_settings(read_json(&hooks_path)?, script_str, CODEX_EVENTS);
-        let text = serde_json::to_string_pretty(&cleaned).map_err(|e| e.to_string())? + "\n";
-        write_atomic(&hooks_path, &text)?;
-    }
+    cleanup_hooks_json(&hooks_path, script_str)?;
     let _ = std::fs::remove_file(&script_path);
     if let Some(dir) = script_path.parent() {
         let _ = std::fs::remove_dir(dir);
@@ -212,5 +236,78 @@ mod tests {
         assert!(out.contains("# flag for multi-agent"));
         assert!(out.contains("multi_agent = true"));
         assert!(out.contains("hooks = true"));
+    }
+
+    fn temp_dir_for(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("tt-codex-hook-cleanup-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    // --- cleanup_hooks_json: PR #176 review findings --------------------------
+
+    #[test]
+    fn cleanup_hooks_json_removes_stale_backslash_entries_given_a_raw_backslash_path() {
+        // Fix 1: on Windows, `script_path.to_str()` yields backslashes. The
+        // stored command may also be backslash (an old Windows build wrote it
+        // raw, no normalize). remove_hook_settings only normalizes the stored
+        // side, so the caller's needle must be normalized too, or nothing
+        // matches and the delegated cleanup silently removes zero entries.
+        let dir = temp_dir_for("backslash-needle");
+        let hooks_path = dir.join("hooks.json");
+        let stale = json!({
+            "hooks": {
+                "PreToolUse": [
+                    { "hooks": [{ "type": "command", "command": r"C:\Users\me\.codex\tempoterm\status-hook.sh active" }] }
+                ]
+            }
+        });
+        std::fs::write(&hooks_path, serde_json::to_string_pretty(&stale).unwrap()).unwrap();
+
+        // Raw, un-normalized script path, exactly as `script_path.to_str()`
+        // would hand it to us on Windows.
+        let raw_script_path = r"C:\Users\me\.codex\tempoterm\status-hook.sh";
+        cleanup_hooks_json(&hooks_path, raw_script_path).unwrap();
+
+        let after: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&hooks_path).unwrap()).unwrap();
+        assert!(after.get("hooks").is_none(), "stale backslash entry should have been removed");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cleanup_hooks_json_skips_rewrite_when_nothing_to_remove() {
+        // Fix 3: a hooks.json with no tempo-term entries must come out
+        // byte-identical, including key order (no preserve_order feature, so
+        // any unconditional rewrite re-sorts keys alphabetically).
+        let dir = temp_dir_for("noop");
+        let hooks_path = dir.join("hooks.json");
+        let original = "{\n  \"zeta\": 1,\n  \"alpha\": 2\n}\n";
+        std::fs::write(&hooks_path, original).unwrap();
+
+        cleanup_hooks_json(&hooks_path, "/home/me/.codex/tempoterm/status-hook.sh").unwrap();
+
+        let after = std::fs::read_to_string(&hooks_path).unwrap();
+        assert_eq!(after, original, "file with nothing to remove must be left byte-identical");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cleanup_hooks_json_rewrites_when_an_entry_is_actually_removed() {
+        let dir = temp_dir_for("changed");
+        let hooks_path = dir.join("hooks.json");
+        let merged = merge_hook_settings(json!({}), "/c/status-hook.sh", CODEX_EVENTS);
+        std::fs::write(&hooks_path, serde_json::to_string_pretty(&merged).unwrap()).unwrap();
+
+        cleanup_hooks_json(&hooks_path, "/c/status-hook.sh").unwrap();
+
+        let after: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&hooks_path).unwrap()).unwrap();
+        assert!(after.get("hooks").is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/modules/codex_status_hook/mod.rs
+++ b/src-tauri/src/modules/codex_status_hook/mod.rs
@@ -7,7 +7,11 @@ use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 use toml_edit::{DocumentMut, Item, Table, value};
 
-use crate::modules::claude_status_hook::{merge_hook_settings, remove_hook_settings, HOOK_SCRIPT};
+use crate::modules::claude_status_hook::remove_hook_settings;
+// Only the non-Windows install path merges our entries and writes the script;
+// on Windows install is cleanup-only (#155), so these would be unused there.
+#[cfg(not(windows))]
+use crate::modules::claude_status_hook::{merge_hook_settings, HOOK_SCRIPT};
 
 /// Codex hook event to status argument. No `Notification` catch-all: Codex signals
 /// approval directly via `PermissionRequest`.
@@ -63,36 +67,45 @@ fn write_atomic(path: &Path, text: &str) -> Result<(), String> {
     })
 }
 
+/// Mirror of `claude_status_hook_install`. On Windows this is a cleanup-only
+/// no-op: the OSC→PTY status mechanism has no Windows backend, and a bare
+/// forward-slash `.sh` hook command pops the Windows "Open With" picker on every
+/// event (#155). Since install runs on every launch, we strip any entries an
+/// older build wrote so affected users recover automatically.
 #[tauri::command]
 pub fn codex_status_hook_install(app: AppHandle) -> Result<(), String> {
-    let (script_path, hooks_path, config_path) = codex_paths(&app)?;
-    if let Some(dir) = script_path.parent() {
-        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
-    }
-    std::fs::write(&script_path, HOOK_SCRIPT).map_err(|e| e.to_string())?;
-    #[cfg(unix)]
+    #[cfg(windows)]
     {
+        return codex_status_hook_uninstall(app);
+    }
+    #[cfg(not(windows))]
+    {
+        let (script_path, hooks_path, config_path) = codex_paths(&app)?;
+        if let Some(dir) = script_path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        std::fs::write(&script_path, HOOK_SCRIPT).map_err(|e| e.to_string())?;
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
             .map_err(|e| e.to_string())?;
-    }
-    let script_str = script_path.to_str().ok_or("script path is not valid UTF-8")?;
+        let script_str = script_path.to_str().ok_or("script path is not valid UTF-8")?;
 
-    // Ensure Codex's hooks feature is on, without clobbering the user's config.
-    let existing_toml = match std::fs::read_to_string(&config_path) {
-        Ok(t) => t,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(err) => return Err(err.to_string()),
-    };
-    if let Some(dir) = config_path.parent() {
-        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
-    }
-    write_atomic(&config_path, &ensure_hooks_feature(&existing_toml)?)?;
+        // Ensure Codex's hooks feature is on, without clobbering the user's config.
+        let existing_toml = match std::fs::read_to_string(&config_path) {
+            Ok(t) => t,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(err) => return Err(err.to_string()),
+        };
+        if let Some(dir) = config_path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        write_atomic(&config_path, &ensure_hooks_feature(&existing_toml)?)?;
 
-    let cleaned = remove_hook_settings(read_json(&hooks_path)?, script_str, CODEX_EVENTS);
-    let merged = merge_hook_settings(cleaned, script_str, CODEX_EVENTS);
-    let text = serde_json::to_string_pretty(&merged).map_err(|e| e.to_string())? + "\n";
-    write_atomic(&hooks_path, &text)
+        let cleaned = remove_hook_settings(read_json(&hooks_path)?, script_str, CODEX_EVENTS);
+        let merged = merge_hook_settings(cleaned, script_str, CODEX_EVENTS);
+        let text = serde_json::to_string_pretty(&merged).map_err(|e| e.to_string())? + "\n";
+        write_atomic(&hooks_path, &text)
+    }
 }
 
 #[tauri::command]
@@ -115,7 +128,9 @@ pub fn codex_status_hook_uninstall(app: AppHandle) -> Result<(), String> {
 
 /// Ensure `[features] hooks = true` in the given config.toml text, preserving all
 /// other keys, tables, and comments. Returns the updated text. A blank input
-/// yields a document containing just the features table.
+/// yields a document containing just the features table. Unused on Windows,
+/// where install is cleanup-only and never enables the feature (#155).
+#[cfg_attr(windows, allow(dead_code))]
 pub fn ensure_hooks_feature(existing_toml: &str) -> Result<String, String> {
     let mut doc = existing_toml
         .parse::<DocumentMut>()


### PR DESCRIPTION
## 問題 (#155)

Windows 上 Claude Code / Codex 以 cmd 執行 `command` hook，而 TempoTerm 注入的指令是裸的正斜線 `.sh` 路徑（`C:/Users/.../status-hook.sh <state>`）。cmd 無法執行 `.sh` → 觸發 Windows ShellExecute 的「挑選應用程式 / Open With」選擇器，**每個 hook 事件彈一個對話框**，一度累積 20+ 個、持續搶焦點。加上 app 每次啟動都會重新注入 `settings.json`，使用者手動移除後重啟又回來。

而這個 hook 依賴 process ancestry + `/dev/$tty` 的 OSC→PTY 機制，在 Windows 本來就無法運作，狀態燈不生效 —— 在 Windows 純粹是有害無益的副作用。

## 修法

Windows 上 `claude_status_hook_install` / `codex_status_hook_install` 改為**只清理、不注入**（委派給對應的 uninstall）。因為 install 在每次啟動、以及開啟「追蹤 Claude session 狀態」時都會呼叫：

1. **不再注入裸 `.sh`** → 對話框不再彈出。
2. **每次啟動自動清除舊版留下的 hook entry** → 已中招的使用者升級後下次啟動即自動復原（將「無條件重寫」改成「移除」）。

macOS / Linux 行為完全不變 —— 注入邏輯原封不動移進 `#[cfg(not(windows))]` 分支；只在非 Windows 使用的 helper 加 `#[cfg_attr(windows, allow(dead_code))]` 保持 Windows build 零 warning。

## 驗證

- 本機（Windows 11）`cargo check --lib`：零 warning、零 error。
- 14 個 status_hook 相關單元測試全數通過。

## 後續

Windows 的狀態燈支援會另開 PR，改用 IPC 遞送方案（native shim + loopback TCP + env 帶 pane id），已在本機實測可行。

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)