### PR TITLE
fix(git-graph): 分支配色不撞相鄰色 + hover 底色不蓋線

### DIFF
--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -237,7 +237,11 @@ export function GitGraph({
               minHeight: `${svgHeight}px`,
             }}
           >
-            <svg className="pointer-events-none absolute inset-0 h-full w-full">
+            {/* z-[1] keeps the branch lines above a hovered/selected row's
+                translucent background (which spans the gutter) but below the
+                commit nodes (z-10), so the lines stay visible instead of being
+                covered by the row tint. */}
+            <svg className="pointer-events-none absolute inset-0 z-[1] h-full w-full">
               {edges.map((edge, idx) => {
                 // Draw every edge overlapping the visible row range so lines
                 // stay continuous even when both endpoints are off-screen.

--- a/src/modules/git-graph/lib/graphLayout.test.ts
+++ b/src/modules/git-graph/lib/graphLayout.test.ts
@@ -125,6 +125,47 @@ describe("computeGraphLayout colouring", () => {
     expect(layouts["z"].colorIndex).not.toBe(layouts["x"].colorIndex);
   });
 
+  it("keeps a fork off the trunk off the trunk's colour even after the palette wraps", () => {
+    // A trunk with seven short side branches that each merge in and immediately
+    // root (freeing their lane). Every fork claims the next palette colour, so
+    // by the seventh a naive per-claim counter would wrap back onto the trunk's
+    // colour (0) — the exact "a branch off the red trunk is also red" bug. The
+    // fork must instead skip the still-active trunk colour.
+    const commits: CommitNode[] = [];
+    for (let i = 1; i <= 7; i++) {
+      const trunkParent = i < 7 ? `m${i + 1}` : "t";
+      commits.push(commit(`m${i}`, [trunkParent, `s${i}`]));
+      commits.push(commit(`s${i}`, []));
+    }
+    commits.push(commit("t", []));
+    const { layouts } = computeGraphLayout(commits);
+
+    // The trunk stays on colour 0 the whole way down.
+    expect(layouts["m7"].colorIndex).toBe(0);
+    // A naive counter would give the seventh fork 7 % 7 === 0 (== trunk); it
+    // must not collide with the trunk it branches from.
+    expect(layouts["s7"].colorIndex).not.toBe(layouts["m7"].colorIndex);
+  });
+
+  it("gives every lane of an octopus merge a distinct colour", () => {
+    // o merges three roots, so three lanes are active on the same row.
+    const commits = [
+      commit("o", ["a", "b", "c"]),
+      commit("a", []),
+      commit("b", []),
+      commit("c", []),
+    ];
+    const { layouts } = computeGraphLayout(commits);
+
+    // o's lane (followed by first parent a), b and c are all concurrent.
+    const colors = new Set([
+      layouts["o"].colorIndex,
+      layouts["b"].colorIndex,
+      layouts["c"].colorIndex,
+    ]);
+    expect(colors.size).toBe(3);
+  });
+
   it("colours a merge bend by the merged branch, not the trunk", () => {
     const commits = [commit("m", ["a", "b"]), commit("b", ["a"]), commit("a", [])];
     const { layouts, edges } = computeGraphLayout(commits);

--- a/src/modules/git-graph/lib/graphLayout.ts
+++ b/src/modules/git-graph/lib/graphLayout.ts
@@ -1,3 +1,5 @@
+import { BRANCH_COLORS } from "./branchColors";
+
 /**
  * Minimal shape the layout algorithm needs: an id and its parent ids. A full
  * `CommitNode` satisfies this structurally, but callers that only have a
@@ -81,19 +83,49 @@ export function computeGraphLayout(
   // Each slot holds the hash a lane is currently waiting for. An empty string
   // marks a freed lane that a new branch can reuse.
   const activeLanes: string[] = [];
-  // Colour id per lane slot. A new branch line (every claim, including reusing a
-  // freed slot) takes the next colour so concurrent lanes never share a colour
-  // and adjacent branches stay visually distinct, independent of lane index.
+  // Palette-relative colour per lane slot. A new branch line (every claim,
+  // including reusing a freed slot) takes a colour not currently shown on any
+  // other active lane, so concurrent lanes never share a colour — until more
+  // than `BRANCH_COLORS.length` lanes are active at once, when the palette is
+  // exhausted and a repeat is unavoidable. This is stronger than a plain
+  // per-claim counter, whose value mod the palette length could wrap back onto
+  // a still-active neighbour (e.g. a branch forking off the trunk landing on
+  // the trunk's own colour).
   const laneColors: number[] = [];
+  const colorCount = BRANCH_COLORS.length;
+  // Where to start scanning for the next colour. Advancing it keeps colours
+  // cycling in palette order when nothing forces a different pick, so adjacent
+  // fresh branches still look distinct.
   let nextColor = 0;
+  const pickColor = (): number => {
+    const used = new Set<number>();
+    for (let idx = 0; idx < activeLanes.length; idx++) {
+      if (activeLanes[idx] !== "") {
+        used.add(laneColors[idx]);
+      }
+    }
+    for (let offset = 0; offset < colorCount; offset++) {
+      const candidate = (nextColor + offset) % colorCount;
+      if (!used.has(candidate)) {
+        nextColor = candidate + 1;
+        return candidate;
+      }
+    }
+    // Every colour is on an active lane (more lanes than colours): fall back to
+    // the running counter and accept the repeat.
+    return nextColor++ % colorCount;
+  };
   const claimLane = (): number => {
+    // The slot being claimed is still "" while pickColor() runs, so it is
+    // skipped there — a lane never counts its own (freed, stale) colour against
+    // itself, and the fresh colour only avoids genuinely active neighbours.
     const free = activeLanes.indexOf("");
     if (free !== -1) {
-      laneColors[free] = nextColor++;
+      laneColors[free] = pickColor();
       return free;
     }
     activeLanes.push("");
-    laneColors.push(nextColor++);
+    laneColors.push(pickColor());
     return activeLanes.length - 1;
   };
 

--- a/src/modules/git-graph/lib/graphLayout.ts
+++ b/src/modules/git-graph/lib/graphLayout.ts
@@ -97,8 +97,11 @@ export function computeGraphLayout(
   // cycling in palette order when nothing forces a different pick, so adjacent
   // fresh branches still look distinct.
   let nextColor = 0;
+  // Reused across every pickColor() call (cleared each time) so laying out a
+  // large repo doesn't allocate a fresh Set per lane claim.
+  const used = new Set<number>();
   const pickColor = (): number => {
-    const used = new Set<number>();
+    used.clear();
     for (let idx = 0; idx < activeLanes.length; idx++) {
       if (activeLanes[idx] !== "") {
         used.add(laneColors[idx]);


### PR DESCRIPTION
## 這個 PR 做了什麼

修正 Git Graph 兩個視覺問題,彼此獨立、分成兩個 commit。

### 1. 分支配色:分支不會再撞到相鄰 lane 的顏色

分支線的顏色原本來自一個**每開一條線就 +1 的全域計數器**,渲染時再對調色盤長度取模(`BRANCH_COLORS[colorIndex % 7]`)。一旦歷來開過的線超過調色盤色數(7),計數器就會繞回——導致**從某條仍活躍的 lane 岔出的分支,可能拿到那條 lane 自己的顏色**。最明顯的症狀就是:**從紅色主幹長出來的分支,自己也是紅色**。

改法:每開一條新線時,**跳過目前仍活躍的其他 lane 已占用的顏色**,再沿著調色盤順序往下取(維持相鄰新分支顏色遞進、視覺上仍分得開)。同時活躍的 lane 從此兩兩不同色——除非同時活躍的 lane 數量超過調色盤色數,那時才被迫重複(7 色的物理上限,無法完全避免)。

因為合併時「本 lane 的第一父」會先寫回 active lanes、才輪到額外父 claim,所以「父子/相鄰不同色」是自動涵蓋的,不需特別處理。

純函式,附單元測試:

- 繞回情境:七條短分支各自併入主幹又立刻歸零(釋放 lane),第七條在舊算法下會 `7 % 7 === 0` 撞回主幹色;新算法確保它避開仍活躍的主幹色。
- octopus 合併:同一列三條 lane 同時活躍 → 三色互異。
- 既有配色測試全部維持通過。

### 2. hover / 選取列的底色不再蓋住分支線

被 hover 或選取的 commit 列,其半透明底色會橫跨整個寬度(含左側 graph 溝槽)。但那個 `absolute` 底色方塊在 DOM 順序上排在 tracks 欄之後,而 SVG 分支線沒有 z-index——commit 節點有 `z-10` 所以壓得住,唯獨線被列底色蓋掉,跟原本註解寫的「底色半透明、讓線仍看得見」正好相反。

改法:給 SVG 線一個 `z-[1]`,夾在列底色(z auto)與節點(`z-10`)之間,線就浮在底色之上、仍在節點之下。

## 測試

- `pnpm vitest run src/modules/git-graph src/modules/source-control` — 159 passed(含新增的配色測試)。
- `tsc --noEmit` — 無誤。
- 本機 `tauri dev` 實際檢視:紅主幹岔出的分支不再是紅色;hover/選取列時分支線清楚可見。
