### PR TITLE
fix(windows): make open_new_window async to avoid webview-creation deadlock

### DIFF
--- a/.claude/skills/windows-tauri/SKILL.md
+++ b/.claude/skills/windows-tauri/SKILL.md
@@ -21,6 +21,7 @@ Apply while writing, not after. Each line links to the detailed rule.
 - [ ] **A `#[cfg(unix)]` API, a cfg-split command, or a new native crate?** It must compile **warning-free** on Windows — `windows-check.yml` runs `cargo check` with `-D warnings` per PR. Provide a Windows arm or cfg-gate cleanly, and `allow(dead_code)`/`allow(unused_variables)` the mac-only bits. [→](#6-unix-only-apis-and-native-crates-must-still-build-on-windows)
 - [ ] **Reaching into `/proc`, `lsof`, a unix socket, pty foreground?** No Windows backend exists; skip the feature there or return a clean `None`. [→](#7-no-windows-backend-skip-do-not-crash-or-spin)
 - [ ] **Frontend behavior gated on platform?** Route Windows through `IS_WINDOWS`, do not leave it `IS_MAC`-only. [→](#8-frontend-gate-on-is_windows-not-just-is_mac)
+- [ ] **Creating a window or webview from a `#[tauri::command]`?** The command must be `async` (and wrap the build in `spawn_blocking`), or WebView2 deadlocks. [→](#9-window-creation-deadlocks-in-a-sync-command)
 - [ ] **Release?** `windows-build.yml` is the bundle/link gate (per-PR `cargo check` already covered compile); `latest.json` notes get re-patched; functional test on a real Windows host. [→](#release-checklist-windows)
 
 ## Failure catalog (what this repo has actually hit)
@@ -38,6 +39,7 @@ Apply while writing, not after. Each line links to the detailed rule.
 | cwd tracking dead / 1.2s poll fires empty IPC every terminal | `pty_cwd` has no Windows backend (`/proc`, `lsof` absent) | Skip the poll on Windows, or use OSC 7 shell integration | #105, #115 |
 | Updater "更新內容" dialog empty after a release | Windows CI `tauri-action` rewrites `latest.json` and wipes `notes` | Re-patch notes post-build from `CHANGELOG-NEXT.md` | #43 |
 | Diff-open lag only in the release build | Same console-flash spawn cost, per git subprocess | `CREATE_NO_WINDOW` (see row 1) | #82 |
+| Ctrl+N opens a blank unclosable window; shortcuts die app-wide | `WebviewWindowBuilder::build()` in a **sync** command deadlocks the WebView2 event loop (wry#583) | Window-creating commands must be `async` + `spawn_blocking` | #209 |
 
 ---
 
@@ -112,6 +114,28 @@ Rule: when a feature's backend is a no-op on Windows, gate the frontend caller t
 ## 8. Frontend: gate on `IS_WINDOWS`, not just `IS_MAC`
 
 Platform branches written as "mac vs everything else" silently break Windows. Terminal paste was suppressed on all platforms and the smart-paste shortcut was `IS_MAC`-only, so Windows had no paste at all (#75). Window decorations are native on Windows and need a custom `TitleBar` (#67). Use `IS_WINDOWS` from `src/lib/platform.ts` and give Windows its own explicit branch.
+
+---
+
+## 9. Window creation deadlocks in a sync command
+
+`WebviewWindowBuilder::build()` (and `WindowBuilder`/`WebviewBuilder`) **deadlocks on Windows when called from a synchronous `#[tauri::command]` or event handler**. WebView2 dispatches window creation as a message to the main event loop and blocks on the reply; a sync command runs on that same thread, so it waits on itself (upstream wry#583, called out in the Tauri builder docs). macOS/WKWebView has no such constraint, so this **never reproduces in dev on the mac** — only on a user's Windows machine.
+
+The symptom is nasty and non-obvious: the OS window shell appears painted only with the builder's `background_color` (a blank dark rectangle — the webview never initializes), `decorations(false)` means no native frame and the React `TitleBar` never renders so there is **no close button**, and the wedged event loop kills every subsequent IPC-based shortcut app-wide. That was #208: a user pressing Ctrl+N (wired to the `open_new_window` command) got an unclosable blank window and a dead app.
+
+The fix is what the Tauri docs prescribe — make the command `async` so it runs off the main thread — plus `spawn_blocking` so the blocking main-thread round-trips (`build()`, `inner_size()`, `scale_factor()`) stay off the shared async worker pool, matching how every other async command here handles blocking work:
+
+```rust
+#[tauri::command]
+async fn open_new_window(app: tauri::AppHandle) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || modules::menu::create_new_window(&app))
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())
+}
+```
+
+Any command that builds a window or webview must follow this shape. Note that `async` commands can now run concurrently, so window-label allocation (`next_window_label`) can race across two rapid invocations — benign here (one window opens, the duplicate `build()` errors), but worth knowing if label collisions ever matter.
 
 ---
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,9 +87,19 @@ fn app_build_info() -> AppBuildInfo {
 /// Open a new window, mirroring the File > New Window menu item. On Windows the
 /// native menu bar is hidden, so its Ctrl+N accelerator never fires; the
 /// frontend invokes this command from its keydown handler instead (see App.tsx).
+///
+/// Must be async: on Windows, building a webview window inside a synchronous
+/// command deadlocks the event loop (wry#583), leaving a blank unclosable
+/// window shell and dead IPC. Async commands run off the main thread, which is
+/// the pattern the Tauri docs prescribe for window creation; spawn_blocking
+/// keeps the blocking main-thread round-trips off the async worker pool,
+/// matching the rest of the codebase.
 #[tauri::command]
-fn open_new_window(app: tauri::AppHandle) -> tauri::Result<()> {
-    modules::menu::create_new_window(&app)
+async fn open_new_window(app: tauri::AppHandle) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || modules::menu::create_new_window(&app))
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]


### PR DESCRIPTION
## What

Pressing Ctrl+N on Windows (or clicking File > New Window in the custom menu bar) produced a completely blank, unclosable window and left many app shortcuts dead afterwards (#208).

## Root cause

`open_new_window` was a **synchronous** `#[tauri::command]`. On Windows, building a `WebviewWindow` inside a sync command deadlocks: window creation is dispatched to the event loop through a channel, and the sync command blocks the very thread that must pump it (documented in the Tauri docs; upstream tauri-apps/wry#583). The result matches the report exactly:

- the Win32 window shell appears, painted only with the builder's `background_color` (#222) — the webview never initializes, so the screenshot shows a pure dark rectangle;
- `decorations(false)` means no native frame, and the React title bar never renders, so there is **no close button**;
- the wedged event loop leaves subsequent IPC-based shortcuts unresponsive.

macOS is unaffected (WKWebView has no such constraint), which is why this never reproduced locally.

## Fix

Make the command `async` (the fix the Tauri docs prescribe) and run the blocking window build via `tauri::async_runtime::spawn_blocking`, keeping the blocking main-thread round-trips (`build()`, `inner_size()`, `scale_factor()`) off the shared async worker pool — consistent with how every other async command in this codebase handles blocking work (`modules::setup`, `modules::git`, …).

The return type changes from `tauri::Result<()>` to `Result<(), String>` to follow the codebase's JoinError-mapping idiom; the frontend call sites (`invoke("open_new_window").catch(() => {})`) are unaffected.

## Review notes

`/tauri-check` (security + performance agents) passed. One LOW note was consciously skipped: two concurrent invocations could race on the `win-{n}` label and one `build()` would fail benignly — one window still opens, no trust-boundary impact, not worth serializing.

## Testing

- `cargo check` clean on macOS; behavior unchanged there (Cmd+N verified working before and after by code path — the macOS native-menu path in `menu.rs` is separate and untouched).
- The Windows behavior can only be validated on a real Windows machine; `cargo-check-windows` CI covers compilation. Will ask the reporter to confirm on the next release build.

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)