### PR TITLE
fix(workspace): localize default name for newly created groups

### DIFF
--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -278,6 +278,7 @@
     },
     "spaces": "Groups",
     "newSpace": "New group",
+    "spaceDefaultName": "Group {{index}}",
     "renameSpace": "Rename group",
     "deleteSpace": "Delete group",
     "addTab": "Add tab",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -278,6 +278,7 @@
     },
     "spaces": "群組",
     "newSpace": "新增群組",
+    "spaceDefaultName": "群組 {{index}}",
     "renameSpace": "重新命名群組",
     "deleteSpace": "刪除群組",
     "addTab": "新增分頁",

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
+import i18n from "@/i18n";
 import { uid } from "@/lib/id";
 import { perWindowStorage } from "@/lib/window";
 import { markFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
@@ -181,6 +182,10 @@ interface TabsState {
 const nextTabId = () => uid("tab");
 const nextPaneId = () => uid("pane");
 const nextSpaceId = () => uid("space");
+
+/** Default name for a newly created space, localized (e.g. "Group 3" / "群組 3"). */
+const defaultSpaceName = (index: number) =>
+  i18n.t("workspace.spaceDefaultName", { index });
 
 function basename(path: string): string {
   const seg = path.replace(/[\\/]+$/, "").split(/[\\/]/).pop();
@@ -395,7 +400,7 @@ export const useTabsStore = create<TabsState>()(
       return current;
     }
     const id = nextSpaceId();
-    const name = `Workspace ${get().spaces.length + 1}`;
+    const name = defaultSpaceName(get().spaces.length + 1);
     set((state) => ({ spaces: [...state.spaces, { id, name }], activeSpaceId: id }));
     return id;
   },
@@ -403,7 +408,7 @@ export const useTabsStore = create<TabsState>()(
   newSpace: (name) => {
     const id = nextSpaceId();
     set((state) => ({
-      spaces: [...state.spaces, { id, name: name ?? `Workspace ${state.spaces.length + 1}` }],
+      spaces: [...state.spaces, { id, name: name ?? defaultSpaceName(state.spaces.length + 1) }],
       activeSpaceId: id,
       activeId: null,
     }));


### PR DESCRIPTION
## Summary

New groups created via the "New group" button (or implicitly via `ensureSpace`) were always named `Workspace N`, regardless of UI language — a leftover from before the feature was renamed to "Group" (#178). This PR localizes the default name:

- English: `Group 1`, `Group 2`, …
- Traditional Chinese: `群組 1`, `群組 2`, …

## Changes

- Add `workspace.spaceDefaultName` key to `en/common.json` and `zh-Hant/common.json`
- Add a `defaultSpaceName()` helper in `tabsStore.ts` backed by `i18n.t`, used by both `ensureSpace` and `newSpace`

## Notes

- The name is resolved at creation time and persisted, so switching language later does not rename existing groups
- Previously persisted `Workspace N` names are user data and stay untouched

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run src/stores/tabsStore.test.ts src/i18n/config.test.ts` — 125 tests pass
- [ ] Manual: create group under zh-Hant → `群組 N`; under en → `Group N`