### PR TITLE
test: close menu-bar seam coverage gaps from #178

### DIFF
--- a/src/App.menu-events.test.tsx
+++ b/src/App.menu-events.test.tsx
@@ -116,6 +116,17 @@ describe("App menu event wiring", () => {
     expect(useTabsStore.getState().tabs.some((t) => t.kind === "terminal")).toBe(true);
   });
 
+  it("menu:new-terminal-tab threads the workspace root as the new tab's cwd", async () => {
+    useWorkspaceStore.setState({ rootPath: "/tmp/demo-project" });
+    render(<App />);
+    await fireMenuEvent("menu:new-terminal-tab");
+    const tab = useTabsStore.getState().tabs.find((t) => t.kind === "terminal")!;
+    expect(tab.cwd).toBe("/tmp/demo-project");
+    // The pane leaf must carry the same cwd, not just the tab — resolveTerminalCwd
+    // ranks the pane's own cwd above the tab's, so the terminal actually spawns there.
+    expect(tab.paneTree).toEqual(leaf(tab.activeLeafId, { kind: "terminal", cwd: "/tmp/demo-project" }));
+  });
+
   it("menu:save saves the focused editor pane via the editor bus", async () => {
     useTabsStore.setState({
       spaces: [{ id: "s1", name: "Space 1" }],
@@ -415,6 +426,40 @@ describe("App menu event wiring", () => {
     await fireMenuEvent("menu:split-right");
     const afterRight = useTabsStore.getState().tabs.find((t) => t.id === "a")!;
     expect(afterRight.paneTree.kind).toBe("split");
+  });
+
+  it("menu:focus-next-pane moves focus to the next pane in a two-pane tab", async () => {
+    // This event is the tail of the menu-click routes: the macOS native menu
+    // (useMacNativeMenu, added in #190) and the Windows in-window WindowMenuBar
+    // both funnel through executeMenuAction -> emitWindowMenuEvent -> this
+    // listener. The keyboard path (Ctrl/Cmd+`) has its own coverage.
+    const paneTree = splitLeaf(
+      leaf("left-leaf", { kind: "launcher" }),
+      "left-leaf",
+      "row",
+      "right-leaf",
+      { kind: "launcher" },
+    );
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space 1" }],
+      activeSpaceId: "s1",
+      tabs: [
+        {
+          id: "a",
+          spaceId: "s1",
+          title: "a",
+          kind: "launcher" as const,
+          paneTree,
+          activeLeafId: "left-leaf",
+          paneOrder: ["left-leaf", "right-leaf"],
+        },
+      ],
+      activeId: "a",
+    });
+    render(<App />);
+    await fireMenuEvent("menu:focus-next-pane");
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
+    expect(tab?.activeLeafId).toBe("right-leaf");
   });
 
   it("menu:check-updates opens settings on About and runs a manual check", async () => {

--- a/src/App.windows.test.tsx
+++ b/src/App.windows.test.tsx
@@ -138,4 +138,36 @@ describe("App shell — Windows keyboard shortcuts", () => {
     fireEvent.keyDown(window, { code: "Backquote", key: "`", ctrlKey: true });
     expect(useTabsStore.getState().activeId).toBe("b");
   });
+
+  it("cycles focus between panes in a two-pane tab with Ctrl+`", () => {
+    const paneTree = splitLeaf(
+      leaf("left-leaf", { kind: "launcher" }),
+      "left-leaf",
+      "row",
+      "right-leaf",
+      { kind: "launcher" },
+    );
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space 1" }],
+      activeSpaceId: "s1",
+      tabs: [
+        {
+          id: "a",
+          spaceId: "s1",
+          title: "a",
+          kind: "launcher" as const,
+          paneTree,
+          activeLeafId: "left-leaf",
+          paneOrder: ["left-leaf", "right-leaf"],
+        },
+      ],
+      activeId: "a",
+    });
+    render(<App />);
+
+    fireEvent.keyDown(window, { code: "Backquote", key: "`", ctrlKey: true });
+
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
+    expect(tab?.activeLeafId).toBe("right-leaf");
+  });
 });

--- a/src/modules/settings/SettingsView.test.tsx
+++ b/src/modules/settings/SettingsView.test.tsx
@@ -101,6 +101,33 @@ describe("SettingsView section deep-link", () => {
     );
   });
 
+  it("keeps the current section and still clears settingsSection when an invalid id arrives while mounted", () => {
+    // A reactive deep-link with an unknown section id must not disturb whatever
+    // section is currently showing (unlike the mount-time fallback, which lands
+    // on Appearance) — but settingsSection is still cleared unconditionally so a
+    // later plain open doesn't replay it.
+    useUiStore.setState({ settingsOpen: true, settingsSection: null });
+    render(<SettingsView />);
+
+    act(() => {
+      useUiStore.getState().openSettings("shortcuts");
+    });
+    expect(screen.getByRole("button", { name: "Shortcuts" })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+
+    act(() => {
+      useUiStore.getState().openSettings("not-a-real-section");
+    });
+
+    expect(screen.getByRole("button", { name: "Shortcuts" })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+    expect(useUiStore.getState().settingsSection).toBeNull();
+  });
+
   it("consumes and clears a stuck section value instead of replaying it on the next plain open", () => {
     // Simulate a value left stuck in the store from a prior deep-link that
     // was never consumed (the bug this regression test guards against).


### PR DESCRIPTION
## Summary

Test-only follow-up closing the coverage gaps listed in #179 (from the #178 review trail):

- `menu:new-terminal-tab`: new test asserts `useWorkspaceStore.rootPath` is threaded through as the new tab's `cwd`, on both the tab and its pane leaf content (exact-value assertions, so a dropped `cwd` fails the test).
- Cycle-pane two-pane fixture, per the post-#190 scope note: the macOS keydown path no longer serves Cmd+` in production (native menu accelerator consumes it), so the fixture exercises the two production routes instead — the Windows `Ctrl+\`` keydown path in `App.windows.test.tsx`, and the `menu:focus-next-pane` event (the landing point of the native-menu-click → `executeMenuAction` → `emitWindowMenuEvent` chain) in `App.menu-events.test.tsx`, which previously had zero App-level coverage.
- `SettingsView`: new test for an invalid section id arriving reactively while the modal is already mounted — the current section stays put and `settingsSection` is still cleared to `null`, mirroring the existing reactive valid-id test.

No production code touched.

## Test plan

- [x] `npx vitest run src/App.menu-events.test.tsx src/App.windows.test.tsx src/modules/settings/SettingsView.test.tsx` — 34/34 green
- [x] `npm run typecheck` — clean

Closes #179