### PR TITLE
feat(context-menu): unify right-click behavior across platforms

### DIFF
--- a/docs/superpowers/plans/2026-07-11-unified-context-menu.md
+++ b/docs/superpowers/plans/2026-07-11-unified-context-menu.md
@@ -1,0 +1,461 @@
+# 跨平台統一右鍵選單 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 macOS 與 Linux 的文字欄位、終端機、空白區右鍵行為統一成與 Windows 相同的自訂選單，終端機選單擴成五項
+
+**Architecture:** 拆掉 #184 留下的兩個 IS_WINDOWS 閘門讓現有跨平台程式碼全平台生效，終端機選單抽成純函式 builder（仿 inputMenuSpecs 模式）方便測試，空白區壓制加 dev build 例外保住 Inspect
+
+**Tech Stack:** React + TypeScript、Vitest + jsdom、xterm.js、i18next
+
+**Spec:** `docs/superpowers/specs/2026-07-11-unified-context-menu-design.md`
+
+## Global Constraints
+
+- 語言慣例：程式碼註解、commit message 一律英文
+- Tiptap（ProseMirror）與 CodeMirror（contentEditable）兩平台維持原生選單，不得動到 isRichEditable 分支
+- 不新增任何套件依賴
+- 每個 task 結束時 `npm run typecheck` 與相關測試檔必須綠
+- commit 不推 master，全部落在 feat/unified-context-menu 分支
+
+---
+
+### Task 1: InputContextMenu 全平台化與 dev 例外
+
+**Files:**
+- Modify: `src/components/inputMenuItems.ts`（加 isDevBuild helper）
+- Modify: `src/components/InputContextMenu.tsx:53-87`（拆閘門、dev 例外、更新註解）
+- Test: `src/components/InputContextMenu.test.tsx`（新檔）
+
+**Interfaces:**
+- Produces: `isDevBuild(): boolean`（inputMenuItems.ts 匯出，Task 1 測試會 mock 它）
+- InputContextMenu 行為契約：文字欄位右鍵出自訂選單（全平台）、contentEditable 放行原生、其餘區域 prod 壓掉 dev 放行
+
+- [ ] **Step 1: 寫失敗測試**
+
+新檔 `src/components/InputContextMenu.test.tsx`：
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { InputContextMenu } from "@/components/InputContextMenu";
+
+// Menu labels come from i18next; follow the same i18n bootstrap convention the
+// existing component tests use (check how SettingsView.test.tsx or
+// App.menu-events.test.tsx get real translations and mirror it — if they rely
+// on an i18n side-effect import, add the same import here). If the suite runs
+// with untranslated keys, assert on the key (e.g. "actions.paste") instead.
+
+// Non-Windows platform: the menu must now work here too (the whole point of
+// the unification), so pin IS_WINDOWS to false.
+vi.mock("@/lib/platform", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/platform")>();
+  return { ...actual, IS_WINDOWS: false };
+});
+
+// The fast Tauri clipboard path is not available in jsdom.
+vi.mock("@/modules/terminal/lib/terminalClipboard", () => ({
+  terminalClipboardText: () => Promise.resolve(""),
+}));
+
+// isDevBuild is flipped per test; the real impl reads import.meta.env.DEV
+// which is always true under Vitest and would mask the prod branch.
+const devMock = vi.hoisted(() => ({ dev: false }));
+vi.mock("@/components/inputMenuItems", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/inputMenuItems")>();
+  return { ...actual, isDevBuild: () => devMock.dev };
+});
+
+function rightClick(target: Element): boolean {
+  let notPrevented = true;
+  act(() => {
+    notPrevented = target.dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 40, clientY: 40 }),
+    );
+  });
+  return notPrevented;
+}
+
+describe("InputContextMenu on non-Windows platforms", () => {
+  beforeEach(() => {
+    devMock.dev = false;
+    document.body.innerHTML = "";
+  });
+
+  it("opens the custom menu on a plain text input", () => {
+    render(<InputContextMenu />);
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = "hello";
+    document.body.appendChild(input);
+
+    const notPrevented = rightClick(input);
+
+    expect(notPrevented).toBe(false);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Paste" })).toBeInTheDocument();
+  });
+
+  it("keeps the native menu on contentEditable (Tiptap/CodeMirror)", () => {
+    render(<InputContextMenu />);
+    const editor = document.createElement("div");
+    Object.defineProperty(editor, "isContentEditable", { value: true });
+    document.body.appendChild(editor);
+
+    expect(rightClick(editor)).toBe(true);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("suppresses the browser menu on blank areas in prod builds", () => {
+    render(<InputContextMenu />);
+    const blank = document.createElement("div");
+    document.body.appendChild(blank);
+
+    expect(rightClick(blank)).toBe(false);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("keeps the native menu on blank areas in dev builds (Inspect stays reachable)", () => {
+    devMock.dev = true;
+    render(<InputContextMenu />);
+    const blank = document.createElement("div");
+    document.body.appendChild(blank);
+
+    expect(rightClick(blank)).toBe(true);
+  });
+
+  it("defers to a menu another component already showed", () => {
+    render(<InputContextMenu />);
+    const host = document.createElement("div");
+    host.addEventListener("contextmenu", (e) => e.preventDefault());
+    document.body.appendChild(host);
+
+    rightClick(host);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `npx vitest run src/components/InputContextMenu.test.tsx`
+Expected: FAIL，第一個測試 menu 不出現（effect 被 IS_WINDOWS 擋掉）、isDevBuild 不存在造成 mock factory 或 import 錯誤
+
+- [ ] **Step 3: 最小實作**
+
+`src/components/inputMenuItems.ts` 檔尾加：
+
+```ts
+/**
+ * Whether this is a dev build. Blank-area context-menu suppression is skipped
+ * in dev so right-click → Inspect Element stays reachable while debugging;
+ * text-field and terminal custom menus still apply so the feature itself is
+ * testable in dev. A function (not a constant) so tests can stub it.
+ */
+export function isDevBuild(): boolean {
+  return import.meta.env.DEV;
+}
+```
+
+`src/components/InputContextMenu.tsx` 兩處修改。effect 開頭與註解：
+
+```tsx
+  useEffect(() => {
+    function onContextMenu(e: MouseEvent) {
+```
+
+（刪掉 `if (!IS_WINDOWS) { return; }` 三行，並把 `import { IS_WINDOWS } from "@/lib/platform";` 移除，`isDevBuild` 加進既有的 inputMenuItems import 清單）
+
+blanket 壓制分支：
+
+```tsx
+      // Everywhere else: kill the browser menu (Reload / Save as / Inspect …).
+      // Dev builds keep it so right-click → Inspect Element still works.
+      if (isDevBuild()) {
+        return;
+      }
+      e.preventDefault();
+```
+
+元件 JSDoc 的 Windows-only 描述同步改為全平台描述（保留 WebView2 慢貼上的歷史脈絡一句即可）
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `npx vitest run src/components/InputContextMenu.test.tsx src/components/inputMenuItems.test.ts`
+Expected: PASS 全綠
+
+- [ ] **Step 5: typecheck 與 commit**
+
+```bash
+npm run typecheck
+git add src/components/inputMenuItems.ts src/components/InputContextMenu.tsx src/components/InputContextMenu.test.tsx
+git commit -m "feat(context-menu): enable the input context menu on all platforms
+
+The IS_WINDOWS gate from #184 is removed: macOS and Linux now get the same
+app-styled cut/copy/paste menu on plain text fields and the same blanket
+suppression of the browser menu elsewhere. Dev builds keep the native menu
+on blank areas so Inspect Element stays reachable."
+```
+
+---
+
+### Task 2: 終端機統一選單五項
+
+**Files:**
+- Create: `src/modules/terminal/lib/terminalMenuItems.ts`
+- Test: `src/modules/terminal/lib/terminalMenuItems.test.ts`（新檔）
+- Modify: `src/modules/terminal/TerminalView.tsx:1482-1533`（拆閘門、改用 builder、五項接線）
+- Modify: `src/i18n/locales/en/common.json:5-6` 附近、`src/i18n/locales/zh-Hant/common.json` 同位置
+
+**Interfaces:**
+- Consumes: 無（獨立於 Task 1）
+- Produces: `terminalMenuSpecs(ctx: TerminalMenuContext): TerminalMenuItemSpec[]`，型別 `TerminalMenuAction = "copy" | "paste" | "selectAll" | "clear" | "search"`、`TerminalMenuContext = { hasSelection: boolean }`、`TerminalMenuItemSpec = { action: TerminalMenuAction; enabled: boolean; group: number }`
+
+- [ ] **Step 1: 寫失敗測試**
+
+新檔 `src/modules/terminal/lib/terminalMenuItems.test.ts`：
+
+```ts
+import { describe, it, expect } from "vitest";
+import { terminalMenuSpecs } from "./terminalMenuItems";
+
+describe("terminalMenuSpecs", () => {
+  it("lists the five actions in stable order with edit and view groups", () => {
+    const specs = terminalMenuSpecs({ hasSelection: true });
+    expect(specs.map((s) => s.action)).toEqual(["copy", "paste", "selectAll", "clear", "search"]);
+    expect(specs.map((s) => s.group)).toEqual([0, 0, 0, 1, 1]);
+  });
+
+  it("greys copy out without a selection instead of hiding it", () => {
+    const withSel = terminalMenuSpecs({ hasSelection: true });
+    expect(withSel.find((s) => s.action === "copy")?.enabled).toBe(true);
+
+    const withoutSel = terminalMenuSpecs({ hasSelection: false });
+    expect(withoutSel.find((s) => s.action === "copy")?.enabled).toBe(false);
+    expect(withoutSel.map((s) => s.action)).toContain("copy");
+  });
+
+  it("keeps paste, select-all, clear and search always enabled", () => {
+    for (const spec of terminalMenuSpecs({ hasSelection: false })) {
+      if (spec.action !== "copy") {
+        expect(spec.enabled).toBe(true);
+      }
+    }
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `npx vitest run src/modules/terminal/lib/terminalMenuItems.test.ts`
+Expected: FAIL，module not found
+
+- [ ] **Step 3: 最小實作 builder**
+
+新檔 `src/modules/terminal/lib/terminalMenuItems.ts`：
+
+```ts
+/**
+ * Pure spec builder for the terminal's context menu, mirroring the
+ * inputMenuSpecs pattern: the component maps specs to ContextMenu items and
+ * wires the handlers. Copy is greyed (not hidden) without a selection so the
+ * menu keeps a stable shape the way native menus do.
+ */
+
+export type TerminalMenuAction = "copy" | "paste" | "selectAll" | "clear" | "search";
+
+export interface TerminalMenuContext {
+  hasSelection: boolean;
+}
+
+export interface TerminalMenuItemSpec {
+  action: TerminalMenuAction;
+  enabled: boolean;
+  /** Group index; ContextMenu draws a divider between consecutive groups. */
+  group: number;
+}
+
+export function terminalMenuSpecs(ctx: TerminalMenuContext): TerminalMenuItemSpec[] {
+  return [
+    { action: "copy", enabled: ctx.hasSelection, group: 0 },
+    { action: "paste", enabled: true, group: 0 },
+    { action: "selectAll", enabled: true, group: 0 },
+    { action: "clear", enabled: true, group: 1 },
+    { action: "search", enabled: true, group: 1 },
+  ];
+}
+```
+
+Run: `npx vitest run src/modules/terminal/lib/terminalMenuItems.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: TerminalView 接線**
+
+`src/modules/terminal/TerminalView.tsx` 三處：
+
+onContextMenu（約 1482 行）拆閘門並更新註解：
+
+```tsx
+      onContextMenu={(event) => {
+        // All platforms get the app menu (unified in the cross-platform
+        // context-menu work; Windows started it in #184 because WebView2's
+        // native paste is ~5s). Backed by the same fast clipboard path as
+        // the paste keybinding.
+        event.preventDefault();
+        setContextMenu({
+          x: event.clientX,
+          y: event.clientY,
+          hasSelection: handleRef.current?.term.hasSelection() ?? false,
+        });
+      }}
+```
+
+選單渲染（約 1499 行起）改為 builder 驅動。先在檔頭 import 區加：
+
+```tsx
+import { terminalMenuSpecs, type TerminalMenuAction } from "./lib/terminalMenuItems";
+import { TextSelect, Eraser, Search } from "lucide-react";
+```
+
+（Copy 與 ClipboardPaste 已在既有 import 裡，把新 icon 併進同一行 lucide-react import）
+
+```tsx
+      {contextMenu && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onClose={() => setContextMenu(null)}
+          items={terminalMenuSpecs({ hasSelection: contextMenu.hasSelection }).map((spec) => {
+            const icons = {
+              copy: Copy,
+              paste: ClipboardPaste,
+              selectAll: TextSelect,
+              clear: Eraser,
+              search: Search,
+            } satisfies Record<TerminalMenuAction, ComponentType<LucideProps>>;
+            // Literal t() calls per key — a dynamic t(labels[action]) can fail
+            // typecheck if the project ever adopts typed i18next keys.
+            const labels: Record<TerminalMenuAction, string> = {
+              copy: t("terminalCopy"),
+              paste: t("terminalPaste"),
+              selectAll: t("terminalSelectAll"),
+              clear: t("terminalClear"),
+              search: t("terminalSearch"),
+            };
+            const actions: Record<TerminalMenuAction, () => void> = {
+              copy: () => {
+                const term = handleRef.current?.term;
+                if (term?.hasSelection()) {
+                  void navigator.clipboard.writeText(term.getSelection());
+                }
+              },
+              // "cmd" so an empty clipboard is a no-op; "ctrl" would inject the
+              // raw paste control byte, which a menu paste should never do.
+              paste: () => {
+                pasteRef.current?.("cmd");
+                handleRef.current?.term.focus();
+              },
+              selectAll: () => handleRef.current?.term.selectAll(),
+              clear: () => handleRef.current?.term.clear(),
+              search: () => setSearchOpen(true),
+            };
+            return {
+              id: spec.action,
+              label: labels[spec.action],
+              icon: icons[spec.action],
+              disabled: !spec.enabled,
+              group: spec.group,
+              onSelect: actions[spec.action],
+            } satisfies ContextMenuItem;
+          })}
+        />
+      )}
+```
+
+若 `ComponentType`／`LucideProps` 尚未 import，從 react 與 lucide-react 補 type import。若既有程式已有 `openSearchBox()` helper（約 531 行 `setSearchOpen(true)` 的包裝），search 動作改呼叫該 helper 保持單一入口
+
+i18n，`src/i18n/locales/en/common.json` 在 terminalPaste 旁加：
+
+```json
+  "terminalSelectAll": "Select All",
+  "terminalClear": "Clear",
+  "terminalSearch": "Search"
+```
+
+`src/i18n/locales/zh-Hant/common.json` 同位置：
+
+```json
+  "terminalSelectAll": "全選",
+  "terminalClear": "清空畫面",
+  "terminalSearch": "搜尋"
+```
+
+- [ ] **Step 5: 跑測試、typecheck、commit**
+
+Run: `npx vitest run src/modules/terminal/ && npm run typecheck`
+Expected: PASS 全綠、typecheck 乾淨
+
+```bash
+git add src/modules/terminal/lib/terminalMenuItems.ts src/modules/terminal/lib/terminalMenuItems.test.ts src/modules/terminal/TerminalView.tsx src/i18n/locales/en/common.json src/i18n/locales/zh-Hant/common.json
+git commit -m "feat(terminal): unified five-item context menu on all platforms
+
+The terminal context menu (Windows-only since #184) now shows on macOS and
+Linux too, and grows from copy/paste to copy, paste, select-all, clear and
+search. Items come from a pure spec builder mirroring inputMenuSpecs; copy is
+greyed without a selection instead of hidden."
+```
+
+---
+
+### Task 3: SourceControlView 壓制器退役與全庫回歸
+
+**Files:**
+- Modify: `src/modules/source-control/SourceControlView.tsx:637-647`
+- Test: 既有 `src/modules/source-control/SourceControlView.test.tsx`（如有壓制器相關斷言則調整）
+
+**Interfaces:**
+- Consumes: Task 1 的全域 blanket 壓制（此 task 移除的區域壓制器由它接手）
+- Produces: 無新介面
+
+- [ ] **Step 1: 移除區域壓制器**
+
+`src/modules/source-control/SourceControlView.tsx` 把根 div 的 onContextMenu 與其註解整段移除：
+
+```tsx
+  return (
+    <div className="flex h-full flex-col bg-bg-inset">
+```
+
+（刪掉原本的 4 行註解與 `onContextMenu={(e) => { ... }}` 整個 prop，其餘 JSX 不動）
+
+- [ ] **Step 2: 跑 source-control 測試**
+
+Run: `npx vitest run src/modules/source-control/`
+Expected: PASS。若有測試斷言 panel 層 preventDefault 行為，把該斷言改為描述新現實（交給全域 handler）或刪除該測試，並在 commit message 說明
+
+- [ ] **Step 3: 全庫回歸與 typecheck**
+
+Run: `npx vitest run && npm run typecheck`
+Expected: 全綠、乾淨
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/modules/source-control/SourceControlView.tsx
+git commit -m "refactor(source-control): drop the panel-level context-menu suppressor
+
+InputContextMenu now suppresses the browser menu app-wide on every platform,
+so the panel's own onContextMenu guard is redundant. Text inputs inside the
+panel switch from the native menu to the app menu, which is the unified
+behavior everywhere else."
+```
+
+---
+
+## 驗收清單（主會話收尾用）
+
+- [ ] `npx vitest run` 全綠、`npm run typecheck` 乾淨
+- [ ] diff 對照 spec 逐段讀過
+- [ ] code review（多維度 + 對抗驗證）
+- [ ] windows-tauri pre-flight：本次移除平台分支、不加平台相依 code，確認無 `#[cfg]`、無 subprocess、無路徑處理變更
+- [ ] PR 帶 label enhancement、milestone、assignee，內文附 spec 連結與平台行為對照表

--- a/docs/superpowers/specs/2026-07-11-unified-context-menu-design.md
+++ b/docs/superpowers/specs/2026-07-11-unified-context-menu-design.md
@@ -14,7 +14,7 @@ PR #184 之後右鍵選單行為在兩個平台分歧：Windows 的純文字欄�
 
 - 三個平台右鍵行為一致：文字欄位出自訂選單、終端機出自訂五項選單、其餘區域無選單
 - 筆記（Tiptap）與編輯器（CodeMirror）兩平台都維持原生選單，行為不變
-- dev build 的空白區域保留原生選單，macOS 開發時右鍵 Inspect Element 不受影響
+- dev build 的空白區域保留原生選單（三平台一致，Windows dev 也會看到原生選單，屬預期），macOS 開發時右鍵 Inspect Element 不受影響
 - Windows 行為與 #184 相比零變化（終端機選單多三項除外）
 - 既有測試全綠，新行為有對應測試
 
@@ -64,9 +64,8 @@ PR #184 之後右鍵選單行為在兩個平台分歧：Windows 的純文字欄�
 
 ### 4. i18n
 
-- `actions.selectAll`、`actions.copy`、`actions.paste`、`actions.search` 已存在
-- 新增 `actions.clear`（en 為 Clear，zh-Hant 為清空畫面）
-- 終端機選單直接沿用 actions 命名空間，不另開
+- 實作時修正：終端機選單沿用既有的 terminal 前綴鍵（terminalCopy、terminalPaste 本來就在），新增 terminalSelectAll、terminalClear，搜尋放 terminalSearch.label（common.json 已有 terminalSearch 物件給 SearchBar 用，攤平鍵會撞名蓋掉它）
+- 原定沿用 actions 命名空間的想法作廢，terminal 前綴的區域性更好
 
 ## 錯誤處理
 

--- a/docs/superpowers/specs/2026-07-11-unified-context-menu-design.md
+++ b/docs/superpowers/specs/2026-07-11-unified-context-menu-design.md
@@ -1,0 +1,89 @@
+# 跨平台統一右鍵選單設計
+
+日期 2026-07-11，延伸自 PR #184
+
+## 背景與目標
+
+PR #184 之後右鍵選單行為在兩個平台分歧：Windows 的純文字欄位有 app 風格的剪下複製貼上選單、終端機有自訂複製貼上選單、其餘區域的預設選單被全面壓掉，macOS 這三塊卻都還是 WKWebView 原生選單。app 自己的八個自訂選單 surface（tab bar、檔案樹、git graph、source control 等）本來就跨平台一致，分歧只在這三塊
+
+目標是把 macOS（含 Linux）的這三塊也統一成跟 Windows 相同的自訂行為，同時把終端機選單內容從陽春的兩項擴成標準五項
+
+已確認的取捨：macOS 文字欄位與終端機會失去原生選單的查詢、翻譯、拼字建議、自動填入等系統功能，使用者已接受，以跨平台一致性優先
+
+成功標準
+
+- 三個平台右鍵行為一致：文字欄位出自訂選單、終端機出自訂五項選單、其餘區域無選單
+- 筆記（Tiptap）與編輯器（CodeMirror）兩平台都維持原生選單，行為不變
+- dev build 的空白區域保留原生選單，macOS 開發時右鍵 Inspect Element 不受影響
+- Windows 行為與 #184 相比零變化（終端機選單多三項除外）
+- 既有測試全綠，新行為有對應測試
+
+## 方案選擇
+
+比較過三條路，採拆閘門擴充案
+
+1. 拆閘門擴充（採用）：#184 的 InputContextMenu 與 TerminalView 選單本來就是跨平台寫法，只是被 IS_WINDOWS 閘門擋住，把閘門拆掉、擴充終端機選單項目即可，改動集中且 Linux 自動跟上
+2. 集中式選單 registry：把全 app 八個選單 surface 重構成單一註冊表，工程量大十倍，解決的是不存在的痛，違反 YAGNI
+3. OS 原生 context menu（muda）：每次右鍵走 IPC 到 Rust 組原生選單，樣式與 app 主題脫節、兩平台外觀又不同，跟統一目標矛盾，也違反本專案自建元件的慣例
+
+## 架構與改動點
+
+### 1. InputContextMenu 全平台化
+
+`src/components/InputContextMenu.tsx`
+
+- 拿掉 effect 開頭的 `if (!IS_WINDOWS) return`，三個平台都掛 window contextmenu listener
+- 文字欄位分支與 rich editable 分支邏輯不變（isPlainTextField 出自訂選單、isContentEditable 保留原生）
+- 空白區域的 blanket `e.preventDefault()` 加 dev 例外：`import.meta.env.DEV` 時不壓，保留右鍵 Inspect 的除錯路徑。文字欄位與終端機的自訂選單在 dev 照常生效，功能仍可在 dev 驗證
+- 貼上維持現有路徑：`terminalClipboardText()` 快路徑優先，失敗 fallback `navigator.clipboard.readText()`，macOS 走 fallback 也沒有 WebView2 慢貼上問題
+
+### 2. 終端機選單統一與擴充
+
+`src/modules/terminal/TerminalView.tsx`
+
+- 拿掉 onContextMenu 裡的 `if (!IS_WINDOWS) return`，三平台都出自訂選單
+- 選單項目從複製、貼上兩項擴成五項，分組如下
+
+| 群組 | 項目 | 行為 | disabled 條件 |
+|------|------|------|---------------|
+| 0 | 複製 | `term.getSelection()` 寫入 clipboard | 無選取時 |
+| 0 | 貼上 | 走既有 `pasteRef.current("cmd")` 快路徑 | 無 |
+| 0 | 全選 | `term.selectAll()` | 無 |
+| 1 | 清空畫面 | 接既有 clear 邏輯（與選單列或快捷鍵同一條路） | 無 |
+| 1 | 搜尋 | 開啟既有 SearchBar | 無 |
+
+- 沿用 #184 加入 ContextMenu 的 disabled 支援，複製在無選取時 greyed 而不是隱藏，選單形狀穩定
+- macOS 既有的 capture-phase paste 攔截（防右鍵貼上與 Edit 選單貼上重複）在原生選單消失後自然不再觸發，保留不動，作為 Edit 選單貼上的防護
+
+### 3. SourceControlView 區域壓制器退役
+
+`src/modules/source-control/SourceControlView.tsx`
+
+- 面板層級的 onContextMenu 壓制器（非 input 目標一律 preventDefault）在全域壓制後成為冗餘，移除
+- 它原本對 input 放行原生選單的行為，統一後由 InputContextMenu 接手出自訂選單，行為從原生選單變成自訂選單，屬預期變化
+
+### 4. i18n
+
+- `actions.selectAll`、`actions.copy`、`actions.paste`、`actions.search` 已存在
+- 新增 `actions.clear`（en 為 Clear，zh-Hant 為清空畫面）
+- 終端機選單直接沿用 actions 命名空間，不另開
+
+## 錯誤處理
+
+- clipboard 寫入失敗沿用 #184 慣例：複製失敗靜默、剪下失敗保留選取不動、貼上失敗 fallback 後仍失敗則無操作
+- 選單動作執行時 pane 已被關閉：所有動作透過 ref 或 store 取得當下狀態，目標消失即靜默 no-op
+- xterm 未就緒（term 為 null）時右鍵：不出選單，交回 blanket 壓制
+
+## 測試策略
+
+- inputMenuItems 純函式測試已存在，不受影響
+- InputContextMenu：新增測試證明非 Windows 平台（IS_WINDOWS false）也會攔截文字欄位右鍵並出選單，dev 例外用 vi.stubEnv 驗證空白區域不壓、prod 壓
+- TerminalView：既有 Windows 選單測試改為平台無關，新增五項選單的行為測試（複製 disabled 條件、清空與搜尋的接線）
+- SourceControlView：移除壓制器後既有測試調整，input 右鍵行為改斷言交給全域 handler
+- App 層跑既有全套回歸
+
+## 風險與備註
+
+- Linux 沒有本機可驗，行為推導自與 macOS 相同的程式路徑，terminal 貼上走 pasteRef 與平台無關
+- macOS 使用者若依賴文字欄位原生選單的系統功能會有感，發版 changelog 要寫清楚
+- windows-tauri skill 的 pre-flight 清單在收尾時過一次，本次改動移除平台分支、不新增平台相依 code，風險低

--- a/src/components/InputContextMenu.test.tsx
+++ b/src/components/InputContextMenu.test.tsx
@@ -1,17 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
 // Menu labels come from i18next; the side-effect import boots the real
 // translations (same convention as SettingsView.test.tsx). jsdom reports
 // navigator.language as en-US, so labels resolve to English.
 import "@/i18n";
 import { InputContextMenu } from "@/components/InputContextMenu";
-
-// Non-Windows platform: the menu must now work here too (the whole point of
-// the unification), so pin IS_WINDOWS to false.
-vi.mock("@/lib/platform", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/platform")>();
-  return { ...actual, IS_WINDOWS: false };
-});
 
 // The fast Tauri clipboard path is not available in jsdom.
 vi.mock("@/modules/terminal/lib/terminalClipboard", () => ({
@@ -36,7 +29,9 @@ function rightClick(target: Element): boolean {
   return notPrevented;
 }
 
-describe("InputContextMenu on non-Windows platforms", () => {
+// The component is platform-independent by design (no platform checks), so a
+// single suite covers every OS.
+describe("InputContextMenu", () => {
   beforeEach(() => {
     devMock.dev = false;
     document.body.innerHTML = "";
@@ -92,5 +87,64 @@ describe("InputContextMenu on non-Windows platforms", () => {
 
     rightClick(host);
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("keeps the native menu inside a read-only CodeMirror editor", () => {
+    render(<InputContextMenu />);
+    // The diff view (EditorView.editable.of(false)) renders cm-content with
+    // contenteditable="false", so isRichEditable alone would not catch it and
+    // the blanket prod suppression would leave the diff view without any menu.
+    const editor = document.createElement("div");
+    editor.className = "cm-editor";
+    const content = document.createElement("div");
+    content.setAttribute("contenteditable", "false");
+    editor.appendChild(content);
+    document.body.appendChild(editor);
+
+    expect(rightClick(content)).toBe(true);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("keeps the native menu on a field during IME composition, custom again after", () => {
+    render(<InputContextMenu />);
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = "こんにちは";
+    document.body.appendChild(input);
+
+    // Mid-composition the native menu must appear: it commits the composition
+    // correctly, while our replaceRange actions would corrupt the composed text.
+    act(() => {
+      input.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+    });
+    expect(rightClick(input)).toBe(true);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    act(() => {
+      input.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+    });
+    expect(rightClick(input)).toBe(false);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("pastes from the web clipboard when the fast path resolves empty (Linux stub)", async () => {
+    // On Linux the Rust clipboard command is a stub that RESOLVES with ""
+    // instead of rejecting, so paste must still fall through to the web
+    // clipboard rather than silently doing nothing.
+    const readText = vi.fn().mockResolvedValue("from web clipboard");
+    Object.defineProperty(navigator, "clipboard", {
+      value: { readText },
+      configurable: true,
+    });
+    render(<InputContextMenu />);
+    const input = document.createElement("input");
+    input.type = "text";
+    document.body.appendChild(input);
+
+    rightClick(input);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Paste" }));
+
+    await waitFor(() => expect(input.value).toBe("from web clipboard"));
+    expect(readText).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/InputContextMenu.test.tsx
+++ b/src/components/InputContextMenu.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+// Menu labels come from i18next; the side-effect import boots the real
+// translations (same convention as SettingsView.test.tsx). jsdom reports
+// navigator.language as en-US, so labels resolve to English.
+import "@/i18n";
+import { InputContextMenu } from "@/components/InputContextMenu";
+
+// Non-Windows platform: the menu must now work here too (the whole point of
+// the unification), so pin IS_WINDOWS to false.
+vi.mock("@/lib/platform", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/platform")>();
+  return { ...actual, IS_WINDOWS: false };
+});
+
+// The fast Tauri clipboard path is not available in jsdom.
+vi.mock("@/modules/terminal/lib/terminalClipboard", () => ({
+  terminalClipboardText: () => Promise.resolve(""),
+}));
+
+// isDevBuild is flipped per test; the real impl reads import.meta.env.DEV
+// which is always true under Vitest and would mask the prod branch.
+const devMock = vi.hoisted(() => ({ dev: false }));
+vi.mock("@/components/inputMenuItems", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/inputMenuItems")>();
+  return { ...actual, isDevBuild: () => devMock.dev };
+});
+
+function rightClick(target: Element): boolean {
+  let notPrevented = true;
+  act(() => {
+    notPrevented = target.dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 40, clientY: 40 }),
+    );
+  });
+  return notPrevented;
+}
+
+describe("InputContextMenu on non-Windows platforms", () => {
+  beforeEach(() => {
+    devMock.dev = false;
+    document.body.innerHTML = "";
+  });
+
+  it("opens the custom menu on a plain text input", () => {
+    render(<InputContextMenu />);
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = "hello";
+    document.body.appendChild(input);
+
+    const notPrevented = rightClick(input);
+
+    expect(notPrevented).toBe(false);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Paste" })).toBeInTheDocument();
+  });
+
+  it("keeps the native menu on contentEditable (Tiptap/CodeMirror)", () => {
+    render(<InputContextMenu />);
+    const editor = document.createElement("div");
+    Object.defineProperty(editor, "isContentEditable", { value: true });
+    document.body.appendChild(editor);
+
+    expect(rightClick(editor)).toBe(true);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("suppresses the browser menu on blank areas in prod builds", () => {
+    render(<InputContextMenu />);
+    const blank = document.createElement("div");
+    document.body.appendChild(blank);
+
+    expect(rightClick(blank)).toBe(false);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("keeps the native menu on blank areas in dev builds (Inspect stays reachable)", () => {
+    devMock.dev = true;
+    render(<InputContextMenu />);
+    const blank = document.createElement("div");
+    document.body.appendChild(blank);
+
+    expect(rightClick(blank)).toBe(true);
+  });
+
+  it("defers to a menu another component already showed", () => {
+    render(<InputContextMenu />);
+    const host = document.createElement("div");
+    host.addEventListener("contextmenu", (e) => e.preventDefault());
+    document.body.appendChild(host);
+
+    rightClick(host);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/InputContextMenu.tsx
+++ b/src/components/InputContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Copy, ClipboardPaste, Scissors, TextSelect } from "lucide-react";
 import type { LucideProps } from "lucide-react";
@@ -8,6 +8,7 @@ import { terminalClipboardText } from "@/modules/terminal/lib/terminalClipboard"
 import {
   isPlainTextField,
   isRichEditable,
+  isEditorSurface,
   readFieldContext,
   inputMenuSpecs,
   replaceRange,
@@ -50,8 +51,21 @@ const ICONS: Record<InputMenuAction, ComponentType<LucideProps>> = {
 export function InputContextMenu() {
   const { t } = useTranslation();
   const [menu, setMenu] = useState<MenuState | null>(null);
+  // The element with an active IME composition, if any. Tracked so a
+  // right-click during composition keeps the native menu (which commits the
+  // composition correctly) instead of ours — replaceRange rewriting the value
+  // mid-composition would corrupt the composed text.
+  const composingRef = useRef<EventTarget | null>(null);
 
   useEffect(() => {
+    function onCompositionStart(e: CompositionEvent) {
+      composingRef.current = e.target;
+    }
+    function onCompositionEnd(e: CompositionEvent) {
+      if (composingRef.current === e.target) {
+        composingRef.current = null;
+      }
+    }
     function onContextMenu(e: MouseEvent) {
       // A component already showed its own menu (tab bar, file tree, git graph,
       // Monaco, the terminal's menu, …) — leave it be.
@@ -59,6 +73,11 @@ export function InputContextMenu() {
         return;
       }
       const target = e.target;
+      // Mid-IME-composition: keep the native menu (no preventDefault), matching
+      // the pre-unification behavior. See composingRef above.
+      if (composingRef.current !== null && target === composingRef.current) {
+        return;
+      }
       if (isPlainTextField(target)) {
         e.preventDefault();
         const { start, end } = getSelectionRange(target);
@@ -72,9 +91,11 @@ export function InputContextMenu() {
         });
         return;
       }
-      // contentEditable (Tiptap notes): keep the native menu — its spellcheck and
-      // copy/paste beat a custom one, and driving it would fight the editor.
-      if (isRichEditable(target)) {
+      // contentEditable (Tiptap notes) and editor surfaces (CodeMirror diff
+      // view, Monaco): keep the native menu — its spellcheck and copy/paste
+      // beat a custom one, and driving it would fight the editor. The surface
+      // check catches read-only CodeMirror, whose content is not contentEditable.
+      if (isRichEditable(target) || isEditorSurface(target)) {
         return;
       }
       // Everywhere else: kill the browser menu (Reload / Save as / Inspect …).
@@ -84,8 +105,16 @@ export function InputContextMenu() {
       }
       e.preventDefault();
     }
+    // Capture phase so composition state is tracked even if an editor stops
+    // propagation of these events in the bubble phase.
+    window.addEventListener("compositionstart", onCompositionStart, true);
+    window.addEventListener("compositionend", onCompositionEnd, true);
     window.addEventListener("contextmenu", onContextMenu);
-    return () => window.removeEventListener("contextmenu", onContextMenu);
+    return () => {
+      window.removeEventListener("compositionstart", onCompositionStart, true);
+      window.removeEventListener("compositionend", onCompositionEnd, true);
+      window.removeEventListener("contextmenu", onContextMenu);
+    };
   }, []);
 
   const runAction = useCallback(
@@ -126,6 +155,12 @@ export function InputContextMenu() {
             } catch {
               text = "";
             }
+          }
+          // On Linux the Rust command is a stub that RESOLVES with "" (no
+          // native clipboard backend there), so the catch above never runs.
+          // Retry the web clipboard whenever the fast path came back empty.
+          if (!text) {
+            text = await navigator.clipboard.readText().catch(() => "");
           }
           if (text) {
             field.focus();

--- a/src/components/InputContextMenu.tsx
+++ b/src/components/InputContextMenu.tsx
@@ -4,7 +4,6 @@ import { Copy, ClipboardPaste, Scissors, TextSelect } from "lucide-react";
 import type { LucideProps } from "lucide-react";
 import type { ComponentType } from "react";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
-import { IS_WINDOWS } from "@/lib/platform";
 import { terminalClipboardText } from "@/modules/terminal/lib/terminalClipboard";
 import {
   isPlainTextField,
@@ -13,6 +12,7 @@ import {
   inputMenuSpecs,
   replaceRange,
   getSelectionRange,
+  isDevBuild,
   type EditableField,
   type FieldContext,
   type InputMenuAction,
@@ -36,10 +36,11 @@ const ICONS: Record<InputMenuAction, ComponentType<LucideProps>> = {
 };
 
 /**
- * Windows-only replacement for the WebView2 context menu on plain text fields
+ * App-styled replacement for the browser context menu on plain text fields
  * (`<input>` / `<textarea>`), and a blanket suppressor of the browser menu
- * everywhere else. Mounted once near the app root. Non-Windows platforms keep
- * their richer native menus, so the effect never installs there.
+ * everywhere else (skipped in dev builds so Inspect Element stays reachable).
+ * Mounted once near the app root and active on every platform; it started as
+ * a Windows-only fix because WebView2's native paste takes ~5s.
  *
  * Actions restore the field's focus and act on the selection captured at
  * right-click time. Cut/paste edit through `replaceRange`, which dispatches an
@@ -51,12 +52,9 @@ export function InputContextMenu() {
   const [menu, setMenu] = useState<MenuState | null>(null);
 
   useEffect(() => {
-    if (!IS_WINDOWS) {
-      return;
-    }
     function onContextMenu(e: MouseEvent) {
       // A component already showed its own menu (tab bar, file tree, git graph,
-      // Monaco, the terminal's Windows menu, …) — leave it be.
+      // Monaco, the terminal's menu, …) — leave it be.
       if (e.defaultPrevented) {
         return;
       }
@@ -80,6 +78,10 @@ export function InputContextMenu() {
         return;
       }
       // Everywhere else: kill the browser menu (Reload / Save as / Inspect …).
+      // Dev builds keep it so right-click → Inspect Element still works.
+      if (isDevBuild()) {
+        return;
+      }
       e.preventDefault();
     }
     window.addEventListener("contextmenu", onContextMenu);

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -106,10 +106,18 @@ describe("TabBar tab context menu", () => {
     render(<TabBar />);
     fireEvent.contextMenu(screen.getByRole("tab"));
     fireEvent.click(screen.getByRole("menuitem", { name: "Rename Tab" }));
-    // Right-clicking the rename field must not bubble up and open a fresh tab
-    // menu over the input being edited.
-    fireEvent.contextMenu(screen.getByRole("textbox"));
-    expect(screen.queryByRole("menuitem")).toBeNull();
+    // Right-clicking the rename field must not open a fresh tab menu, but the
+    // event must still bubble to the window so the app-wide text-field menu
+    // (InputContextMenu) can handle it.
+    const onWindowContextMenu = vi.fn();
+    window.addEventListener("contextmenu", onWindowContextMenu);
+    try {
+      fireEvent.contextMenu(screen.getByRole("textbox"));
+      expect(screen.queryByRole("menuitem")).toBeNull();
+      expect(onWindowContextMenu).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener("contextmenu", onWindowContextMenu);
+    }
   });
 
   it("marks the tab strip as a drop target for open-in-new-tab", () => {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -122,6 +122,9 @@ function TabItem({ id }: { id: string }) {
       onClick={() => setActive(tab.id)}
       onDoubleClick={startRename}
       onContextMenu={(e) => {
+        // Right-clicks on the rename input skip the tab menu and bubble to the
+        // window-level InputContextMenu, like every other text field.
+        if (e.target instanceof HTMLInputElement) return;
         e.preventDefault();
         setMenu({ x: e.clientX, y: e.clientY });
       }}
@@ -150,7 +153,6 @@ function TabItem({ id }: { id: string }) {
           onBlur={commit}
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
-          onContextMenu={(e) => e.stopPropagation()}
           onKeyDown={(e) => {
             if (e.key === "Enter") commit();
             if (e.key === "Escape") setEditing(false);

--- a/src/components/inputMenuItems.test.ts
+++ b/src/components/inputMenuItems.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   isPlainTextField,
   isRichEditable,
+  isEditorSurface,
   readFieldContext,
   inputMenuSpecs,
   replaceRange,
@@ -66,6 +67,37 @@ describe("isRichEditable", () => {
     expect(isRichEditable(editable)).toBe(true);
     expect(isRichEditable(document.createElement("input"))).toBe(false);
     expect(isRichEditable(null)).toBe(false);
+  });
+});
+
+describe("isEditorSurface", () => {
+  it("is true inside a read-only CodeMirror editor (contenteditable false)", () => {
+    // The diff view sets EditorView.editable.of(false), which renders
+    // cm-content with contenteditable="false" — isRichEditable misses it.
+    const editor = document.createElement("div");
+    editor.className = "cm-editor";
+    const content = document.createElement("div");
+    content.setAttribute("contenteditable", "false");
+    editor.appendChild(content);
+    expect(isEditorSurface(content)).toBe(true);
+  });
+
+  it("is true inside Monaco and ProseMirror surfaces", () => {
+    for (const cls of ["monaco-editor", "ProseMirror"]) {
+      const host = document.createElement("div");
+      host.className = cls;
+      const child = document.createElement("span");
+      host.appendChild(child);
+      expect(isEditorSurface(child)).toBe(true);
+    }
+  });
+
+  it("is false for plain fields, blank elements, and non-elements", () => {
+    const input = document.createElement("input");
+    input.type = "text";
+    expect(isEditorSurface(input)).toBe(false);
+    expect(isEditorSurface(document.createElement("div"))).toBe(false);
+    expect(isEditorSurface(null)).toBe(false);
   });
 });
 

--- a/src/components/inputMenuItems.test.ts
+++ b/src/components/inputMenuItems.test.ts
@@ -99,6 +99,16 @@ describe("isEditorSurface", () => {
     expect(isEditorSurface(document.createElement("div"))).toBe(false);
     expect(isEditorSurface(null)).toBe(false);
   });
+
+  it("is true for SVG decorations inside an editor (fold arrows, lint markers)", () => {
+    // SVG elements are Element but not HTMLElement; the check must not lose
+    // them or the editor's native menu dies on icon right-clicks in prod.
+    const editor = document.createElement("div");
+    editor.className = "cm-editor";
+    const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    editor.appendChild(icon);
+    expect(isEditorSurface(icon)).toBe(true);
+  });
 });
 
 describe("readFieldContext", () => {

--- a/src/components/inputMenuItems.ts
+++ b/src/components/inputMenuItems.ts
@@ -150,3 +150,13 @@ export function inputMenuSpecs(ctx: FieldContext): InputMenuItemSpec[] {
   specs.push({ action: "selectAll", enabled: ctx.hasValue });
   return specs;
 }
+
+/**
+ * Whether this is a dev build. Blank-area context-menu suppression is skipped
+ * in dev so right-click → Inspect Element stays reachable while debugging;
+ * text-field and terminal custom menus still apply so the feature itself is
+ * testable in dev. A function (not a constant) so tests can stub it.
+ */
+export function isDevBuild(): boolean {
+  return import.meta.env.DEV;
+}

--- a/src/components/inputMenuItems.ts
+++ b/src/components/inputMenuItems.ts
@@ -65,7 +65,9 @@ export function isRichEditable(target: EventTarget | null): boolean {
  * otherwise leave it with no menu at all.
  */
 export function isEditorSurface(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
+  // Element, not HTMLElement: editors decorate with SVG (fold arrows, lint
+  // markers), and those must keep the editor's native menu too.
+  if (!(target instanceof Element)) {
     return false;
   }
   return target.closest(".cm-editor, .monaco-editor, .ProseMirror") !== null;

--- a/src/components/inputMenuItems.ts
+++ b/src/components/inputMenuItems.ts
@@ -55,6 +55,22 @@ export function isRichEditable(target: EventTarget | null): boolean {
   return target.isContentEditable === true;
 }
 
+/**
+ * True when the target sits inside a code/rich editor surface (CodeMirror,
+ * Monaco, ProseMirror), which must keep its native context menu. Needed on top
+ * of `isRichEditable` because a read-only CodeMirror — the diff view uses
+ * `EditorView.editable.of(false)` — renders its content with
+ * `contenteditable="false"`, so `isContentEditable` is false there even though
+ * the element is still an editor surface, and the blanket suppression would
+ * otherwise leave it with no menu at all.
+ */
+export function isEditorSurface(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return target.closest(".cm-editor, .monaco-editor, .ProseMirror") !== null;
+}
+
 export interface FieldContext {
   /** A non-empty selection exists, so Cut/Copy have something to act on. */
   hasSelection: boolean;

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -4,6 +4,8 @@
   "terminalConnecting": "Starting shell…",
   "terminalCopy": "Copy",
   "terminalPaste": "Paste",
+  "terminalSelectAll": "Select All",
+  "terminalClear": "Clear",
   "outputThrottled": "Output throttled, skipped {{size}} to keep the UI responsive",
   "openLinkHint": "{{mods}}-click to open",
   "actionLinks": {
@@ -23,6 +25,7 @@
     "cancel": "Cancel"
   },
   "terminalSearch": {
+    "label": "Search",
     "placeholder": "Find in terminal",
     "next": "Find next",
     "previous": "Find previous",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -4,6 +4,8 @@
   "terminalConnecting": "啟動中…",
   "terminalCopy": "複製",
   "terminalPaste": "貼上",
+  "terminalSelectAll": "全選",
+  "terminalClear": "清空畫面",
   "outputThrottled": "輸出太快，已略過 {{size}} 以維持介面流暢",
   "openLinkHint": "{{mods}} + 點擊開啟",
   "actionLinks": {
@@ -23,6 +25,7 @@
     "cancel": "取消"
   },
   "terminalSearch": {
+    "label": "搜尋",
     "placeholder": "在終端機中搜尋",
     "next": "下一個",
     "previous": "上一個",

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -634,18 +634,7 @@ export function SourceControlView() {
   }
 
   return (
-    // Suppress the WebView's own context menu anywhere in the panel; rows
-    // layer the app ContextMenu on top via their own handlers. Text inputs
-    // keep the native menu — it's how right-click paste works.
-    <div
-      className="flex h-full flex-col bg-bg-inset"
-      onContextMenu={(e) => {
-        const el = e.target as HTMLElement;
-        if (!(el instanceof HTMLTextAreaElement) && !(el instanceof HTMLInputElement)) {
-          e.preventDefault();
-        }
-      }}
-    >
+    <div className="flex h-full flex-col bg-bg-inset">
       <div className="flex h-9 shrink-0 items-center justify-between border-b border-border px-3">
         <span className="text-xs font-semibold uppercase tracking-wide text-fg-subtle">
           {t("title")}

--- a/src/modules/terminal/TerminalView.contextmenu.test.tsx
+++ b/src/modules/terminal/TerminalView.contextmenu.test.tsx
@@ -1,0 +1,322 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { act, useLayoutEffect } from "react";
+import { TerminalView } from "./TerminalView";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts?.name ? `${key}:${opts.name}` : key,
+  }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+
+// TerminalView calls getCurrentWebview() on mount to listen for native OS file
+// drags — no Tauri runtime exists in jsdom.
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: () => Promise.resolve(() => {}),
+  }),
+}));
+
+// Non-Windows platform: the terminal menu must work here too (the point of the
+// cross-platform context-menu unification), so pin IS_WINDOWS to false.
+vi.mock("@/lib/platform", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/platform")>();
+  return { ...actual, IS_WINDOWS: false };
+});
+
+// Real xterm renders no measurable grid in jsdom, and the menu tests need to
+// observe calls like term.clear/selectAll, so replace createTerminal with a
+// spy-only handle. `current` always holds the most recently created handle.
+const fakeTerminal = vi.hoisted(() => {
+  function makeHandle() {
+    const disposable = () => ({ dispose: vi.fn() });
+    return {
+      term: {
+        open: vi.fn(),
+        element: null,
+        options: {} as Record<string, unknown>,
+        parser: { registerOscHandler: vi.fn(() => disposable()) },
+        attachCustomKeyEventHandler: vi.fn(),
+        registerLinkProvider: vi.fn(() => disposable()),
+        onData: vi.fn(() => disposable()),
+        onWriteParsed: vi.fn(() => disposable()),
+        write: vi.fn(),
+        paste: vi.fn(),
+        focus: vi.fn(),
+        dispose: vi.fn(),
+        clear: vi.fn(),
+        selectAll: vi.fn(),
+        clearSelection: vi.fn(),
+        hasSelection: vi.fn(() => false),
+        getSelection: vi.fn(() => ""),
+        cols: 80,
+        rows: 24,
+      },
+      fit: { fit: vi.fn() },
+      search: {
+        findNext: vi.fn(() => false),
+        findPrevious: vi.fn(() => false),
+        clearDecorations: vi.fn(),
+      },
+    };
+  }
+  return { makeHandle, current: null as ReturnType<typeof makeHandle> | null };
+});
+
+vi.mock("./lib/createTerminal", () => ({
+  createTerminal: () => {
+    fakeTerminal.current = fakeTerminal.makeHandle();
+    return fakeTerminal.current;
+  },
+}));
+
+// The paste tests need a live session (handleTerminalPaste no-ops without one),
+// and openPty cannot reach the Rust backend in jsdom.
+const fakeSession = vi.hoisted(() => {
+  function makeSession() {
+    return {
+      id: 1,
+      write: vi.fn(() => Promise.resolve()),
+      resize: vi.fn(() => Promise.resolve()),
+      close: vi.fn(() => Promise.resolve()),
+      cwd: vi.fn(() => Promise.resolve<string | null>(null)),
+      foregroundCommand: vi.fn(() => Promise.resolve<string | null>(null)),
+    };
+  }
+  return { makeSession, current: null as ReturnType<typeof makeSession> | null };
+});
+
+vi.mock("./lib/pty-bridge", () => ({
+  openPty: () => {
+    fakeSession.current = fakeSession.makeSession();
+    return Promise.resolve(fakeSession.current);
+  },
+}));
+
+// The Tauri clipboard probes are invoke-based; expose them as controllable
+// stubs while keeping resolvePasteAction/formatPathsForTerminal real, so the
+// paste tests exercise the genuine decision chain.
+const clipboardProbes = vi.hoisted(() => ({
+  text: "",
+  paths: [] as string[],
+  images: [] as string[],
+}));
+
+vi.mock("./lib/terminalClipboard", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./lib/terminalClipboard")>();
+  return {
+    ...actual,
+    terminalClipboardText: () => Promise.resolve(clipboardProbes.text),
+    terminalClipboardPaths: () => Promise.resolve(clipboardProbes.paths),
+    terminalClipboardImagePaths: () => Promise.resolve(clipboardProbes.images),
+  };
+});
+
+const readTextMock = vi.fn<() => Promise<string>>();
+
+function renderTerminal() {
+  const view = render(<TerminalView active />);
+  const terminal = view.container.firstElementChild as HTMLElement;
+  return { view, terminal };
+}
+
+/** Dispatches a native contextmenu event; returns true when NOT prevented. */
+function rightClick(target: Element): boolean {
+  let notPrevented = true;
+  act(() => {
+    notPrevented = target.dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 40, clientY: 40 }),
+    );
+  });
+  return notPrevented;
+}
+
+function clickMenuItem(name: string) {
+  fireEvent.click(screen.getByRole("menuitem", { name }));
+}
+
+/** Waits for the mocked PTY session to be wired up (term.onData registered). */
+async function waitForSession() {
+  await waitFor(() => expect(fakeTerminal.current!.term.onData).toHaveBeenCalled());
+}
+
+/** Runs before TerminalView's passive mount effect creates the handle. */
+function LayoutProbe({ run }: { run: () => void }) {
+  useLayoutEffect(() => {
+    run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
+}
+
+beforeEach(() => {
+  fakeTerminal.current = null;
+  fakeSession.current = null;
+  clipboardProbes.text = "";
+  clipboardProbes.paths = [];
+  clipboardProbes.images = [];
+  readTextMock.mockReset();
+  readTextMock.mockResolvedValue("");
+  // jsdom ships no navigator.clipboard; the paste fallback reads it.
+  Object.defineProperty(navigator, "clipboard", {
+    value: { readText: readTextMock, writeText: vi.fn(() => Promise.resolve()) },
+    configurable: true,
+  });
+});
+
+describe("TerminalView context menu on non-Windows platforms", () => {
+  it("opens the five-item menu on right-click", () => {
+    const { terminal } = renderTerminal();
+
+    const notPrevented = rightClick(terminal);
+
+    expect(notPrevented).toBe(false);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getAllByRole("menuitem").map((el) => el.textContent)).toEqual([
+      "terminalCopy",
+      "terminalPaste",
+      "terminalSelectAll",
+      "terminalClear",
+      "terminalSearch.label",
+    ]);
+  });
+
+  it("greys out Copy without a selection and enables it with one", () => {
+    const { terminal } = renderTerminal();
+
+    rightClick(terminal);
+    expect(screen.getByRole("menuitem", { name: "terminalCopy" })).toBeDisabled();
+
+    fireEvent.keyDown(document, { key: "Escape" }); // close the menu
+    fakeTerminal.current!.term.hasSelection.mockReturnValue(true);
+    rightClick(terminal);
+    expect(screen.getByRole("menuitem", { name: "terminalCopy" })).toBeEnabled();
+  });
+
+  it("Clear calls term.clear", () => {
+    const { terminal } = renderTerminal();
+
+    rightClick(terminal);
+    clickMenuItem("terminalClear");
+
+    expect(fakeTerminal.current!.term.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("Select All calls term.selectAll", () => {
+    const { terminal } = renderTerminal();
+
+    rightClick(terminal);
+    clickMenuItem("terminalSelectAll");
+
+    expect(fakeTerminal.current!.term.selectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("Search opens the search bar", () => {
+    const { terminal } = renderTerminal();
+
+    rightClick(terminal);
+    clickMenuItem("terminalSearch.label");
+
+    expect(screen.getByPlaceholderText("terminalSearch.placeholder")).toBeInTheDocument();
+  });
+
+  it("Search refocuses and selects the input when the bar is already open", () => {
+    const { terminal } = renderTerminal();
+    rightClick(terminal);
+    clickMenuItem("terminalSearch.label");
+    const input = screen.getByPlaceholderText("terminalSearch.placeholder") as HTMLInputElement;
+    expect(input).toHaveFocus();
+    fireEvent.change(input, { target: { value: "abc" } });
+    act(() => input.blur());
+    expect(input).not.toHaveFocus();
+
+    rightClick(terminal);
+    clickMenuItem("terminalSearch.label");
+
+    expect(input).toHaveFocus();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(3);
+  });
+
+  it("leaves a text field inside the pane to the input context menu", () => {
+    const { terminal } = renderTerminal();
+    rightClick(terminal);
+    clickMenuItem("terminalSearch.label");
+    const input = screen.getByPlaceholderText("terminalSearch.placeholder");
+
+    const notPrevented = rightClick(input);
+
+    expect(notPrevented).toBe(true);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("keeps the terminal menu for xterm's own hidden helper textarea", () => {
+    const { terminal } = renderTerminal();
+    // The mocked createTerminal renders no DOM, so fabricate the structure the
+    // real xterm produces: a .xterm wrapper with the hidden helper textarea.
+    const xtermHost = document.createElement("div");
+    xtermHost.className = "xterm";
+    const helper = document.createElement("textarea");
+    xtermHost.appendChild(helper);
+    terminal.appendChild(xtermHost);
+
+    const notPrevented = rightClick(helper);
+
+    expect(notPrevented).toBe(false);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("shows no menu and does not preventDefault before the terminal handle exists", () => {
+    let notPrevented: boolean | null = null;
+    render(
+      <>
+        <TerminalView active />
+        <LayoutProbe
+          run={() => {
+            // Layout effects run before TerminalView's passive mount effect,
+            // so the terminal handle has not been created yet at this point.
+            const container = document.querySelector("div.relative.h-full.w-full");
+            notPrevented = container!.dispatchEvent(
+              new MouseEvent("contextmenu", { bubbles: true, cancelable: true }),
+            );
+          }}
+        />
+      </>,
+    );
+
+    expect(notPrevented).toBe(true);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+});
+
+describe("TerminalView menu paste clipboard fallback", () => {
+  it("falls back to the web clipboard when every native probe is empty (Linux stub)", async () => {
+    readTextMock.mockResolvedValue("web clipboard text");
+    const { terminal } = renderTerminal();
+    await waitForSession();
+
+    rightClick(terminal);
+    clickMenuItem("terminalPaste");
+
+    await waitFor(() =>
+      expect(fakeTerminal.current!.term.paste).toHaveBeenCalledWith("web clipboard text"),
+    );
+  });
+
+  it("lets copied file paths win without consulting the web clipboard", async () => {
+    clipboardProbes.paths = ["/tmp/report.txt"];
+    readTextMock.mockResolvedValue("must not be used");
+    const { terminal } = renderTerminal();
+    await waitForSession();
+
+    rightClick(terminal);
+    clickMenuItem("terminalPaste");
+
+    await waitFor(() =>
+      expect(fakeTerminal.current!.term.paste).toHaveBeenCalledWith("/tmp/report.txt "),
+    );
+    expect(readTextMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/terminal/TerminalView.contextmenu.test.tsx
+++ b/src/modules/terminal/TerminalView.contextmenu.test.tsx
@@ -252,6 +252,20 @@ describe("TerminalView context menu on non-Windows platforms", () => {
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 
+  it("leaves overlay chrome (buttons and other widgets) to the window-level handler", () => {
+    // The search bar's close button, the action card and future overlays all
+    // float above the xterm mount; the terminal menu's Paste writes into the
+    // pty, so only the terminal surface itself may open it.
+    const { terminal } = renderTerminal();
+    const chrome = document.createElement("button");
+    terminal.appendChild(chrome);
+
+    const notPrevented = rightClick(chrome);
+
+    expect(notPrevented).toBe(true);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
   it("keeps the terminal menu for xterm's own hidden helper textarea", () => {
     const { terminal } = renderTerminal();
     // The mocked createTerminal renders no DOM, so fabricate the structure the

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -1512,16 +1512,15 @@ export function TerminalView({
         // native paste is ~5s). Backed by the same fast clipboard path as
         // the paste keybinding.
         const target = event.target;
-        // Text fields rendered inside this pane (e.g. the search bar's input)
-        // must NOT get the terminal menu — its Paste would write the clipboard
-        // into the pty instead of the field. Returning without preventDefault
-        // leaves the event to the window-level InputContextMenu, which shows
-        // the proper text-field menu. xterm's own hidden helper textarea
-        // (inside .xterm) is exempt: right-clicking the terminal lands on it,
-        // and it must keep the terminal menu.
+        // Only the terminal surface itself (anything inside the .xterm mount,
+        // or the pane's own background) gets the terminal menu — its Paste
+        // writes the clipboard into the pty. Overlay chrome floating above the
+        // mount (the search bar and its buttons, the action card, future
+        // widgets) falls through without preventDefault to the window-level
+        // InputContextMenu, which shows the right menu per element.
         if (
-          (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) &&
-          !target.closest(".xterm")
+          !(target instanceof Element) ||
+          (!target.closest(".xterm") && target !== event.currentTarget)
         ) {
           return;
         }

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -1,8 +1,17 @@
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { listen } from "@tauri-apps/api/event";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ComponentType } from "react";
 import { useTranslation } from "react-i18next";
-import { ClipboardPaste, Copy, Loader2, WifiOff } from "lucide-react";
+import {
+  ClipboardPaste,
+  Copy,
+  Eraser,
+  Loader2,
+  Search,
+  TextSelect,
+  WifiOff,
+  type LucideProps,
+} from "lucide-react";
 import { consumeFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import { createTerminal, type TerminalHandle } from "./lib/createTerminal";
 import { createOutputWriter } from "./lib/outputWriter";
@@ -60,6 +69,7 @@ import { actionsFor, findActionLinks, type TerminalAction } from "./lib/actionLi
 import { ActionCard } from "./ActionCard";
 import { buildCellPositions, gatherLogicalLine } from "./lib/cellPositions";
 import { terminalKeySequence, isAppShortcut } from "./lib/terminalKeymap";
+import { terminalMenuSpecs, type TerminalMenuAction } from "./lib/terminalMenuItems";
 import { shouldCdToRoot } from "./lib/cwdSync";
 import { parseOsc7Cwd, parseOsc7RemotePath } from "./lib/osc7";
 import { remoteCwdStore } from "@/modules/ssh/lib/remoteCwdStore";
@@ -1480,13 +1490,10 @@ export function TerminalView({
         void handlePathDrop(paths, files);
       }}
       onContextMenu={(event) => {
-        // Windows only: replace the WebView2 native menu (whose paste is slow,
-        // ~5s) with our own, backed by the same fast clipboard path as Ctrl+V.
-        // macOS and Linux keep their native menus — neither has the slow-paste
-        // problem, so there's no reason to override their richer native menu.
-        if (!IS_WINDOWS) {
-          return;
-        }
+        // All platforms get the app menu (unified in the cross-platform
+        // context-menu work; Windows started it in #184 because WebView2's
+        // native paste is ~5s). Backed by the same fast clipboard path as
+        // the paste keybinding.
         event.preventDefault();
         setContextMenu({
           x: event.clientX,
@@ -1501,34 +1508,49 @@ export function TerminalView({
           x={contextMenu.x}
           y={contextMenu.y}
           onClose={() => setContextMenu(null)}
-          items={[
-            ...(contextMenu.hasSelection
-              ? [
-                  {
-                    id: "copy",
-                    label: t("terminalCopy"),
-                    icon: Copy,
-                    onSelect: () => {
-                      const term = handleRef.current?.term;
-                      if (term?.hasSelection()) {
-                        void navigator.clipboard.writeText(term.getSelection());
-                      }
-                    },
-                  } satisfies ContextMenuItem,
-                ]
-              : []),
-            {
-              id: "paste",
-              label: t("terminalPaste"),
-              icon: ClipboardPaste,
+          items={terminalMenuSpecs({ hasSelection: contextMenu.hasSelection }).map((spec) => {
+            const icons = {
+              copy: Copy,
+              paste: ClipboardPaste,
+              selectAll: TextSelect,
+              clear: Eraser,
+              search: Search,
+            } satisfies Record<TerminalMenuAction, ComponentType<LucideProps>>;
+            // Literal t() calls per key — a dynamic t(labels[action]) can fail
+            // typecheck if the project ever adopts typed i18next keys.
+            const labels: Record<TerminalMenuAction, string> = {
+              copy: t("terminalCopy"),
+              paste: t("terminalPaste"),
+              selectAll: t("terminalSelectAll"),
+              clear: t("terminalClear"),
+              search: t("terminalSearch.label"),
+            };
+            const actions: Record<TerminalMenuAction, () => void> = {
+              copy: () => {
+                const term = handleRef.current?.term;
+                if (term?.hasSelection()) {
+                  void navigator.clipboard.writeText(term.getSelection());
+                }
+              },
               // "cmd" so an empty clipboard is a no-op; "ctrl" would inject the
               // raw paste control byte, which a menu paste should never do.
-              onSelect: () => {
+              paste: () => {
                 pasteRef.current?.("cmd");
                 handleRef.current?.term.focus();
               },
-            } satisfies ContextMenuItem,
-          ]}
+              selectAll: () => handleRef.current?.term.selectAll(),
+              clear: () => handleRef.current?.term.clear(),
+              search: () => setSearchOpen(true),
+            };
+            return {
+              id: spec.action,
+              label: labels[spec.action],
+              icon: icons[spec.action],
+              disabled: !spec.enabled,
+              group: spec.group,
+              onSelect: actions[spec.action],
+            } satisfies ContextMenuItem;
+          })}
         />
       )}
       {actionCard && (

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -224,6 +224,9 @@ export function TerminalView({
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; hasSelection: boolean } | null>(null);
   // Lets the right-click menu call the in-effect smart-paste handler.
   const pasteRef = useRef<((kind: "ctrl" | "cmd") => void) | null>(null);
+  // Lets the right-click menu call the in-effect openSearchBox, which also
+  // refocuses and selects the input when the bar is already open.
+  const openSearchRef = useRef<(() => void) | null>(null);
   // The hover action card (IP / host:port / archive quick commands), positioned
   // at the cursor. A short hide delay lets the pointer travel from the link into
   // the card without it vanishing.
@@ -428,9 +431,20 @@ export function TerminalView({
             : null;
         }
       }
+      // On Linux the Rust clipboard backend is a stub: terminal_clipboard_text
+      // resolves Ok("") and the path/image probes return nothing (see
+      // src-tauri/src/modules/clipboard.rs), which would make a menu paste a
+      // silent no-op there. When every native probe came back empty, read the
+      // web clipboard instead. File paths win before this fallback is
+      // consulted, so the Windows files-copied flow is unchanged, and
+      // macOS/Windows return real text through the fast path above.
+      const effectiveClipboardText =
+        !clipboardText && filePaths.length === 0 && imagePaths.length === 0
+          ? await navigator.clipboard.readText().catch(() => "")
+          : clipboardText;
       const action = resolvePasteAction({
         shortcut: kind,
-        clipboardText,
+        clipboardText: effectiveClipboardText,
         filePaths,
         imagePaths,
         foregroundCommand: command,
@@ -454,6 +468,9 @@ export function TerminalView({
       }
     }
     pasteRef.current = handleTerminalPaste;
+    // openSearchBox is declared further down in this effect; function
+    // declarations hoist, so wiring the ref here keeps it beside pasteRef.
+    openSearchRef.current = openSearchBox;
 
     function isTerminalPasteShortcut(event: KeyboardEvent): "ctrl" | "cmd" | null {
       const isV = event.code === "KeyV" || event.key.toLowerCase() === "v";
@@ -1494,11 +1511,31 @@ export function TerminalView({
         // context-menu work; Windows started it in #184 because WebView2's
         // native paste is ~5s). Backed by the same fast clipboard path as
         // the paste keybinding.
+        const target = event.target;
+        // Text fields rendered inside this pane (e.g. the search bar's input)
+        // must NOT get the terminal menu — its Paste would write the clipboard
+        // into the pty instead of the field. Returning without preventDefault
+        // leaves the event to the window-level InputContextMenu, which shows
+        // the proper text-field menu. xterm's own hidden helper textarea
+        // (inside .xterm) is exempt: right-clicking the terminal lands on it,
+        // and it must keep the terminal menu.
+        if (
+          (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) &&
+          !target.closest(".xterm")
+        ) {
+          return;
+        }
+        // Terminal not mounted yet: show no menu (spec: error handling) and
+        // fall back to the app-wide blanket suppression.
+        const handle = handleRef.current;
+        if (!handle) {
+          return;
+        }
         event.preventDefault();
         setContextMenu({
           x: event.clientX,
           y: event.clientY,
-          hasSelection: handleRef.current?.term.hasSelection() ?? false,
+          hasSelection: handle.term.hasSelection(),
         });
       }}
     >
@@ -1540,7 +1577,7 @@ export function TerminalView({
               },
               selectAll: () => handleRef.current?.term.selectAll(),
               clear: () => handleRef.current?.term.clear(),
-              search: () => setSearchOpen(true),
+              search: () => openSearchRef.current?.(),
             };
             return {
               id: spec.action,

--- a/src/modules/terminal/lib/terminalMenuItems.test.ts
+++ b/src/modules/terminal/lib/terminalMenuItems.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { terminalMenuSpecs } from "./terminalMenuItems";
+
+describe("terminalMenuSpecs", () => {
+  it("lists the five actions in stable order with edit and view groups", () => {
+    const specs = terminalMenuSpecs({ hasSelection: true });
+    expect(specs.map((s) => s.action)).toEqual(["copy", "paste", "selectAll", "clear", "search"]);
+    expect(specs.map((s) => s.group)).toEqual([0, 0, 0, 1, 1]);
+  });
+
+  it("greys copy out without a selection instead of hiding it", () => {
+    const withSel = terminalMenuSpecs({ hasSelection: true });
+    expect(withSel.find((s) => s.action === "copy")?.enabled).toBe(true);
+
+    const withoutSel = terminalMenuSpecs({ hasSelection: false });
+    expect(withoutSel.find((s) => s.action === "copy")?.enabled).toBe(false);
+    expect(withoutSel.map((s) => s.action)).toContain("copy");
+  });
+
+  it("keeps paste, select-all, clear and search always enabled", () => {
+    for (const spec of terminalMenuSpecs({ hasSelection: false })) {
+      if (spec.action !== "copy") {
+        expect(spec.enabled).toBe(true);
+      }
+    }
+  });
+});

--- a/src/modules/terminal/lib/terminalMenuItems.ts
+++ b/src/modules/terminal/lib/terminalMenuItems.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure spec builder for the terminal's context menu, mirroring the
+ * inputMenuSpecs pattern: the component maps specs to ContextMenu items and
+ * wires the handlers. Copy is greyed (not hidden) without a selection so the
+ * menu keeps a stable shape the way native menus do.
+ */
+
+export type TerminalMenuAction = "copy" | "paste" | "selectAll" | "clear" | "search";
+
+export interface TerminalMenuContext {
+  hasSelection: boolean;
+}
+
+export interface TerminalMenuItemSpec {
+  action: TerminalMenuAction;
+  enabled: boolean;
+  /** Group index; ContextMenu draws a divider between consecutive groups. */
+  group: number;
+}
+
+export function terminalMenuSpecs(ctx: TerminalMenuContext): TerminalMenuItemSpec[] {
+  return [
+    { action: "copy", enabled: ctx.hasSelection, group: 0 },
+    { action: "paste", enabled: true, group: 0 },
+    { action: "selectAll", enabled: true, group: 0 },
+    { action: "clear", enabled: true, group: 1 },
+    { action: "search", enabled: true, group: 1 },
+  ];
+}

--- a/src/modules/workspace/WorkspacePanel.test.tsx
+++ b/src/modules/workspace/WorkspacePanel.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, within } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/i18n";
 import { WorkspacePanel } from "./WorkspacePanel";
 import { useTabsStore } from "@/stores/tabsStore";
@@ -340,6 +340,26 @@ describe("WorkspacePanel", () => {
     expect(useTabsStore.getState().tabs.find((tab) => tab.id === "t2")).toBeDefined();
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+  });
+
+  it("does not reopen the card context menu when right-clicking the rename input", () => {
+    render(<WorkspacePanel />);
+    const alpha = screen.getByRole("button", { name: /alpha/ });
+    fireEvent.contextMenu(alpha);
+    fireEvent.click(screen.getByRole("menuitem", { name: /Rename Tab/i }));
+    // Right-clicking the rename field must not reopen the card menu, but the
+    // event must still bubble to the window so the app-wide text-field menu
+    // (InputContextMenu) can handle it.
+    const onWindowContextMenu = vi.fn();
+    window.addEventListener("contextmenu", onWindowContextMenu);
+    try {
+      fireEvent.contextMenu(screen.getByDisplayValue("alpha"));
+      expect(screen.queryByRole("menuitem", { name: /Rename Tab/i })).toBeNull();
+      expect(screen.queryByRole("menuitem", { name: /Close Tab/i })).toBeNull();
+      expect(onWindowContextMenu).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener("contextmenu", onWindowContextMenu);
+    }
   });
 
   it("renames a tab from the sidebar context menu", () => {

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -288,6 +288,9 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
       type="button"
       onClick={() => setActive(tab.id)}
       onContextMenu={(event) => {
+        // Right-clicks on the rename input skip the card menu and bubble to
+        // the window-level InputContextMenu, like every other text field.
+        if (event.target instanceof HTMLInputElement) return;
         event.preventDefault();
         setMenu({ x: event.clientX, y: event.clientY });
       }}
@@ -311,7 +314,6 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
               onBlur={commitRename}
               onClick={(event) => event.stopPropagation()}
               onPointerDown={(event) => event.stopPropagation()}
-              onContextMenu={(event) => event.stopPropagation()}
               onKeyDown={(event) => {
                 if (event.key === "Enter") commitRename();
                 if (event.key === "Escape") setEditing(false);


### PR DESCRIPTION
## Summary

Extends #184 to make right-click behavior identical on macOS, Windows and Linux, per the design spec (`docs/superpowers/specs/2026-07-11-unified-context-menu-design.md`).

| Surface | Before (macOS/Linux) | After (all platforms) |
|---|---|---|
| Plain text fields | Native WebView menu | App cut/copy/paste/select-all menu (#184's, gate removed) |
| Terminal | Native menu | App menu, grown to copy / paste / select all / clear / search |
| Blank areas | Native menu (Reload, Save as…) | Suppressed in prod; dev builds keep it so Inspect Element works |
| Notes (Tiptap), editor (CodeMirror) | Native | Native (unchanged, incl. read-only CodeMirror diff view) |

## Key decisions

- Terminal menu items come from a pure spec builder (`terminalMenuSpecs`) mirroring `inputMenuSpecs`; copy is greyed without a selection instead of hidden.
- The trade-off that macOS text fields lose Look Up / Translate / spelling suggestions was accepted explicitly in the design phase, prioritizing cross-platform consistency.
- `SourceControlView`'s panel-level suppressor retired — the app-wide one covers it.

## Hardening from review (2 adversarial review rounds, 9 findings fixed)

- Right-clicking a text field inside the terminal pane (search bar) no longer opens the terminal menu — its Paste would have written the clipboard into the pty.
- Paste falls back to the web clipboard when the native path resolves empty: the Linux Rust clipboard backend is a stub, so menu paste would have been a silent no-op app-wide on Linux.
- Read-only CodeMirror (diff view) keeps its native menu via a new `isEditorSurface` check — `isContentEditable` alone missed it and prod builds would have shown no menu at all there.
- Right-click during an active IME composition keeps the native menu; rewriting the field mid-composition corrupts the composed text.
- Tab/workspace rename inputs join the unified menu (they were the last text fields still showing the platform-native one).
- No terminal menu before the xterm handle exists; menu Search refocuses an already-open search bar.

## Test plan

- [x] `npx vitest run` — 1515/1515 across 178 files (34 new tests: TerminalView context-menu component tests, InputContextMenu behavior tests incl. dev/prod suppression, IME guard, editor-surface carve-outs, rename-input routing)
- [x] `npm run typecheck` — clean
- [x] Round-3 verification included revert-testing: restoring pre-fix sources makes the new tests fail
- [x] Windows pre-flight: frontend-only diff (tsx/ts/json), no Rust, no subprocess, no path handling, no cfg changes

## Follow-ups (not in this PR)

- Linux clipboard backend in Rust is still a stub; the web-clipboard fallback covers paste, but native file/image paste stays macOS/Windows-only.
- macOS users relying on system Look Up / Translate in text fields will notice the change — worth a line in the next release notes.