### PR TITLE
test: export initReactI18next from react-i18next mocks

### DIFF
--- a/src/modules/explorer/FileFinder.test.tsx
+++ b/src/modules/explorer/FileFinder.test.tsx
@@ -6,6 +6,7 @@ import { useRecentFilesStore } from "./lib/recentFiles";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
 vi.mock("./lib/fsBridge", () => ({

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -6,6 +6,7 @@ import { useTabsStore } from "@/stores/tabsStore";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
 vi.mock("./lib/fsBridge", () => ({

--- a/src/modules/notes/NotesSidebar.test.tsx
+++ b/src/modules/notes/NotesSidebar.test.tsx
@@ -8,6 +8,7 @@ import { pickNotesFolder } from "./lib/pickNotesFolder";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
 vi.mock("./lib/pickNotesFolder", () => ({

--- a/src/modules/sessions/SessionsPanel.test.tsx
+++ b/src/modules/sessions/SessionsPanel.test.tsx
@@ -50,6 +50,7 @@ vi.mock("react-i18next", () => ({
     t: (key: string, opts?: Record<string, unknown>) =>
       opts?.count !== undefined ? `${key}:${opts.count}` : key,
   }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
 function session(overrides: Partial<SessionSummary>): SessionSummary {

--- a/src/modules/sessions/SessionsTabContent.test.tsx
+++ b/src/modules/sessions/SessionsTabContent.test.tsx
@@ -86,6 +86,7 @@ vi.mock("react-i18next", () => ({
     t: (key: string, opts?: Record<string, unknown>) =>
       opts?.count !== undefined ? `${key}:${opts.count}` : key,
   }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
 function session(overrides: Partial<SessionSummary>): SessionSummary {

--- a/src/modules/ssh/ConnectionsPanel.test.tsx
+++ b/src/modules/ssh/ConnectionsPanel.test.tsx
@@ -9,6 +9,7 @@ vi.mock("react-i18next", () => ({
     t: (key: string, opts?: Record<string, unknown>) =>
       opts?.name ? `${key}:${opts.name}` : key,
   }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
 const CONNECTION = {

--- a/src/modules/terminal/PaneTabContent.test.tsx
+++ b/src/modules/terminal/PaneTabContent.test.tsx
@@ -13,6 +13,7 @@ vi.mock("react-i18next", () => ({
     t: (key: string, opts?: Record<string, unknown>) =>
       opts?.name ? `${key}:${opts.name}` : key,
   }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
 // TerminalView (rendered by every pane here) calls getCurrentWebview() on mount


### PR DESCRIPTION
Closes #192

## Summary

Seven test files failed at collection with `No "initReactI18next" export is defined on the "react-i18next" mock`. They transitively import `@/stores/tabsStore` → `@/i18n`, whose module-load side effect calls `i18n.use(initReactI18next).init(...)`, but each file's `vi.mock("react-i18next", ...)` factory only stubbed `useTranslation`. Pre-existing on master (reproduced on e0f4817).

Fix: add `initReactI18next: { type: "3rdParty", init: () => {} }` to each of the seven mock factories. Test-only change; no production code touched, no assertions altered.

## Test plan

- [x] The seven files collect and pass
- [x] Full suite: 174/174 test files, 1470/1470 tests passing (previously 167 files / 1364 tests collected)
- [x] `tsc --noEmit` clean