### PR TITLE
feat(sessions): session 標題優先採用 Claude Code /rename 名稱

### DIFF
--- a/src-tauri/src/modules/claude_progress/mod.rs
+++ b/src-tauri/src/modules/claude_progress/mod.rs
@@ -17,11 +17,14 @@ use tauri::{AppHandle, Emitter, Manager, State};
 /// Longest session title we keep; longer text is truncated for display.
 const MAX_TITLE_CHARS: usize = 80;
 
-/// Derive a human-readable title for a session from its transcript JSONL: the
-/// latest `ai-title` record's title, else the first user text message. Returns
-/// trimmed text truncated to MAX_TITLE_CHARS characters, or None when neither
-/// source exists.
+/// Derive a human-readable title for a session from its transcript JSONL, in
+/// priority order: the name the user set with Claude Code's `/rename` (latest
+/// wins), else the latest `ai-title` record, else the first user text message.
+/// Returns trimmed text truncated to MAX_TITLE_CHARS characters, or None when no
+/// source exists. The `/rename` name is preferred because it is the user's
+/// explicit intent; the other two are the fallback when they never renamed.
 pub fn extract_session_title(contents: &str) -> Option<String> {
+    let mut renamed: Option<String> = None;
     let mut ai_title: Option<String> = None;
     let mut first_user: Option<String> = None;
     for line in contents.lines() {
@@ -39,18 +42,46 @@ pub fn extract_session_title(contents: &str) -> Option<String> {
                     ai_title = Some(title.to_string());
                 }
             }
+            // `/rename` is echoed into the transcript as a local-command result
+            // ("<local-command-stdout>Session renamed to: NAME</local-command-stdout>").
+            // Latest one wins, so keep overwriting.
+            Some("system") => {
+                if let Some(name) = value
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .and_then(parse_renamed_name)
+                {
+                    renamed = Some(name);
+                }
+            }
             Some("user") if first_user.is_none() => {
                 first_user = user_message_text(&value);
             }
             _ => {}
         }
     }
-    let raw = ai_title.or(first_user)?;
+    let raw = renamed.or(ai_title).or(first_user)?;
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return None;
     }
     Some(trimmed.chars().take(MAX_TITLE_CHARS).collect())
+}
+
+/// Extract the name from a Claude Code `/rename` local-command output string,
+/// e.g. "<local-command-stdout>Session renamed to: my-name</local-command-stdout>"
+/// -> "my-name". None when the marker is absent or the name is empty.
+fn parse_renamed_name(content: &str) -> Option<String> {
+    const MARKER: &str = "Session renamed to: ";
+    let start = content.rfind(MARKER)? + MARKER.len();
+    let rest = &content[start..];
+    let end = rest.find("</local-command-stdout>").unwrap_or(rest.len());
+    let name = rest[..end].trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
 }
 
 /// The text of a user message whose content is a plain string or a list holding
@@ -407,6 +438,48 @@ mod tests {
             "\n",
         );
         assert_eq!(extract_session_title(contents).as_deref(), Some("Refined title"));
+    }
+
+    #[test]
+    fn title_prefers_the_rename_over_ai_title_and_first_message() {
+        let contents = concat!(
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"do a thing"}]}}"#,
+            "\n",
+            r#"{"type":"ai-title","aiTitle":"Auto title"}"#,
+            "\n",
+            r#"{"type":"system","subtype":"local_command","content":"<local-command-stdout>Session renamed to: old-name</local-command-stdout>"}"#,
+            "\n",
+            r#"{"type":"system","subtype":"local_command","content":"<local-command-stdout>Session renamed to: my-feature</local-command-stdout>"}"#,
+            "\n",
+        );
+        // Latest /rename wins over the auto ai-title and the first message.
+        assert_eq!(extract_session_title(contents).as_deref(), Some("my-feature"));
+    }
+
+    #[test]
+    fn title_falls_back_when_no_rename_present() {
+        // A system line that is not a rename must not break the ai-title fallback.
+        let contents = concat!(
+            r#"{"type":"system","subtype":"local_command","content":"<local-command-stdout>something else</local-command-stdout>"}"#,
+            "\n",
+            r#"{"type":"ai-title","aiTitle":"Auto title"}"#,
+            "\n",
+        );
+        assert_eq!(extract_session_title(contents).as_deref(), Some("Auto title"));
+    }
+
+    #[test]
+    fn parse_renamed_name_extracts_and_guards_empty() {
+        assert_eq!(
+            parse_renamed_name("<local-command-stdout>Session renamed to: abc</local-command-stdout>").as_deref(),
+            Some("abc"),
+        );
+        assert_eq!(parse_renamed_name("Session renamed to: bare-name").as_deref(), Some("bare-name"));
+        assert_eq!(parse_renamed_name("no marker here"), None);
+        assert_eq!(
+            parse_renamed_name("<local-command-stdout>Session renamed to: </local-command-stdout>"),
+            None,
+        );
     }
 
     #[test]

--- a/src-tauri/src/modules/claude_progress/mod.rs
+++ b/src-tauri/src/modules/claude_progress/mod.rs
@@ -44,8 +44,11 @@ pub fn extract_session_title(contents: &str) -> Option<String> {
             }
             // `/rename` is echoed into the transcript as a local-command result
             // ("<local-command-stdout>Session renamed to: NAME</local-command-stdout>").
-            // Latest one wins, so keep overwriting.
-            Some("system") => {
+            // Restrict to `local_command` so an unrelated system line that merely
+            // quotes the phrase can't be mistaken for a rename. Latest one wins.
+            Some("system")
+                if value.get("subtype").and_then(Value::as_str) == Some("local_command") =>
+            {
                 if let Some(name) = value
                     .get("content")
                     .and_then(Value::as_str)
@@ -76,7 +79,9 @@ fn parse_renamed_name(content: &str) -> Option<String> {
     let start = content.rfind(MARKER)? + MARKER.len();
     let rest = &content[start..];
     let end = rest.find("</local-command-stdout>").unwrap_or(rest.len());
-    let name = rest[..end].trim();
+    // Only the first line: guards against trailing hooks/prompt output that some
+    // shells append after the rename notice.
+    let name = rest[..end].lines().next().unwrap_or("").trim();
     if name.is_empty() {
         None
     } else {
@@ -480,6 +485,24 @@ mod tests {
             parse_renamed_name("<local-command-stdout>Session renamed to: </local-command-stdout>"),
             None,
         );
+        // Trailing hook/prompt output after the name is dropped (first line only).
+        assert_eq!(
+            parse_renamed_name("Session renamed to: my-name\nhook: did a thing\n$ ").as_deref(),
+            Some("my-name"),
+        );
+    }
+
+    #[test]
+    fn rename_only_counts_local_command_system_lines() {
+        // A system line that quotes the phrase but is NOT a local_command must be
+        // ignored, so the title falls back rather than mis-reading it as a rename.
+        let contents = concat!(
+            r#"{"type":"system","subtype":"info","content":"note: Session renamed to: not-a-real-rename"}"#,
+            "\n",
+            r#"{"type":"ai-title","aiTitle":"Auto title"}"#,
+            "\n",
+        );
+        assert_eq!(extract_session_title(contents).as_deref(), Some("Auto title"));
     }
 
     #[test]


### PR DESCRIPTION
## 摘要
AI session 列表原本只用 `ai-title` 或第一則 user 訊息當標題，常顯示 `<system-reminder>…`、`<command-name>/clear` 等雜訊。改成**優先顯示使用者用 Claude Code `/rename` 設定的名稱**。

## 作法
`extract_session_title()`（`claude_progress/mod.rs`）新增優先序：
1. **`/rename` 名稱**（最新一次）— 從 transcript 的 local-command 輸出 `Session renamed to: NAME` 擷取。
2. `ai-title` 記錄（原有）。
3. 第一則 user 訊息（原有）。

抓不到 rename 就退回 2/3，即原本行為，**不會變空白**。純後端、無前端改動。

## 測試
新增 3 個測試（rename 優先且最新一次勝出、無 rename 時 fallback、`parse_renamed_name` 邊界含空名），`cargo test claude_progress` 23 passed。

## 備註
- Codex：其 `thread_name` 目前也是自動衍生、CLI 無互動式 rename，改讀效益低，本 PR 不含。
- Antigravity：無已知命名機制，不含。
- session 索引會快取標題，既有 session 需重新索引後才更新（新對話即時生效）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)