### PR TITLE
fix(macos): native menus follow the app language (declaration + per-app sync)

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Merged into the generated bundle Info.plist at build time (keys here
+	     win). Without a localization declaration, macOS renders every
+	     system-provided UI surface — most visibly the WKWebView context menu
+	     kept native in editors/notes — in English regardless of the user's
+	     system language. Declaring the app's supported localizations lets
+	     AppKit/WebKit pick the user's language for those menus. -->
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>zh-Hant</string>
+	</array>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,6 +65,7 @@ use modules::sessions_index::{
     sessions_project_stats, sessions_stats, SessionsIndexState,
 };
 use modules::setup::{detect_tools, install_tool};
+use modules::locale::set_app_languages;
 use modules::menu::set_native_menu;
 
 #[derive(serde::Serialize)]
@@ -206,6 +207,7 @@ pub fn run() {
             app_build_info,
             open_new_window,
             set_native_menu,
+            set_app_languages,
             terminal_clipboard_paths,
             terminal_clipboard_image_paths,
             terminal_clipboard_text,

--- a/src-tauri/src/modules/locale.rs
+++ b/src-tauri/src/modules/locale.rs
@@ -1,0 +1,109 @@
+//! Per-app language preference for macOS native UI.
+//!
+//! The bundle declares its supported localizations in Info.plist, but AppKit
+//! picks which one to use from the user's language list — the system one, or
+//! the per-app `AppleLanguages` default when set. Writing that default when
+//! the user switches the in-app language lets the native surfaces we keep
+//! (the editor/notes context menu) follow the app's language after a
+//! relaunch. Other platforms have no equivalent concept, so the command is a
+//! no-op there.
+
+/// Locales the app actually ships (mirror of SUPPORTED_LANGUAGES in
+/// src/i18n/config.ts — keep in sync when adding a locale). The webview is
+/// the caller, so reject anything else: the impact ceiling is only junk in
+/// the app's own preference, but there is no reason to accept it.
+const ALLOWED_LANGUAGES: [&str; 2] = ["en", "zh-Hant"];
+
+fn validate_languages(languages: &[String]) -> Result<(), String> {
+    if languages.is_empty() || languages.len() > ALLOWED_LANGUAGES.len() {
+        return Err("invalid languages length".to_string());
+    }
+    if !languages
+        .iter()
+        .all(|l| ALLOWED_LANGUAGES.contains(&l.as_str()))
+    {
+        return Err("unsupported language".to_string());
+    }
+    Ok(())
+}
+
+/// Arguments for `defaults write <bundle-id> AppleLanguages -array <langs…>`.
+/// Split out so the shape is unit-testable without touching the real
+/// preferences store.
+#[cfg(any(target_os = "macos", test))]
+fn defaults_write_args(bundle_id: &str, languages: &[String]) -> Vec<String> {
+    let mut args = vec![
+        "write".to_string(),
+        bundle_id.to_string(),
+        "AppleLanguages".to_string(),
+        "-array".to_string(),
+    ];
+    args.extend(languages.iter().cloned());
+    args
+}
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub async fn set_app_languages(
+    app: tauri::AppHandle,
+    languages: Vec<String>,
+) -> Result<(), String> {
+    validate_languages(&languages)?;
+    let bundle_id = app.config().identifier.clone();
+    let args = defaults_write_args(&bundle_id, &languages);
+    let output = std::process::Command::new("defaults")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("failed to run defaults: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "defaults write failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+#[tauri::command]
+pub async fn set_app_languages(languages: Vec<String>) -> Result<(), String> {
+    // No per-app language preference concept off macOS; still validate so the
+    // command behaves uniformly across platforms.
+    validate_languages(&languages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_the_defaults_write_invocation() {
+        let args = defaults_write_args(
+            "com.tempoterm.desktop",
+            &["zh-Hant".to_string()],
+        );
+        assert_eq!(
+            args,
+            vec!["write", "com.tempoterm.desktop", "AppleLanguages", "-array", "zh-Hant"]
+        );
+    }
+
+    #[test]
+    fn rejects_languages_outside_the_shipped_set() {
+        assert!(validate_languages(&["zh-Hant".to_string()]).is_ok());
+        assert!(validate_languages(&["en".to_string(), "zh-Hant".to_string()]).is_ok());
+        assert!(validate_languages(&[]).is_err());
+        assert!(validate_languages(&["fr".to_string()]).is_err());
+        assert!(validate_languages(&["-currentHost".to_string()]).is_err());
+        assert!(validate_languages(&vec!["en".to_string(); 3]).is_err());
+    }
+
+    #[test]
+    fn keeps_multiple_languages_in_order() {
+        let args = defaults_write_args(
+            "com.tempoterm.desktop",
+            &["zh-Hant".to_string(), "en".to_string()],
+        );
+        assert_eq!(args[4..], ["zh-Hant".to_string(), "en".to_string()]);
+    }
+}

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -10,6 +10,7 @@ pub mod editor_watch;
 pub mod fonts;
 pub mod fs;
 pub mod git;
+pub mod locale;
 pub mod menu;
 pub mod notes;
 pub mod ports;

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -70,7 +70,8 @@
     "description": "Choose the language used across the interface",
     "system": "Follow system",
     "en": "English",
-    "zh-Hant": "正體中文"
+    "zh-Hant": "正體中文",
+    "restartHint": "Native menus in the editor and notes follow this language after you restart the app"
   },
   "theme": {
     "label": "Theme",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -70,7 +70,8 @@
     "description": "選擇整個介面使用的語言",
     "system": "跟隨系統",
     "en": "English",
-    "zh-Hant": "正體中文"
+    "zh-Hant": "正體中文",
+    "restartHint": "編輯器與筆記的原生選單要重新啟動 app 後才會跟著切換"
   },
   "theme": {
     "label": "主題",

--- a/src/lib/launchLanguage.ts
+++ b/src/lib/launchLanguage.ts
@@ -1,0 +1,10 @@
+import { useSettingsStore } from "@/stores/settingsStore";
+import type { SupportedLanguage } from "@/i18n/config";
+
+/**
+ * The display language the app booted with. macOS reads the per-app
+ * AppleLanguages preference once at launch, so native menus (kept in editors
+ * and notes) only follow a language change after a restart — the settings
+ * panel compares against this to know when to show its restart hint.
+ */
+export const LANGUAGE_AT_LAUNCH: SupportedLanguage = useSettingsStore.getState().language;

--- a/src/modules/settings/SettingsView.test.tsx
+++ b/src/modules/settings/SettingsView.test.tsx
@@ -1,8 +1,25 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/i18n";
 import { SettingsView } from "./SettingsView";
 import { useUiStore } from "@/stores/uiStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+// Flippable per test: the AppleLanguages sync and its restart hint are
+// macOS-only (native menus are an AppKit concern).
+const platformMock = vi.hoisted(() => ({ isMac: true }));
+vi.mock("@/lib/platform", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/platform")>();
+  return {
+    ...actual,
+    get IS_MAC() {
+      return platformMock.isMac;
+    },
+  };
+});
+
+const invokeMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
 
 // Every settings section pulls in its own Tauri/store dependencies (invoke,
 // openUrl, secretsHasKey, ...); stub them all so this test stays focused on
@@ -29,9 +46,13 @@ vi.mock("./AboutSettingsSection", () => ({
 // Snapshot the store (actions included) at load so each test starts from a
 // complete, clean state rather than only resetting the fields we touch.
 const initialUiState = useUiStore.getState();
+const initialSettingsState = useSettingsStore.getState();
 
 beforeEach(() => {
   useUiStore.setState(initialUiState, true);
+  useSettingsStore.setState(initialSettingsState, true);
+  platformMock.isMac = true;
+  invokeMock.mockClear();
 });
 
 describe("SettingsView section deep-link", () => {
@@ -155,5 +176,45 @@ describe("SettingsView section deep-link", () => {
       "aria-current",
       "false",
     );
+  });
+});
+
+describe("SettingsView language switch native-menu sync (macOS)", () => {
+  function openAppearance() {
+    useUiStore.setState({ settingsOpen: true, settingsSection: "appearance" });
+    render(<SettingsView />);
+  }
+
+  it("writes the per-app AppleLanguages preference when the language changes", () => {
+    openAppearance();
+
+    fireEvent.click(screen.getByRole("button", { name: "正體中文" }));
+
+    expect(invokeMock).toHaveBeenCalledWith("set_app_languages", {
+      languages: ["zh-Hant"],
+    });
+  });
+
+  it("shows a restart hint once the language differs from the one at launch", () => {
+    openAppearance();
+    expect(screen.queryByTestId("language-restart-hint")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "正體中文" }));
+    expect(screen.getByTestId("language-restart-hint")).toBeInTheDocument();
+
+    // Switching back to the launch language: native menus already match it,
+    // so the hint disappears.
+    fireEvent.click(screen.getByRole("button", { name: "English" }));
+    expect(screen.queryByTestId("language-restart-hint")).not.toBeInTheDocument();
+  });
+
+  it("does nothing on non-macOS platforms", () => {
+    platformMock.isMac = false;
+    openAppearance();
+
+    fireEvent.click(screen.getByRole("button", { name: "正體中文" }));
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("language-restart-hint")).not.toBeInTheDocument();
   });
 });

--- a/src/modules/settings/SettingsView.tsx
+++ b/src/modules/settings/SettingsView.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Check } from "lucide-react";
+import { invoke } from "@tauri-apps/api/core";
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "@/i18n/config";
+import { IS_MAC } from "@/lib/platform";
+import { LANGUAGE_AT_LAUNCH } from "@/lib/launchLanguage";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useUiStore } from "@/stores/uiStore";
 import { getTheme, THEMES, type AppTheme } from "@/themes/themes";
@@ -90,7 +93,15 @@ function AppearanceSection() {
               key={lng}
               type="button"
               aria-pressed={language === lng}
-              onClick={() => setLanguage(lng as SupportedLanguage)}
+              onClick={() => {
+                setLanguage(lng as SupportedLanguage);
+                if (IS_MAC) {
+                  // Keep the per-app AppleLanguages preference in step so the
+                  // native menus (editor, notes) follow after a relaunch —
+                  // AppKit only reads it at launch.
+                  void invoke("set_app_languages", { languages: [lng] }).catch(() => {});
+                }
+              }}
               className={`rounded-md border px-3 py-1.5 text-xs transition-colors ${
                 language === lng
                   ? "border-accent bg-bg-elevated text-fg"
@@ -101,6 +112,11 @@ function AppearanceSection() {
             </button>
           ))}
         </div>
+        {IS_MAC && language !== LANGUAGE_AT_LAUNCH && (
+          <p data-testid="language-restart-hint" className="mt-2 text-xs text-fg-muted">
+            {t("language.restartHint")}
+          </p>
+        )}
       </div>
 
       <div>


### PR DESCRIPTION
## Problem

The unified context-menu work (#199) deliberately keeps native menus in editors and notes — but on a zh-Hant system those native menus render in English (Look Up, Translate, Cut/Copy/Paste…). And even with localizations declared, the native menus follow the **system** language, not the in-app language setting.

## Fix (two commits)

**1. Declare the app's localizations** (`src-tauri/Info.plist`, auto-merged into the bundle plist at build time — verified against tauri-cli 2.11.2 sources, `interface/rust.rs` + `helpers/plist.rs`, merge is last-wins):

- `CFBundleLocalizations` = `[en, zh-Hant]`, `CFBundleDevelopmentRegion` = `en`, `CFBundleAllowMixedLocalizations` = `true`
- Native menus now render in the system language instead of hardcoded English. Verified on a local build (`plutil -p` on the produced bundle + visual check).

**2. Sync the per-app language on switch** so native menus follow the in-app setting too:

- New `set_app_languages` command writes the per-app `AppleLanguages` default (`defaults write`, no shell). macOS-only; validated no-op elsewhere.
- The settings panel calls it when the display language changes and shows a restart hint while the chosen language differs from the one the app booted with — AppKit only reads the preference at launch.
- Languages are validated against the shipped locale allowlist before shelling out. Security review passed; the reviewer empirically ruled out argument injection (post-`-array` tokens are literals to `defaults`) and the allowlist is defense-in-depth on top.

## Test plan

- [x] `cargo test locale` — 6/6 (arg building, ordering, allowlist rejection incl. dash-prefixed and oversized input)
- [x] `cargo check` — clean, no warnings
- [x] `npx vitest run` — 1520/1520 (3 new: AppleLanguages invoke on switch, restart-hint lifecycle, non-macOS no-op)
- [x] `npm run typecheck` — clean
- [x] Local build: bundle plist carries the localization keys; native menu renders in the system language
- [ ] Visual: switch language in settings → hint appears → relaunch → editor right-click menu follows the chosen language
- [x] Windows pre-flight: subprocess spawn is `#[cfg(target_os = "macos")]`-gated; other platforms compile a pure validation no-op; frontend gates the invoke behind `IS_MAC`

🤖 Generated with [Claude Code](https://claude.com/claude-code)