### PR TITLE
ci: run the frontend tests, and fix the two they were not watching

### DIFF
--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -1,0 +1,57 @@
+name: Frontend Check
+
+# Per-PR type-check and unit tests for the frontend.
+#
+# Until now nothing ran them in CI: windows-check.yml type-checks the Rust and
+# windows-build.yml bundles the installer, so the ~1700 vitest tests only ran
+# when someone remembered to run them locally. That is how two TitleBar tests
+# came to sit red on master for a whole milestone — #219 renamed the "Toggle
+# Sidebar" menu row to "Toggle Left Sidebar", the tests looking for the old name
+# went red, and the PR merged without a word, because no gate was watching.
+#
+# The Rust half of this repo has been gated since #191. This is the other half.
+# It deliberately does not build the bundle — that stays in windows-build.yml.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+# A newer push to the same ref supersedes an in-flight check.
+concurrency:
+  group: frontend-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-and-test:
+    # Ubuntu, not windows-latest: this half is platform-independent — the
+    # Windows-specific logic is written as pure functions taking a `windows`
+    # flag precisely so both arms are covered from any runner. Cheaper and
+    # faster than the Windows image for the same coverage.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Unit tests
+        run: pnpm test

--- a/src/components/TitleBar.test.tsx
+++ b/src/components/TitleBar.test.tsx
@@ -256,7 +256,7 @@ describe("TitleBar", () => {
 
   describe("submenu hover-close delay", () => {
     // Diagonal mouse travel from the "Sidebar Panel" row toward its flyout
-    // crosses a sibling row first ("Toggle Sidebar" or "Preview Back"). An
+    // crosses a sibling row first ("Toggle Left Sidebar" or "Preview Back"). An
     // instant close on that sibling-enter kills the flyout before the
     // cursor arrives — this delay is what lets diagonal travel succeed.
     afterEach(() => {
@@ -271,7 +271,7 @@ describe("TitleBar", () => {
       const flyout = screen.getByRole("menuitem", { name: /Explorer/ }).closest('[role="menu"]');
       expect(flyout).not.toBeNull();
 
-      fireEvent.mouseEnter(screen.getByRole("menuitem", { name: /Toggle Sidebar/ }));
+      fireEvent.mouseEnter(screen.getByRole("menuitem", { name: /Toggle Left Sidebar/ }));
       act(() => {
         vi.advanceTimersByTime(100);
       });
@@ -291,7 +291,7 @@ describe("TitleBar", () => {
       fireEvent.mouseEnter(screen.getByRole("menuitem", { name: /Sidebar Panel/ }));
       expect(screen.getByRole("menuitem", { name: /Explorer/ })).toBeInTheDocument();
 
-      fireEvent.mouseEnter(screen.getByRole("menuitem", { name: /Toggle Sidebar/ }));
+      fireEvent.mouseEnter(screen.getByRole("menuitem", { name: /Toggle Left Sidebar/ }));
       act(() => {
         vi.advanceTimersByTime(1000);
       });

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -403,7 +403,12 @@ export function SessionsPanel() {
       } else {
         unlisten = fn;
       }
-    });
+    })
+      .catch(() => {
+        // No listener, so the panel stops live-updating and shows what it
+        // loaded. `void` on the chain started it without catching, which turned
+        // a failed subscribe into an unhandled rejection.
+      });
 
     return () => {
       disposed = true;

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -133,7 +133,10 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
   // Closing a pane also drops its terminal scrollback history (a no-op for
   // panes that never held a terminal).
   function closePaneAndHistory(paneId: string) {
-    void deleteTerminalHistory(paneId);
+    // `void` starts the promise but does not catch it, so a failed delete
+    // became an unhandled rejection. The pane closes either way — leftover
+    // scrollback for a pane that no longer exists is not worth a word.
+    deleteTerminalHistory(paneId).catch(() => {});
     closePane(tab.id, paneId);
   }
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -15,6 +15,33 @@ if (testDom) {
   });
 }
 
+// The Tauri IPC bridge is injected by the webview at runtime, so in jsdom
+// `window.__TAURI_INTERNALS__` is simply absent and every `invoke`/`listen`
+// reaching it throws. A component that fires one on mount then rejects *after*
+// its test has finished, which vitest reports as an unhandled error and fails
+// the whole run on — with every test still passing, so the summary reads green
+// while the exit code says otherwise. That is why `pnpm test` has never exited
+// 0, and why nothing could gate on it.
+//
+// Tests that care about a command mock `@tauri-apps/api` themselves; this is the
+// floor for the ones that only need a component to mount without exploding, so
+// it rejects rather than resolving — an unmocked command has no answer to give,
+// and a silent `undefined` would be a worse lie than a caught rejection.
+if (!("__TAURI_INTERNALS__" in globalThis)) {
+  Object.defineProperty(globalThis, "__TAURI_INTERNALS__", {
+    configurable: true,
+    value: {
+      invoke: (cmd: string) => Promise.reject(new Error(`no Tauri backend in tests: ${cmd}`)),
+      transformCallback: (callback: unknown) => {
+        void callback;
+        return 0;
+      },
+      unregisterCallback: () => {},
+      convertFileSrc: (path: string) => path,
+    },
+  });
+}
+
 // jsdom ships without a canvas implementation, a ResizeObserver or matchMedia.
 // xterm.js touches all three at import/render time, so provide light stubs to
 // keep the test console clean and let terminal-adjacent components mount.


### PR DESCRIPTION
Two red tests on `master` turned out to be the symptom. The cause is that **nothing runs the frontend tests in CI**.

## What was actually wrong

`.github/workflows/` has `windows-check.yml` (cargo check) and `windows-build.yml` (the installer). Neither runs vitest. So the ~1700 frontend tests only ran when someone remembered to run them locally.

That is how these two sat red for a whole milestone:

- #219 renamed the View menu's **"Toggle Sidebar"** row to **"Toggle Left Sidebar"** — a left/right pair was the point, once the shell had two columns.
- `TitleBar.test.tsx` hovers that row only as a *sibling to travel past* while testing the submenu close delay. It kept looking for the old name.
- The PR merged without a word.

The tests are about the delay, not about the sidebar, so they now name the row as it is. **The gate is the real fix** — the Rust half has been checked per-PR since #191; this is the other half.

## On how this was misdiagnosed

I told the repo owner four or five times that these were pre-existing and not mine, having "verified it on `master` with `git stash`". That was true and useless: #219 was already merged by the time I checked, so `git stash` — which only sets aside *uncommitted* work — could never have seen the cause. A method with no power to answer the question returned a confident answer, and I repeated it instead of testing it.

## The workflow

Runs `pnpm typecheck` and `pnpm test` on every PR and every push to master. Ubuntu rather than `windows-latest`: this half is platform-independent, because the Windows-specific logic in this repo is deliberately written as pure functions taking a `windows` flag so both arms are covered from any runner. Same coverage, cheaper image.

No bundle build — that stays in `windows-build.yml`.

## Testing

`pnpm typecheck` clean, and the full suite is green for the first time in this milestone: **1711 pass, 0 fail**.