### PR TITLE
feat(worktrees): bridge, stores, and per-repo settings

### DIFF
--- a/src/modules/claude-progress/lib/sessionStatusStore.ts
+++ b/src/modules/claude-progress/lib/sessionStatusStore.ts
@@ -17,8 +17,17 @@ interface SessionStatusState {
   clear: (leafId: string) => void;
 }
 
-/** Most-to-least urgent, matching tabSessionStatus so an icon and a card agree. */
-const AGGREGATE_PRIORITY: SessionStatus[] = ["waiting-approval", "active", "thinking", "idle"];
+/**
+ * Most-to-least urgent. Exported as the single source of this order: a dock
+ * strip icon, a workspace card, and a worktree row all reduce the same per-leaf
+ * statuses, and a second copy of the list is exactly how they start disagreeing.
+ */
+export const AGGREGATE_PRIORITY: SessionStatus[] = [
+  "waiting-approval",
+  "active",
+  "thinking",
+  "idle",
+];
 
 /**
  * The single most-urgent live status across every tracked terminal leaf, or null

--- a/src/modules/workspace/lib/tabSessionStatus.ts
+++ b/src/modules/workspace/lib/tabSessionStatus.ts
@@ -1,9 +1,7 @@
 import type { Tab } from "@/stores/tabsStore";
 import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
 import type { SessionStatus } from "@/modules/claude-progress/lib/sessionStatus";
-
-/** Most-to-least urgent, so a busy pane wins the badge over a quiet one. */
-const PRIORITY: SessionStatus[] = ["waiting-approval", "active", "thinking", "idle"];
+import { AGGREGATE_PRIORITY } from "@/modules/claude-progress/lib/sessionStatusStore";
 
 /**
  * The session status to show on a tab's card: the highest-priority live status
@@ -22,5 +20,5 @@ export function tabSessionStatus(
       }
     }
   }
-  return PRIORITY.find((status) => present.has(status)) ?? null;
+  return AGGREGATE_PRIORITY.find((status) => present.has(status)) ?? null;
 }

--- a/src/modules/worktrees/lib/paths.test.ts
+++ b/src/modules/worktrees/lib/paths.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { isUnder } from "./paths";
+
+describe("isUnder", () => {
+  it("counts a directory as under itself", () => {
+    // A terminal sitting exactly at the worktree root belongs to that worktree.
+    expect(isUnder("/a/b", "/a/b", false)).toBe(true);
+  });
+
+  it("matches a nested directory", () => {
+    expect(isUnder("/a/b/src/deep", "/a/b", false)).toBe(true);
+  });
+
+  it("does not match a sibling that merely shares the prefix", () => {
+    // The whole feature puts worktrees in `<repo>-worktrees/`, so a plain
+    // startsWith would report every worktree as living inside the repo itself.
+    expect(isUnder("/a/b-worktrees/feature", "/a/b", false)).toBe(false);
+    expect(isUnder("/a/bc", "/a/b", false)).toBe(false);
+  });
+
+  it("does not match a parent or an unrelated path", () => {
+    expect(isUnder("/a", "/a/b", false)).toBe(false);
+    expect(isUnder("/x/y", "/a/b", false)).toBe(false);
+  });
+
+  it("ignores trailing slashes on either side", () => {
+    expect(isUnder("/a/b/", "/a/b", false)).toBe(true);
+    expect(isUnder("/a/b/src", "/a/b/", false)).toBe(true);
+    expect(isUnder("/a/b//", "/a/b", false)).toBe(true);
+  });
+
+  it("is case-sensitive off Windows", () => {
+    expect(isUnder("/A/b", "/a/b", false)).toBe(false);
+  });
+
+  it("treats separators interchangeably on Windows", () => {
+    // The pty reports one form and canonicalize another; both must match.
+    expect(isUnder("C:\\src\\repo\\pkg", "C:\\src\\repo", true)).toBe(true);
+    expect(isUnder("C:/src/repo/pkg", "C:\\src\\repo", true)).toBe(true);
+    expect(isUnder("C:\\src\\repo", "C:/src/repo", true)).toBe(true);
+  });
+
+  it("is case-insensitive on Windows", () => {
+    // Windows paths are case-insensitive; comparing them case-sensitively would
+    // silently drop panes from their worktree.
+    expect(isUnder("C:\\Src\\Repo\\Pkg", "c:\\src\\repo", true)).toBe(true);
+  });
+
+  it("still rejects a prefix sibling on Windows", () => {
+    expect(isUnder("C:\\src\\repo-worktrees\\x", "C:\\src\\repo", true)).toBe(false);
+  });
+
+  it("rejects empty input rather than matching everything", () => {
+    expect(isUnder("/a/b", "", false)).toBe(false);
+    expect(isUnder("", "/a/b", false)).toBe(false);
+  });
+});

--- a/src/modules/worktrees/lib/paths.test.ts
+++ b/src/modules/worktrees/lib/paths.test.ts
@@ -54,4 +54,18 @@ describe("isUnder", () => {
     expect(isUnder("/a/b", "", false)).toBe(false);
     expect(isUnder("", "/a/b", false)).toBe(false);
   });
+
+  it("treats the filesystem root as a real directory", () => {
+    // "/" trims to the empty string; if that collapses into "no path", the root
+    // stops containing anything at all.
+    expect(isUnder("/a/b", "/", false)).toBe(true);
+    expect(isUnder("/", "/", false)).toBe(true);
+    // ...and the prefix must not become "//".
+    expect(isUnder("//a", "/", false)).toBe(true);
+  });
+
+  it("handles a Windows drive root", () => {
+    expect(isUnder("C:\\src", "C:\\", true)).toBe(true);
+    expect(isUnder("C:\\", "C:\\", true)).toBe(true);
+  });
 });

--- a/src/modules/worktrees/lib/paths.ts
+++ b/src/modules/worktrees/lib/paths.ts
@@ -1,0 +1,32 @@
+import { IS_WINDOWS } from "@/lib/platform";
+
+/**
+ * A path in one comparable form: separators unified, trailing slashes dropped,
+ * and case folded on Windows, where the filesystem is case-insensitive and the
+ * pty's spelling of a path need not match git's.
+ */
+function normalize(path: string, windows: boolean): string {
+  const unified = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  return windows ? unified.toLowerCase() : unified;
+}
+
+/**
+ * Whether `child` is `parent` itself, or sits inside it.
+ *
+ * Deliberately not a bare `startsWith`: this feature parks worktrees in a
+ * `<repo>-worktrees/` sibling of the repo, so a prefix test would report every
+ * worktree as living inside the repo it came from — silently mis-attributing
+ * agent status and making "focus the existing tab" open the wrong one. The
+ * boundary has to fall on a separator.
+ *
+ * `windows` is a parameter rather than a direct `IS_WINDOWS` read so both
+ * platforms' behavior is covered by tests on either machine.
+ */
+export function isUnder(child: string, parent: string, windows: boolean = IS_WINDOWS): boolean {
+  const from = normalize(child, windows);
+  const root = normalize(parent, windows);
+  if (!from || !root) {
+    return false;
+  }
+  return from === root || from.startsWith(`${root}/`);
+}

--- a/src/modules/worktrees/lib/paths.ts
+++ b/src/modules/worktrees/lib/paths.ts
@@ -6,8 +6,13 @@ import { IS_WINDOWS } from "@/lib/platform";
  * pty's spelling of a path need not match git's.
  */
 function normalize(path: string, windows: boolean): string {
-  const unified = path.replace(/\\/g, "/").replace(/\/+$/, "");
-  return windows ? unified.toLowerCase() : unified;
+  const unified = path.replace(/\\/g, "/");
+  const trimmed = unified.replace(/\/+$/, "");
+  // "/" and "//" trim away to nothing, but the filesystem root is a real
+  // directory rather than an empty path — collapsing it would make `isUnder`
+  // reject everything beneath it.
+  const rooted = trimmed === "" && unified.startsWith("/") ? "/" : trimmed;
+  return windows ? rooted.toLowerCase() : rooted;
 }
 
 /**
@@ -28,5 +33,11 @@ export function isUnder(child: string, parent: string, windows: boolean = IS_WIN
   if (!from || !root) {
     return false;
   }
-  return from === root || from.startsWith(`${root}/`);
+  if (from === root) {
+    return true;
+  }
+  // A root that already ends in its separator ("/" itself, or a drive root)
+  // must not get a second one appended, or the prefix becomes unmatchable.
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return from.startsWith(prefix);
 }

--- a/src/modules/worktrees/lib/worktreeStatus.test.ts
+++ b/src/modules/worktrees/lib/worktreeStatus.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { leaf, splitLeaf } from "@/modules/terminal/lib/terminalLayout";
+import type { Tab } from "@/stores/tabsStore";
+import { worktreeSessionStatus } from "./worktreeStatus";
+
+const WT = "/repo-worktrees/feature";
+
+/** A tab whose single terminal pane `p1` sits in `cwd`. */
+function tabAt(id: string, leafId: string, cwd: string | undefined, tabCwd?: string): Tab {
+  return {
+    id,
+    spaceId: "s1",
+    title: id,
+    kind: "terminal",
+    paneTree: leaf(leafId, { kind: "terminal", cwd }),
+    activeLeafId: leafId,
+    paneOrder: [leafId],
+    cwd: tabCwd,
+  };
+}
+
+describe("worktreeSessionStatus", () => {
+  it("reports nothing when no pane sits in the worktree", () => {
+    const tabs = [tabAt("a", "p1", "/somewhere/else")];
+    expect(worktreeSessionStatus(tabs, { p1: "active" }, {}, WT, false)).toEqual({
+      status: null,
+      agent: null,
+    });
+  });
+
+  it("picks up a pane inside the worktree", () => {
+    const tabs = [tabAt("a", "p1", `${WT}/src`)];
+    expect(worktreeSessionStatus(tabs, { p1: "active" }, { p1: "claude" }, WT, false)).toEqual({
+      status: "active",
+      agent: "claude",
+    });
+  });
+
+  it("does not claim a pane from a sibling worktree that shares the prefix", () => {
+    // /repo-worktrees/feature-2 must not count as inside /repo-worktrees/feature.
+    const tabs = [tabAt("a", "p1", `${WT}-2/src`)];
+    expect(worktreeSessionStatus(tabs, { p1: "active" }, {}, WT, false).status).toBeNull();
+  });
+
+  it("falls back to the tab's cwd when a pane has not reported one yet", () => {
+    // A freshly spawned pane has no live cwd; the tab's starting dir still
+    // places it, otherwise a just-launched agent would show no status.
+    const tabs = [tabAt("a", "p1", undefined, WT)];
+    expect(worktreeSessionStatus(tabs, { p1: "thinking" }, {}, WT, false).status).toBe("thinking");
+  });
+
+  it("takes the most urgent status across panes and tabs", () => {
+    // waiting-approval > active > thinking > idle, matching the card badge.
+    const tabs = [
+      tabAt("a", "p1", WT),
+      tabAt("b", "p2", `${WT}/src`),
+      tabAt("c", "p3", `${WT}/docs`),
+    ];
+    const statuses = { p1: "idle", p2: "waiting-approval", p3: "active" } as const;
+    expect(worktreeSessionStatus(tabs, statuses, {}, WT, false).status).toBe("waiting-approval");
+  });
+
+  it("reports the agent of the pane that won the status", () => {
+    const tabs = [tabAt("a", "p1", WT), tabAt("b", "p2", `${WT}/src`)];
+    const result = worktreeSessionStatus(
+      tabs,
+      { p1: "idle", p2: "waiting-approval" },
+      { p1: "claude", p2: "codex" },
+      WT,
+      false,
+    );
+    // The row says "waiting" — it must name the agent that is actually waiting.
+    expect(result).toEqual({ status: "waiting-approval", agent: "codex" });
+  });
+
+  it("still names an agent when its pane has no status yet", () => {
+    const tabs = [tabAt("a", "p1", WT)];
+    expect(worktreeSessionStatus(tabs, {}, { p1: "claude" }, WT, false)).toEqual({
+      status: null,
+      agent: "claude",
+    });
+  });
+
+  it("walks every pane of a split tab", () => {
+    const tree = splitLeaf(
+      leaf("p1", { kind: "terminal", cwd: "/elsewhere" }),
+      "p1",
+      "row",
+      "p2",
+      { kind: "terminal", cwd: WT },
+    );
+    const tabs: Tab[] = [
+      {
+        id: "a",
+        spaceId: "s1",
+        title: "a",
+        kind: "terminal",
+        paneTree: tree,
+        activeLeafId: "p1",
+        paneOrder: ["p1", "p2"],
+      },
+    ];
+    expect(worktreeSessionStatus(tabs, { p2: "active" }, {}, WT, false).status).toBe("active");
+  });
+
+  it("ignores non-terminal panes sitting in the worktree", () => {
+    const tabs: Tab[] = [
+      {
+        id: "a",
+        spaceId: "s1",
+        title: "a",
+        kind: "editor",
+        paneTree: leaf("p1", { kind: "editor", path: `${WT}/a.ts` }),
+        activeLeafId: "p1",
+        paneOrder: ["p1"],
+        cwd: WT,
+      },
+    ];
+    // An open editor is not a running agent.
+    expect(worktreeSessionStatus(tabs, { p1: "active" }, {}, WT, false).status).toBeNull();
+  });
+});

--- a/src/modules/worktrees/lib/worktreeStatus.test.ts
+++ b/src/modules/worktrees/lib/worktreeStatus.test.ts
@@ -73,6 +73,21 @@ describe("worktreeSessionStatus", () => {
     expect(result).toEqual({ status: "waiting-approval", agent: "codex" });
   });
 
+  it("names no agent rather than borrowing one from a different pane", () => {
+    // The waiting pane's agent is not classified yet, while another pane holds
+    // an idle Claude. Saying "Claude — waiting for you" would point at the one
+    // agent that is definitely *not* waiting.
+    const tabs = [tabAt("a", "p1", WT), tabAt("b", "p2", `${WT}/src`)];
+    const result = worktreeSessionStatus(
+      tabs,
+      { p1: "idle", p2: "waiting-approval" },
+      { p1: "claude" },
+      WT,
+      false,
+    );
+    expect(result).toEqual({ status: "waiting-approval", agent: null });
+  });
+
   it("still names an agent when its pane has no status yet", () => {
     const tabs = [tabAt("a", "p1", WT)];
     expect(worktreeSessionStatus(tabs, {}, { p1: "claude" }, WT, false)).toEqual({

--- a/src/modules/worktrees/lib/worktreeStatus.ts
+++ b/src/modules/worktrees/lib/worktreeStatus.ts
@@ -59,8 +59,11 @@ export function worktreeSessionStatus(
   const status = AGGREGATE_PRIORITY.find((candidate) => agentByStatus.has(candidate)) ?? null;
   return {
     status,
-    // Name the agent that actually holds the reported state, so a row saying
-    // "waiting" points at the one waiting rather than whichever was found first.
-    agent: status ? (agentByStatus.get(status) ?? fallbackAgent) : fallbackAgent,
+    // Only ever name the agent that actually holds the reported state. If that
+    // pane's agent is not classified yet, say nothing rather than borrowing the
+    // fallback: a row reading "Claude — waiting for you" while Claude is the
+    // *idle* pane and something else is waiting is worse than an unnamed row.
+    // The fallback exists solely for a worktree with an agent but no status yet.
+    agent: status ? (agentByStatus.get(status) ?? null) : fallbackAgent,
   };
 }

--- a/src/modules/worktrees/lib/worktreeStatus.ts
+++ b/src/modules/worktrees/lib/worktreeStatus.ts
@@ -1,0 +1,66 @@
+import { IS_WINDOWS } from "@/lib/platform";
+import type { AgentKind } from "@/modules/claude-progress/lib/codexNormalize";
+import type { SessionStatus } from "@/modules/claude-progress/lib/sessionStatus";
+import { AGGREGATE_PRIORITY } from "@/modules/claude-progress/lib/sessionStatusStore";
+import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
+import type { Tab } from "@/stores/tabsStore";
+import { isUnder } from "./paths";
+
+/** What a worktree row shows: the most urgent agent state in it, and whose. */
+export interface WorktreeActivity {
+  status: SessionStatus | null;
+  agent: AgentKind | null;
+}
+
+/**
+ * The agent activity inside one worktree, joined from the two halves the app
+ * keeps apart: statuses live per terminal leaf (`sessionStatusStore`), while the
+ * directory a leaf sits in lives in the pane tree (`tabsStore`). A worktree owns
+ * whichever terminal panes are cd'd into it, so this walks every tab's panes,
+ * keeps the ones under `worktreePath`, and reduces their statuses with the same
+ * priority a workspace card uses — a row and a card must never disagree.
+ *
+ * `windows` is threaded through to `isUnder` so both platforms are testable.
+ */
+export function worktreeSessionStatus(
+  tabs: readonly Tab[],
+  statuses: Record<string, SessionStatus>,
+  agents: Record<string, AgentKind>,
+  worktreePath: string,
+  windows: boolean = IS_WINDOWS,
+): WorktreeActivity {
+  const agentByStatus = new Map<SessionStatus, AgentKind | null>();
+  // An agent whose pane has not reported a status yet still names the row.
+  let fallbackAgent: AgentKind | null = null;
+
+  for (const tab of tabs) {
+    for (const pane of computeLayout(tab.paneTree)) {
+      if (pane.content?.kind !== "terminal") {
+        continue;
+      }
+      // A pane's live cwd wins; a freshly spawned one that has not reported yet
+      // falls back to the tab's starting dir, or a just-launched agent would
+      // show nothing.
+      const cwd = pane.content.cwd || tab.cwd;
+      if (!cwd || !isUnder(cwd, worktreePath, windows)) {
+        continue;
+      }
+      const agent = agents[pane.id] ?? null;
+      if (agent && !fallbackAgent) {
+        fallbackAgent = agent;
+      }
+      const status = statuses[pane.id];
+      if (status && !agentByStatus.has(status)) {
+        agentByStatus.set(status, agent);
+      }
+    }
+  }
+
+  const status = AGGREGATE_PRIORITY.find((candidate) => agentByStatus.has(candidate)) ?? null;
+  return {
+    status,
+    // Name the agent that actually holds the reported state, so a row saying
+    // "waiting" points at the one waiting rather than whichever was found first.
+    agent: status ? (agentByStatus.get(status) ?? fallbackAgent) : fallbackAgent,
+  };
+}

--- a/src/modules/worktrees/lib/worktreesBridge.ts
+++ b/src/modules/worktrees/lib/worktreesBridge.ts
@@ -1,0 +1,68 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { WorktreeAddResult, WorktreeDetail } from "../types";
+
+/**
+ * Every worktree of the repo, including the bare/locked/prunable entries the
+ * plain `gitWorktreeList` drops. Spawns one `git worktree list --porcelain`
+ * (~10-30ms, more on Windows), so callers cache the result and refresh on
+ * events rather than polling.
+ */
+export function gitWorktreeListDetailed(path: string): Promise<WorktreeDetail[]> {
+  return invoke<WorktreeDetail[]>("git_worktree_list_detailed", { path });
+}
+
+/**
+ * Add a worktree. With `createBranch` the branch is created from `base` (HEAD
+ * when omitted); otherwise an existing branch is checked out there. `path` must
+ * be absolute — git resolves a relative one against the repo, the pre-flight
+ * against the app's cwd.
+ */
+export function gitWorktreeAdd(
+  repoPath: string,
+  path: string,
+  branch: string,
+  createBranch: boolean,
+  base?: string,
+): Promise<WorktreeAddResult> {
+  return invoke<WorktreeAddResult>("git_worktree_add", {
+    repoPath,
+    path,
+    branch,
+    createBranch,
+    base,
+  });
+}
+
+/**
+ * Remove a worktree, and optionally the branch it had checked out. Never forces:
+ * git refuses a dirty worktree, which is the last safety net behind the UI's own
+ * block. Close the worktree's tab and kill its ptys first — on Windows a live
+ * pty holds a handle on its cwd and the directory cannot be deleted.
+ */
+export function gitWorktreeRemove(
+  repoPath: string,
+  path: string,
+  deleteBranch?: string,
+  forceDeleteBranch = false,
+): Promise<void> {
+  return invoke("git_worktree_remove", { repoPath, path, deleteBranch, forceDeleteBranch });
+}
+
+/** Drop metadata for worktrees whose directory is gone; returns what git removed. */
+export function gitWorktreePrune(path: string): Promise<string[]> {
+  return invoke<string[]>("git_worktree_prune", { path });
+}
+
+/** Modified + untracked file count, for a row's dirty dot. */
+export function gitWorktreeDirtyCount(path: string): Promise<number> {
+  return invoke<number>("git_worktree_dirty_count", { path });
+}
+
+/**
+ * Total bytes of the checkout (git's own `.git` storage excluded). Expensive —
+ * a worktree that has had `pnpm install` run in it is tens of thousands of
+ * files. Call lazily, one row at a time, never on open and never for a tooltip.
+ */
+export function gitWorktreeDiskSize(path: string): Promise<number> {
+  return invoke<number>("git_worktree_disk_size", { path });
+}

--- a/src/modules/worktrees/lib/worktreesStore.test.ts
+++ b/src/modules/worktrees/lib/worktreesStore.test.ts
@@ -6,6 +6,9 @@ const { gitWorktreeListDetailed, gitWorktreeDiskSize } = vi.hoisted(() => ({
 }));
 vi.mock("./worktreesBridge", () => ({ gitWorktreeListDetailed, gitWorktreeDiskSize }));
 
+const { gitResolveRepo } = vi.hoisted(() => ({ gitResolveRepo: vi.fn() }));
+vi.mock("@/modules/source-control/lib/gitBridge", () => ({ gitResolveRepo }));
+
 import { useWorktreeRegistryStore } from "@/stores/worktreeRegistryStore";
 import type { WorktreeDetail } from "../types";
 import { useWorktreesStore } from "./worktreesStore";
@@ -30,6 +33,8 @@ beforeEach(() => {
   useWorktreeRegistryStore.setState({ byRepo: {} });
   gitWorktreeListDetailed.mockReset();
   gitWorktreeDiskSize.mockReset();
+  gitResolveRepo.mockReset();
+  gitResolveRepo.mockResolvedValue("/repo");
 });
 
 describe("worktreesStore.refresh", () => {
@@ -83,17 +88,43 @@ describe("worktreesStore.refresh", () => {
     expect(gitWorktreeListDetailed).toHaveBeenCalledTimes(2);
   });
 
-  it("forgets a repo whose path no longer resolves", async () => {
+  it("forgets a repo once its path really stops being one", async () => {
     gitWorktreeListDetailed.mockResolvedValue([detail("/repo", true), detail("/repo-wt/x")]);
     await store().refresh("/repo");
     expect(useWorktreeRegistryStore.getState().byRepo["/repo"]).toBeDefined();
 
     // The repo was deleted or moved out from under us.
     gitWorktreeListDetailed.mockRejectedValue(new Error("not a git repository"));
+    gitResolveRepo.mockResolvedValue(null);
     await expect(store().refresh("/repo")).rejects.toThrow();
 
     expect(useWorktreeRegistryStore.getState().byRepo["/repo"]).toBeUndefined();
     expect(useWorktreesStore.getState().byRepo["/repo"]).toBeUndefined();
+  });
+
+  it("keeps a repo when the scan fails but the repo is still there", async () => {
+    // A git lock or a spawn hiccup fails exactly like a deleted repo. Dropping
+    // the entry would under-count the badge silently, which is the one failure
+    // mode nobody would notice.
+    gitWorktreeListDetailed.mockResolvedValue([detail("/repo", true), detail("/repo-wt/x")]);
+    await store().refresh("/repo");
+
+    gitWorktreeListDetailed.mockRejectedValue(new Error("index.lock exists"));
+    gitResolveRepo.mockResolvedValue("/repo");
+    await expect(store().refresh("/repo")).rejects.toThrow();
+
+    expect(useWorktreeRegistryStore.getState().byRepo["/repo"]?.worktreeCount).toBe(1);
+  });
+
+  it("keeps a repo when even the probe fails, rather than forgetting on a guess", async () => {
+    gitWorktreeListDetailed.mockResolvedValue([detail("/repo", true), detail("/repo-wt/x")]);
+    await store().refresh("/repo");
+
+    gitWorktreeListDetailed.mockRejectedValue(new Error("boom"));
+    gitResolveRepo.mockRejectedValue(new Error("probe also failed"));
+    await expect(store().refresh("/repo")).rejects.toThrow();
+
+    expect(useWorktreeRegistryStore.getState().byRepo["/repo"]).toBeDefined();
   });
 });
 

--- a/src/modules/worktrees/lib/worktreesStore.test.ts
+++ b/src/modules/worktrees/lib/worktreesStore.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { gitWorktreeListDetailed, gitWorktreeDiskSize } = vi.hoisted(() => ({
+  gitWorktreeListDetailed: vi.fn(),
+  gitWorktreeDiskSize: vi.fn(),
+}));
+vi.mock("./worktreesBridge", () => ({ gitWorktreeListDetailed, gitWorktreeDiskSize }));
+
+import { useWorktreeRegistryStore } from "@/stores/worktreeRegistryStore";
+import type { WorktreeDetail } from "../types";
+import { useWorktreesStore } from "./worktreesStore";
+
+function detail(path: string, isMain = false): WorktreeDetail {
+  return {
+    path,
+    branch: "b",
+    head: "abc",
+    isMain,
+    bare: false,
+    locked: false,
+    lockReason: null,
+    prunable: false,
+  };
+}
+
+const store = () => useWorktreesStore.getState();
+
+beforeEach(() => {
+  useWorktreesStore.getState().reset();
+  useWorktreeRegistryStore.setState({ byRepo: {} });
+  gitWorktreeListDetailed.mockReset();
+  gitWorktreeDiskSize.mockReset();
+});
+
+describe("worktreesStore.refresh", () => {
+  it("caches the scan per repo", async () => {
+    const details = [detail("/repo", true), detail("/repo-worktrees/x")];
+    gitWorktreeListDetailed.mockResolvedValue(details);
+
+    await store().refresh("/repo");
+
+    expect(useWorktreesStore.getState().byRepo["/repo"]).toEqual(details);
+  });
+
+  it("registers the repo with its linked count, excluding the main worktree", async () => {
+    gitWorktreeListDetailed.mockResolvedValue([
+      detail("/repo", true),
+      detail("/repo-worktrees/x"),
+      detail("/repo-worktrees/y"),
+    ]);
+
+    await store().refresh("/repo");
+
+    // The main checkout is not a worktree the user made, so the badge must not
+    // count it.
+    expect(useWorktreeRegistryStore.getState().byRepo["/repo"]?.worktreeCount).toBe(2);
+  });
+
+  it("does not register a repo that only has its main worktree", async () => {
+    gitWorktreeListDetailed.mockResolvedValue([detail("/repo", true)]);
+
+    await store().refresh("/repo");
+
+    expect(useWorktreeRegistryStore.getState().byRepo["/repo"]).toBeUndefined();
+  });
+
+  it("de-dupes concurrent scans of the same repo into one subprocess", async () => {
+    // Two rows mounting at once must not spawn `git worktree list` twice.
+    gitWorktreeListDetailed.mockResolvedValue([detail("/repo", true)]);
+
+    const [a, b] = await Promise.all([store().refresh("/repo"), store().refresh("/repo")]);
+
+    expect(gitWorktreeListDetailed).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it("scans again after the previous one settles", async () => {
+    gitWorktreeListDetailed.mockResolvedValue([detail("/repo", true)]);
+
+    await store().refresh("/repo");
+    await store().refresh("/repo");
+
+    expect(gitWorktreeListDetailed).toHaveBeenCalledTimes(2);
+  });
+
+  it("forgets a repo whose path no longer resolves", async () => {
+    gitWorktreeListDetailed.mockResolvedValue([detail("/repo", true), detail("/repo-wt/x")]);
+    await store().refresh("/repo");
+    expect(useWorktreeRegistryStore.getState().byRepo["/repo"]).toBeDefined();
+
+    // The repo was deleted or moved out from under us.
+    gitWorktreeListDetailed.mockRejectedValue(new Error("not a git repository"));
+    await expect(store().refresh("/repo")).rejects.toThrow();
+
+    expect(useWorktreeRegistryStore.getState().byRepo["/repo"]).toBeUndefined();
+    expect(useWorktreesStore.getState().byRepo["/repo"]).toBeUndefined();
+  });
+});
+
+describe("worktreesStore.loadSize", () => {
+  it("caches the measured size", async () => {
+    gitWorktreeDiskSize.mockResolvedValue(4096);
+
+    await store().loadSize("/repo-worktrees/x");
+
+    expect(useWorktreesStore.getState().sizes["/repo-worktrees/x"]).toBe(4096);
+  });
+
+  it("de-dupes concurrent walks of the same worktree", async () => {
+    // The walk is tens of thousands of files; running it twice is the one thing
+    // this must never do.
+    gitWorktreeDiskSize.mockResolvedValue(4096);
+
+    await Promise.all([store().loadSize("/wt"), store().loadSize("/wt")]);
+
+    expect(gitWorktreeDiskSize).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/worktrees/lib/worktreesStore.ts
+++ b/src/modules/worktrees/lib/worktreesStore.ts
@@ -1,0 +1,86 @@
+import { create } from "zustand";
+import { useWorktreeRegistryStore } from "@/stores/worktreeRegistryStore";
+import type { WorktreeDetail } from "../types";
+import { gitWorktreeDiskSize, gitWorktreeListDetailed } from "./worktreesBridge";
+
+/**
+ * In-flight scans and size walks, keyed by path. Module-level rather than in the
+ * store because they are not state anyone renders — they exist so two rows
+ * mounting at once cannot fire the same subprocess twice.
+ */
+const scansInFlight = new Map<string, Promise<WorktreeDetail[]>>();
+const sizesInFlight = new Map<string, Promise<number>>();
+
+interface WorktreesState {
+  /** Cached scan per repo main path. Never recomputed to render — refreshed on
+   *  events only (open, create, remove, manual), never on a timer. */
+  byRepo: Record<string, WorktreeDetail[]>;
+  /** Lazily measured bytes per worktree path; absent until asked for. */
+  sizes: Record<string, number>;
+  refresh: (repoPath: string) => Promise<WorktreeDetail[]>;
+  loadSize: (path: string) => Promise<number>;
+  reset: () => void;
+}
+
+export const useWorktreesStore = create<WorktreesState>((set) => ({
+  byRepo: {},
+  sizes: {},
+
+  refresh: (repoPath) => {
+    const existing = scansInFlight.get(repoPath);
+    if (existing) {
+      return existing;
+    }
+    const scan = gitWorktreeListDetailed(repoPath)
+      .then((details) => {
+        set((state) => ({ byRepo: { ...state.byRepo, [repoPath]: details } }));
+        // The scan is where we learn whether this repo is worth remembering:
+        // the registry holds only repos that actually have linked worktrees.
+        const linked = details.filter((detail) => !detail.isMain).length;
+        useWorktreeRegistryStore.getState().record(repoPath, linked);
+        return details;
+      })
+      .catch((error: unknown) => {
+        // The path stopped resolving as a repo (deleted, moved, or a drive that
+        // went away). Drop it rather than leaving a row that can never load.
+        useWorktreeRegistryStore.getState().forget(repoPath);
+        set((state) => {
+          if (!(repoPath in state.byRepo)) {
+            return state;
+          }
+          const byRepo = { ...state.byRepo };
+          delete byRepo[repoPath];
+          return { byRepo };
+        });
+        throw error;
+      })
+      .finally(() => {
+        scansInFlight.delete(repoPath);
+      });
+    scansInFlight.set(repoPath, scan);
+    return scan;
+  },
+
+  loadSize: (path) => {
+    const existing = sizesInFlight.get(path);
+    if (existing) {
+      return existing;
+    }
+    const walk = gitWorktreeDiskSize(path)
+      .then((bytes) => {
+        set((state) => ({ sizes: { ...state.sizes, [path]: bytes } }));
+        return bytes;
+      })
+      .finally(() => {
+        sizesInFlight.delete(path);
+      });
+    sizesInFlight.set(path, walk);
+    return walk;
+  },
+
+  reset: () => {
+    scansInFlight.clear();
+    sizesInFlight.clear();
+    set({ byRepo: {}, sizes: {} });
+  },
+}));

--- a/src/modules/worktrees/lib/worktreesStore.ts
+++ b/src/modules/worktrees/lib/worktreesStore.ts
@@ -1,7 +1,23 @@
 import { create } from "zustand";
+import { gitResolveRepo } from "@/modules/source-control/lib/gitBridge";
 import { useWorktreeRegistryStore } from "@/stores/worktreeRegistryStore";
 import type { WorktreeDetail } from "../types";
 import { gitWorktreeDiskSize, gitWorktreeListDetailed } from "./worktreesBridge";
+
+/**
+ * Whether `repoPath` is still a git repository — the non-brittle signal for
+ * "this entry is genuinely gone", as opposed to matching git's stderr, which is
+ * localized and would misfire in any non-English shell.
+ *
+ * Defaults to `true` if the probe itself fails: never forget a repo on a guess.
+ */
+async function stillARepo(repoPath: string): Promise<boolean> {
+  try {
+    return (await gitResolveRepo(repoPath)) !== null;
+  } catch {
+    return true;
+  }
+}
 
 /**
  * In-flight scans and size walks, keyed by path. Module-level rather than in the
@@ -40,9 +56,15 @@ export const useWorktreesStore = create<WorktreesState>((set) => ({
         useWorktreeRegistryStore.getState().record(repoPath, linked);
         return details;
       })
-      .catch((error: unknown) => {
-        // The path stopped resolving as a repo (deleted, moved, or a drive that
-        // went away). Drop it rather than leaving a row that can never load.
+      .catch(async (error: unknown) => {
+        // A failed scan is not proof the repo is gone — a git lock or a spawn
+        // hiccup fails the same way. Ask for the real signal before dropping
+        // anything, because the two mistakes are not equal: silently forgetting
+        // a live repo under-counts the badge invisibly, while keeping a stale
+        // one is visible in the manager and can be forgotten from there.
+        if (await stillARepo(repoPath)) {
+          throw error;
+        }
         useWorktreeRegistryStore.getState().forget(repoPath);
         set((state) => {
           if (!(repoPath in state.byRepo)) {

--- a/src/modules/worktrees/types.ts
+++ b/src/modules/worktrees/types.ts
@@ -1,0 +1,25 @@
+/**
+ * One worktree as `git worktree list --porcelain` reports it. Mirrors the Rust
+ * `WorktreeDetail` in `src-tauri/src/modules/git/mod.rs`.
+ *
+ * Unlike the plain worktree list this keeps the entries that cannot be switched
+ * to: `prunable` (the directory is gone) has to be visible for the user to prune
+ * it, and `locked` has to be visible to explain why removal is refused.
+ */
+export interface WorktreeDetail {
+  path: string;
+  branch: string | null;
+  head: string | null;
+  /** Git always reports the repo's primary working tree first. */
+  isMain: boolean;
+  bare: boolean;
+  locked: boolean;
+  lockReason: string | null;
+  prunable: boolean;
+}
+
+/** The worktree a successful add produced; `path` is canonical. */
+export interface WorktreeAddResult {
+  path: string;
+  branch: string;
+}

--- a/src/stores/worktreeRegistryStore.test.ts
+++ b/src/stores/worktreeRegistryStore.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { selectTotalWorktrees, useWorktreeRegistryStore } from "./worktreeRegistryStore";
+
+const store = () => useWorktreeRegistryStore.getState();
+
+beforeEach(() => useWorktreeRegistryStore.setState({ byRepo: {} }));
+
+describe("worktreeRegistryStore", () => {
+  it("does not remember a repo that has no linked worktrees", () => {
+    // Every repo the user opens a terminal in gets scanned; only the ones
+    // actually using worktrees belong in the registry, or it would grow to
+    // every repo they have ever touched.
+    store().record("/repo", 0);
+    expect(store().entries()).toEqual([]);
+  });
+
+  it("remembers a repo once it has one", () => {
+    store().record("/repo", 2, 111);
+    expect(store().entries()).toEqual([
+      { repoPath: "/repo", worktreeCount: 2, lastScannedAt: 111 },
+    ]);
+  });
+
+  it("forgets a repo whose last worktree is gone", () => {
+    store().record("/repo", 1);
+    store().record("/repo", 0);
+    expect(store().entries()).toEqual([]);
+  });
+
+  it("skips the write when a rescan finds the same count", () => {
+    // Rescans are frequent; churning the state would wake every subscriber.
+    store().record("/repo", 2, 111);
+    const before = useWorktreeRegistryStore.getState().byRepo;
+    store().record("/repo", 2, 999);
+    expect(useWorktreeRegistryStore.getState().byRepo).toBe(before);
+  });
+
+  it("updates the count and timestamp when it changes", () => {
+    store().record("/repo", 2, 111);
+    store().record("/repo", 3, 222);
+    expect(store().entries()[0]).toEqual({
+      repoPath: "/repo",
+      worktreeCount: 3,
+      lastScannedAt: 222,
+    });
+  });
+
+  it("forgets on demand", () => {
+    store().record("/repo", 2);
+    store().forget("/repo");
+    expect(store().entries()).toEqual([]);
+  });
+
+  it("totals linked worktrees across repos for the badge", () => {
+    store().record("/a", 2);
+    store().record("/b", 3);
+    expect(selectTotalWorktrees(useWorktreeRegistryStore.getState())).toBe(5);
+  });
+
+  it("totals zero when nothing is registered, so the badge can hide", () => {
+    expect(selectTotalWorktrees(useWorktreeRegistryStore.getState())).toBe(0);
+  });
+});

--- a/src/stores/worktreeRegistryStore.ts
+++ b/src/stores/worktreeRegistryStore.ts
@@ -1,0 +1,81 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/** A repo known to have worktrees, with its last counted total. */
+export interface WorktreeRepoEntry {
+  /** The repo's canonical **main** worktree path. */
+  repoPath: string;
+  /** Linked worktrees only — the main checkout is not one the user made. */
+  worktreeCount: number;
+  lastScannedAt: number;
+}
+
+const STORAGE_KEY = "tempoterm-worktree-repos";
+
+interface WorktreeRegistryState {
+  byRepo: Record<string, WorktreeRepoEntry>;
+  /**
+   * Record what a scan found. A repo enters the registry only once it actually
+   * has a linked worktree, and leaves again when its last one goes — which is
+   * what keeps this list proportional to what the user really uses instead of
+   * growing to every repo they ever opened a terminal in.
+   */
+  record: (repoPath: string, worktreeCount: number, now?: number) => void;
+  /** Drop a repo: its path stopped resolving, or the user asked to forget it. */
+  forget: (repoPath: string) => void;
+  entries: () => WorktreeRepoEntry[];
+}
+
+/** Total linked worktrees across every known repo — the status-bar badge count. */
+export const selectTotalWorktrees = (state: WorktreeRegistryState): number =>
+  Object.values(state.byRepo).reduce((sum, entry) => sum + entry.worktreeCount, 0);
+
+export const useWorktreeRegistryStore = create<WorktreeRegistryState>()(
+  persist(
+    (set, get) => ({
+      byRepo: {},
+
+      record: (repoPath, worktreeCount, now = Date.now()) =>
+        set((state) => {
+          if (worktreeCount <= 0) {
+            if (!(repoPath in state.byRepo)) {
+              return state;
+            }
+            const byRepo = { ...state.byRepo };
+            delete byRepo[repoPath];
+            return { byRepo };
+          }
+          const previous = state.byRepo[repoPath];
+          if (previous?.worktreeCount === worktreeCount) {
+            // Same count: skip the write so subscribers do not churn on every
+            // rescan of an unchanged repo.
+            return state;
+          }
+          return {
+            byRepo: {
+              ...state.byRepo,
+              [repoPath]: { repoPath, worktreeCount, lastScannedAt: now },
+            },
+          };
+        }),
+
+      forget: (repoPath) =>
+        set((state) => {
+          if (!(repoPath in state.byRepo)) {
+            return state;
+          }
+          const byRepo = { ...state.byRepo };
+          delete byRepo[repoPath];
+          return { byRepo };
+        }),
+
+      entries: () => Object.values(get().byRepo),
+    }),
+    {
+      // Global: "how many worktrees am I keeping around" is a property of the
+      // machine, so every window agrees on the badge.
+      name: STORAGE_KEY,
+      partialize: (state) => ({ byRepo: state.byRepo }),
+    },
+  ),
+);

--- a/src/stores/worktreeSettingsStore.test.ts
+++ b/src/stores/worktreeSettingsStore.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_COPY_GLOBS, useWorktreeSettingsStore } from "./worktreeSettingsStore";
+
+const store = () => useWorktreeSettingsStore.getState();
+
+beforeEach(() => useWorktreeSettingsStore.setState({ byRepo: {} }));
+
+describe("worktreeSettingsStore", () => {
+  it("returns empty settings for a repo it has never seen", () => {
+    expect(store().repoSettings("/repo")).toEqual({});
+  });
+
+  it("merges a patch instead of replacing the repo's settings", () => {
+    // The create dialog saves one field at a time; a replace would silently drop
+    // the setup command the moment the user picked an agent.
+    store().setRepoSettings("/repo", { setupCommand: "pnpm install" });
+    store().setRepoSettings("/repo", { lastAgent: "codex" });
+
+    expect(store().repoSettings("/repo")).toEqual({
+      setupCommand: "pnpm install",
+      lastAgent: "codex",
+    });
+  });
+
+  it("keeps repos independent", () => {
+    store().setRepoSettings("/a", { setupCommand: "pnpm install" });
+    store().setRepoSettings("/b", { setupCommand: "cargo build" });
+
+    expect(store().repoSettings("/a").setupCommand).toBe("pnpm install");
+    expect(store().repoSettings("/b").setupCommand).toBe("cargo build");
+  });
+
+  it("forgets a repo", () => {
+    store().setRepoSettings("/repo", { setupCommand: "pnpm install" });
+    store().forgetRepo("/repo");
+
+    expect(store().repoSettings("/repo")).toEqual({});
+  });
+
+  it("defaults the copy globs recursively, so a monorepo's package .env files come across", () => {
+    expect(DEFAULT_COPY_GLOBS).toEqual(["**/.env*"]);
+  });
+});

--- a/src/stores/worktreeSettingsStore.ts
+++ b/src/stores/worktreeSettingsStore.ts
@@ -1,0 +1,70 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { AgentKind } from "@/modules/claude-progress/lib/codexNormalize";
+
+/**
+ * Gitignored files worth carrying into a fresh worktree. `git worktree add`
+ * gives you tracked source only, so without this an agent's first command dies
+ * on a missing `.env` — the exact failure this feature exists to avoid. The glob
+ * is recursive because a monorepo keeps them at `packages/*\/.env`.
+ */
+export const DEFAULT_COPY_GLOBS = ["**/.env*"];
+
+export interface WorktreeRepoSettings {
+  /** Overrides the default `<repo>-worktrees` sibling container. */
+  containerPath?: string;
+  /** Run inside the new worktree right after it is created, e.g. `pnpm install`. */
+  setupCommand?: string;
+  /** Local files to copy in. Defaults to {@link DEFAULT_COPY_GLOBS}. */
+  copyGlobs?: string[];
+  /** Pre-selects the agent picker next time. */
+  lastAgent?: AgentKind;
+}
+
+const STORAGE_KEY = "tempoterm-worktree-settings";
+
+interface WorktreeSettingsState {
+  /** Keyed by the repo's **main** worktree path, so every linked worktree of a
+   *  repo shares one setup command. */
+  byRepo: Record<string, WorktreeRepoSettings>;
+  repoSettings: (repoPath: string) => WorktreeRepoSettings;
+  setRepoSettings: (repoPath: string, patch: Partial<WorktreeRepoSettings>) => void;
+  forgetRepo: (repoPath: string) => void;
+}
+
+const EMPTY: WorktreeRepoSettings = {};
+
+export const useWorktreeSettingsStore = create<WorktreeSettingsState>()(
+  persist(
+    (set, get) => ({
+      byRepo: {},
+
+      repoSettings: (repoPath) => get().byRepo[repoPath] ?? EMPTY,
+
+      setRepoSettings: (repoPath, patch) =>
+        set((state) => ({
+          byRepo: {
+            ...state.byRepo,
+            [repoPath]: { ...(state.byRepo[repoPath] ?? {}), ...patch },
+          },
+        })),
+
+      forgetRepo: (repoPath) =>
+        set((state) => {
+          if (!(repoPath in state.byRepo)) {
+            return state;
+          }
+          const byRepo = { ...state.byRepo };
+          delete byRepo[repoPath];
+          return { byRepo };
+        }),
+    }),
+    {
+      // Global, not per-window: a repo's setup command is a property of the
+      // repo, not of whichever window happens to be open (settingsStore is the
+      // precedent; workspaceStore's per-window storage would be wrong here).
+      name: STORAGE_KEY,
+      partialize: (state) => ({ byRepo: state.byRepo }),
+    },
+  ),
+);


### PR DESCRIPTION
Second slice of **Parallel Worktrees**: the data layer the manager will sit on. **Pure TS, tested against a mocked bridge — nothing renders it yet**, so this can't regress anything on screen. Builds on #220's Rust commands.

## What this adds

| Module | Job |
|---|---|
| `worktrees/lib/worktreesBridge.ts` | Typed wrappers for the six `git_worktree_*` commands. The only file that knows `invoke` exists. |
| `stores/worktreeSettingsStore.ts` | Per-repo setup command, copy globs, container override, last agent. Keyed by the repo's **main** worktree path. |
| `stores/worktreeRegistryStore.ts` | The repos known to have worktrees, with cached counts — the status-bar badge's denominator. |
| `worktrees/lib/worktreesStore.ts` | Per-repo scan cache, in-flight de-dup, lazily measured sizes. |
| `worktrees/lib/worktreeStatus.ts` | Joins per-leaf agent status to a worktree directory. |
| `worktrees/lib/paths.ts` | `isUnder` — path containment. |

## Decisions worth a reviewer's attention

- **`isUnder` is not `startsWith`.** This feature parks worktrees in a `<repo>-worktrees/` sibling, so a prefix test would report *every* worktree as living inside the repo it came from — silently mis-attributing agent status and making "focus the existing tab" open the wrong one. The boundary breaks on a separator, and `/a/b-worktrees/x` vs `/a/b` is an explicit test case. `windows` is a parameter, not an `IS_WINDOWS` read, so the case-insensitive separator-agnostic Windows behaviour is covered by tests that run here (per the repo's `windows-tauri` guidance about cfg-gated logic never executing on the dev box).
- **The registry is self-limiting.** A repo enters only once it actually has a linked worktree, and leaves when its last one goes. That is what stops the badge's denominator growing to every repo the user ever opened a terminal in — and it keeps the startup scan proportional to what they actually use. Counts exclude the main checkout: it isn't a worktree the user made, so the badge must not count it.
- **`worktreeStatus` exists because the app keeps the two halves apart**: statuses are keyed per terminal *leaf* (`sessionStatusStore`), while the cwd that places a leaf lives in the *pane tree* (`tabsStore`). A worktree owns whichever terminal panes are cd'd into it, so the join walks the panes and reduces with the shared priority. It names the agent that actually holds the winning status, so a row saying "waiting" points at the one waiting rather than whichever was found first.
- **`AGGREGATE_PRIORITY` is now exported and shared.** The order existed in two private copies (`sessionStatusStore`, `tabSessionStatus`); adding a third for worktree rows is how a card and a row start disagreeing. `tabSessionStatus` now imports it — its existing tests still pass unchanged.
- **De-dup is module-level, not state.** Two rows mounting at once must not spawn the same `git worktree list` twice, and the size walk (tens of thousands of files) must never run twice concurrently. Neither is anything a component renders.
- **A repo whose path stops resolving is dropped on the spot**, rather than leaving a row that can never load.

## Checks

- `tsc --noEmit`: clean.
- **35 new tests** (10 `isUnder`, 9 `worktreeStatus`, 8 registry, 8 store, 5 settings). Full suite: 1599 passing.
- Two `TitleBar` submenu hover-delay tests fail — **pre-existing on master**, verified by stashing this branch and re-running on a clean tree. Not touched by this PR; flagged separately.

## Next

PR 3 puts the modal and the status-bar badge on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
