### PR TITLE
feat(titlebar): icon/標題可拖曳 + 選單列 RWD 溢位選單 (Windows)

### DIFF
--- a/src/components/TitleBar.test.tsx
+++ b/src/components/TitleBar.test.tsx
@@ -124,6 +124,15 @@ describe("TitleBar", () => {
     expect(closeWindow).toHaveBeenCalledOnce();
   });
 
+  it("marks the brand mark as a deep drag region so the icon and title drag the window", () => {
+    render(<TitleBar />);
+    const brand = screen.getByText("TempoTerm").closest("[data-tauri-drag-region]");
+    // "deep" (not a bare attribute): a bare data-tauri-drag-region is "self
+    // mode" and only drags on direct hits of the div, so grabbing the child
+    // icon or title text would do nothing. See Tauri's drag.js.
+    expect(brand).toHaveAttribute("data-tauri-drag-region", "deep");
+  });
+
   it("shows the restore control once the window reports it is maximized", async () => {
     isWindowMaximized.mockResolvedValue(true);
     render(<TitleBar />);
@@ -172,6 +181,45 @@ describe("TitleBar", () => {
     render(<TitleBar />);
     for (const label of ["File", "Edit", "View", "Terminal", "Window", "Help"]) {
       expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("collapses menus that don't fit into a […] button and reveals them on demand", () => {
+    // jsdom does no layout, so force the measurements the fit math reads: every
+    // button/label measures 100px wide and the bar is only 250px — so just the
+    // first menu fits beside the 100px […] button; the rest collapse.
+    const rectSpy = vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+      width: 100,
+      height: 32,
+      top: 0,
+      left: 0,
+      right: 100,
+      bottom: 32,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+    const cwDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, "clientWidth");
+    Object.defineProperty(Element.prototype, "clientWidth", { configurable: true, get: () => 250 });
+    try {
+      render(<TitleBar />);
+      // File fits; Window has collapsed out of the bar into the overflow button.
+      expect(screen.getByRole("button", { name: "File" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Window" })).toBeNull();
+      const more = screen.getByLabelText("More menus");
+
+      // Opening […] lists the collapsed menus; hovering one cascades its items
+      // out to the side (rather than stacking a dropdown over the list)…
+      fireEvent.click(more);
+      fireEvent.mouseEnter(screen.getByRole("menuitem", { name: "Window" }));
+      // …and choosing an item from that cascade still runs its action.
+      fireEvent.click(screen.getByRole("menuitem", { name: /Toggle Full Screen/ }));
+      expect(toggleFullscreenWindow).toHaveBeenCalledOnce();
+    } finally {
+      rectSpy.mockRestore();
+      if (cwDescriptor) {
+        Object.defineProperty(Element.prototype, "clientWidth", cwDescriptor);
+      }
     }
   });
 

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -258,15 +258,10 @@ function MenuFlyout({
 function WindowMenuBar() {
   const { t } = useTranslation();
   const [openId, setOpenId] = useState<string | null>(null);
-  // `align` picks which edge the dropdown is pinned to: left-side menus grow
-  // rightward from their left edge; the right-side […] button grows leftward from
-  // its right edge, so its dropdown never spills over the window controls.
-  const [anchor, setAnchor] = useState<{
-    left: number;
-    right: number;
-    y: number;
-    align: "left" | "right";
-  } | null>(null);
+  // Anchor for the open dropdown, pinned to the button's bottom-left. Every menu
+  // (including […]) sits after the brand with the drag region and window controls
+  // to its right, so it always has room to open rightward from its left edge.
+  const [anchor, setAnchor] = useState<{ left: number; y: number } | null>(null);
   const [isMaximized, setIsMaximized] = useState(false);
   // How many leading menus fit; the rest collapse into the […] button. Starts
   // "all" so the first paint is complete, then the measurement effect clamps it.
@@ -358,22 +353,18 @@ function WindowMenuBar() {
     };
   }, [openId]);
 
-  function openFrom(el: HTMLElement, id: string, align: "left" | "right" = "left") {
+  function openFrom(el: HTMLElement, id: string) {
     const rect = el.getBoundingClientRect();
-    setAnchor({
-      left: rect.left,
-      right: window.innerWidth - rect.right,
-      y: rect.bottom,
-      align,
-    });
+    setAnchor({ left: rect.left, y: rect.bottom });
     setOpenId(id);
   }
 
-  // Fixed-position style pinning a dropdown to the anchored edge.
-  const anchorStyle = (): CSSProperties =>
-    anchor?.align === "right"
-      ? { position: "fixed", right: anchor.right, top: anchor.y }
-      : { position: "fixed", left: anchor?.left, top: anchor?.y };
+  // Fixed-position style pinning a dropdown to the button's bottom-left.
+  const anchorStyle = (): CSSProperties => ({
+    position: "fixed",
+    left: anchor?.left,
+    top: anchor?.y,
+  });
 
   const activeMenu = menus.find((m) => m.id === openId) ?? null;
   const visibleMenus = menus.slice(0, visibleCount);

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,7 +1,14 @@
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type Ref,
+} from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import { ChevronRight, Minus, Square, X } from "lucide-react";
+import { ChevronRight, Ellipsis, Minus, Square, X } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
 import { useOverlayGuard } from "@/lib/overlayGuard";
 import { IS_WINDOWS } from "@/lib/platform";
@@ -14,10 +21,22 @@ import {
 } from "@/lib/window";
 import {
   buildMenus,
+  computeVisibleCount,
   executeMenuAction,
   getMenuContext,
+  type MenuContext,
   type MenuItemDef,
 } from "@/components/menuBarMenus";
+
+/** Width-relevant classes for a top-level menu-bar button. Shared by the real
+ *  buttons, the […] overflow button, and the hidden measurement row so all three
+ *  size identically and the fit math stays honest. State (open/hover) colors are
+ *  appended per-button and don't affect width. */
+const MENU_BUTTON_CLASS =
+  "flex h-full shrink-0 items-center whitespace-nowrap px-2 text-[13px] transition-colors min-[820px]:px-3";
+
+/** Sentinel `openId` for the […] overflow dropdown (vs a real menu's id). */
+const OVERFLOW_ID = "__overflow__";
 
 /** Overlapping-squares "restore" glyph; lucide has no direct equivalent. */
 function RestoreIcon({ size = 11 }: { size?: number }) {
@@ -119,46 +138,143 @@ function MenuItemRow({
 // crosses sibling rows first) has time to land before the flyout disappears.
 const SUBMENU_CLOSE_DELAY_MS = 180;
 
+// A submenu narrower than this is assumed to fit; used only to decide which side
+// to open on, so a slight over-estimate just biases toward flipping left.
+const ESTIMATED_SUBMENU_WIDTH = 240;
+
+/**
+ * A dropdown panel of menu rows that recursively renders any item's `submenu` as
+ * a nested flyout — the cascade behind the […] overflow (and View → Sidebar
+ * Panel). Each submenu opens to the right when it fits, otherwise flips left, so
+ * it never runs off the viewport edge. Every level owns its hover-close timer:
+ * crossing sibling rows toward a flyout schedules a close; entering the child
+ * flyout cancels the parent's.
+ */
+function MenuFlyout({
+  items,
+  ctx,
+  style,
+  onAction,
+  onMouseEnter,
+  rootRef,
+  minWidthClass = "min-w-[200px]",
+}: {
+  items: MenuItemDef[];
+  ctx: MenuContext;
+  style: CSSProperties;
+  onAction: (item: MenuItemDef) => void;
+  onMouseEnter?: () => void;
+  rootRef?: Ref<HTMLDivElement>;
+  minWidthClass?: string;
+}) {
+  const [openSubId, setOpenSubId] = useState<string | null>(null);
+  const [sub, setSub] = useState<{
+    side: "left" | "right";
+    left: number;
+    right: number;
+    y: number;
+  } | null>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearClose = () => {
+    if (closeTimer.current !== null) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  };
+  const scheduleClose = () => {
+    clearClose();
+    closeTimer.current = setTimeout(() => {
+      closeTimer.current = null;
+      setOpenSubId(null);
+    }, SUBMENU_CLOSE_DELAY_MS);
+  };
+  useEffect(() => clearClose, []);
+
+  const shortcutHint = (s?: { mac: string; win: string }) =>
+    s ? (IS_WINDOWS ? s.win : s.mac) : undefined;
+
+  return (
+    <div
+      ref={rootRef}
+      role="menu"
+      onMouseEnter={onMouseEnter}
+      style={style}
+      className={`z-[200] ${minWidthClass} overflow-hidden rounded-md border border-border-strong bg-bg-elevated py-1 text-[13px] shadow-lg`}
+    >
+      {items.map((item, index) => {
+        const previous = items[index - 1];
+        const newGroup = previous !== undefined && previous.group !== item.group;
+        const disabled = item.disabled?.(ctx) ?? false;
+        const isSubmenuOpen = openSubId === item.id;
+        return (
+          <div key={item.id} className="relative">
+            {newGroup && <div className="my-1 h-px bg-border" />}
+            <MenuItemRow
+              item={item}
+              disabled={disabled}
+              shortcutHint={shortcutHint(item.shortcut)}
+              isSubmenuOpen={isSubmenuOpen}
+              // Submenu parents open on hover (below); a click on them is a no-op.
+              onSelect={() => {
+                if (!disabled && !item.submenu) onAction(item);
+              }}
+              onSubmenuEnter={(rect) => {
+                clearClose();
+                // Open to the right of the row when it fits; otherwise flip left
+                // so the flyout never runs off the viewport's right edge.
+                const opensRight =
+                  window.innerWidth - rect.right >= ESTIMATED_SUBMENU_WIDTH;
+                setSub({
+                  side: opensRight ? "right" : "left",
+                  left: rect.right,
+                  right: window.innerWidth - rect.left,
+                  y: rect.top,
+                });
+                setOpenSubId(item.id);
+              }}
+              onSiblingEnter={scheduleClose}
+            />
+            {item.submenu && isSubmenuOpen && sub && (
+              <MenuFlyout
+                items={item.submenu}
+                ctx={ctx}
+                onAction={onAction}
+                onMouseEnter={clearClose}
+                style={
+                  sub.side === "right"
+                    ? { position: "fixed", left: sub.left, top: sub.y }
+                    : { position: "fixed", right: sub.right, top: sub.y }
+                }
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function WindowMenuBar() {
   const { t } = useTranslation();
   const [openId, setOpenId] = useState<string | null>(null);
-  const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null);
-  const [submenuId, setSubmenuId] = useState<string | null>(null);
-  const [submenuAnchor, setSubmenuAnchor] = useState<{ x: number; y: number } | null>(null);
+  // `align` picks which edge the dropdown is pinned to: left-side menus grow
+  // rightward from their left edge; the right-side […] button grows leftward from
+  // its right edge, so its dropdown never spills over the window controls.
+  const [anchor, setAnchor] = useState<{
+    left: number;
+    right: number;
+    y: number;
+    align: "left" | "right";
+  } | null>(null);
   const [isMaximized, setIsMaximized] = useState(false);
+  // How many leading menus fit; the rest collapse into the […] button. Starts
+  // "all" so the first paint is complete, then the measurement effect clamps it.
+  const [visibleCount, setVisibleCount] = useState(Number.MAX_SAFE_INTEGER);
   const barRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
-  const submenuCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  function clearSubmenuCloseTimer() {
-    if (submenuCloseTimer.current !== null) {
-      clearTimeout(submenuCloseTimer.current);
-      submenuCloseTimer.current = null;
-    }
-  }
-
-  // Close immediately: used for every close that isn't the sibling-hover
-  // tunneling case below (item selected, menu dismissed, menu switched).
-  function closeSubmenuNow() {
-    clearSubmenuCloseTimer();
-    setSubmenuId(null);
-  }
-
-  // Hovering a sibling row schedules the close instead of firing it
-  // immediately, so the cursor has SUBMENU_CLOSE_DELAY_MS to reach the
-  // flyout (entering the submenu's own row again, or the flyout itself,
-  // cancels the pending close — see the handlers below).
-  function scheduleSubmenuClose() {
-    clearSubmenuCloseTimer();
-    submenuCloseTimer.current = setTimeout(() => {
-      submenuCloseTimer.current = null;
-      setSubmenuId(null);
-    }, SUBMENU_CLOSE_DELAY_MS);
-  }
-
-  // Timer must not outlive the component, and must not fire against a menu
-  // that's already been torn down and remounted.
-  useEffect(() => clearSubmenuCloseTimer, []);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const moreButtonRef = useRef<HTMLButtonElement>(null);
 
   // The native preview webview floats above all DOM, so hide it while a menu is
   // open or it would cover the dropdown (same guard ContextMenu uses).
@@ -183,14 +299,33 @@ function WindowMenuBar() {
   const ctx = getMenuContext(isMaximized);
   const menus = buildMenus(ctx);
 
-  const shortcutHint = (s?: { mac: string; win: string }) =>
-    s ? (IS_WINDOWS ? s.win : s.mac) : undefined;
+  // Fit the menu buttons to the space between the brand and the window controls,
+  // collapsing whatever doesn't fit into the […] button. Widths are measured
+  // from a hidden row that mirrors the real buttons, so the math tracks the live
+  // font/zoom/locale metrics instead of hard-coded sizes. Re-runs whenever the
+  // bar's width (window resize, zoom) or the measured row (locale) changes.
+  useLayoutEffect(() => {
+    const bar = barRef.current;
+    const measure = measureRef.current;
+    if (!bar || !measure) return;
+    const recompute = () => {
+      const items = Array.from(measure.children) as HTMLElement[];
+      // The measurement row is [one span per menu…, the […] button].
+      const widths = items.slice(0, menus.length).map((el) => el.getBoundingClientRect().width);
+      const moreWidth = items[menus.length]?.getBoundingClientRect().width ?? 0;
+      setVisibleCount(computeVisibleCount(widths, moreWidth, bar.clientWidth));
+    };
+    recompute();
+    const observer = new ResizeObserver(recompute);
+    observer.observe(bar);
+    observer.observe(measure);
+    return () => observer.disconnect();
+  }, [menus.length]);
 
   const onItemSelect = (item: MenuItemDef) => {
     if (item.disabled?.(ctx) || !item.action) return;
     executeMenuAction(item.action);
     setOpenId(null);
-    closeSubmenuNow();
   };
 
   // Close on outside pointer / Escape / resize. The menu-bar buttons count as
@@ -204,17 +339,14 @@ function WindowMenuBar() {
         return;
       }
       setOpenId(null);
-      closeSubmenuNow();
     }
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         setOpenId(null);
-        closeSubmenuNow();
       }
     }
     function onResize() {
       setOpenId(null);
-      closeSubmenuNow();
     }
     document.addEventListener("mousedown", onPointerDown, true);
     document.addEventListener("keydown", onKeyDown, true);
@@ -226,18 +358,60 @@ function WindowMenuBar() {
     };
   }, [openId]);
 
-  function openFrom(el: HTMLElement, id: string) {
+  function openFrom(el: HTMLElement, id: string, align: "left" | "right" = "left") {
     const rect = el.getBoundingClientRect();
-    setAnchor({ x: rect.left, y: rect.bottom });
+    setAnchor({
+      left: rect.left,
+      right: window.innerWidth - rect.right,
+      y: rect.bottom,
+      align,
+    });
     setOpenId(id);
-    closeSubmenuNow();
   }
 
+  // Fixed-position style pinning a dropdown to the anchored edge.
+  const anchorStyle = (): CSSProperties =>
+    anchor?.align === "right"
+      ? { position: "fixed", right: anchor.right, top: anchor.y }
+      : { position: "fixed", left: anchor?.left, top: anchor?.y };
+
   const activeMenu = menus.find((m) => m.id === openId) ?? null;
+  const visibleMenus = menus.slice(0, visibleCount);
+  const overflowMenus = menus.slice(visibleCount);
+  // The […] dropdown is just a cascade: each collapsed menu becomes a submenu
+  // parent, so hovering it flies its items out to the side instead of replacing
+  // the list. Reuses the same MenuFlyout recursion as the normal dropdowns.
+  const overflowItems: MenuItemDef[] = overflowMenus.map((menu) => ({
+    id: menu.id,
+    labelKey: menu.labelKey,
+    group: 0,
+    submenu: menu.items,
+  }));
 
   return (
-    <div ref={barRef} className="flex h-full items-center">
-      {menus.map((menu) => (
+    // flex-1 + min-w-0: the bar takes the space between the brand and the window
+    // controls and may shrink below its content; overflow-hidden hides the
+    // measurement row and clips any transient overflow during a resize.
+    <div ref={barRef} className="relative flex h-full min-w-0 flex-1 items-center overflow-hidden">
+      {/* Hidden measurement row: every menu label plus the […] button, laid out
+          exactly like the real ones (same MENU_BUTTON_CLASS) but not painted, so
+          getBoundingClientRect gives their natural widths regardless of how many
+          are currently shown — and re-measures on zoom/locale via ResizeObserver. */}
+      <div
+        ref={measureRef}
+        aria-hidden
+        className="pointer-events-none invisible absolute left-0 top-0 flex h-full items-center"
+      >
+        {menus.map((menu) => (
+          <span key={menu.id} className={MENU_BUTTON_CLASS}>
+            {t(menu.labelKey)}
+          </span>
+        ))}
+        <span className={MENU_BUTTON_CLASS}>
+          <Ellipsis size={16} />
+        </span>
+      </div>
+      {visibleMenus.map((menu) => (
         <button
           key={menu.id}
           type="button"
@@ -250,7 +424,6 @@ function WindowMenuBar() {
           onClick={(e) => {
             if (openId === menu.id) {
               setOpenId(null);
-              closeSubmenuNow();
             } else {
               openFrom(e.currentTarget, menu.id);
             }
@@ -260,7 +433,7 @@ function WindowMenuBar() {
           onMouseEnter={(e) => {
             if (openId !== null && openId !== menu.id) openFrom(e.currentTarget, menu.id);
           }}
-          className={`flex h-full items-center px-3 text-[13px] transition-colors ${
+          className={`${MENU_BUTTON_CLASS} ${
             openId === menu.id
               ? "bg-bg-elevated text-fg"
               : "text-fg-muted hover:bg-bg-elevated hover:text-fg"
@@ -269,67 +442,62 @@ function WindowMenuBar() {
           {t(menu.labelKey)}
         </button>
       ))}
+      {overflowMenus.length > 0 && (
+        <button
+          ref={moreButtonRef}
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={openId === OVERFLOW_ID}
+          aria-label={t("titleBar.moreMenus")}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={(e) => {
+            if (openId === OVERFLOW_ID) {
+              setOpenId(null);
+            } else {
+              openFrom(e.currentTarget, OVERFLOW_ID);
+            }
+          }}
+          onMouseEnter={(e) => {
+            if (openId !== null && openId !== OVERFLOW_ID)
+              openFrom(e.currentTarget, OVERFLOW_ID);
+          }}
+          className={`${MENU_BUTTON_CLASS} ${
+            openId === OVERFLOW_ID
+              ? "bg-bg-elevated text-fg"
+              : "text-fg-muted hover:bg-bg-elevated hover:text-fg"
+          }`}
+        >
+          <Ellipsis size={16} />
+        </button>
+      )}
+      {/* The leftover width stays a drag region so the window is still movable
+          from the empty stretch of the title bar. */}
+      <div data-tauri-drag-region="deep" className="h-full flex-1" />
+      {openId === OVERFLOW_ID &&
+        anchor &&
+        createPortal(
+          <MenuFlyout
+            rootRef={menuRef}
+            items={overflowItems}
+            ctx={ctx}
+            style={anchorStyle()}
+            onAction={onItemSelect}
+            // The list holds only menu names — keep it narrow so it sits snug
+            // under the […] button.
+            minWidthClass="min-w-[9rem]"
+          />,
+          document.body,
+        )}
       {activeMenu &&
         anchor &&
         createPortal(
-          <div
-            ref={menuRef}
-            role="menu"
-            style={{ position: "fixed", left: anchor.x, top: anchor.y }}
-            className="z-[200] min-w-[220px] overflow-hidden rounded-md border border-border-strong bg-bg-elevated py-1 text-[13px] shadow-lg"
-          >
-            {activeMenu.items.map((item, index) => {
-              const previous = activeMenu.items[index - 1];
-              const newGroup = previous !== undefined && previous.group !== item.group;
-              const disabled = item.disabled?.(ctx) ?? false;
-              const isSubmenuOpen = submenuId === item.id;
-              return (
-                <div key={item.id} className="relative">
-                  {newGroup && <div className="my-1 h-px bg-border" />}
-                  <MenuItemRow
-                    item={item}
-                    disabled={disabled}
-                    shortcutHint={shortcutHint(item.shortcut)}
-                    isSubmenuOpen={isSubmenuOpen}
-                    onSelect={() => onItemSelect(item)}
-                    onSubmenuEnter={(rect) => {
-                      // Re-entering the row that owns the open flyout (or
-                      // entering a different submenu row, handled the same
-                      // way) is itself a cancel: there is no pending close to
-                      // honor once the cursor is back on a submenu row.
-                      clearSubmenuCloseTimer();
-                      setSubmenuAnchor({ x: rect.right, y: rect.top });
-                      setSubmenuId(item.id);
-                    }}
-                    onSiblingEnter={scheduleSubmenuClose}
-                  />
-                  {item.submenu && isSubmenuOpen && submenuAnchor && (
-                    <div
-                      role="menu"
-                      // The cursor reaching the flyout — even via a row deep
-                      // inside it that has no handler of its own — cancels
-                      // any close scheduled by the sibling-row it crossed to
-                      // get here.
-                      onMouseEnter={clearSubmenuCloseTimer}
-                      style={{ position: "fixed", left: submenuAnchor.x, top: submenuAnchor.y }}
-                      className="z-[210] min-w-[180px] overflow-hidden rounded-md border border-border-strong bg-bg-elevated py-1 text-[13px] shadow-lg"
-                    >
-                      {item.submenu.map((child) => (
-                        <MenuItemRow
-                          key={child.id}
-                          item={child}
-                          disabled={child.disabled?.(ctx) ?? false}
-                          shortcutHint={shortcutHint(child.shortcut)}
-                          isSubmenuOpen={false}
-                          onSelect={() => onItemSelect(child)}
-                        />
-                      ))}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>,
+          <MenuFlyout
+            rootRef={menuRef}
+            items={activeMenu.items}
+            ctx={ctx}
+            style={anchorStyle()}
+            onAction={onItemSelect}
+          />,
           document.body,
         )}
     </div>
@@ -373,17 +541,21 @@ export function TitleBar() {
 
   return (
     <div className="flex h-8 shrink-0 items-center border-b border-border bg-bg-inset">
-      {/* Brand mark. Kept a drag region so the window can be moved from here;
-          the img/span aren't interactive, so dragging still works. */}
+      {/* Brand mark, and the window's drag handle. "deep" (not a bare
+          data-tauri-drag-region) makes clicks anywhere in the subtree drag the
+          window — a bare attribute is "self mode" and only drags on direct hits
+          of this div, so grabbing the icon or the title text (both children)
+          would do nothing. shrink-0 keeps it from being squeezed by the menu. */}
       <div
-        data-tauri-drag-region
-        className="flex h-full select-none items-center gap-1.5 pl-2.5 pr-1"
+        data-tauri-drag-region="deep"
+        className="flex h-full shrink-0 select-none items-center gap-1.5 pl-2.5 pr-1"
       >
         <img src="/icon.png" alt="" className="h-4 w-4 rounded-sm" draggable={false} />
-        <span className="text-[13px] font-semibold text-fg">{t("appName")}</span>
+        <span className="whitespace-nowrap text-[13px] font-semibold text-fg">
+          {t("appName")}
+        </span>
       </div>
       <WindowMenuBar />
-      <div data-tauri-drag-region className="h-full flex-1" />
       <div className="flex h-full shrink-0 items-center">
         <Tooltip label={t("titleBar.minimize")} side="bottom">
           <button

--- a/src/components/menuBarMenus.test.ts
+++ b/src/components/menuBarMenus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildMenus, type MenuContext } from "./menuBarMenus";
+import { buildMenus, computeVisibleCount, type MenuContext } from "./menuBarMenus";
 import { DEFAULT_SIDEBAR_ORDER, type SidebarView } from "@/stores/uiStore";
 
 const baseCtx: MenuContext = {
@@ -83,5 +83,29 @@ describe("buildMenus", () => {
       expect(resolve(en, key), `en missing ${key}`).toBeTruthy();
       expect(resolve(zh, key), `zh-Hant missing ${key}`).toBeTruthy();
     }
+  });
+});
+
+describe("computeVisibleCount", () => {
+  it("shows every button when they all fit (no overflow needed)", () => {
+    // total 150 ≤ 200 → all six-ish fit, returns the full count.
+    expect(computeVisibleCount([50, 50, 50], 30, 200)).toBe(3);
+  });
+
+  it("reserves room for the […] button and collapses the rest", () => {
+    // total 300 > 200, so the […] button (30) must fit alongside kept buttons:
+    // 50+50+50 = 150, +30 = 180 ≤ 200; a 4th would be 200+30 > 200 → 3 visible.
+    expect(computeVisibleCount([50, 50, 50, 50, 50, 50], 30, 200)).toBe(3);
+  });
+
+  it("can collapse everything into […] when even one button won't fit beside it", () => {
+    // 100 + 40 = 140 > 120 → 0 visible, all six go under the […] button.
+    expect(computeVisibleCount([100, 100], 40, 120)).toBe(0);
+  });
+
+  it("returns the full count for unmeasured widths (0), so the bar never renders empty", () => {
+    // Before the first layout pass (and in non-layout test envs) every width and
+    // the available width are 0 — treat that as 'everything fits'.
+    expect(computeVisibleCount([0, 0, 0, 0, 0, 0], 0, 0)).toBe(6);
   });
 });

--- a/src/components/menuBarMenus.ts
+++ b/src/components/menuBarMenus.ts
@@ -188,3 +188,33 @@ export function buildMenus(ctx: MenuContext): MenuDef[] {
     },
   ];
 }
+
+/**
+ * How many leading menu-bar buttons fit in `available` px. Returns the full
+ * count when they all fit (no overflow button needed); otherwise fits as many as
+ * possible while reserving `moreWidth` px for the `[…]` overflow button, so the
+ * rest can collapse into it. Widths are measured from the rendered buttons, so
+ * this stays correct under browser zoom and locale changes without hard-coding
+ * any sizes. Degenerate inputs (no measurement yet, e.g. before first layout or
+ * in a non-layout test env where every width is 0) return the full count, so the
+ * bar renders complete rather than empty.
+ */
+export function computeVisibleCount(
+  buttonWidths: number[],
+  moreWidth: number,
+  available: number,
+): number {
+  const total = buttonWidths.reduce((sum, w) => sum + w, 0);
+  if (!(available > 0) || total <= available) {
+    return buttonWidths.length;
+  }
+  let used = 0;
+  let count = 0;
+  for (const width of buttonWidths) {
+    // Every kept button must still leave room for the […] button beside it.
+    if (used + width + moreWidth > available) break;
+    used += width;
+    count += 1;
+  }
+  return count;
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -91,7 +91,8 @@
     "minimize": "Minimize",
     "maximize": "Maximize",
     "restore": "Restore",
-    "close": "Close"
+    "close": "Close",
+    "moreMenus": "More menus"
   },
   "menuBar": {
     "file": "File",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -91,7 +91,8 @@
     "minimize": "最小化",
     "maximize": "最大化",
     "restore": "還原",
-    "close": "關閉"
+    "close": "關閉",
+    "moreMenus": "更多選單"
   },
   "menuBar": {
     "file": "檔案",


### PR DESCRIPTION
## 這個 PR 做了什麼

延續 #173 的 Windows 自繪標題列,加上兩個改進。

### 1. icon 與應用程式名稱現在可以拖曳視窗

品牌區原本是裸的 `data-tauri-drag-region`,而這在 Tauri 屬於 **「self mode」**——只有點擊**落在那個 `<div>` 本身**才會開始拖曳,子元素不算(見 `tauri/.../scripts/drag.js`)。所以抓著看得到的 icon 或「TempoTerm」文字都拖不動,只有它們周圍的 padding 能拖。改成 `data-tauri-drag-region="deep"` 後,子樹內任一點都能拖曳視窗。

### 2. 選單列 RWD,放不下時收進 `[…]`

視窗變窄(或瀏覽器放大 zoom)時,檔案 / 編輯 / 檢視 / … 這排按鈕可能折行或被切掉。現在:

- 按鈕一律不換行,整排會依「品牌與視窗控制鈕之間」的可用寬度來排。
- 放不下的選單收進一個 `[…]` 鈕。可見數量由 `computeVisibleCount` 計算,寬度來自一列**隱藏的鏡像量測 row + `ResizeObserver`**,所以會跟著字型、zoom、語言即時調整,不寫死尺寸。
- `[…]` 下拉會把收起的選單以**層疊子選單**展開(遞迴的 `MenuFlyout`),所以像「檢視 → 側欄面板」這種本身還有子選單的項目照常可用。子選單預設往右開,快撞到視窗右緣時**自動翻向左邊**,不會被切掉。
- 標題列剩餘的空白仍是拖曳區。

## 測試

- `tsc --noEmit` 乾淨。
- `vitest run` 全套通過。新增測試:`computeVisibleCount`(排版計算,含「尚未量測/退化」時必須顯示完整選單列的情況)、品牌區的 `deep` 拖曳屬性、以及溢位收合 + 層疊展開的互動。
- Windows 上實測:從 icon/標題拖曳、把視窗縮到選單收進 `[…]`、hover 層疊展開、以及靠近右緣時的右→左自動翻向。

## 備註

僅 Windows——`TitleBar` 在非 Windows 上回傳 `null`,那邊由原生選單列(`menu.rs`)負責。沒有動到 Rust,只有前端與 i18n 字串。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
