### PR TITLE
fix(windows): restore DOM focus when the window regains focus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ import { installStatusHook, installCodexStatusHook } from "@/modules/claude-prog
 import { installSessionNotifications } from "@/modules/claude-progress/lib/sessionNotifications";
 import { ensureNotificationPermission } from "@/modules/claude-progress/lib/notify";
 import { useWatchNotes } from "@/modules/notes/lib/useWatchNotes";
-import { registerSecondaryWindowCleanup } from "@/lib/windowLifecycle";
+import { registerSecondaryWindowCleanup, restoreFocusOnWindowRefocus } from "@/lib/windowLifecycle";
 import { SshPromptDialog } from "@/modules/ssh/SshPromptDialog";
 import { SetupWizard } from "@/modules/setup/SetupWizard";
 import { detectTools, isToolReady } from "@/modules/setup/lib/setupTools";
@@ -300,6 +300,30 @@ function App() {
       })
       .catch(() => {});
     return () => unlisten?.();
+  }, []);
+
+  // On Windows, WebView2 drops DOM focus when the window regains focus, so
+  // keyboard input dies until the user clicks (issue #205). Restore it. No-op
+  // off Windows, where WKWebView already does this natively. `disposed` guards
+  // the async gap: the hook attaches a focusin listener synchronously, so if
+  // this effect tears down before registration resolves (StrictMode remount),
+  // we still dispose it the moment it does.
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let disposed = false;
+    void restoreFocusOnWindowRefocus()
+      .then((off) => {
+        if (disposed) {
+          off?.();
+          return;
+        }
+        unlisten = off;
+      })
+      .catch(() => {});
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
   }, []);
 
   // Close any open SFTP connections when this window goes away so no remote

--- a/src/lib/windowLifecycle.test.ts
+++ b/src/lib/windowLifecycle.test.ts
@@ -150,6 +150,15 @@ describe("restoreFocusOnWindowRefocus", () => {
     expect(document.activeElement).toBe(document.body);
   });
 
+  it("removes the focusin listener if registration fails", async () => {
+    const onFocusChanged = vi.fn().mockRejectedValue(new Error("ipc failed"));
+    getCurrentWindow.mockReturnValue({ onFocusChanged });
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    await expect(restoreFocusOnWindowRefocus()).rejects.toThrow("ipc failed");
+    expect(removeSpy).toHaveBeenCalledWith("focusin", expect.any(Function));
+  });
+
   it("stops tracking focus after the returned unlisten is called", async () => {
     const win = mockFocusWindow();
     const unlisten = await restoreFocusOnWindowRefocus();

--- a/src/lib/windowLifecycle.test.ts
+++ b/src/lib/windowLifecycle.test.ts
@@ -1,16 +1,42 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { getCurrentWindow } = vi.hoisted(() => ({ getCurrentWindow: vi.fn() }));
 const { closeLocalSessions } = vi.hoisted(() => ({ closeLocalSessions: vi.fn() }));
+const platform = vi.hoisted(() => ({ IS_WINDOWS: true }));
 vi.mock("@tauri-apps/api/window", () => ({ getCurrentWindow }));
 vi.mock("@/modules/terminal/lib/pty-bridge", () => ({ closeLocalSessions }));
+vi.mock("@/lib/platform", () => ({
+  get IS_WINDOWS() {
+    return platform.IS_WINDOWS;
+  },
+}));
 
-import { registerSecondaryWindowCleanup } from "./windowLifecycle";
+import { registerSecondaryWindowCleanup, restoreFocusOnWindowRefocus } from "./windowLifecycle";
 
 afterEach(() => {
   getCurrentWindow.mockReset();
   closeLocalSessions.mockReset();
+  platform.IS_WINDOWS = true;
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
 });
+
+/** Mock getCurrentWindow so onFocusChanged hands its callback back to the test. */
+function mockFocusWindow() {
+  let cb: (e: { payload: boolean }) => void = () => {};
+  const onFocusChanged = vi.fn(async (fn) => {
+    cb = fn;
+    return () => {
+      cb = () => {};
+    };
+  });
+  getCurrentWindow.mockReturnValue({ onFocusChanged });
+  return {
+    onFocusChanged,
+    blur: () => cb({ payload: false }),
+    focus: () => cb({ payload: true }),
+  };
+}
 
 describe("registerSecondaryWindowCleanup", () => {
   it("registers nothing in the main window", async () => {
@@ -40,5 +66,102 @@ describe("registerSecondaryWindowCleanup", () => {
     expect(preventDefault).toHaveBeenCalled();
     expect(closeLocalSessions).toHaveBeenCalled();
     expect(destroy).toHaveBeenCalled();
+  });
+});
+
+describe("restoreFocusOnWindowRefocus", () => {
+  // This webview holds OS focus by default; the sibling-webview case overrides it.
+  beforeEach(() => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  });
+
+  it("registers nothing off Windows", async () => {
+    platform.IS_WINDOWS = false;
+    const win = mockFocusWindow();
+    const unlisten = await restoreFocusOnWindowRefocus();
+    expect(unlisten).toBeNull();
+    expect(win.onFocusChanged).not.toHaveBeenCalled();
+  });
+
+  it("restores focus to the last-focused element when the window regains focus", async () => {
+    const win = mockFocusWindow();
+    await restoreFocusOnWindowRefocus();
+
+    const input = document.createElement("textarea");
+    document.body.appendChild(input);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    win.blur();
+    // Simulate WebView2 dropping DOM focus while the window is in the background.
+    input.blur();
+    expect(document.activeElement).toBe(document.body);
+
+    win.focus();
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("does not steal focus if another element grabbed it while away", async () => {
+    const win = mockFocusWindow();
+    await restoreFocusOnWindowRefocus();
+
+    const terminal = document.createElement("textarea");
+    const dialogInput = document.createElement("input");
+    document.body.append(terminal, dialogInput);
+    terminal.focus();
+
+    win.blur();
+    // A dialog opened while away and took focus; we must not yank it back.
+    dialogInput.focus();
+
+    win.focus();
+    expect(document.activeElement).toBe(dialogInput);
+  });
+
+  it("does not restore focus when a sibling webview holds it (e.g. native preview)", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    const win = mockFocusWindow();
+    await restoreFocusOnWindowRefocus();
+
+    const terminal = document.createElement("textarea");
+    document.body.appendChild(terminal);
+    terminal.focus();
+
+    win.blur();
+    terminal.blur();
+    // The OS window regained focus, but a sibling child webview holds it, not us.
+    win.focus();
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it("does not restore focus to an element detached while away", async () => {
+    const win = mockFocusWindow();
+    await restoreFocusOnWindowRefocus();
+
+    const terminal = document.createElement("textarea");
+    document.body.appendChild(terminal);
+    terminal.focus();
+
+    win.blur();
+    // Its tab closed while the window was in the background.
+    terminal.remove();
+
+    win.focus();
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it("stops tracking focus after the returned unlisten is called", async () => {
+    const win = mockFocusWindow();
+    const unlisten = await restoreFocusOnWindowRefocus();
+
+    const input = document.createElement("textarea");
+    document.body.appendChild(input);
+    input.focus();
+
+    unlisten?.();
+    input.blur();
+    win.focus();
+    // Tracking is torn down, so nothing is restored.
+    expect(document.activeElement).toBe(document.body);
   });
 });

--- a/src/lib/windowLifecycle.ts
+++ b/src/lib/windowLifecycle.ts
@@ -57,18 +57,25 @@ export async function restoreFocusOnWindowRefocus(): Promise<(() => void) | null
     }
   };
   document.addEventListener("focusin", track);
-  const unlisten = await win.onFocusChanged(({ payload: focused }) => {
-    if (!focused) {
-      return;
-    }
-    const active = document.activeElement;
-    const focusWasLost = active === null || active === document.body;
-    if (document.hasFocus() && focusWasLost && lastFocused?.isConnected) {
-      lastFocused.focus({ preventScroll: true });
-    }
-  });
-  return () => {
+  try {
+    const unlisten = await win.onFocusChanged(({ payload: focused }) => {
+      if (!focused) {
+        return;
+      }
+      const active = document.activeElement;
+      const focusWasLost = active === null || active === document.body;
+      if (document.hasFocus() && focusWasLost && lastFocused?.isConnected) {
+        lastFocused.focus({ preventScroll: true });
+      }
+    });
+    return () => {
+      document.removeEventListener("focusin", track);
+      unlisten();
+    };
+  } catch (error) {
+    // Registration failed: drop the listener we already attached so it can't
+    // leak, since we never hand back a cleanup function.
     document.removeEventListener("focusin", track);
-    unlisten();
-  };
+    throw error;
+  }
 }

--- a/src/lib/windowLifecycle.ts
+++ b/src/lib/windowLifecycle.ts
@@ -1,5 +1,6 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { isMainWindow } from "@/lib/window";
+import { IS_WINDOWS } from "@/lib/platform";
 import { closeLocalSessions } from "@/modules/terminal/lib/pty-bridge";
 
 /**
@@ -23,4 +24,51 @@ export async function registerSecondaryWindowCleanup(): Promise<(() => void) | n
     await closeLocalSessions();
     await win.destroy();
   });
+}
+
+/**
+ * On Windows, WebView2 does not restore DOM focus to the previously-focused
+ * element when the OS window regains focus, so keystrokes go nowhere until the
+ * user clicks (issue #205). WKWebView on macOS restores it natively, so this is
+ * a no-op there — and skipping macOS also avoids fighting its native handling.
+ *
+ * We track the last-focused element via a `focusin` listener rather than reading
+ * `document.activeElement` at window-blur time: WebView2 may drop DOM focus
+ * before the blur event reaches us, so the active element is unreliable by then.
+ * On re-focus we restore it — but only if (a) this webview actually holds focus
+ * (`onFocusChanged` fires for the whole OS window, so a sibling child webview
+ * like the native preview regaining focus would otherwise steal it back into the
+ * main webview), (b) focus was genuinely lost, and (c) the element is still in
+ * the DOM — so we never yank focus from a dialog that opened meanwhile or a tab
+ * that closed while we were away. Restoring the element (not just calling
+ * webview.set_focus in Rust) is required because set_focus only focuses the
+ * webview container, not the DOM node.
+ */
+export async function restoreFocusOnWindowRefocus(): Promise<(() => void) | null> {
+  if (!IS_WINDOWS) {
+    return null;
+  }
+  const win = getCurrentWindow();
+  let lastFocused: HTMLElement | null = null;
+  const track = (event: FocusEvent) => {
+    const el = event.target;
+    if (el instanceof HTMLElement && el !== document.body) {
+      lastFocused = el;
+    }
+  };
+  document.addEventListener("focusin", track);
+  const unlisten = await win.onFocusChanged(({ payload: focused }) => {
+    if (!focused) {
+      return;
+    }
+    const active = document.activeElement;
+    const focusWasLost = active === null || active === document.body;
+    if (document.hasFocus() && focusWasLost && lastFocused?.isConnected) {
+      lastFocused.focus({ preventScroll: true });
+    }
+  });
+  return () => {
+    document.removeEventListener("focusin", track);
+    unlisten();
+  };
 }


### PR DESCRIPTION
## What

On Windows, switching to another app and back left the terminal (or whatever was focused) without keyboard focus — you had to click the window once before typing worked again. macOS was unaffected (#205).

## Root cause

When the OS window regains focus, **WebView2 does not restore DOM focus** to the element that had it, whereas **WKWebView (macOS) does**. Nothing in the app re-focuses on window refocus: the terminal's auto-focus effect is keyed on `active`/`isActiveTab` React state, which doesn't change on an OS-level window switch, so it never re-runs. Confirmed against the Tauri/wry runtime: `webview.set_focus()` from Rust only focuses the webview *container*, not the DOM node, so the restore has to happen in JS.

## Fix

`restoreFocusOnWindowRefocus()` in `src/lib/windowLifecycle.ts` (frontend-only, no Rust change), gated to `IS_WINDOWS` since WKWebView already does this natively:

- tracks the last-focused element via a document `focusin` listener (more reliable than reading `document.activeElement` at blur time, since WebView2 may drop focus before the blur event arrives);
- on `getCurrentWindow().onFocusChanged(true)`, refocuses it **only when** this webview actually holds focus (`document.hasFocus()`), focus was genuinely lost (`activeElement` is `body`/null), and the element is still connected.

The `document.hasFocus()` guard matters because `onFocusChanged` fires for the whole OS window — without it, a **sibling child webview** (the native preview) regaining focus would get robbed back into the main webview. Wired from `App.tsx` with a `disposed` guard so the synchronously-added `focusin` listener can't leak across the async registration (StrictMode remount).

## Review

`code-reviewer` pass applied: added the `document.hasFocus()` sibling-webview guard (was MEDIUM) and the `disposed` leak guard (LOW). One LOW skipped: focus can't be restored into a `display:none` background tab, but that leaves focus on `body` exactly as before this change — no regression, and the reported case (active terminal tab) is covered.

## Testing

- `tsc --noEmit` clean; full `vitest run` green (1533 tests). 8 unit tests cover: off-Windows no-op, happy-path restore, dialog handoff (don't steal), sibling-webview holds focus (don't steal), detached element, and listener teardown.
- **Windows behavior can only be validated on a real Windows machine** — the dev box is macOS, where the bug doesn't reproduce. `cargo-check-windows` CI covers compilation only; will ask the reporter to confirm on the next build.

Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)