### PR TITLE
feat(status): Windows session status over a loopback socket (route 2, #155)

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -2,6 +2,8 @@
 
 ### feat
 
+- Windows 現在也能追蹤 Claude Code / Codex 的 session 狀態燈：改用本機 loopback socket 遞送狀態（app 內建的原生 shim，取代在 Windows 無法運作的 `/dev/tty` OSC 機制），狀態訊息以每個分頁的 pty id 標記回對應面板 (#155)
+
 ### fix
 
 - 修復 Windows 上狀態 hook 反覆彈出「挑選應用程式」對話框的問題；由於 OSC→PTY 狀態機制在 Windows 無法運作，改為不再注入 hook，並自動清除舊版留下的設定 (#155)
@@ -9,6 +11,8 @@
 ## English
 
 ### feat
+
+- Windows can now track Claude Code / Codex session status too: state is delivered over a local loopback socket (a native shim built into the app, replacing the `/dev/tty` OSC mechanism that has no Windows backend), tagged with each pane's pty id so it lights the right card (#155)
 
 ### fix
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -88,6 +88,17 @@ fn open_new_window(app: tauri::AppHandle) -> tauri::Result<()> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Native status-hook shim: `tempo-term --status-hook <state>`. On Windows the
+    // CLI's settings.json registers this instead of a bare `.sh` (which cmd can't
+    // run — issue #155). Handle it before Tauri starts and exit; it's a no-op
+    // outside a tempo-term pane (guards on the TEMPOTERM_* env we inject there).
+    let mut args = std::env::args().skip(1);
+    if args.next().as_deref() == Some("--status-hook") {
+        let state = args.next().unwrap_or_default();
+        modules::status_ipc::run_hook_shim(&state);
+        return;
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
@@ -149,6 +160,20 @@ pub fn run() {
                     .resolve("resources/zsh-autosuggestions.zsh", tauri::path::BaseDirectory::Resource)
                 {
                     modules::pty::shell::init_autosuggest_zdotdir(&dir, &plugin);
+                }
+            }
+            // Windows delivers Claude/Codex session status over a loopback
+            // socket instead of the Unix OSC/tty path (#155): bind the listener
+            // now, before any pane spawns, and stash its address+token so each
+            // pane's env can point its status-hook shim back here. A bind failure
+            // just leaves status tracking off — never blocks startup.
+            #[cfg(windows)]
+            {
+                match modules::status_ipc::start(app.handle()) {
+                    Ok(ipc) => {
+                        app.manage(ipc);
+                    }
+                    Err(err) => eprintln!("status-ipc listener disabled: {err}"),
                 }
             }
             modules::menu::init(app)?;

--- a/src-tauri/src/modules/claude_status_hook/mod.rs
+++ b/src-tauri/src/modules/claude_status_hook/mod.rs
@@ -49,6 +49,17 @@ pub const SHIM_MARKER: &str = "--status-hook";
 /// install/uninstall also cleans up entries a pre-IPC build wrote.
 pub const LEGACY_SCRIPT_MARKER: &str = "status-hook.sh";
 
+/// Build the shim prefix command from an already-resolved executable path.
+/// Split out from `windows_shim_prefix` so the string logic is testable on any
+/// platform (`current_exe()` itself is not worth mocking). Applies `normalize`
+/// for the same reason the script-path flows do: Claude Code runs `command`
+/// hooks through bash on a git-bash setup, which treats `\` as an escape and
+/// mangles a raw Windows path, so the shim would never run.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn windows_shim_prefix_from_exe(exe: &str) -> String {
+    format!("\"{}\" {SHIM_MARKER}", normalize(exe))
+}
+
 /// The command prefix for the native shim on Windows: the app's own executable
 /// invoked as `--status-hook`, double-quoted so cmd handles a path with spaces
 /// (e.g. under `Program Files`). `merge_hook_settings` appends ` <state>`.
@@ -56,7 +67,7 @@ pub const LEGACY_SCRIPT_MARKER: &str = "status-hook.sh";
 pub fn windows_shim_prefix() -> Result<String, String> {
     let exe = std::env::current_exe().map_err(|e| e.to_string())?;
     let exe = exe.to_str().ok_or("executable path is not valid UTF-8")?;
-    Ok(format!("\"{exe}\" {SHIM_MARKER}"))
+    Ok(windows_shim_prefix_from_exe(exe))
 }
 
 /// Canonicalize a hook command (or our script path) for storage and comparison.
@@ -486,6 +497,16 @@ mod tests {
             .filter_map(|e| e["hooks"][0]["command"].as_str())
             .collect();
         assert_eq!(cmds, vec![r#""C:\new\tempo-term.exe" --status-hook active"#]);
+    }
+
+    #[test]
+    fn windows_shim_prefix_normalizes_backslashes() {
+        // Claude Code runs `command` hooks through bash on a git-bash setup; a
+        // raw backslash path (`C:\Program Files\...`) gets its backslashes eaten
+        // as escapes and the shim never runs. The prefix must be built on the
+        // same forward-slash form as the script-path flows (see `normalize`).
+        let prefix = windows_shim_prefix_from_exe(r"C:\Program Files\TempoTerm\tempo-term.exe");
+        assert_eq!(prefix, r#""C:/Program Files/TempoTerm/tempo-term.exe" --status-hook"#);
     }
 
     #[test]

--- a/src-tauri/src/modules/claude_status_hook/mod.rs
+++ b/src-tauri/src/modules/claude_status_hook/mod.rs
@@ -33,9 +33,30 @@ const EVENTS: &[(&str, &str)] = &[
     ("SessionEnd", "end"),
 ];
 
-#[cfg_attr(windows, allow(dead_code))]
-fn our_command(script_path: &str, state: &str) -> String {
-    format!("{script_path} {state}")
+/// Build a hook command from a prefix and the state argument. The prefix is the
+/// Unix `.sh` script path, or on Windows the native shim invocation
+/// (`"<exe>" --status-hook`); either way the state is appended as the final arg.
+fn our_command(prefix: &str, state: &str) -> String {
+    format!("{prefix} {state}")
+}
+
+/// Substring identifying our native status-hook shim command in settings.json
+/// (`"<exe>" --status-hook <state>`). Used to strip stale shim entries on
+/// reinstall/uninstall no matter where the executable now lives.
+pub const SHIM_MARKER: &str = "--status-hook";
+
+/// Substring identifying the legacy Unix `.sh` hook command, so a Windows
+/// install/uninstall also cleans up entries a pre-IPC build wrote.
+pub const LEGACY_SCRIPT_MARKER: &str = "status-hook.sh";
+
+/// The command prefix for the native shim on Windows: the app's own executable
+/// invoked as `--status-hook`, double-quoted so cmd handles a path with spaces
+/// (e.g. under `Program Files`). `merge_hook_settings` appends ` <state>`.
+#[cfg(windows)]
+pub fn windows_shim_prefix() -> Result<String, String> {
+    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+    let exe = exe.to_str().ok_or("executable path is not valid UTF-8")?;
+    Ok(format!("\"{exe}\" {SHIM_MARKER}"))
 }
 
 /// Canonicalize a hook command (or our script path) for storage and comparison.
@@ -53,9 +74,8 @@ pub(crate) fn normalize(s: &str) -> String {
 }
 
 /// Add our hook entry to each event without disturbing the user's own hooks.
-/// Idempotent: re-running never duplicates our entries. Unused on Windows, where
-/// install is cleanup-only and never merges our entries in (#155).
-#[cfg_attr(windows, allow(dead_code))]
+/// Idempotent: re-running never duplicates our entries. `script_path` is the
+/// command prefix (the `.sh` path on Unix, the shim invocation on Windows).
 pub fn merge_hook_settings(mut existing: Value, script_path: &str, events: &[(&str, &str)]) -> Value {
     if !existing.is_object() {
         existing = json!({});
@@ -164,20 +184,28 @@ fn write_settings(settings_path: &PathBuf, value: &Value) -> Result<(), String> 
     Ok(())
 }
 
-/// Write the hook script and register its entries in settings.json. Idempotent.
+/// Register the status hook in settings.json. Idempotent.
 ///
-/// On Windows this is a cleanup-only no-op: the status mechanism (walk the
-/// process ancestry to the PTY and write an OSC to `/dev/$tty`) has no Windows
-/// backend, and Claude Code runs `command` hooks through cmd, which cannot
-/// execute a bare forward-slash `.sh` path — it pops the Windows "Open With"
-/// picker on every hook event (#155). Since install runs on every launch when
-/// tracking is enabled, we instead strip any entries an older build wrote so
-/// affected users recover automatically.
+/// Unix writes the `.sh` script and points the hook at it, delivering state as an
+/// OSC to `/dev/$tty`. Windows can't run a bare `.sh` through cmd (it pops the
+/// "Open With" picker — #155) and has no `/dev/$tty`, so it registers the native
+/// shim (`"<exe>" --status-hook <state>`) that reports over loopback instead (see
+/// `status_ipc`); it writes no script and migrates away any legacy `.sh` entry.
 #[tauri::command]
 pub fn claude_status_hook_install(app: AppHandle) -> Result<(), String> {
     #[cfg(windows)]
     {
-        return claude_status_hook_uninstall(app);
+        let (script_path, settings_path) = paths(&app)?;
+        // No script file on Windows — the shim is our own executable. Remove a
+        // stale `.sh` a pre-IPC build may have written.
+        let _ = std::fs::remove_file(&script_path);
+        let prefix = windows_shim_prefix()?;
+        // Strip legacy `.sh` entries and any earlier shim entry (the exe path may
+        // have moved between installs), then merge the current shim command.
+        let cleaned = remove_hook_settings(read_settings(&settings_path)?, LEGACY_SCRIPT_MARKER, EVENTS);
+        let cleaned = remove_hook_settings(cleaned, SHIM_MARKER, EVENTS);
+        let merged = merge_hook_settings(cleaned, &prefix, EVENTS);
+        return write_settings(&settings_path, &merged);
     }
     #[cfg(not(windows))]
     {
@@ -221,6 +249,10 @@ fn cleanup_settings(settings_path: &PathBuf, raw_script_path: &str) -> Result<()
     let script_path = normalize(raw_script_path);
     let existing = read_settings(settings_path)?;
     let cleaned = remove_hook_settings(existing.clone(), &script_path, EVENTS);
+    // On Windows our entry is the native shim, not the `.sh` path; strip it by
+    // its stable marker too (the exe path may have moved since install).
+    #[cfg(windows)]
+    let cleaned = remove_hook_settings(cleaned, SHIM_MARKER, EVENTS);
     if cleaned != existing {
         write_settings(settings_path, &cleaned)?;
     }
@@ -412,5 +444,60 @@ mod tests {
             .filter_map(|e| e["hooks"][0]["command"].as_str())
             .collect();
         assert_eq!(cmds, vec!["C:/Users/me/.claude/tempoterm/status-hook.sh active"]);
+    }
+
+    // The Windows install registers a native shim command instead of a `.sh`.
+    // These exercise that prefix through the shared merge/remove logic; pure, so
+    // they run on every CI runner.
+    const SHIM_PREFIX: &str = r#""C:\Program Files\TempoTerm\tempo-term.exe" --status-hook"#;
+
+    #[test]
+    fn shim_prefix_produces_quoted_exe_command() {
+        let merged = merge_hook_settings(json!({}), SHIM_PREFIX, EVENTS);
+        assert_eq!(
+            merged["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+            format!("{SHIM_PREFIX} active")
+        );
+        // Notification still forwards the sentinel the shim resolves off stdin.
+        assert_eq!(
+            merged["hooks"]["Notification"][0]["hooks"][0]["command"],
+            format!("{SHIM_PREFIX} notification")
+        );
+    }
+
+    #[test]
+    fn shim_marker_strips_our_entry_regardless_of_exe_path() {
+        let merged = merge_hook_settings(json!({}), SHIM_PREFIX, EVENTS);
+        let cleaned = remove_hook_settings(merged, SHIM_MARKER, EVENTS);
+        assert!(cleaned.get("hooks").is_none());
+    }
+
+    #[test]
+    fn windows_reinstall_replaces_a_moved_exe_shim() {
+        // A prior install pointed the shim at an old exe path; reinstall (remove
+        // by marker, then merge) must leave exactly one entry at the new path.
+        let old = merge_hook_settings(json!({}), r#""C:\old\tempo-term.exe" --status-hook"#, EVENTS);
+        let cleaned = remove_hook_settings(old, SHIM_MARKER, EVENTS);
+        let merged = merge_hook_settings(cleaned, r#""C:\new\tempo-term.exe" --status-hook"#, EVENTS);
+        let cmds: Vec<&str> = merged["hooks"]["PreToolUse"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|e| e["hooks"][0]["command"].as_str())
+            .collect();
+        assert_eq!(cmds, vec![r#""C:\new\tempo-term.exe" --status-hook active"#]);
+    }
+
+    #[test]
+    fn windows_install_strips_legacy_sh_entry() {
+        // A pre-IPC Windows build left a bare `.sh` entry (the #155 culprit); the
+        // install's remove-by-LEGACY_SCRIPT_MARKER pass must drop it.
+        let legacy = json!({
+            "hooks": { "PreToolUse": [
+                { "hooks": [{ "type": "command", "command": "C:/Users/me/.claude/tempoterm/status-hook.sh active" }] }
+            ]}
+        });
+        let cleaned = remove_hook_settings(legacy, LEGACY_SCRIPT_MARKER, EVENTS);
+        assert!(cleaned.get("hooks").is_none());
     }
 }

--- a/src-tauri/src/modules/claude_status_hook/mod.rs
+++ b/src-tauri/src/modules/claude_status_hook/mod.rs
@@ -47,6 +47,7 @@ pub const SHIM_MARKER: &str = "--status-hook";
 
 /// Substring identifying the legacy Unix `.sh` hook command, so a Windows
 /// install/uninstall also cleans up entries a pre-IPC build wrote.
+#[cfg_attr(not(windows), allow(dead_code))]
 pub const LEGACY_SCRIPT_MARKER: &str = "status-hook.sh";
 
 /// Build the shim prefix command from an already-resolved executable path.

--- a/src-tauri/src/modules/codex_status_hook/mod.rs
+++ b/src-tauri/src/modules/codex_status_hook/mod.rs
@@ -7,11 +7,12 @@ use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 use toml_edit::{DocumentMut, Item, Table, value};
 
-use crate::modules::claude_status_hook::{normalize, remove_hook_settings};
-// Only the non-Windows install path merges our entries and writes the script;
-// on Windows install is cleanup-only (#155), so these would be unused there.
+use crate::modules::claude_status_hook::{merge_hook_settings, normalize, remove_hook_settings};
+// The `.sh` body is only written on Unix; Windows registers the native shim.
 #[cfg(not(windows))]
-use crate::modules::claude_status_hook::{merge_hook_settings, HOOK_SCRIPT};
+use crate::modules::claude_status_hook::HOOK_SCRIPT;
+#[cfg(windows)]
+use crate::modules::claude_status_hook::{windows_shim_prefix, LEGACY_SCRIPT_MARKER, SHIM_MARKER};
 
 /// Codex hook event to status argument. No `Notification` catch-all: Codex signals
 /// approval directly via `PermissionRequest`.
@@ -67,16 +68,36 @@ fn write_atomic(path: &Path, text: &str) -> Result<(), String> {
     })
 }
 
-/// Mirror of `claude_status_hook_install`. On Windows this is a cleanup-only
-/// no-op: the OSC→PTY status mechanism has no Windows backend, and a bare
-/// forward-slash `.sh` hook command pops the Windows "Open With" picker on every
-/// event (#155). Since install runs on every launch, we strip any entries an
-/// older build wrote so affected users recover automatically.
+/// Mirror of `claude_status_hook_install`. Unix writes the `.sh` and points the
+/// hook at it; Windows registers the native shim (`"<exe>" --status-hook`) that
+/// reports over loopback (see `status_ipc`), because cmd can't run a bare `.sh`
+/// (#155). Either way Codex's `hooks` feature is enabled so it runs the hook.
 #[tauri::command]
 pub fn codex_status_hook_install(app: AppHandle) -> Result<(), String> {
     #[cfg(windows)]
     {
-        return codex_status_hook_uninstall(app);
+        let (script_path, hooks_path, config_path) = codex_paths(&app)?;
+        // No script file on Windows — remove a stale `.sh` a pre-IPC build wrote.
+        let _ = std::fs::remove_file(&script_path);
+
+        // Ensure Codex's hooks feature is on so it runs our shim hook.
+        let existing_toml = match std::fs::read_to_string(&config_path) {
+            Ok(t) => t,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(err) => return Err(err.to_string()),
+        };
+        if let Some(dir) = config_path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        write_atomic(&config_path, &ensure_hooks_feature(&existing_toml)?)?;
+
+        let prefix = windows_shim_prefix()?;
+        // Strip legacy `.sh` and any earlier shim entry, then merge the current one.
+        let cleaned = remove_hook_settings(read_json(&hooks_path)?, LEGACY_SCRIPT_MARKER, CODEX_EVENTS);
+        let cleaned = remove_hook_settings(cleaned, SHIM_MARKER, CODEX_EVENTS);
+        let merged = merge_hook_settings(cleaned, &prefix, CODEX_EVENTS);
+        let text = serde_json::to_string_pretty(&merged).map_err(|e| e.to_string())? + "\n";
+        return write_atomic(&hooks_path, &text);
     }
     #[cfg(not(windows))]
     {
@@ -125,6 +146,10 @@ fn cleanup_hooks_json(hooks_path: &PathBuf, raw_script_path: &str) -> Result<(),
     let script_path = normalize(raw_script_path);
     let existing = read_json(hooks_path)?;
     let cleaned = remove_hook_settings(existing.clone(), &script_path, CODEX_EVENTS);
+    // On Windows our entry is the native shim, not the `.sh` path; strip it by
+    // its stable marker too (the exe path may have moved since install).
+    #[cfg(windows)]
+    let cleaned = remove_hook_settings(cleaned, SHIM_MARKER, CODEX_EVENTS);
     if cleaned != existing {
         let text = serde_json::to_string_pretty(&cleaned).map_err(|e| e.to_string())? + "\n";
         write_atomic(hooks_path, &text)?;
@@ -152,9 +177,7 @@ pub fn codex_status_hook_uninstall(app: AppHandle) -> Result<(), String> {
 
 /// Ensure `[features] hooks = true` in the given config.toml text, preserving all
 /// other keys, tables, and comments. Returns the updated text. A blank input
-/// yields a document containing just the features table. Unused on Windows,
-/// where install is cleanup-only and never enables the feature (#155).
-#[cfg_attr(windows, allow(dead_code))]
+/// yields a document containing just the features table.
 pub fn ensure_hooks_feature(existing_toml: &str) -> Result<String, String> {
     let mut doc = existing_toml
         .parse::<DocumentMut>()

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -20,5 +20,6 @@ pub mod secrets;
 pub mod session_log;
 pub mod sessions_index;
 pub mod setup;
+pub mod status_ipc;
 pub mod sysmon;
 pub mod terminal_history;

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -62,6 +62,7 @@ fn build_shell_command(
     cwd: Option<String>,
     suggestions: bool,
     shell_override: Option<String>,
+    status_env: Vec<(String, String)>,
 ) -> (CommandBuilder, String) {
     let shell = resolve_shell_with(shell_override);
     let mut cmd = CommandBuilder::new(&shell);
@@ -101,6 +102,13 @@ fn build_shell_command(
     // so Claude sessions in other terminals never touch our UI.
     cmd.env("TEMPOTERM", "1");
 
+    // On Windows, point this pane's status-hook shim back at the app's loopback
+    // listener and tag it with the pane's pty id (see status_ipc). Empty on Unix,
+    // which delivers status through the OSC/tty path instead.
+    for (key, value) in status_env {
+        cmd.env(key, value);
+    }
+
     // When enabled, point zsh at a wrapper ZDOTDIR that loads the user's config
     // and then the bundled autosuggestions plugin. No-op for non-zsh shells.
     for (key, value) in autosuggest_env(&shell, suggestions) {
@@ -121,6 +129,7 @@ fn build_shell_command(
 /// reading) and reports the exit code through `on_exit`.
 pub fn spawn_with_sinks(
     state: &PtyState,
+    id: u32,
     cols: u16,
     rows: u16,
     cmd: CommandBuilder,
@@ -147,7 +156,6 @@ pub fn spawn_with_sinks(
         shell_name,
     });
 
-    let id = state.alloc_id();
     state.sessions.write().unwrap().insert(id, session);
 
     // Coalesce PTY output before it crosses the IPC boundary. The old design sent
@@ -241,7 +249,23 @@ pub fn spawn(
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
-    let (cmd, shell_name) = build_shell_command(cwd, suggestions, shell_override);
+    // Allocate the pty id up front so it can tag this pane's status env (the
+    // frontend matches session-status events back to the pane by this id).
+    let id = state.alloc_id();
+
+    // On Windows, hand the pane the loopback address + token + its id so its
+    // status-hook shim can report state (see status_ipc). Empty elsewhere.
+    #[cfg(windows)]
+    let status_env = {
+        use tauri::Manager;
+        app.try_state::<crate::modules::status_ipc::StatusIpc>()
+            .map(|ipc| ipc.env_for(id))
+            .unwrap_or_default()
+    };
+    #[cfg(not(windows))]
+    let status_env: Vec<(String, String)> = Vec::new();
+
+    let (cmd, shell_name) = build_shell_command(cwd, suggestions, shell_override, status_env);
 
     // Best-effort per-session logger; failure to start logging must not block
     // opening the terminal, so we discard the error and just don't log.
@@ -251,6 +275,7 @@ pub fn spawn(
 
     spawn_with_sinks(
         state,
+        id,
         cols,
         rows,
         cmd,
@@ -437,6 +462,7 @@ mod tests {
 
         spawn_with_sinks(
             &state,
+            state.alloc_id(),
             80,
             24,
             cmd,
@@ -481,7 +507,7 @@ mod tests {
     fn registers_session_in_state() {
         let state = PtyState::new();
         let cmd = CommandBuilder::new("/bin/echo");
-        let id = spawn_with_sinks(&state, 80, 24, cmd, "echo".to_string(), |_| true, |_| {})
+        let id = spawn_with_sinks(&state, state.alloc_id(), 80, 24, cmd, "echo".to_string(), |_| true, |_| {})
             .expect("spawn should succeed");
         assert!(state.get(id).is_ok());
     }

--- a/src-tauri/src/modules/status_ipc/mod.rs
+++ b/src-tauri/src/modules/status_ipc/mod.rs
@@ -36,12 +36,14 @@ pub const ENV_MARKER: &str = "TEMPOTERM";
 
 /// The Tauri event the listener emits; the frontend routes it to the pane whose
 /// pty id matches `pane_id` (see TerminalView).
+#[cfg_attr(not(windows), allow(dead_code))]
 pub const STATUS_EVENT: &str = "session-status";
 
 /// A parsed status message. `kind` is `status` (a direct state like
 /// `active`/`idle`) or `notify` (a Claude notification_type the app resolves).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(not(windows), allow(dead_code))]
 pub struct StatusMessage {
     pub pane_id: u32,
     pub kind: String,
@@ -52,6 +54,7 @@ pub struct StatusMessage {
 /// `<token>\t<paneId>\t<kind>\t<payload>`. Returns the message only when the
 /// token matches and the pane id parses, so a spoofed or malformed line is
 /// dropped. Pure so it can be unit-tested without a socket.
+#[cfg_attr(not(windows), allow(dead_code))]
 pub fn parse_message(line: &str, expected_token: &str) -> Option<StatusMessage> {
     let mut parts = line.trim_end_matches(['\n', '\r']).splitn(4, '\t');
     let token = parts.next()?;

--- a/src-tauri/src/modules/status_ipc/mod.rs
+++ b/src-tauri/src/modules/status_ipc/mod.rs
@@ -22,6 +22,11 @@ use std::net::TcpListener;
 
 use serde::Serialize;
 
+/// How long the shim waits to connect (and to write) before giving up. A status
+/// ping must never stall the hook that sent it (see module docs), so both the
+/// connect and the write below are bounded to this.
+const SEND_TIMEOUT: Duration = Duration::from_millis(200);
+
 /// Environment variable names shared by the app (which sets them per pane) and
 /// the shim (which reads them). Public so `pty::session` and the shim agree.
 pub const ENV_ADDR: &str = "TEMPOTERM_STATUS_ADDR";
@@ -103,6 +108,14 @@ impl StatusIpc {
 /// Each accepted connection is one status message; valid ones are emitted to the
 /// frontend as [`STATUS_EVENT`]. Returns the [`StatusIpc`] handle to manage, or
 /// an error if the port can't be bound (then status tracking is simply off).
+///
+/// Connections are handled sequentially on the accept-loop thread rather than
+/// one thread per connection: any local process can open connections to this
+/// loopback port, and an unbounded thread-per-connection loop lets it exhaust
+/// the process's threads. A status ping is one short line, and the tight read
+/// timeout in `handle_connection` bounds how long a slow or hung client can
+/// occupy the loop, so a flood of connections costs bounded time per
+/// connection rather than one OS thread each.
 #[cfg(windows)]
 pub fn start(app: &tauri::AppHandle) -> Result<StatusIpc, String> {
     let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| e.to_string())?;
@@ -114,11 +127,7 @@ pub fn start(app: &tauri::AppHandle) -> Result<StatusIpc, String> {
     std::thread::spawn(move || {
         for stream in listener.incoming() {
             let Ok(stream) = stream else { continue };
-            let app = app.clone();
-            let token = accept_token.clone();
-            // A short-lived thread per connection so one slow/hung client never
-            // blocks other panes' status pings.
-            std::thread::spawn(move || handle_connection(stream, &token, &app));
+            handle_connection(stream, &accept_token, &app);
         }
     });
 
@@ -130,13 +139,18 @@ pub fn start(app: &tauri::AppHandle) -> Result<StatusIpc, String> {
 
 #[cfg(windows)]
 fn handle_connection(stream: TcpStream, token: &str, app: &tauri::AppHandle) {
-    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+    // Bounded so a slow or hung client can only occupy the (single) accept
+    // loop for a short, fixed time — see `start`.
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(200)));
     let mut buf = String::new();
     // A status line is tiny; cap the read so a misbehaving client can't stream
     // unbounded data into memory.
     if stream.take(4096).read_to_string(&mut buf).is_err() {
         return;
     }
+    // The token check (first field parsed in `parse_message`) is the first
+    // gate on an accepted connection: an untrusted local process still has to
+    // guess the per-run secret before anything it sends is acted on.
     if let Some(msg) = parse_message(&buf, token) {
         use tauri::Emitter;
         let _ = app.emit(STATUS_EVENT, msg);
@@ -190,10 +204,19 @@ pub fn run_hook_shim(state: &str) {
     };
 
     let line = encode_message(&token, &pane_id, kind, &payload);
-    if let Ok(mut stream) = TcpStream::connect(&addr) {
-        let _ = stream.set_write_timeout(Some(Duration::from_millis(200)));
-        let _ = stream.write_all(line.as_bytes());
-    }
+    send_status(&addr, &line);
+}
+
+/// Connect to `addr` and write `line`, bounded by [`SEND_TIMEOUT`] on both the
+/// connect and the write so a dead or firewalled listener can never stall the
+/// hook that called us. Any failure (bad address, refused/timed-out connect,
+/// write error) is a silent no-op — see module docs. Split out from
+/// `run_hook_shim` so the socket logic is unit-testable on its own.
+fn send_status(addr: &str, line: &str) {
+    let Ok(socket_addr) = addr.parse::<std::net::SocketAddr>() else { return };
+    let Ok(mut stream) = TcpStream::connect_timeout(&socket_addr, SEND_TIMEOUT) else { return };
+    let _ = stream.set_write_timeout(Some(SEND_TIMEOUT));
+    let _ = stream.write_all(line.as_bytes());
 }
 
 /// Pull `notification_type` out of the hook's stdin JSON. Tolerant of surrounding
@@ -304,5 +327,33 @@ mod tests {
         let b = generate_token();
         assert!(!a.is_empty());
         assert_ne!(a, b, "two tokens should not collide");
+    }
+
+    #[test]
+    fn send_status_to_an_unused_port_returns_quickly() {
+        // Bind an ephemeral listener just to learn a currently-unused port, then
+        // drop it immediately so nothing is listening. A blocking connect with
+        // no timeout can stall for many seconds against a dead/firewalled
+        // listener; connect_timeout must bound the wait so a status ping can
+        // never stall the hook that sent it.
+        let addr = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap()
+        };
+        let start = std::time::Instant::now();
+        send_status(&addr.to_string(), "token\t1\tstatus\tactive");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "send_status must not block waiting on a dead listener"
+        );
+    }
+
+    #[test]
+    fn send_status_ignores_an_unparseable_address() {
+        // Not a valid SocketAddr; must return immediately rather than panic or
+        // attempt a connect.
+        let start = std::time::Instant::now();
+        send_status("not-an-address", "token\t1\tstatus\tactive");
+        assert!(start.elapsed() < std::time::Duration::from_millis(50));
     }
 }

--- a/src-tauri/src/modules/status_ipc/mod.rs
+++ b/src-tauri/src/modules/status_ipc/mod.rs
@@ -1,0 +1,308 @@
+//! Windows status delivery over a loopback socket, replacing the Unix
+//! `/dev/$tty` OSC mechanism that has no Windows backend (see
+//! `claude_status_hook`). On Windows, Claude Code / Codex run `command` hooks
+//! through cmd, which cannot execute a bare `.sh` (issue #155); instead we
+//! register a native shim — this very binary invoked as `tempo-term --status-hook
+//! <state>` — that reports the pane's live state to a small TCP listener the app
+//! runs on `127.0.0.1`. The frontend then lights the same session-status badge
+//! it lights from the OSC path on Unix.
+//!
+//! Correlation: each pane's shell is spawned with `TEMPOTERM_PANE_ID` (the pty
+//! session id) and `TEMPOTERM_STATUS_ADDR` in its environment — the same channel
+//! that already carries `TEMPOTERM=1`. The hook subprocess inherits them, so the
+//! backend knows exactly which pane a status belongs to without walking process
+//! ancestry. `TEMPOTERM_STATUS_TOKEN` is a per-run secret the shim echoes back so
+//! another local process can't spoof a pane's badge over the open loopback port.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+#[cfg(windows)]
+use std::net::TcpListener;
+
+use serde::Serialize;
+
+/// Environment variable names shared by the app (which sets them per pane) and
+/// the shim (which reads them). Public so `pty::session` and the shim agree.
+pub const ENV_ADDR: &str = "TEMPOTERM_STATUS_ADDR";
+pub const ENV_TOKEN: &str = "TEMPOTERM_STATUS_TOKEN";
+pub const ENV_PANE_ID: &str = "TEMPOTERM_PANE_ID";
+pub const ENV_MARKER: &str = "TEMPOTERM";
+
+/// The Tauri event the listener emits; the frontend routes it to the pane whose
+/// pty id matches `pane_id` (see TerminalView).
+pub const STATUS_EVENT: &str = "session-status";
+
+/// A parsed status message. `kind` is `status` (a direct state like
+/// `active`/`idle`) or `notify` (a Claude notification_type the app resolves).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusMessage {
+    pub pane_id: u32,
+    pub kind: String,
+    pub payload: String,
+}
+
+/// Wire format sent by the shim, one message per connection:
+/// `<token>\t<paneId>\t<kind>\t<payload>`. Returns the message only when the
+/// token matches and the pane id parses, so a spoofed or malformed line is
+/// dropped. Pure so it can be unit-tested without a socket.
+pub fn parse_message(line: &str, expected_token: &str) -> Option<StatusMessage> {
+    let mut parts = line.trim_end_matches(['\n', '\r']).splitn(4, '\t');
+    let token = parts.next()?;
+    // Constant-time-ish token check is overkill for a cosmetic loopback badge;
+    // a plain compare rejects spoofers well enough.
+    if token != expected_token || expected_token.is_empty() {
+        return None;
+    }
+    let pane_id: u32 = parts.next()?.parse().ok()?;
+    let kind = parts.next()?;
+    let payload = parts.next().unwrap_or("");
+    if kind != "status" && kind != "notify" {
+        return None;
+    }
+    if payload.is_empty() {
+        return None;
+    }
+    Some(StatusMessage {
+        pane_id,
+        kind: kind.to_string(),
+        payload: payload.to_string(),
+    })
+}
+
+/// Build the wire line the shim sends. Kept next to `parse_message` so the two
+/// stay in sync.
+fn encode_message(token: &str, pane_id: &str, kind: &str, payload: &str) -> String {
+    format!("{token}\t{pane_id}\t{kind}\t{payload}")
+}
+
+/// Live listener details handed to each pane so its shim can phone home.
+/// Windows-only: Unix delivers status through the OSC/`/dev/tty` path instead.
+#[cfg(windows)]
+pub struct StatusIpc {
+    addr: String,
+    token: String,
+}
+
+#[cfg(windows)]
+impl StatusIpc {
+    /// The `(name, value)` env pairs to inject into a pane spawned as `pane_id`,
+    /// so its status hook can reach us and be trusted. Returns `None` when the
+    /// listener never started (then panes simply carry no status env).
+    pub fn env_for(&self, pane_id: u32) -> Vec<(String, String)> {
+        vec![
+            (ENV_ADDR.to_string(), self.addr.clone()),
+            (ENV_TOKEN.to_string(), self.token.clone()),
+            (ENV_PANE_ID.to_string(), pane_id.to_string()),
+        ]
+    }
+}
+
+/// Bind a loopback listener on an OS-assigned port and spawn the accept loop.
+/// Each accepted connection is one status message; valid ones are emitted to the
+/// frontend as [`STATUS_EVENT`]. Returns the [`StatusIpc`] handle to manage, or
+/// an error if the port can't be bound (then status tracking is simply off).
+#[cfg(windows)]
+pub fn start(app: &tauri::AppHandle) -> Result<StatusIpc, String> {
+    let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| e.to_string())?;
+    let port = listener.local_addr().map_err(|e| e.to_string())?.port();
+    let token = generate_token();
+
+    let app = app.clone();
+    let accept_token = token.clone();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            let app = app.clone();
+            let token = accept_token.clone();
+            // A short-lived thread per connection so one slow/hung client never
+            // blocks other panes' status pings.
+            std::thread::spawn(move || handle_connection(stream, &token, &app));
+        }
+    });
+
+    Ok(StatusIpc {
+        addr: format!("127.0.0.1:{port}"),
+        token,
+    })
+}
+
+#[cfg(windows)]
+fn handle_connection(stream: TcpStream, token: &str, app: &tauri::AppHandle) {
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+    let mut buf = String::new();
+    // A status line is tiny; cap the read so a misbehaving client can't stream
+    // unbounded data into memory.
+    if stream.take(4096).read_to_string(&mut buf).is_err() {
+        return;
+    }
+    if let Some(msg) = parse_message(&buf, token) {
+        use tauri::Emitter;
+        let _ = app.emit(STATUS_EVENT, msg);
+    }
+}
+
+/// 16 random bytes, URL-safe base64. Enough to keep a co-resident local process
+/// from guessing the token and spoofing a pane's badge.
+#[cfg(windows)]
+fn generate_token() -> String {
+    use base64::Engine;
+    let mut bytes = [0u8; 16];
+    // Fall back to a weak-but-present token if the OS RNG somehow fails, rather
+    // than disabling status delivery entirely; the token only guards a cosmetic
+    // badge on a loopback-only port.
+    if orion::util::secure_rand_bytes(&mut bytes).is_err() {
+        return "tempoterm-status".to_string();
+    }
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// The status-hook shim: `tempo-term --status-hook <state>`. Reads the pane env
+/// the app injected, then delivers one status message over loopback. Runs before
+/// Tauri starts (see `run()`), does nothing outside tempo-term, and is
+/// best-effort — a status ping must never fail or slow the hook that spawned it.
+///
+/// For the `notification` catch-all state, Claude passes the event JSON on stdin;
+/// we read `notification_type` off it and forward that as the payload (kind
+/// `notify`), mirroring the Unix script. Every other state forwards directly
+/// (kind `status`).
+pub fn run_hook_shim(state: &str) {
+    if std::env::var(ENV_MARKER).ok().filter(|v| !v.is_empty()).is_none() {
+        return;
+    }
+    let addr = match std::env::var(ENV_ADDR) {
+        Ok(a) if !a.is_empty() => a,
+        _ => return,
+    };
+    let token = std::env::var(ENV_TOKEN).unwrap_or_default();
+    let pane_id = std::env::var(ENV_PANE_ID).unwrap_or_default();
+
+    let (kind, payload) = if state == "notification" {
+        let mut stdin = String::new();
+        let _ = std::io::stdin().read_to_string(&mut stdin);
+        match notification_type(&stdin) {
+            Some(t) => ("notify", t),
+            None => return, // unknown/missing type: emit nothing, like the .sh
+        }
+    } else {
+        ("status", state.to_string())
+    };
+
+    let line = encode_message(&token, &pane_id, kind, &payload);
+    if let Ok(mut stream) = TcpStream::connect(&addr) {
+        let _ = stream.set_write_timeout(Some(Duration::from_millis(200)));
+        let _ = stream.write_all(line.as_bytes());
+    }
+}
+
+/// Pull `notification_type` out of the hook's stdin JSON. Tolerant of surrounding
+/// fields; returns `None` if absent so the shim stays quiet on unknown events.
+fn notification_type(stdin_json: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(stdin_json).ok()?;
+    value
+        .get("notification_type")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOKEN: &str = "secret-token";
+
+    #[test]
+    fn parses_a_valid_status_line() {
+        let line = encode_message(TOKEN, "7", "status", "active");
+        assert_eq!(
+            parse_message(&line, TOKEN),
+            Some(StatusMessage { pane_id: 7, kind: "status".into(), payload: "active".into() })
+        );
+    }
+
+    #[test]
+    fn parses_a_notify_line() {
+        let line = encode_message(TOKEN, "3", "notify", "permission_prompt");
+        assert_eq!(
+            parse_message(&line, TOKEN),
+            Some(StatusMessage { pane_id: 3, kind: "notify".into(), payload: "permission_prompt".into() })
+        );
+    }
+
+    #[test]
+    fn tolerates_a_trailing_newline() {
+        let line = format!("{}\n", encode_message(TOKEN, "1", "status", "idle"));
+        assert!(parse_message(&line, TOKEN).is_some());
+    }
+
+    #[test]
+    fn rejects_a_wrong_token() {
+        let line = encode_message("attacker", "1", "status", "active");
+        assert_eq!(parse_message(&line, TOKEN), None);
+    }
+
+    #[test]
+    fn rejects_when_expected_token_is_empty() {
+        // A blank expected token must never match (would let any sender through).
+        let line = encode_message("", "1", "status", "active");
+        assert_eq!(parse_message(&line, ""), None);
+    }
+
+    #[test]
+    fn rejects_an_unknown_kind() {
+        let line = encode_message(TOKEN, "1", "bogus", "active");
+        assert_eq!(parse_message(&line, TOKEN), None);
+    }
+
+    #[test]
+    fn rejects_a_non_numeric_pane_id() {
+        let line = encode_message(TOKEN, "abc", "status", "active");
+        assert_eq!(parse_message(&line, TOKEN), None);
+    }
+
+    #[test]
+    fn rejects_an_empty_payload() {
+        let line = encode_message(TOKEN, "1", "status", "");
+        assert_eq!(parse_message(&line, TOKEN), None);
+    }
+
+    #[test]
+    fn payload_may_contain_hyphens_but_not_tabs() {
+        let line = encode_message(TOKEN, "9", "status", "waiting-approval");
+        assert_eq!(parse_message(&line, TOKEN).unwrap().payload, "waiting-approval");
+    }
+
+    #[test]
+    fn extracts_notification_type_from_stdin_json() {
+        let json = r#"{"session_id":"x","notification_type":"idle_prompt","other":1}"#;
+        assert_eq!(notification_type(json).as_deref(), Some("idle_prompt"));
+    }
+
+    #[test]
+    fn notification_type_absent_or_blank_is_none() {
+        assert_eq!(notification_type(r#"{"foo":"bar"}"#), None);
+        assert_eq!(notification_type(r#"{"notification_type":""}"#), None);
+        assert_eq!(notification_type("not json"), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn env_for_carries_addr_token_and_pane_id() {
+        let ipc = StatusIpc { addr: "127.0.0.1:5000".into(), token: "tok".into() };
+        let env = ipc.env_for(42);
+        assert!(env.contains(&(ENV_ADDR.to_string(), "127.0.0.1:5000".to_string())));
+        assert!(env.contains(&(ENV_TOKEN.to_string(), "tok".to_string())));
+        assert!(env.contains(&(ENV_PANE_ID.to_string(), "42".to_string())));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn generated_tokens_are_nonempty_and_vary() {
+        let a = generate_token();
+        let b = generate_token();
+        assert!(!a.is_empty());
+        assert_ne!(a, b, "two tokens should not collide");
+    }
+}

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -1,4 +1,5 @@
 import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ClipboardPaste, Copy, Loader2, WifiOff } from "lucide-react";
@@ -149,6 +150,9 @@ export function TerminalView({
   const containerRef = useRef<HTMLDivElement>(null);
   const handleRef = useRef<TerminalHandle | null>(null);
   const sessionRef = useRef<PtySession | SshSession | null>(null);
+  // The backend pty id of this pane's local session, if any. Windows matches
+  // `session-status` IPC events (see status_ipc) back to the pane by this id.
+  const ptyIdRef = useRef<number | null>(null);
   // The debounced PTY-resize pusher created in the mount effect (see its
   // comment for why it's debounced), exposed here so other effects that
   // change the pane's size (e.g. the padding-change effect below) can share
@@ -321,6 +325,40 @@ export function TerminalView({
       }
       return true; // consume so the sequence never reaches the screen
     });
+
+    // Windows delivers session status over a loopback socket instead of the
+    // OSC/tty path above, which has no Windows backend (#155). The Rust listener
+    // (see status_ipc) emits `session-status` tagged with the reporting pane's
+    // pty id; match it to this pane and feed the same store. Reconstruct the OSC
+    // payload so `parseStatusOsc` stays the single source of truth for the
+    // notify→status mapping and validation.
+    let statusEventUnlisten: (() => void) | undefined;
+    let statusEventDisposed = false;
+    if (IS_WINDOWS) {
+      void listen<{ paneId: number; kind: string; payload: string }>(
+        "session-status",
+        (event) => {
+          if (event.payload.paneId !== ptyIdRef.current) return;
+          const leaf = leafIdRef.current;
+          if (!leaf) return;
+          const parsed = parseStatusOsc(
+            `tempoterm;${event.payload.kind};${event.payload.payload}`,
+          );
+          if (parsed?.kind === "status") {
+            useSessionStatusStore.getState().setStatus(leaf, parsed.status);
+          } else if (parsed?.kind === "end") {
+            useSessionStatusStore.getState().clear(leaf);
+          }
+        },
+      )
+        .then((un) => {
+          // Race-safe under StrictMode: if the effect already cleaned up before
+          // listen() resolved, unsubscribe immediately.
+          if (statusEventDisposed) un();
+          else statusEventUnlisten = un;
+        })
+        .catch(() => {});
+    }
 
     // OSC 7 cwd reports. Two emitters use this pane-lifetime handler: the
     // Windows local shell integration (see lib/osc7.ts), and — on every
@@ -836,6 +874,9 @@ export function TerminalView({
           return;
         }
         sessionRef.current = session;
+        // Record the pty id so Windows status-IPC events can be matched to this
+        // pane (see the session-status listener); SSH panes have no pty id.
+        ptyIdRef.current = isPtySession(session) ? session.id : null;
         // Register live SSH session so ConnectionsPanel can show forwarding status.
         const paneSshConn = sshRef.current;
         if (paneSshConn && !isPtySession(session)) {
@@ -960,6 +1001,8 @@ export function TerminalView({
       document.removeEventListener("keydown", onKeyDownCapture, true);
       document.removeEventListener("paste", onPasteCapture, true);
       statusOscHandler.dispose();
+      statusEventDisposed = true;
+      statusEventUnlisten?.();
       osc7Handler?.dispose();
       if (leafIdRef.current) {
         unregisterTerminal(leafIdRef.current);


### PR DESCRIPTION
> **Stacked on #176.** Base is the #176 branch so this diff shows only route 2. Retarget to `master` once #176 merges. **Draft** pending one manual Windows E2E check (see below).

## 背景

Unix 的狀態 hook 靠走 process ancestry 找到 `/dev/$tty` 再寫 OSC —— 這兩者在 Windows 都不存在,所以狀態燈在 Windows 從來沒生效過。#176 先「止血」:Windows 上不注入 hook,擋掉 OpenWith 對話框。本 PR 補上 Windows 真正可行的遞送路徑(route 2),已在 Windows 11 實測。

## 做法

- **原生 shim**:本執行檔以 `tempo-term --status-hook <state>` 呼叫,在 Tauri 啟動前處理。cmd 執行 `.exe` 乾淨無對話框(不像裸 `.sh`)。讀取分頁 env 後,經 loopback TCP 送一則訊息;best-effort,永不阻塞 hook。
- **loopback listener**:`127.0.0.1` OS 指派埠,setup 時啟動;合法訊息以 Tauri 事件 `session-status` 發給前端。
- **關聯靠 env**:每個分頁 shell 注入 `TEMPOTERM_PANE_ID`(該分頁的 pty id)+ `TEMPOTERM_STATUS_ADDR` + 每次執行隨機的 `TEMPOTERM_STATUS_TOKEN`,走的正是 `TEMPOTERM=1` 既有那條 env 通道。token 防止同機其他 process 偽造(僅為裝飾性 badge)。
- **install 改動**:Windows 上 claude / codex install 改註冊 shim 指令(並清除舊版 `.sh` entry),同時開啟 Codex 的 hooks 功能;**Unix 的 `.sh`+OSC 路徑完全不動**。
- **前端**:`TerminalView` 監聽 `session-status`,以 pty id 對應回面板,重用 `parseStatusOsc`(notify→status 對應與驗證只有一處)。OSC handler 保留給 Unix 與遠端 SSH。

## 為什麼安全改動風險低

所有新接線都是 `#[cfg(windows)]` 或 `IS_WINDOWS` gate,**Unix 行為逐位元組不變**。開發機是 Windows,無法驗證 macOS,因此刻意不碰 Unix 路徑。

## 驗證

- 342 個 Rust lib 測試 + 259 個前端測試通過(4 個 pty/git 失敗是本機環境問題 —— `/bin/echo` 不存在、CRLF —— 與本 PR 無關,在 master 上也失敗)。
- **實測真實編譯出的 shim**:透過 `cmd /c` 呼叫 `tempo-term.exe --status-hook`,五種直接狀態 + 兩種 notification(從 stdin 讀 `notification_type`)全部正確送達,token/pane/格式無誤;無 `TEMPOTERM` 時靜默。
- 傳輸層(TCP + cmd + env)先前已用獨立原型在本機證實可行。

## 合併前尚需人工確認

在 Windows build 裡跑一個**真實 Claude session**,確認 card badge 會亮 —— 這一步無法在此無頭環境驅動(需要 GUI + 真的 hook 執行鏈)。這也是本 PR 維持 draft 的原因。

🤖 Generated with [Claude Code](https://claude.com/claude-code)