### PR TITLE
feat(sessions): add a project filter dropdown to the sessions panel

### DIFF
--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -321,6 +321,8 @@
     "all": "All",
     "modelFilterAll": "All models",
     "modelFilterLabel": "Filter by model",
+    "projectFilterAll": "All projects",
+    "projectFilterLabel": "Filter by project",
     "empty": "No sessions found",
     "messages": "{{count}} msgs",
     "resume": "Resume",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -321,6 +321,8 @@
     "all": "全部",
     "modelFilterAll": "所有 model",
     "modelFilterLabel": "以 model 篩選",
+    "projectFilterAll": "所有專案",
+    "projectFilterLabel": "以專案篩選",
     "empty": "沒有符合的對話",
     "messages": "{{count}} 則訊息",
     "resume": "接續對話",

--- a/src/modules/sessions/DashboardView.tsx
+++ b/src/modules/sessions/DashboardView.tsx
@@ -215,6 +215,7 @@ export function DashboardView() {
   const query = useSessionsStore((s) => s.query);
   const agentFilter = useSessionsStore((s) => s.agentFilter);
   const modelFilter = useSessionsStore((s) => s.modelFilter);
+  const projectFilter = useSessionsStore((s) => s.projectFilter);
   const [range, setRange] = useState<RangeDays>(365);
   const [stats, setStats] = useState<SessionsStats>(EMPTY_STATS);
   const [topTab, setTopTab] = useState<"messages" | "tokens">("messages");
@@ -298,10 +299,16 @@ export function DashboardView() {
   }, [locale]);
 
   // Exports exactly the sessions currently visible under the active
-  // search/agent/model filters (not the full unfiltered index), mirroring
-  // what the sessions panel itself shows.
+  // search/agent/model/project filters (not the full unfiltered index),
+  // mirroring what the sessions panel itself shows.
   async function handleExportCsv() {
-    const { pinned, history } = visibleSessions(sessions, query, agentFilter, modelFilter);
+    const { pinned, history } = visibleSessions(
+      sessions,
+      query,
+      agentFilter,
+      modelFilter,
+      projectFilter,
+    );
     const csv = toSessionsCsv([...pinned, ...history]);
     const path = await saveFile("ai-sessions.csv", [{ name: "CSV", extensions: ["csv"] }]);
     if (path === null) {

--- a/src/modules/sessions/SessionsPanel.test.tsx
+++ b/src/modules/sessions/SessionsPanel.test.tsx
@@ -100,6 +100,7 @@ describe("SessionsPanel", () => {
       query: "",
       agentFilter: "all",
       modelFilter: "all",
+      projectFilter: "all",
       selectedId: null,
     });
     useTabsStore.setState({ spaces: [], activeSpaceId: null, tabs: [], activeId: null });
@@ -182,6 +183,54 @@ describe("SessionsPanel", () => {
 
     expect(screen.getByText("Codex session")).toBeInTheDocument();
     expect(screen.queryByText("Claude session")).not.toBeInTheDocument();
+  });
+
+  it("filters the list by project via the project dropdown", async () => {
+    seedSessions([
+      session({ id: "a", title: "Tempo session", project_cwd: "/Users/muki/tempo-term" }),
+      session({ id: "b", title: "Blog session", project_cwd: "/Users/muki/blog" }),
+    ]);
+    await renderSettled();
+
+    // Open the dropdown (trigger and chevron share the aria-label), then pick
+    // the option inside the popup list — the row meta line renders the same
+    // basename text, so the click must be scoped to the combobox.
+    fireEvent.click(screen.getAllByLabelText("sessions.projectFilterLabel")[0]);
+    const listbox = document.querySelector("[data-combobox]") as HTMLElement;
+    fireEvent.click(within(listbox).getByRole("button", { name: "blog" }));
+
+    expect(screen.getByText("Blog session")).toBeInTheDocument();
+    expect(screen.queryByText("Tempo session")).not.toBeInTheDocument();
+  });
+
+  it("hides the project dropdown when every session shares one project", async () => {
+    seedSessions([
+      session({ id: "a", title: "One", project_cwd: "/Users/muki/tempo-term" }),
+      session({ id: "b", title: "Two", project_cwd: "/Users/muki/tempo-term" }),
+    ]);
+    await renderSettled();
+
+    expect(screen.queryByLabelText("sessions.projectFilterLabel")).not.toBeInTheDocument();
+  });
+
+  it("resets a stale project filter to \"all\" once its project drops out of the option list", async () => {
+    seedSessions([
+      session({ id: "a", title: "Tempo session", project_cwd: "/Users/muki/tempo-term" }),
+      session({ id: "b", title: "Blog session", project_cwd: "/Users/muki/blog" }),
+    ]);
+    await renderSettled();
+    act(() => {
+      useSessionsStore.setState({ projectFilter: "/Users/muki/tempo-term" });
+    });
+
+    // Simulate a refresh that drops the filtered project's only session.
+    act(() => {
+      useSessionsStore.setState({
+        sessions: [session({ id: "b", title: "Blog session", project_cwd: "/Users/muki/blog" })],
+      });
+    });
+
+    expect(useSessionsStore.getState().projectFilter).toBe("all");
   });
 
   it("resets a stale model filter to \"all\" once its model drops out of the option list", async () => {

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -464,7 +464,13 @@ export function SessionsPanel() {
   const projectComboboxValue =
     projects.find((p) => p.cwd === projectFilter)?.label ?? projectFilterAllLabel;
 
-  const { pinned, history } = visibleSessions(sessions, query, agentFilter, modelFilter, projectFilter);
+  // Memoized because the panel re-renders on plenty of unrelated state
+  // (selection, scroll containers, the delete dialog) and the index can hold
+  // tens of thousands of sessions — no reason to re-filter on each of those.
+  const { pinned, history } = useMemo(
+    () => visibleSessions(sessions, query, agentFilter, modelFilter, projectFilter),
+    [sessions, query, agentFilter, modelFilter, projectFilter],
+  );
   const isEmpty = pinned.length === 0 && history.length === 0;
 
   return (

--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -8,7 +8,7 @@ import { Combobox } from "@/components/Combobox";
 import { useTabsStore } from "@/stores/tabsStore";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
 import { onSessionsUpdated, type SessionAgent, type SessionSummary } from "./lib/sessionsBridge";
-import { useSessionsStore, visibleSessions } from "./lib/sessionsStore";
+import { projectOptions, useSessionsStore, visibleSessions } from "./lib/sessionsStore";
 import { sessionsDelete } from "./lib/statsBridge";
 import { formatRelativeTime } from "./lib/relativeTime";
 import { deriveLiveSessions, type LiveSession } from "./lib/liveSessions";
@@ -342,10 +342,12 @@ export function SessionsPanel() {
   const query = useSessionsStore((s) => s.query);
   const agentFilter = useSessionsStore((s) => s.agentFilter);
   const modelFilter = useSessionsStore((s) => s.modelFilter);
+  const projectFilter = useSessionsStore((s) => s.projectFilter);
   const selectedId = useSessionsStore((s) => s.selectedId);
   const setQuery = useSessionsStore((s) => s.setQuery);
   const setAgentFilter = useSessionsStore((s) => s.setAgentFilter);
   const setModelFilter = useSessionsStore((s) => s.setModelFilter);
+  const setProjectFilter = useSessionsStore((s) => s.setProjectFilter);
   const select = useSessionsStore((s) => s.select);
   const openSessionsTab = useTabsStore((s) => s.openSessionsTab);
   // The virtualized history list reads its viewport from this scroll
@@ -443,7 +445,26 @@ export function SessionsPanel() {
   const modelComboboxOptions = modelOptions.map((m) => (m === "all" ? modelFilterAllLabel : m));
   const modelComboboxValue = modelFilter === "all" ? modelFilterAllLabel : modelFilter;
 
-  const { pinned, history } = visibleSessions(sessions, query, agentFilter, modelFilter);
+  // Distinct projects, each labelled short but unambiguously (basename, plus
+  // parent segments on a collision). Same worth-showing gate as the models.
+  const projects = useMemo(() => projectOptions(sessions), [sessions]);
+
+  // Same stranding reset as the model filter above: a filtered project whose
+  // sessions were all deleted would hide the dropdown and leave no way back.
+  useEffect(() => {
+    if (projectFilter !== "all" && !projects.some((p) => p.cwd === projectFilter)) {
+      setProjectFilter("all");
+    }
+  }, [projects, projectFilter, setProjectFilter]);
+
+  // The filter's value is a cwd but the Combobox trades in display labels, so
+  // map label → cwd on change; an unknown label (the "all" entry) resets.
+  const projectFilterAllLabel = t("sessions.projectFilterAll");
+  const projectComboboxOptions = [projectFilterAllLabel, ...projects.map((p) => p.label)];
+  const projectComboboxValue =
+    projects.find((p) => p.cwd === projectFilter)?.label ?? projectFilterAllLabel;
+
+  const { pinned, history } = visibleSessions(sessions, query, agentFilter, modelFilter, projectFilter);
   const isEmpty = pinned.length === 0 && history.length === 0;
 
   return (
@@ -496,15 +517,31 @@ export function SessionsPanel() {
               {key === "all" ? t("sessions.all") : t(`sessions.agents.${key}`)}
             </button>
           ))}
-          {modelOptions.length > 1 && (
-            <Combobox
-              value={modelComboboxValue}
-              options={modelComboboxOptions}
-              onChange={(v) => setModelFilter(v === modelFilterAllLabel ? "all" : v)}
-              ariaLabel={t("sessions.modelFilterLabel")}
-              size="sm"
-              className="ml-auto w-32"
-            />
+          {(projects.length > 1 || modelOptions.length > 1) && (
+            <div className="ml-auto flex flex-wrap items-center justify-end gap-1">
+              {projects.length > 1 && (
+                <Combobox
+                  value={projectComboboxValue}
+                  options={projectComboboxOptions}
+                  onChange={(v) =>
+                    setProjectFilter(projects.find((p) => p.label === v)?.cwd ?? "all")
+                  }
+                  ariaLabel={t("sessions.projectFilterLabel")}
+                  size="sm"
+                  className="w-32"
+                />
+              )}
+              {modelOptions.length > 1 && (
+                <Combobox
+                  value={modelComboboxValue}
+                  options={modelComboboxOptions}
+                  onChange={(v) => setModelFilter(v === modelFilterAllLabel ? "all" : v)}
+                  ariaLabel={t("sessions.modelFilterLabel")}
+                  size="sm"
+                  className="w-32"
+                />
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/src/modules/sessions/lib/sessionsStore.test.ts
+++ b/src/modules/sessions/lib/sessionsStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { useSessionsStore, visibleSessions } from "./sessionsStore";
+import { projectOptions, useSessionsStore, visibleSessions } from "./sessionsStore";
 import type { SessionSummary } from "./sessionsBridge";
 
 function session(overrides: Partial<SessionSummary>): SessionSummary {
@@ -131,6 +131,50 @@ describe("visibleSessions", () => {
     expect(visibleSessions(sessions, "", "all", "claude-opus-4-8").history.map((s) => s.id)).toEqual(["a"]);
   });
 
+  it("filters by exact project_cwd, with 'all' passing everything", () => {
+    const a = session({ id: "a", project_cwd: "/Users/muki/tempo-term" });
+    const b = session({ id: "b", project_cwd: "/Users/muki/other" });
+    const c = session({ id: "c", project_cwd: "" });
+
+    expect(visibleSessions([a, b, c], "", "all", "all", "all").history.map((s) => s.id)).toEqual([
+      "a", "b", "c",
+    ]);
+    expect(
+      visibleSessions([a, b, c], "", "all", "all", "/Users/muki/tempo-term").history.map((s) => s.id),
+    ).toEqual(["a"]);
+  });
+
+  it("combines the project filter with query and agent filters", () => {
+    const match = session({ id: "m", agent: "claude", title: "deploy", project_cwd: "/p/one" });
+    const wrongProject = session({ id: "wp", agent: "claude", title: "deploy", project_cwd: "/p/two" });
+    const wrongAgent = session({ id: "wa", agent: "codex", title: "deploy", project_cwd: "/p/one" });
+
+    const { history } = visibleSessions(
+      [match, wrongProject, wrongAgent],
+      "deploy",
+      "claude",
+      "all",
+      "/p/one",
+    );
+
+    expect(history).toEqual([match]);
+  });
+
+  it("ignores a project filter for a project absent from the dataset (self-heals stranding)", () => {
+    const a = session({ id: "a", project_cwd: "/p/one" });
+    const b = session({ id: "b", project_cwd: "/p/two" });
+
+    // The selected project no longer exists in any session (its sessions were
+    // deleted). Rather than strand an empty list, the filter is ignored.
+    expect(visibleSessions([a, b], "", "all", "all", "/p/gone").history.map((s) => s.id)).toEqual([
+      "a", "b",
+    ]);
+
+    // But a project that DOES exist is still honored even when other filters
+    // narrow it to zero.
+    expect(visibleSessions([a, b], "nomatch-query", "all", "all", "/p/one").history).toEqual([]);
+  });
+
   it("ignores a model filter for a model absent from the dataset (self-heals stranding)", () => {
     const mk = (id: string, model: string | null) =>
       ({ id, agent: "claude", project_cwd: "/p", title: id, started_at: 0, ended_at: 0,
@@ -146,6 +190,50 @@ describe("visibleSessions", () => {
     // post-filter result.
     const present = [mk("x", "claude-opus-4-8")];
     expect(visibleSessions(present, "nomatch-query", "all", "claude-opus-4-8").history).toEqual([]);
+  });
+});
+
+describe("projectOptions", () => {
+  it("dedupes cwds, labels them by basename, and sorts by label", () => {
+    const sessions = [
+      session({ id: "a", project_cwd: "/Users/muki/tempo-term" }),
+      session({ id: "b", project_cwd: "/Users/muki/tempo-term" }),
+      session({ id: "c", project_cwd: "/Users/muki/blog" }),
+    ];
+
+    expect(projectOptions(sessions)).toEqual([
+      { cwd: "/Users/muki/blog", label: "blog" },
+      { cwd: "/Users/muki/tempo-term", label: "tempo-term" },
+    ]);
+  });
+
+  it("skips sessions with an empty cwd", () => {
+    const sessions = [
+      session({ id: "a", project_cwd: "" }),
+      session({ id: "b", project_cwd: "/p/one" }),
+    ];
+
+    expect(projectOptions(sessions)).toEqual([{ cwd: "/p/one", label: "one" }]);
+  });
+
+  it("disambiguates duplicate basenames with parent segments", () => {
+    const sessions = [
+      session({ id: "a", project_cwd: "/Users/muki/work/app" }),
+      session({ id: "b", project_cwd: "/Users/muki/side/app" }),
+      session({ id: "c", project_cwd: "/Users/muki/blog" }),
+    ];
+
+    expect(projectOptions(sessions)).toEqual([
+      { cwd: "/Users/muki/blog", label: "blog" },
+      { cwd: "/Users/muki/side/app", label: "side/app" },
+      { cwd: "/Users/muki/work/app", label: "work/app" },
+    ]);
+  });
+
+  it("labels a Windows path by its last segment", () => {
+    const sessions = [session({ id: "a", project_cwd: "C:\\Users\\muki\\proj" })];
+
+    expect(projectOptions(sessions)).toEqual([{ cwd: "C:\\Users\\muki\\proj", label: "proj" }]);
   });
 });
 

--- a/src/modules/sessions/lib/sessionsStore.ts
+++ b/src/modules/sessions/lib/sessionsStore.ts
@@ -13,6 +13,8 @@ interface SessionsState {
   query: string;
   agentFilter: SessionAgent | "all";
   modelFilter: string;
+  /** A project cwd to narrow the list to, or "all". */
+  projectFilter: string;
   selectedId: string | null;
   /** The project cwd shown by the project view, or `null` when it's not
    *  open. Mutually exclusive with `selectedId` — selecting one clears the
@@ -26,6 +28,7 @@ interface SessionsState {
   setQuery: (query: string) => void;
   setAgentFilter: (filter: SessionAgent | "all") => void;
   setModelFilter: (model: string) => void;
+  setProjectFilter: (cwd: string) => void;
   select: (id: string | null) => void;
   selectProject: (cwd: string | null) => void;
   /** Flips a session's pinned state optimistically, then persists it;
@@ -39,6 +42,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
   query: "",
   agentFilter: "all",
   modelFilter: "all",
+  projectFilter: "all",
   selectedId: null,
   selectedProject: null,
 
@@ -63,6 +67,7 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
   setQuery: (query) => set({ query }),
   setAgentFilter: (agentFilter) => set({ agentFilter }),
   setModelFilter: (modelFilter) => set({ modelFilter }),
+  setProjectFilter: (projectFilter) => set({ projectFilter }),
   select: (selectedId) => set({ selectedId, selectedProject: null }),
   selectProject: (selectedProject) => set({ selectedProject, selectedId: null }),
 
@@ -90,15 +95,16 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
 /**
  * Pure selector splitting `sessions` into pinned (sorted by most recently
  * ended) and history (everything else), after applying the agent filter, the
- * model filter, and a case-insensitive title/project_cwd query match.
- * Exported for tests and for the sessions panel to derive its two list
- * sections.
+ * model filter, the project filter, and a case-insensitive title/project_cwd
+ * query match. Exported for tests and for the sessions panel to derive its
+ * two list sections.
  */
 export function visibleSessions(
   sessions: SessionSummary[],
   query: string,
   agentFilter: SessionAgent | "all",
   modelFilter: string,
+  projectFilter: string = "all",
 ): { pinned: SessionSummary[]; history: SessionSummary[] } {
   const q = query.trim().toLowerCase();
 
@@ -111,11 +117,20 @@ export function visibleSessions(
   const effectiveModelFilter =
     modelFilter === "all" || sessions.some((s) => s.model === modelFilter) ? modelFilter : "all";
 
+  // Same self-heal for the project filter.
+  const effectiveProjectFilter =
+    projectFilter === "all" || sessions.some((s) => s.project_cwd === projectFilter)
+      ? projectFilter
+      : "all";
+
   const filtered = sessions.filter((s) => {
     if (agentFilter !== "all" && s.agent !== agentFilter) {
       return false;
     }
     if (effectiveModelFilter !== "all" && s.model !== effectiveModelFilter) {
+      return false;
+    }
+    if (effectiveProjectFilter !== "all" && s.project_cwd !== effectiveProjectFilter) {
       return false;
     }
     if (q === "") {
@@ -128,4 +143,60 @@ export function visibleSessions(
   const history = filtered.filter((s) => !s.pinned);
 
   return { pinned, history };
+}
+
+/**
+ * The distinct project cwds across `sessions` (empty cwds skipped), each with
+ * a short display label for the project filter dropdown: the basename, with
+ * parent segments prepended one at a time until labels stop colliding — two
+ * different `~/work/app` and `~/side/app` projects show as `work/app` and
+ * `side/app`, not two identical `app` entries. Sorted by label. Exported for
+ * the sessions panel and its tests.
+ */
+export function projectOptions(
+  sessions: SessionSummary[],
+): Array<{ cwd: string; label: string }> {
+  const cwds = [...new Set(sessions.map((s) => s.project_cwd).filter((c) => c !== ""))];
+  // Split on both separators so Windows paths (C:\...) label correctly too.
+  const segments = new Map(cwds.map((c) => [c, c.split(/[/\\]/).filter(Boolean)]));
+  const depth = new Map(cwds.map((c) => [c, 1]));
+  const label = (c: string) => {
+    const parts = segments.get(c) ?? [];
+    return parts.slice(-Math.min(depth.get(c) ?? 1, parts.length)).join("/") || c;
+  };
+
+  // Deepen every colliding label together until all are unique or fully
+  // spelled out. Bounded: each pass grows at least one depth, and depth is
+  // capped at the path's segment count.
+  for (;;) {
+    const groups = new Map<string, string[]>();
+    for (const c of cwds) {
+      const l = label(c);
+      const group = groups.get(l);
+      if (group) {
+        group.push(c);
+      } else {
+        groups.set(l, [c]);
+      }
+    }
+    let deepened = false;
+    for (const group of groups.values()) {
+      if (group.length < 2) {
+        continue;
+      }
+      for (const c of group) {
+        const max = segments.get(c)?.length ?? 1;
+        const current = depth.get(c) ?? 1;
+        if (current < max) {
+          depth.set(c, current + 1);
+          deepened = true;
+        }
+      }
+    }
+    if (!deepened) {
+      return cwds
+        .map((cwd) => ({ cwd, label: label(cwd) }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+    }
+  }
 }


### PR DESCRIPTION
## Summary

The AI sessions panel can filter by agent and model, but not by project. Search doesn't help much here either — it only matches the session title and the project path, so a session whose keyword lives mid-conversation is unfindable. This PR adds a project dropdown so the list can at least be narrowed to one project at a glance.

(Full-text search over transcripts is a separate, backend-side effort — the SQLite index deliberately stores no message bodies — and will be tracked in its own issue.)

## Changes

- **`sessionsStore`**: new `projectFilter` state + setter; `visibleSessions()` takes the project as a fifth filter, with the same self-heal-on-stranding behavior as the model filter (a selected project whose sessions were all deleted is ignored instead of stranding an empty list).
- **`projectOptions()`** helper: distinct project cwds labelled by basename, deepened with parent segments when two projects share a basename (`work/app` vs `side/app`), since `Combobox` uses the option string as both value and label.
- **`SessionsPanel`**: a project `Combobox` next to the model one, shown only when there's more than one project; same stale-filter reset effect as the model dropdown.
- **`DashboardView`**: CSV export passes the project filter too, so the export keeps mirroring exactly what the panel shows.
- **i18n**: `sessions.projectFilterAll` / `sessions.projectFilterLabel` in en and zh-Hant.

## Tests

- `visibleSessions`: project filtering, combination with query/agent filters, self-heal for an absent project.
- `projectOptions`: dedupe + basename labels, empty-cwd skip, collision disambiguation, Windows paths.
- `SessionsPanel`: filtering via the dropdown, dropdown hidden with a single project, stale-filter reset.

All 1755 frontend tests pass; `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)