### PR TITLE
ci: add per-PR Windows cargo check (#191)

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -1,0 +1,58 @@
+name: Windows Check
+
+# Lightweight per-PR Windows compile check.
+#
+# PR #190 introduced the first cfg-split Rust code: `set_native_menu`'s
+# `#[cfg(not(target_os = "macos"))]` no-op stub plus `dead_code`-guarded model
+# structs. Those guards only get exercised against a Windows target, which
+# previously happened solely at release time via windows-build.yml (a `v*` tag),
+# so a broken guard or a Windows-only warning would surface at release instead of
+# on the PR that caused it.
+#
+# This job runs `cargo check` on `windows-latest` for every PR and every push to
+# master, with warnings promoted to errors, so Windows compile cleanliness is
+# verified on each change. It deliberately does NOT build the installer — that
+# stays in windows-build.yml; this is just a fast type-check.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+# A newer push to the same ref supersedes an in-flight check.
+concurrency:
+  group: windows-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-check-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # `cargo check` skips beforeBuildCommand and never bundles, so the frontend
+      # never has to be built here: tauri-build tolerates the missing
+      # `frontendDist` (../dist) during a check — verified locally. We only care
+      # about the Rust type-check, so no pnpm install / frontend build is needed.
+      - name: Cargo check (warnings as errors)
+        shell: bash
+        working-directory: src-tauri
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: cargo check --target x86_64-pc-windows-msvc


### PR DESCRIPTION
## What

Adds a lightweight `cargo check` job on `windows-latest` that runs on every PR and push to master.

Closes #191.

## Why

PR #190 introduced the first cfg-split Rust code — `set_native_menu`'s `#[cfg(not(target_os = "macos"))]` no-op stub plus `dead_code`-guarded model structs. Those guards are only exercised against a Windows target, which until now only happened at release time via `windows-build.yml` (a `v*` tag). A broken cfg guard or a Windows-only warning would therefore surface at **release** instead of on the PR that caused it (as it just did with the `unused variable: app` warning in `menu.rs`).

## How

- New workflow `.github/workflows/windows-check.yml`
- `cargo check --target x86_64-pc-windows-msvc` with `RUSTFLAGS: -D warnings` so any Windows warning fails the check
- Type-check only — no `pnpm install`, no frontend build, no bundle. `tauri-build` tolerates the missing `frontendDist` (`../dist`) during a plain `cargo check` (verified locally on Windows)
- `concurrency` cancels superseded runs; `permissions: contents: read` keeps it least-privilege

## Verification

Ran the exact CI command locally on Windows — passes warning-free:

```
RUSTFLAGS="-D warnings" cargo check --target x86_64-pc-windows-msvc
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

This PR self-tests: the new job runs against this very PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)