### PR TITLE
test: restore localStorage in Node 26

### DIFF
--- a/src/test/setup.test.ts
+++ b/src/test/setup.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+describe("test setup", () => {
+  it("exposes jsdom localStorage on the test global", () => {
+    const testDom = (globalThis as typeof globalThis & {
+      jsdom: { window: Window };
+    }).jsdom;
+
+    expect(globalThis.localStorage).toBe(testDom.window.localStorage);
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,20 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
+// Node 26 exposes a disabled localStorage accessor by default. Vitest 3 sees
+// that accessor and skips copying jsdom's Storage instance onto the test global,
+// leaving localStorage undefined. Restore jsdom's browser-faithful storage.
+const testDom = (globalThis as typeof globalThis & {
+  jsdom?: { window: Window };
+}).jsdom;
+
+if (testDom) {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: testDom.window.localStorage,
+  });
+}
+
 // jsdom ships without a canvas implementation, a ResizeObserver or matchMedia.
 // xterm.js touches all three at import/render time, so provide light stubs to
 // keep the test console clean and let terminal-adjacent components mount.


### PR DESCRIPTION
## Summary
- restore jsdom localStorage in the Vitest setup when Node 26 exposes a disabled global accessor
- add a regression test that verifies the test global uses jsdom storage

## Validation
- `pnpm typecheck`
- `pnpm test`: 1,337 tests pass; this removes the localStorage cascade. The remaining 7 failed suites are the pre-existing `react-i18next` incomplete-mock issue, intentionally out of scope for this focused test-harness fix.