### PR TITLE
feat(worktrees): open a worktree, or split it beside your work

### DIFF
--- a/src/i18n/locales/en/worktrees.json
+++ b/src/i18n/locales/en/worktrees.json
@@ -10,14 +10,20 @@
   "row": {
     "main": "main",
     "detached": "detached",
-    "open": "Open in this window",
+    "open": "Open",
     "dirty": "{{count}} uncommitted change",
     "dirty_other": "{{count}} uncommitted changes",
     "locked": "Locked",
     "lockedReason": "Locked: {{reason}}",
     "stale": "Directory is gone",
     "measure": "Measure size",
-    "measuring": "Measuring…"
+    "measuring": "Measuring…",
+    "openHint": "Open a terminal in this worktree",
+    "focusHint": "Go to the terminal already in this worktree",
+    "split": "Split",
+    "splitHint": "Open it beside what you are working in",
+    "splitFull": "This tab is full",
+    "openStale": "The directory is gone — nothing to open"
   },
   "agent": {
     "active": "Working",

--- a/src/i18n/locales/zh-Hant/worktrees.json
+++ b/src/i18n/locales/zh-Hant/worktrees.json
@@ -10,14 +10,20 @@
   "row": {
     "main": "主要",
     "detached": "分離 HEAD",
-    "open": "已在這個視窗開著",
+    "open": "開啟",
     "dirty": "{{count}} 個未提交變更",
     "dirty_other": "{{count}} 個未提交變更",
     "locked": "已鎖定",
     "lockedReason": "已鎖定：{{reason}}",
     "stale": "目錄已不存在",
     "measure": "計算佔用",
-    "measuring": "計算中…"
+    "measuring": "計算中…",
+    "openHint": "在這個 worktree 開一個終端機",
+    "focusHint": "跳到已經在這個 worktree 的終端機",
+    "split": "分割",
+    "splitHint": "開在你正在做的事情旁邊",
+    "splitFull": "這個分頁已經滿了",
+    "openStale": "目錄不見了,沒東西可開"
   },
   "agent": {
     "active": "執行中",

--- a/src/modules/worktrees/WorktreeRow.actions.test.tsx
+++ b/src/modules/worktrees/WorktreeRow.actions.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { gitWorktreeDirtyCount } = vi.hoisted(() => ({ gitWorktreeDirtyCount: vi.fn() }));
+vi.mock("./lib/worktreesBridge", () => ({ gitWorktreeDirtyCount }));
+
+import "@/i18n";
+import { computeLayout, leaf, type LayoutNode } from "@/modules/terminal/lib/terminalLayout";
+import { MAX_PANES, useTabsStore, type Tab } from "@/stores/tabsStore";
+import { useUiStore } from "@/stores/uiStore";
+import type { WorktreeDetail } from "./types";
+import { WorktreeRow } from "./WorktreeRow";
+
+const WT = "/code/repo-worktrees/feat-a";
+
+function detail(overrides: Partial<WorktreeDetail> = {}): WorktreeDetail {
+  return {
+    path: WT,
+    branch: "feat/a",
+    head: "abc",
+    isMain: false,
+    bare: false,
+    locked: false,
+    lockReason: null,
+    prunable: false,
+    ...overrides,
+  };
+}
+
+function tab(id: string, paneTree: LayoutNode, paneOrder: string[], cwd?: string): Tab {
+  return {
+    id,
+    spaceId: "s1",
+    title: id,
+    kind: "terminal",
+    paneTree,
+    activeLeafId: paneOrder[0],
+    paneOrder,
+    cwd,
+  };
+}
+
+function seedTabs(tabs: Tab[], activeId: string | null) {
+  useTabsStore.setState({
+    tabs,
+    activeId,
+    spaces: [{ id: "s1", name: "S" }],
+    activeSpaceId: "s1",
+  });
+}
+
+/** Every terminal pane's cwd across every tab — what actually got opened where. */
+function terminalCwds(): string[] {
+  return useTabsStore
+    .getState()
+    .tabs.flatMap((t) =>
+      computeLayout(t.paneTree)
+        .filter((p) => p.content?.kind === "terminal")
+        .map((p) => (p.content as { cwd?: string }).cwd ?? t.cwd ?? ""),
+    );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  gitWorktreeDirtyCount.mockResolvedValue(0);
+  useUiStore.setState({ worktreesModal: { scope: "global", repoPath: null } });
+  seedTabs([tab("t1", leaf("p1", { kind: "terminal", cwd: "/elsewhere" }), ["p1"])], "t1");
+});
+
+const openButton = () => screen.getByRole("button", { name: /open/i });
+const splitButton = () => screen.getByRole("button", { name: /split/i });
+
+describe("WorktreeRow — opening", () => {
+  it("spawns a terminal in the worktree when nothing is there yet", () => {
+    render(<WorktreeRow detail={detail()} />);
+
+    fireEvent.click(openButton());
+
+    expect(terminalCwds()).toContain(WT);
+    expect(useTabsStore.getState().tabs).toHaveLength(2);
+  });
+
+  it("focuses the tab already in the worktree instead of spawning a second shell", () => {
+    seedTabs(
+      [
+        tab("t1", leaf("p1", { kind: "terminal", cwd: "/elsewhere" }), ["p1"]),
+        tab("t2", leaf("p2", { kind: "terminal", cwd: `${WT}/src` }), ["p2"]),
+      ],
+      "t1",
+    );
+
+    render(<WorktreeRow detail={detail()} />);
+    fireEvent.click(openButton());
+
+    expect(useTabsStore.getState().activeId).toBe("t2");
+    expect(useTabsStore.getState().tabs).toHaveLength(2);
+  });
+
+  it("closes the manager once it has taken you somewhere", () => {
+    render(<WorktreeRow detail={detail()} />);
+
+    fireEvent.click(openButton());
+
+    expect(useUiStore.getState().worktreesModal).toBeNull();
+  });
+
+  it("will not open a worktree whose directory is gone", () => {
+    render(<WorktreeRow detail={detail({ prunable: true })} />);
+
+    expect(openButton()).toBeDisabled();
+  });
+});
+
+describe("WorktreeRow — splitting", () => {
+  it("puts the worktree beside the pane you were in", () => {
+    render(<WorktreeRow detail={detail()} />);
+
+    fireEvent.click(splitButton());
+
+    const active = useTabsStore.getState().tabs.find((t) => t.id === "t1")!;
+    expect(active.paneOrder).toHaveLength(2);
+    expect(terminalCwds()).toContain(WT);
+    // Split means beside what you had — not a new tab.
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+  });
+
+  it("refuses to split a tab that is already full", () => {
+    const panes = Array.from({ length: MAX_PANES }, (_, i) => `p${i}`);
+    seedTabs([tab("t1", leaf("p0", { kind: "terminal", cwd: "/elsewhere" }), panes)], "t1");
+
+    render(<WorktreeRow detail={detail()} />);
+
+    expect(splitButton()).toBeDisabled();
+  });
+
+  it("offers no split when there is nothing to split", () => {
+    seedTabs([], null);
+
+    render(<WorktreeRow detail={detail()} />);
+
+    expect(screen.queryByRole("button", { name: /split/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/modules/worktrees/WorktreeRow.actions.test.tsx
+++ b/src/modules/worktrees/WorktreeRow.actions.test.tsx
@@ -140,4 +140,23 @@ describe("WorktreeRow — splitting", () => {
 
     expect(screen.queryByRole("button", { name: /split/i })).not.toBeInTheDocument();
   });
+
+  it("offers no split into a launcher tab, whose panes are never rendered", () => {
+    const launcher = tab("t1", leaf("p1", { kind: "launcher" }), ["p1"]);
+    seedTabs([{ ...launcher, kind: "launcher" }], "t1");
+
+    render(<WorktreeRow detail={detail()} />);
+
+    expect(screen.queryByRole("button", { name: /split/i })).not.toBeInTheDocument();
+  });
+
+  it("still opens into a tab of its own from a launcher tab", () => {
+    const launcher = tab("t1", leaf("p1", { kind: "launcher" }), ["p1"]);
+    seedTabs([{ ...launcher, kind: "launcher" }], "t1");
+
+    render(<WorktreeRow detail={detail()} />);
+    fireEvent.click(openButton());
+
+    expect(terminalCwds()).toContain(WT);
+  });
 });

--- a/src/modules/worktrees/WorktreeRow.tsx
+++ b/src/modules/worktrees/WorktreeRow.tsx
@@ -3,11 +3,11 @@ import { useTranslation } from "react-i18next";
 import { AlertTriangle, Columns2, FolderOpen, HardDrive, Lock } from "lucide-react";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
 import { formatBytes } from "@/modules/sysmon/lib/format";
-import { MAX_PANES, useTabsStore } from "@/stores/tabsStore";
+import { useTabsStore } from "@/stores/tabsStore";
 import { useUiStore } from "@/stores/uiStore";
 import type { WorktreeDetail } from "./types";
 import { gitWorktreeDirtyCount } from "./lib/worktreesBridge";
-import { findWorktreePane } from "./lib/openWorktree";
+import { canSplitInto, findWorktreePane, hasPaneRoom } from "./lib/openWorktree";
 import { useWorktreesStore } from "./lib/worktreesStore";
 import { worktreeSessionStatus } from "./lib/worktreeStatus";
 import type { SessionStatus } from "@/modules/claude-progress/lib/sessionStatus";
@@ -45,6 +45,7 @@ export function WorktreeRow({ detail }: { detail: WorktreeDetail }) {
   // shell in, and a bare one has no working tree at all.
   const unopenable = detail.prunable || detail.bare;
   const activeTab = tabs.find((tab) => tab.id === activeId) ?? null;
+  const splitTarget = canSplitInto(activeTab) ? activeTab : null;
 
   const open = () => {
     const tabsApi = useTabsStore.getState();
@@ -64,12 +65,19 @@ export function WorktreeRow({ detail }: { detail: WorktreeDetail }) {
   };
 
   const split = () => {
-    if (!activeTab) {
+    // Re-read rather than trust this render's snapshot: which tab is active, and
+    // how many panes it holds, can both move between paint and click.
+    const tabsApi = useTabsStore.getState();
+    const target = tabsApi.tabs.find((tab) => tab.id === tabsApi.activeId);
+    if (!canSplitInto(target) || !hasPaneRoom(target)) {
       return;
     }
-    useTabsStore
-      .getState()
-      .splitPaneWith(activeTab.id, activeTab.activeLeafId, { kind: "terminal", cwd: detail.path }, "row");
+    tabsApi.splitPaneWith(
+      target.id,
+      target.activeLeafId,
+      { kind: "terminal", cwd: detail.path },
+      "row",
+    );
     closeWorktrees();
   };
 
@@ -180,14 +188,12 @@ export function WorktreeRow({ detail }: { detail: WorktreeDetail }) {
 
         {/* Only offered when there is something to sit beside. Splitting is for
             comparing this worktree against what you already have open. */}
-        {activeTab && !unopenable && (
+        {splitTarget && !unopenable && (
           <button
             type="button"
             onClick={split}
-            disabled={activeTab.paneOrder.length >= MAX_PANES}
-            title={
-              activeTab.paneOrder.length >= MAX_PANES ? t("row.splitFull") : t("row.splitHint")
-            }
+            disabled={!hasPaneRoom(splitTarget)}
+            title={hasPaneRoom(splitTarget) ? t("row.splitHint") : t("row.splitFull")}
             aria-label={`${t("row.split")}: ${detail.branch ?? t("row.detached")}`}
             className="flex items-center gap-1 rounded px-1 text-fg-subtle transition-colors hover:text-fg disabled:opacity-40"
           >

--- a/src/modules/worktrees/WorktreeRow.tsx
+++ b/src/modules/worktrees/WorktreeRow.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { AlertTriangle, HardDrive, Lock } from "lucide-react";
+import { AlertTriangle, Columns2, FolderOpen, HardDrive, Lock } from "lucide-react";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
 import { formatBytes } from "@/modules/sysmon/lib/format";
-import { useTabsStore } from "@/stores/tabsStore";
+import { MAX_PANES, useTabsStore } from "@/stores/tabsStore";
+import { useUiStore } from "@/stores/uiStore";
 import type { WorktreeDetail } from "./types";
 import { gitWorktreeDirtyCount } from "./lib/worktreesBridge";
+import { findWorktreePane } from "./lib/openWorktree";
 import { useWorktreesStore } from "./lib/worktreesStore";
 import { worktreeSessionStatus } from "./lib/worktreeStatus";
 import type { SessionStatus } from "@/modules/claude-progress/lib/sessionStatus";
@@ -19,22 +21,57 @@ const STATUS_DOT: Record<SessionStatus, string> = {
 };
 
 /**
- * One worktree: what branch it holds, whether it has uncommitted work, and
- * whether an agent is busy in it right now.
+ * One worktree: what branch it holds, whether it has uncommitted work, whether
+ * an agent is busy in it right now, and the two ways in — a tab of its own, or
+ * a split beside whatever you are already looking at.
  *
- * Read-only for now — open / split / remove arrive with their own slices.
+ * Removal arrives with its own slice.
  */
 export function WorktreeRow({ detail }: { detail: WorktreeDetail }) {
   const { t } = useTranslation("worktrees");
   const [dirty, setDirty] = useState<number | null>(null);
   const tabs = useTabsStore((s) => s.tabs);
+  const activeId = useTabsStore((s) => s.activeId);
   const statuses = useSessionStatusStore((s) => s.statuses);
   const agents = useSessionStatusStore((s) => s.agents);
   const size = useWorktreesStore((s) => s.sizes[detail.path]);
   const loadSize = useWorktreesStore((s) => s.loadSize);
+  const closeWorktrees = useUiStore((s) => s.closeWorktrees);
   const [measuring, setMeasuring] = useState(false);
 
   const activity = worktreeSessionStatus(tabs, statuses, agents, detail.path);
+  const alreadyOpen = findWorktreePane(tabs, detail.path);
+  // A worktree whose directory git can no longer find has nothing to spawn a
+  // shell in, and a bare one has no working tree at all.
+  const unopenable = detail.prunable || detail.bare;
+  const activeTab = tabs.find((tab) => tab.id === activeId) ?? null;
+
+  const open = () => {
+    const tabsApi = useTabsStore.getState();
+    if (alreadyOpen) {
+      // Take them to the shell that is already there rather than starting a
+      // second one in the same directory — two terminals in one worktree is
+      // something to ask for, not something to get by accident.
+      tabsApi.setActive(alreadyOpen.tabId);
+      tabsApi.setActiveLeaf(alreadyOpen.tabId, alreadyOpen.leafId);
+    } else {
+      // Seeds the cwd onto the pane, not just the tab: `resolveTerminalCwd`
+      // ranks the explorer's root above the tab's own dir, so a tab carrying
+      // only `cwd` would spawn its shell wherever the explorer happens to be.
+      tabsApi.newTerminalTab(detail.path);
+    }
+    closeWorktrees();
+  };
+
+  const split = () => {
+    if (!activeTab) {
+      return;
+    }
+    useTabsStore
+      .getState()
+      .splitPaneWith(activeTab.id, activeTab.activeLeafId, { kind: "terminal", cwd: detail.path }, "row");
+    closeWorktrees();
+  };
 
   useEffect(() => {
     // A gone directory has nothing to count, and git2 would just error. Clear
@@ -63,30 +100,44 @@ export function WorktreeRow({ detail }: { detail: WorktreeDetail }) {
   };
 
   return (
-    <div className="flex items-center gap-3 border-b border-border px-3 py-2 last:border-b-0">
-      <span className="flex w-3 shrink-0 justify-center">
-        {activity.status && (
-          <span
-            aria-label={t(`agent.${activity.status}`)}
-            title={`${t(`agent.${activity.status}`)}${activity.agent ? ` · ${activity.agent}` : ""}`}
-            className={`h-2 w-2 rounded-full ${STATUS_DOT[activity.status]}`}
-          />
-        )}
-      </span>
-
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="truncate text-sm text-fg">
-            {detail.branch ?? t("row.detached")}
-          </span>
-          {detail.isMain && (
-            <span className="shrink-0 rounded border border-border px-1 text-[10px] uppercase text-fg-subtle">
-              {t("row.main")}
-            </span>
+    <div className="group flex items-center gap-3 border-b border-border px-3 py-2 transition-colors last:border-b-0 hover:bg-bg-inset">
+      {/* The row's own body is the way in, so the target is the whole line
+          rather than a control the eye has to find first. */}
+      <button
+        type="button"
+        onClick={open}
+        disabled={unopenable}
+        title={unopenable ? t("row.openStale") : alreadyOpen ? t("row.focusHint") : t("row.openHint")}
+        aria-label={`${t("row.open")}: ${detail.branch ?? t("row.detached")}`}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left disabled:cursor-default"
+      >
+        <span className="flex w-3 shrink-0 justify-center">
+          {activity.status && (
+            <span
+              aria-label={t(`agent.${activity.status}`)}
+              title={`${t(`agent.${activity.status}`)}${activity.agent ? ` · ${activity.agent}` : ""}`}
+              className={`h-2 w-2 rounded-full ${STATUS_DOT[activity.status]}`}
+            />
           )}
-        </div>
-        <div className="truncate font-mono text-[11px] text-fg-subtle">{detail.path}</div>
-      </div>
+        </span>
+
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-2">
+            <span className={`truncate text-sm ${unopenable ? "text-fg-subtle" : "text-fg"}`}>
+              {detail.branch ?? t("row.detached")}
+            </span>
+            {detail.isMain && (
+              <span className="shrink-0 rounded border border-border px-1 text-[10px] uppercase text-fg-subtle">
+                {t("row.main")}
+              </span>
+            )}
+            {alreadyOpen && (
+              <FolderOpen size={11} className="shrink-0 text-fg-subtle" aria-hidden />
+            )}
+          </span>
+          <span className="block truncate font-mono text-[11px] text-fg-subtle">{detail.path}</span>
+        </span>
+      </button>
 
       <div className="flex shrink-0 items-center gap-3 text-[11px] text-fg-muted">
         {detail.locked && (
@@ -125,6 +176,24 @@ export function WorktreeRow({ detail }: { detail: WorktreeDetail }) {
               {measuring ? t("row.measuring") : t("row.measure")}
             </button>
           )
+        )}
+
+        {/* Only offered when there is something to sit beside. Splitting is for
+            comparing this worktree against what you already have open. */}
+        {activeTab && !unopenable && (
+          <button
+            type="button"
+            onClick={split}
+            disabled={activeTab.paneOrder.length >= MAX_PANES}
+            title={
+              activeTab.paneOrder.length >= MAX_PANES ? t("row.splitFull") : t("row.splitHint")
+            }
+            aria-label={`${t("row.split")}: ${detail.branch ?? t("row.detached")}`}
+            className="flex items-center gap-1 rounded px-1 text-fg-subtle transition-colors hover:text-fg disabled:opacity-40"
+          >
+            <Columns2 size={12} />
+            {t("row.split")}
+          </button>
         )}
       </div>
     </div>

--- a/src/modules/worktrees/lib/openWorktree.test.ts
+++ b/src/modules/worktrees/lib/openWorktree.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { leaf, splitLeaf, type LayoutNode } from "@/modules/terminal/lib/terminalLayout";
+import type { Tab } from "@/stores/tabsStore";
+import { findWorktreePane } from "./openWorktree";
+
+function tab(id: string, paneTree: LayoutNode, cwd?: string): Tab {
+  return {
+    id,
+    spaceId: "s1",
+    title: id,
+    kind: "terminal",
+    paneTree,
+    activeLeafId: "p1",
+    paneOrder: ["p1"],
+    cwd,
+  };
+}
+
+function terminalLeaf(paneId: string, cwd?: string): LayoutNode {
+  return leaf(paneId, cwd ? { kind: "terminal", cwd } : { kind: "terminal" });
+}
+
+const WT = "/code/repo-worktrees/feat-a";
+
+describe("findWorktreePane", () => {
+  it("finds the pane sitting in the worktree", () => {
+    const tabs = [tab("t1", terminalLeaf("p1", WT))];
+    expect(findWorktreePane(tabs, WT, false)).toEqual({ tabId: "t1", leafId: "p1" });
+  });
+
+  it("counts a pane that has cd'd deeper in — it is still that worktree", () => {
+    const tabs = [tab("t1", terminalLeaf("p1", `${WT}/src/lib`))];
+    expect(findWorktreePane(tabs, WT, false)).toEqual({ tabId: "t1", leafId: "p1" });
+  });
+
+  it("does not mistake a sibling worktree for this one", () => {
+    // The whole point of isUnder: these two share a prefix up to the separator.
+    const tabs = [tab("t1", terminalLeaf("p1", "/code/repo-worktrees/feat-ab"))];
+    expect(findWorktreePane(tabs, WT, false)).toBeNull();
+  });
+
+  it("does not mistake the repo it came from for the worktree", () => {
+    const tabs = [tab("t1", terminalLeaf("p1", "/code/repo"))];
+    expect(findWorktreePane(tabs, WT, false)).toBeNull();
+  });
+
+  it("falls back to the tab's starting dir for a pane that has not reported yet", () => {
+    const tabs = [tab("t1", terminalLeaf("p1"), WT)];
+    expect(findWorktreePane(tabs, WT, false)).toEqual({ tabId: "t1", leafId: "p1" });
+  });
+
+  it("ignores panes that are not terminals", () => {
+    const tabs = [tab("t1", leaf("p1", { kind: "editor", path: `${WT}/README.md` }))];
+    expect(findWorktreePane(tabs, WT, false)).toBeNull();
+  });
+
+  it("looks past the first tab and into splits", () => {
+    const split = splitLeaf(terminalLeaf("p1", "/elsewhere"), "p1", "row", "p2", {
+      kind: "terminal",
+      cwd: WT,
+    });
+    const tabs = [tab("t0", terminalLeaf("p9", "/other")), tab("t1", split)];
+    expect(findWorktreePane(tabs, WT, false)).toEqual({ tabId: "t1", leafId: "p2" });
+  });
+
+  it("returns nothing when the worktree is not open anywhere", () => {
+    const tabs = [tab("t1", terminalLeaf("p1", "/elsewhere"))];
+    expect(findWorktreePane(tabs, WT, false)).toBeNull();
+  });
+
+  it("matches case-insensitively on Windows, where the pty's spelling need not match git's", () => {
+    const tabs = [tab("t1", terminalLeaf("p1", "C:/Code/Repo-Worktrees/Feat-A"))];
+    expect(findWorktreePane(tabs, "c:\\code\\repo-worktrees\\feat-a", true)).toEqual({
+      tabId: "t1",
+      leafId: "p1",
+    });
+  });
+});

--- a/src/modules/worktrees/lib/openWorktree.test.ts
+++ b/src/modules/worktrees/lib/openWorktree.test.ts
@@ -68,6 +68,17 @@ describe("findWorktreePane", () => {
     expect(findWorktreePane(tabs, WT, false)).toBeNull();
   });
 
+  it("never offers an SSH shell as the way into a local worktree", () => {
+    // `ssh` is a flag on ordinary terminal content, and an SSH pane split into a
+    // tab that sits in a worktree inherits that tab's cwd. Focusing it would put
+    // the user on a remote host and call it their worktree.
+    const tabs = [
+      tab("t1", leaf("p1", { kind: "terminal", ssh: { connectionId: "c1" } }), WT),
+      tab("t2", leaf("p2", { kind: "terminal", cwd: WT, ssh: { connectionId: "c2" } })),
+    ];
+    expect(findWorktreePane(tabs, WT, false)).toBeNull();
+  });
+
   it("matches case-insensitively on Windows, where the pty's spelling need not match git's", () => {
     const tabs = [tab("t1", terminalLeaf("p1", "C:/Code/Repo-Worktrees/Feat-A"))];
     expect(findWorktreePane(tabs, "c:\\code\\repo-worktrees\\feat-a", true)).toEqual({

--- a/src/modules/worktrees/lib/openWorktree.ts
+++ b/src/modules/worktrees/lib/openWorktree.ts
@@ -1,0 +1,44 @@
+import { IS_WINDOWS } from "@/lib/platform";
+import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
+import type { Tab } from "@/stores/tabsStore";
+import { isUnder } from "./paths";
+
+/** Where a worktree is already open. */
+export interface OpenWorktreePane {
+  tabId: string;
+  leafId: string;
+}
+
+/**
+ * The pane already sitting in this worktree, if there is one.
+ *
+ * Opening a worktree that is already open should take you to it rather than
+ * spawn a second shell in the same directory — two terminals in one worktree is
+ * a thing to ask for, not a thing to get by accident.
+ *
+ * A pane counts as being in the worktree when it has cd'd anywhere inside it,
+ * not only at its root: `cd src` does not leave the worktree.
+ *
+ * `windows` is a parameter rather than a direct `IS_WINDOWS` read so both
+ * platforms' behavior is covered by tests on either machine.
+ */
+export function findWorktreePane(
+  tabs: readonly Tab[],
+  worktreePath: string,
+  windows: boolean = IS_WINDOWS,
+): OpenWorktreePane | null {
+  for (const tab of tabs) {
+    for (const pane of computeLayout(tab.paneTree)) {
+      if (pane.content?.kind !== "terminal") {
+        continue;
+      }
+      // A pane's live cwd wins; one spawned moments ago has not reported yet and
+      // only the tab's starting dir says where it is.
+      const cwd = pane.content.cwd || tab.cwd;
+      if (cwd && isUnder(cwd, worktreePath, windows)) {
+        return { tabId: tab.id, leafId: pane.id };
+      }
+    }
+  }
+  return null;
+}

--- a/src/modules/worktrees/lib/openWorktree.ts
+++ b/src/modules/worktrees/lib/openWorktree.ts
@@ -1,6 +1,7 @@
 import { IS_WINDOWS } from "@/lib/platform";
 import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
-import type { Tab } from "@/stores/tabsStore";
+import { MAX_PANES, type Tab } from "@/stores/tabsStore";
+import { localTerminalCwd } from "./panes";
 import { isUnder } from "./paths";
 
 /** Where a worktree is already open. */
@@ -29,16 +30,29 @@ export function findWorktreePane(
 ): OpenWorktreePane | null {
   for (const tab of tabs) {
     for (const pane of computeLayout(tab.paneTree)) {
-      if (pane.content?.kind !== "terminal") {
-        continue;
-      }
-      // A pane's live cwd wins; one spawned moments ago has not reported yet and
-      // only the tab's starting dir says where it is.
-      const cwd = pane.content.cwd || tab.cwd;
+      const cwd = localTerminalCwd(pane.content, tab.cwd);
       if (cwd && isUnder(cwd, worktreePath, windows)) {
         return { tabId: tab.id, leafId: pane.id };
       }
     }
   }
   return null;
+}
+
+/**
+ * Whether a tab can take a split.
+ *
+ * A launcher tab is not a candidate: `TabsArea` renders `LauncherPanel` for it
+ * and never looks at its pane tree, so a pane split into one silently vanishes.
+ * And `splitPaneWith` takes an explicit target rather than the active pane, so
+ * unlike `splitActivePane` it does not hold the pane cap for its callers.
+ */
+export function canSplitInto(tab: Tab | null | undefined): tab is Tab {
+  return !!tab && tab.kind !== "launcher";
+}
+
+/** Whether that tab still has room. Separate from `canSplitInto`: a full tab is
+ * a "not right now", which the UI says by disabling rather than hiding. */
+export function hasPaneRoom(tab: Tab): boolean {
+  return tab.paneOrder.length < MAX_PANES;
 }

--- a/src/modules/worktrees/lib/panes.test.ts
+++ b/src/modules/worktrees/lib/panes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { localTerminalCwd } from "./panes";
+
+describe("localTerminalCwd", () => {
+  it("takes the pane's own live directory", () => {
+    expect(localTerminalCwd({ kind: "terminal", cwd: "/a" }, "/b")).toBe("/a");
+  });
+
+  it("falls back to the tab's starting dir for a pane that has not reported yet", () => {
+    expect(localTerminalCwd({ kind: "terminal" }, "/b")).toBe("/b");
+  });
+
+  it("gives no local directory for an SSH pane, whose shell is on another host", () => {
+    expect(localTerminalCwd({ kind: "terminal", cwd: "/a", ssh: { connectionId: "c1" } }, "/b")).toBeNull();
+  });
+
+  it("gives no local directory for an SSH pane borrowing the tab's dir either", () => {
+    // The trap: `ssh` is a flag on ordinary terminal content, and an SSH pane
+    // split into a tab that sits in a worktree inherits that tab's cwd.
+    expect(localTerminalCwd({ kind: "terminal", ssh: { connectionId: "c1" } }, "/worktree")).toBeNull();
+  });
+
+  it("ignores panes that are not terminals", () => {
+    expect(localTerminalCwd({ kind: "editor", path: "/a/f.ts" }, "/b")).toBeNull();
+    expect(localTerminalCwd({ kind: "launcher" }, "/b")).toBeNull();
+    expect(localTerminalCwd(undefined, "/b")).toBeNull();
+  });
+
+  it("has no answer when neither the pane nor its tab knows where it is", () => {
+    expect(localTerminalCwd({ kind: "terminal" }, undefined)).toBeNull();
+  });
+});

--- a/src/modules/worktrees/lib/panes.ts
+++ b/src/modules/worktrees/lib/panes.ts
@@ -1,0 +1,27 @@
+import type { PaneContent } from "@/modules/terminal/lib/terminalLayout";
+
+/**
+ * Where a pane's shell sits **on this machine**, or null when that question has
+ * no local answer.
+ *
+ * Shared by everything that asks "which panes belong to this worktree", so the
+ * two rules below are stated once:
+ *
+ * - An SSH pane is a terminal like any other as far as the pane tree is
+ *   concerned — `ssh` is just a flag on the same content — but its shell runs on
+ *   a remote host. It has no local directory, whatever path it reports. Left in,
+ *   it would lend a remote shell to a local worktree: it inherits `tab.cwd` when
+ *   it has none of its own, and `openFromSidebar` puts SSH panes into whatever
+ *   tab is active — including one already sitting in a worktree.
+ * - A pane spawned moments ago has not reported its cwd yet, and only the tab's
+ *   starting dir knows where it went.
+ */
+export function localTerminalCwd(
+  content: PaneContent | undefined,
+  tabCwd: string | undefined,
+): string | null {
+  if (content?.kind !== "terminal" || content.ssh) {
+    return null;
+  }
+  return content.cwd || tabCwd || null;
+}

--- a/src/modules/worktrees/lib/worktreeStatus.test.ts
+++ b/src/modules/worktrees/lib/worktreeStatus.test.ts
@@ -20,6 +20,28 @@ function tabAt(id: string, leafId: string, cwd: string | undefined, tabCwd?: str
 }
 
 describe("worktreeSessionStatus", () => {
+  it("does not lend an SSH pane's agent to a local worktree", () => {
+    // `ssh` is a flag on ordinary terminal content, so an SSH pane split into a
+    // tab sitting in a worktree inherits that tab's cwd — and would report a
+    // remote host's agent as this worktree's.
+    const tabs: Tab[] = [
+      {
+        id: "a",
+        spaceId: "s1",
+        title: "a",
+        kind: "terminal",
+        paneTree: leaf("p1", { kind: "terminal", ssh: { connectionId: "c1" } }),
+        activeLeafId: "p1",
+        paneOrder: ["p1"],
+        cwd: WT,
+      },
+    ];
+    expect(worktreeSessionStatus(tabs, { p1: "active" }, { p1: "claude" }, WT, false)).toEqual({
+      status: null,
+      agent: null,
+    });
+  });
+
   it("reports nothing when no pane sits in the worktree", () => {
     const tabs = [tabAt("a", "p1", "/somewhere/else")];
     expect(worktreeSessionStatus(tabs, { p1: "active" }, {}, WT, false)).toEqual({

--- a/src/modules/worktrees/lib/worktreeStatus.ts
+++ b/src/modules/worktrees/lib/worktreeStatus.ts
@@ -4,6 +4,7 @@ import type { SessionStatus } from "@/modules/claude-progress/lib/sessionStatus"
 import { AGGREGATE_PRIORITY } from "@/modules/claude-progress/lib/sessionStatusStore";
 import { computeLayout } from "@/modules/terminal/lib/terminalLayout";
 import type { Tab } from "@/stores/tabsStore";
+import { localTerminalCwd } from "./panes";
 import { isUnder } from "./paths";
 
 /** What a worktree row shows: the most urgent agent state in it, and whose. */
@@ -35,13 +36,7 @@ export function worktreeSessionStatus(
 
   for (const tab of tabs) {
     for (const pane of computeLayout(tab.paneTree)) {
-      if (pane.content?.kind !== "terminal") {
-        continue;
-      }
-      // A pane's live cwd wins; a freshly spawned one that has not reported yet
-      // falls back to the tab's starting dir, or a just-launched agent would
-      // show nothing.
-      const cwd = pane.content.cwd || tab.cwd;
+      const cwd = localTerminalCwd(pane.content, tab.cwd);
       if (!cwd || !isUnder(cwd, worktreePath, windows)) {
         continue;
       }

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -313,6 +313,14 @@ export function sshAlreadyOpen(tabs: Tab[], spaceId: string, connectionId: strin
 
 export const TABS_STORAGE_KEY = "tempoterm-tabs";
 
+/**
+ * How many panes one tab will hold. Past this they are too small to work in, and
+ * each one is a live shell. Exported because callers that split through
+ * `splitPaneWith` — which takes an explicit target rather than the active pane —
+ * have to enforce it themselves.
+ */
+export const MAX_PANES = 8;
+
 /** Shape of a tab as persisted before the unified paneTree model (v0). */
 interface PersistedV0Tab {
   id: string;
@@ -714,7 +722,7 @@ export const useTabsStore = create<TabsState>()(
       return { status: "opened" };
     }
 
-    if (activeTab.paneOrder.length >= 8) {
+    if (activeTab.paneOrder.length >= MAX_PANES) {
       return { status: "at-capacity" };
     }
 
@@ -924,7 +932,7 @@ export const useTabsStore = create<TabsState>()(
   splitActivePane: (direction) =>
     set((state) => {
       const tab = state.tabs.find((t) => t.id === state.activeId);
-      if (!tab || tab.paneOrder.length >= 8) {
+      if (!tab || tab.paneOrder.length >= MAX_PANES) {
         return state;
       }
       const newId = nextPaneId();


### PR DESCRIPTION
Fourth slice of Parallel Worktrees, on top of #222. The manager could only look; now it can take you somewhere — which is the point where the feature stops being a dashboard.

## What lands

- **Open** — the row's body is the target, so the way in is the whole line rather than a control you have to find. Spawns a terminal in that worktree, in a tab of its own.
- **Split** — puts the worktree beside the pane you are in. This is what you want when you are comparing two worktrees rather than moving to one.
- **Focus instead of duplicate** — opening a worktree that is already open takes you to the shell that is there. Two terminals in one worktree is a thing to ask for, not a thing to get by accident.

## Three traps this had to avoid

**Never `setRoot`.** Pointing the explorer at a directory types `cd` into whatever shell has focus — straight into a live agent's prompt. Both paths go through the tab store instead. The file explorer's own context menu already carries this warning in a comment; same rule here.

**The cwd goes on the pane, not the tab.** `resolveTerminalCwd` is `paneCwd || rootPath || tabCwd`, so a tab carrying only `cwd` spawns its shell wherever the *explorer* happens to be pointing. `newTerminalTab` seeds both; the split passes the cwd in its pane content. A hand-rolled tab that set only `Tab.cwd` would be a live bug.

**Prefix matching would open the wrong worktree.** Worktrees are siblings in `<repo>-worktrees/`, so `startsWith` calls `feat-ab` a match for `feat-a`. `findWorktreePane` uses `isUnder`, whose boundary falls on a separator. A pane that has cd'd deeper still counts — `cd src` does not leave the worktree.

## Edges covered

- Stale (`prunable`) and bare worktrees cannot be opened — there is no directory to spawn a shell in. The row says so instead of failing at the pty.
- Split is offered only when there is a pane to sit beside, and stops at the pane cap. `splitPaneWith` takes an explicit target rather than the active pane, so unlike `splitActivePane` it does not enforce the cap for itself — this caller does.
- That cap was two bare `>= 8`s in `tabsStore`. This is the third place that has to agree on it, so it is now `MAX_PANES`.

## Testing

- 9 tests on `findWorktreePane` (sibling worktrees, the parent repo, cd'd-deeper panes, splits, non-terminal panes, Windows case-folding), 7 driving the row against the real tab store — asserting on where terminals actually landed rather than on spies.
- `pnpm typecheck` clean. Full suite: 1630 pass; the two TitleBar hover-delay failures reproduce on `master` (pre-existing, unrelated).
- No `src-tauri/` changes.