### PR TITLE
chore: silence release-only unused-variable warning in sessions_index

### DIFF
--- a/src-tauri/src/modules/sessions_index/sync.rs
+++ b/src-tauri/src/modules/sessions_index/sync.rs
@@ -113,9 +113,12 @@ fn parse_meta(agent: &'static str, path: &Path) -> Option<ParsedSession> {
 fn commit(index: &Index, session: &ParsedSession, file_path: &str, mtime: i64, size: i64) -> bool {
     match index.upsert_session(session, file_path, mtime, size) {
         Ok(()) => true,
-        Err(err) => {
+        Err(_err) => {
+            // Only read by the debug-only log below, so it is unused in release
+            // builds; the underscore keeps -D-warnings-clean without dropping the
+            // debug message.
             #[cfg(debug_assertions)]
-            eprintln!("sessions_index: failed to upsert {file_path}: {err}");
+            eprintln!("sessions_index: failed to upsert {file_path}: {_err}");
             false
         }
     }

--- a/src-tauri/src/modules/sessions_index/sync.rs
+++ b/src-tauri/src/modules/sessions_index/sync.rs
@@ -113,12 +113,12 @@ fn parse_meta(agent: &'static str, path: &Path) -> Option<ParsedSession> {
 fn commit(index: &Index, session: &ParsedSession, file_path: &str, mtime: i64, size: i64) -> bool {
     match index.upsert_session(session, file_path, mtime, size) {
         Ok(()) => true,
-        Err(_err) => {
-            // Only read by the debug-only log below, so it is unused in release
-            // builds; the underscore keeps -D-warnings-clean without dropping the
-            // debug message.
+        Err(err) => {
             #[cfg(debug_assertions)]
-            eprintln!("sessions_index: failed to upsert {file_path}: {_err}");
+            eprintln!("sessions_index: failed to upsert {file_path}: {err}");
+            // The log above is compiled out in release, so consume `err` here to
+            // stay warning-clean without an underscore-prefixed binding.
+            let _ = err;
             false
         }
     }


### PR DESCRIPTION
`commit()`'s error arm binds `err`, but it is only read by the `#[cfg(debug_assertions)]` `eprintln!`, so release builds warned `unused variable: err` (surfaced during the v0.1.1 release build). Prefix it with an underscore and reference `{_err}` in the debug log, so both profiles stay warning-clean and the debug message is unchanged.

Verified: `cargo check --release` (debug_assertions off) is warning-free, and `cargo check` (debug) still compiles the log path.