### PR TITLE
fix(workspace): per-session tab titles for concurrent sessions in one directory

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -4,8 +4,12 @@
 
 ### fix
 
+- 修正同一目錄同時跑多個 Claude session 時，工作區卡片標題互相覆蓋的問題：標題改以各 session 的 transcript 為準，ai-title 與 `/rename` 也會在 session 進行中即時更新 (#233)
+
 ## English
 
 ### feat
 
 ### fix
+
+- Fix workspace card titles overwriting each other when several Claude sessions run in one directory: titles now follow each session's own transcript, and ai-titles / `/rename` refresh mid-session (#233)

--- a/src-tauri/src/modules/claude_progress/mod.rs
+++ b/src-tauri/src/modules/claude_progress/mod.rs
@@ -130,6 +130,41 @@ pub fn latest_session_title(dir: &Path) -> Option<String> {
     extract_session_title(&contents)
 }
 
+/// Whether a Claude session id is safe to use as a transcript filename.
+fn valid_session_id(session_id: &str) -> bool {
+    !session_id.is_empty()
+        && session_id.len() <= 128
+        && session_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+}
+
+/// The title extracted from `<session_id>.jsonl` in `dir`, or None when the id
+/// is invalid, the transcript cannot be read, or it has no usable title.
+fn session_title_for(dir: &Path, session_id: &str) -> Option<String> {
+    if !valid_session_id(session_id) {
+        return None;
+    }
+    let path = dir.join(session_id).with_extension("jsonl");
+    let contents = std::fs::read_to_string(path).ok()?;
+    extract_session_title(&contents)
+}
+
+/// Resolve the title for a title request. Any requested session id answers for
+/// that exact transcript only — never the directory's newest: a just-started
+/// session with no title yet would otherwise wear a concurrent sibling's title,
+/// the very cross-session bleed the per-session lookup exists to prevent. An
+/// invalid id is treated the same (None, no guessing) so a future id-format
+/// change can never silently reopen that leak. The caller shows its own
+/// directory-name fallback on None; only a request with no id at all keeps the
+/// legacy newest-transcript behavior.
+fn resolve_session_title(dir: &Path, session_id: Option<&str>) -> Option<String> {
+    match session_id {
+        Some(id) => session_title_for(dir, id),
+        None => latest_session_title(dir),
+    }
+}
+
 /// Event name carrying a freshly appended batch of transcript lines to the
 /// frontend, tagged with the cwd they belong to.
 const PROGRESS_EVENT: &str = "claude-progress:lines";
@@ -423,10 +458,16 @@ pub fn claude_progress_unwatch(state: State<ClaudeProgressState>) {
     state.watchers.lock().unwrap().clear();
 }
 
-/// The title of the newest Claude session for `cwd`, derived from its
-/// transcript. Returns None when the project has no transcript yet.
+/// The title of the requested Claude session for `cwd`; only a request with no
+/// session id at all answers with the newest transcript (see
+/// `resolve_session_title` for why a provided id — valid or not — never falls
+/// back).
 #[tauri::command]
-pub async fn claude_session_title(app: AppHandle, cwd: String) -> Option<String> {
+pub async fn claude_session_title(
+    app: AppHandle,
+    cwd: String,
+    session_id: Option<String>,
+) -> Option<String> {
     // Reading and JSON-parsing the whole transcript scales with session length;
     // run it on a blocking thread so a long session never freezes the UI. This is
     // the main-thread work that grew with transcript size (see fonts_report).
@@ -438,7 +479,7 @@ pub async fn claude_session_title(app: AppHandle, cwd: String) -> Option<String>
         if !dir.is_dir() {
             return None;
         }
-        latest_session_title(&dir)
+        resolve_session_title(&dir, session_id.as_deref())
     })
     .await
     .ok()
@@ -610,6 +651,17 @@ mod tests {
     }
 
     #[test]
+    fn validates_safe_session_ids() {
+        assert!(valid_session_id("550e8400-e29b-41d4-a716-446655440000"));
+        assert!(valid_session_id("session_123"));
+        assert!(!valid_session_id("../x"));
+        assert!(!valid_session_id("a/b"));
+        assert!(!valid_session_id(r"a\b"));
+        assert!(!valid_session_id(""));
+        assert!(!valid_session_id(&"a".repeat(129)));
+    }
+
+    #[test]
     fn returns_complete_lines_and_leaves_a_partial_line_unconsumed() {
         let (lines, offset) = split_new_lines("a\nb\nc", 0);
         assert_eq!(lines, vec!["a", "b"]);
@@ -667,6 +719,86 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn session_title_for_returns_the_requested_session_not_the_latest() {
+        let dir = temp_progress_dir("requested-title");
+        let session_a = "session-a";
+        let session_b = "session-b";
+        let path_a = dir.join(session_a).with_extension("jsonl");
+        let path_b = dir.join(session_b).with_extension("jsonl");
+        std::fs::write(&path_a, r#"{"type":"ai-title","aiTitle":"Title A"}"#).unwrap();
+        std::fs::write(&path_b, r#"{"type":"ai-title","aiTitle":"Title B"}"#).unwrap();
+
+        let now = std::time::SystemTime::now();
+        let older = now.checked_sub(std::time::Duration::from_secs(60)).unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path_a)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(older))
+            .unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path_b)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(now))
+            .unwrap();
+
+        assert_eq!(latest_session_title(&dir).as_deref(), Some("Title B"));
+        assert_eq!(
+            session_title_for(&dir, session_a).as_deref(),
+            Some("Title A")
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn session_title_for_returns_none_when_the_session_is_missing() {
+        let dir = temp_progress_dir("missing-title");
+        assert_eq!(session_title_for(&dir, "missing-session"), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_requested_titleless_session_never_borrows_the_newest_sibling_title() {
+        // Session A just started (transcript exists but has no title yet) while
+        // sibling B, written more recently, has one. Requesting A must yield
+        // None — falling back to "newest" would put B's title on A's card, the
+        // exact cross-session bleed this lookup exists to prevent.
+        let dir = temp_progress_dir("titleless-request");
+        let path_a = dir.join("session-a.jsonl");
+        let path_b = dir.join("session-b.jsonl");
+        std::fs::write(&path_a, "{\"type\":\"summary\"}\n").unwrap();
+        std::fs::write(&path_b, r#"{"type":"ai-title","aiTitle":"Title B"}"#).unwrap();
+        let now = std::time::SystemTime::now();
+        let older = now.checked_sub(std::time::Duration::from_secs(60)).unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path_a)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(older))
+            .unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path_b)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(now))
+            .unwrap();
+
+        assert_eq!(resolve_session_title(&dir, Some("session-a")), None);
+        // A request for a valid id whose transcript is missing entirely also
+        // stays None rather than guessing the newest.
+        assert_eq!(resolve_session_title(&dir, Some("session-c")), None);
+        // An invalid id answers None too — falling back to newest would let a
+        // malformed id reintroduce the sibling-title leak.
+        assert_eq!(resolve_session_title(&dir, Some("../evil")), None);
+        // Only a request with no id at all keeps the newest-transcript answer.
+        assert_eq!(resolve_session_title(&dir, None).as_deref(), Some("Title B"));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/modules/status_ipc/mod.rs
+++ b/src-tauri/src/modules/status_ipc/mod.rs
@@ -45,14 +45,16 @@ pub struct StatusMessage {
     pub pane_id: u32,
     pub kind: String,
     pub payload: String,
+    pub session_id: Option<String>,
 }
 
 /// Wire format sent by the shim, one message per connection:
-/// `<token>\t<paneId>\t<kind>\t<payload>`. Returns the message only when the
-/// token matches and the pane id parses, so a spoofed or malformed line is
-/// dropped. Pure so it can be unit-tested without a socket.
+/// `<token>\t<paneId>\t<kind>\t<payload>\t<sessionId>`. The final field is
+/// optional for compatibility with older four-field shims. Returns the message
+/// only when the token matches and the pane id parses, so a spoofed or malformed
+/// line is dropped. Pure so it can be unit-tested without a socket.
 pub fn parse_message(line: &str, expected_token: &str) -> Option<StatusMessage> {
-    let mut parts = line.trim_end_matches(['\n', '\r']).splitn(4, '\t');
+    let mut parts = line.trim_end_matches(['\n', '\r']).splitn(5, '\t');
     let token = parts.next()?;
     // Constant-time-ish token check is overkill for a cosmetic loopback badge;
     // a plain compare rejects spoofers well enough.
@@ -62,6 +64,10 @@ pub fn parse_message(line: &str, expected_token: &str) -> Option<StatusMessage> 
     let pane_id: u32 = parts.next()?.parse().ok()?;
     let kind = parts.next()?;
     let payload = parts.next().unwrap_or("");
+    let session_id = parts
+        .next()
+        .filter(|session_id| !session_id.is_empty())
+        .map(str::to_string);
     if kind != "status" && kind != "notify" {
         return None;
     }
@@ -72,13 +78,20 @@ pub fn parse_message(line: &str, expected_token: &str) -> Option<StatusMessage> 
         pane_id,
         kind: kind.to_string(),
         payload: payload.to_string(),
+        session_id,
     })
 }
 
 /// Build the wire line the shim sends. Kept next to `parse_message` so the two
 /// stay in sync.
-fn encode_message(token: &str, pane_id: &str, kind: &str, payload: &str) -> String {
-    format!("{token}\t{pane_id}\t{kind}\t{payload}")
+fn encode_message(
+    token: &str,
+    pane_id: &str,
+    kind: &str,
+    payload: &str,
+    session_id: &str,
+) -> String {
+    format!("{token}\t{pane_id}\t{kind}\t{payload}\t{session_id}")
 }
 
 /// Live listener details handed to each pane so its shim can phone home.
@@ -165,30 +178,65 @@ fn generate_token() -> String {
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
 }
 
+/// How long the shim waits for its stdin payload before giving up on it. The
+/// hook runner writes the event JSON at spawn and closes the pipe, so a healthy
+/// read finishes in microseconds; the deadline only exists so a runner that
+/// keeps stdin open (inherited tty, a future runner change) can never hang the
+/// hook — the same "never stall the caller" contract the socket side bounds
+/// with [`SEND_TIMEOUT`].
+const STDIN_TIMEOUT: Duration = Duration::from_millis(200);
+
+/// Read up to `limit` bytes of `reader` into a String on a helper thread,
+/// giving up after `deadline`. None on timeout or a read error (non-UTF-8).
+/// The thread drains any remainder as a courtesy, but only for as long as the
+/// shim process lives — a writer still going when the shim exits gets EPIPE,
+/// which hook runners already tolerated (pre-session-id shims never read stdin
+/// on most events at all).
+fn read_bounded_with_deadline<R>(reader: R, limit: u64, deadline: Duration) -> Option<String>
+where
+    R: Read + Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = reader;
+        let mut buf = String::new();
+        let ok = reader.by_ref().take(limit).read_to_string(&mut buf).is_ok();
+        let _ = tx.send(ok.then_some(buf));
+        let _ = std::io::copy(&mut reader, &mut std::io::sink());
+    });
+    rx.recv_timeout(deadline).ok().flatten()
+}
+
 /// The status-hook shim: `tempo-term --status-hook <state>`. Reads the pane env
 /// the app injected, then delivers one status message over loopback. Runs before
 /// Tauri starts (see `run()`), does nothing outside tempo-term, and is
 /// best-effort — a status ping must never fail or slow the hook that spawned it.
 ///
-/// For the `notification` catch-all state, Claude passes the event JSON on stdin;
-/// we read `notification_type` off it and forward that as the payload (kind
-/// `notify`), mirroring the Unix script. Every other state forwards directly
-/// (kind `status`).
+/// Claude passes every hook event's JSON on stdin. We retain at most 512 KiB in
+/// memory (bounded by [`STDIN_TIMEOUT`], remainder drained so a large payload
+/// does not receive EPIPE) and forward its `session_id` when present. For the
+/// `notification` catch-all state, `notification_type` becomes the payload
+/// (kind `notify`), mirroring the Unix script. Every other state forwards
+/// directly (kind `status`).
 pub fn run_hook_shim(state: &str) {
     if std::env::var(ENV_MARKER).ok().filter(|v| !v.is_empty()).is_none() {
         return;
     }
+    // Resolve the listener address before touching stdin: without one there is
+    // nobody to report to, so the payload read would be pure wasted latency.
     let addr = match std::env::var(ENV_ADDR) {
         Ok(a) if !a.is_empty() => a,
         _ => return,
     };
+
+    let stdin_json =
+        read_bounded_with_deadline(std::io::stdin(), 512 * 1024, STDIN_TIMEOUT).unwrap_or_default();
+
     let token = std::env::var(ENV_TOKEN).unwrap_or_default();
     let pane_id = std::env::var(ENV_PANE_ID).unwrap_or_default();
 
     let (kind, payload) = if state == "notification" {
-        let mut stdin = String::new();
-        let _ = std::io::stdin().read_to_string(&mut stdin);
-        match notification_type(&stdin) {
+        match notification_type(&stdin_json) {
             Some(t) => ("notify", t),
             None => return, // unknown/missing type: emit nothing, like the .sh
         }
@@ -196,7 +244,14 @@ pub fn run_hook_shim(state: &str) {
         ("status", state.to_string())
     };
 
-    let line = encode_message(&token, &pane_id, kind, &payload);
+    let session_id = extract_session_id(&stdin_json);
+    let line = encode_message(
+        &token,
+        &pane_id,
+        kind,
+        &payload,
+        session_id.as_deref().unwrap_or(""),
+    );
     send_status(&addr, &line);
 }
 
@@ -223,6 +278,17 @@ fn notification_type(stdin_json: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Pull a non-empty Claude session id out of a hook event's stdin JSON.
+/// Malformed or truncated input is ignored because the hook shim is best-effort.
+fn extract_session_id(stdin_json: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(stdin_json).ok()?;
+    value
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .filter(|session_id| !session_id.is_empty())
+        .map(str::to_string)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -231,62 +297,104 @@ mod tests {
 
     #[test]
     fn parses_a_valid_status_line() {
-        let line = encode_message(TOKEN, "7", "status", "active");
+        let line = encode_message(TOKEN, "7", "status", "active", "");
         assert_eq!(
             parse_message(&line, TOKEN),
-            Some(StatusMessage { pane_id: 7, kind: "status".into(), payload: "active".into() })
+            Some(StatusMessage {
+                pane_id: 7,
+                kind: "status".into(),
+                payload: "active".into(),
+                session_id: None,
+            })
         );
     }
 
     #[test]
     fn parses_a_notify_line() {
-        let line = encode_message(TOKEN, "3", "notify", "permission_prompt");
+        let line = encode_message(TOKEN, "3", "notify", "permission_prompt", "");
         assert_eq!(
             parse_message(&line, TOKEN),
-            Some(StatusMessage { pane_id: 3, kind: "notify".into(), payload: "permission_prompt".into() })
+            Some(StatusMessage {
+                pane_id: 3,
+                kind: "notify".into(),
+                payload: "permission_prompt".into(),
+                session_id: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_a_five_field_line_with_session_id() {
+        let message = parse_message("secret-token\t7\tstatus\tactive\tsession-123", TOKEN).unwrap();
+        assert_eq!(message.session_id.as_deref(), Some("session-123"));
+    }
+
+    #[test]
+    fn parses_a_legacy_four_field_line_without_session_id() {
+        let message = parse_message("secret-token\t7\tstatus\tactive", TOKEN).unwrap();
+        assert_eq!(message.session_id, None);
+    }
+
+    #[test]
+    fn parses_an_empty_session_id_as_none() {
+        let message = parse_message("secret-token\t7\tstatus\tactive\t", TOKEN).unwrap();
+        assert_eq!(message.session_id, None);
+    }
+
+    #[test]
+    fn roundtrips_a_session_id_through_encode_and_parse() {
+        let line = encode_message(TOKEN, "7", "status", "active", "session-123");
+        assert_eq!(
+            parse_message(&line, TOKEN),
+            Some(StatusMessage {
+                pane_id: 7,
+                kind: "status".into(),
+                payload: "active".into(),
+                session_id: Some("session-123".into()),
+            })
         );
     }
 
     #[test]
     fn tolerates_a_trailing_newline() {
-        let line = format!("{}\n", encode_message(TOKEN, "1", "status", "idle"));
+        let line = format!("{}\n", encode_message(TOKEN, "1", "status", "idle", ""));
         assert!(parse_message(&line, TOKEN).is_some());
     }
 
     #[test]
     fn rejects_a_wrong_token() {
-        let line = encode_message("attacker", "1", "status", "active");
+        let line = encode_message("attacker", "1", "status", "active", "");
         assert_eq!(parse_message(&line, TOKEN), None);
     }
 
     #[test]
     fn rejects_when_expected_token_is_empty() {
         // A blank expected token must never match (would let any sender through).
-        let line = encode_message("", "1", "status", "active");
+        let line = encode_message("", "1", "status", "active", "");
         assert_eq!(parse_message(&line, ""), None);
     }
 
     #[test]
     fn rejects_an_unknown_kind() {
-        let line = encode_message(TOKEN, "1", "bogus", "active");
+        let line = encode_message(TOKEN, "1", "bogus", "active", "");
         assert_eq!(parse_message(&line, TOKEN), None);
     }
 
     #[test]
     fn rejects_a_non_numeric_pane_id() {
-        let line = encode_message(TOKEN, "abc", "status", "active");
+        let line = encode_message(TOKEN, "abc", "status", "active", "");
         assert_eq!(parse_message(&line, TOKEN), None);
     }
 
     #[test]
     fn rejects_an_empty_payload() {
-        let line = encode_message(TOKEN, "1", "status", "");
+        let line = encode_message(TOKEN, "1", "status", "", "");
         assert_eq!(parse_message(&line, TOKEN), None);
     }
 
     #[test]
     fn payload_may_contain_hyphens_but_not_tabs() {
-        let line = encode_message(TOKEN, "9", "status", "waiting-approval");
+        let line = encode_message(TOKEN, "9", "status", "waiting-approval", "");
         assert_eq!(parse_message(&line, TOKEN).unwrap().payload, "waiting-approval");
     }
 
@@ -301,6 +409,53 @@ mod tests {
         assert_eq!(notification_type(r#"{"foo":"bar"}"#), None);
         assert_eq!(notification_type(r#"{"notification_type":""}"#), None);
         assert_eq!(notification_type("not json"), None);
+    }
+
+    #[test]
+    fn bounded_read_returns_the_payload_and_truncates_at_the_limit() {
+        let payload = std::io::Cursor::new(b"{\"session_id\":\"s\"}".to_vec());
+        assert_eq!(
+            read_bounded_with_deadline(payload, 512, Duration::from_secs(1)).as_deref(),
+            Some("{\"session_id\":\"s\"}")
+        );
+        let long = std::io::Cursor::new(vec![b'a'; 64]);
+        assert_eq!(
+            read_bounded_with_deadline(long, 8, Duration::from_secs(1)).as_deref(),
+            Some("aaaaaaaa")
+        );
+    }
+
+    #[test]
+    fn bounded_read_gives_up_when_the_reader_never_finishes() {
+        // A hook runner that keeps stdin open (inherited tty) must not hang the
+        // shim: the deadline path returns None well before the reader is done.
+        struct NeverDone;
+        impl Read for NeverDone {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                std::thread::sleep(Duration::from_secs(5));
+                Ok(0)
+            }
+        }
+        let start = std::time::Instant::now();
+        let result = read_bounded_with_deadline(NeverDone, 512, Duration::from_millis(50));
+        assert_eq!(result, None);
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "deadline must bound the wait, not the reader"
+        );
+    }
+
+    #[test]
+    fn extracts_session_id_from_stdin_json() {
+        let json = r#"{"session_id":"session-123","other":1}"#;
+        assert_eq!(extract_session_id(json).as_deref(), Some("session-123"));
+    }
+
+    #[test]
+    fn session_id_absent_blank_or_invalid_json_is_none() {
+        assert_eq!(extract_session_id(r#"{"foo":"bar"}"#), None);
+        assert_eq!(extract_session_id(r#"{"session_id":""}"#), None);
+        assert_eq!(extract_session_id("not json"), None);
     }
 
     #[test]

--- a/src/modules/claude-progress/lib/sessionNotifications.test.ts
+++ b/src/modules/claude-progress/lib/sessionNotifications.test.ts
@@ -1,5 +1,39 @@
-import { describe, it, expect } from "vitest";
-import { notificationForTransition, resolvePaneLabel } from "./sessionNotifications";
+import { waitFor } from "@testing-library/react";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+const { isFocused, notifyDesktop } = vi.hoisted(() => ({
+  isFocused: vi.fn(),
+  notifyDesktop: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ isFocused }),
+}));
+vi.mock("./notify", () => ({ notifyDesktop }));
+
+import {
+  installSessionNotifications,
+  notificationForTransition,
+  resolvePaneLabel,
+} from "./sessionNotifications";
+import { useSessionStatusStore } from "./sessionStatusStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useTabsStore } from "@/stores/tabsStore";
+import { leaf } from "@/modules/terminal/lib/terminalLayout";
+import { titleKey, useTitlesStore } from "@/modules/workspace/lib/titlesStore";
+
+beforeEach(() => {
+  isFocused.mockReset();
+  isFocused.mockResolvedValue(false);
+  notifyDesktop.mockReset();
+  notifyDesktop.mockResolvedValue(undefined);
+  useSessionStatusStore.setState({
+    statuses: {},
+    agents: {},
+    sessionIds: {},
+    statusEpochs: {},
+  });
+  useTitlesStore.setState({ titles: {}, fetchedFingerprints: {}, inFlight: {} });
+});
 
 describe("resolvePaneLabel", () => {
   it("uses the tab's own title when the user renamed it, even with a cwd", () => {
@@ -66,5 +100,45 @@ describe("notificationForTransition", () => {
   it("treats a cleared status (next undefined) as no notification", () => {
     expect(notificationForTransition("active", undefined)).toBeNull();
     expect(notificationForTransition("waiting-approval", undefined)).toBeNull();
+  });
+});
+
+describe("session notification labels", () => {
+  it("uses the exact session title when the leaf has a Claude session id", async () => {
+    useSettingsStore.setState({ claudeNotifications: true });
+    useTabsStore.setState({
+      tabs: [
+        {
+          id: "tab-1",
+          spaceId: "space-1",
+          title: "shared",
+          kind: "terminal",
+          paneTree: leaf("leaf-1", { kind: "terminal", cwd: "/shared" }),
+          activeLeafId: "leaf-1",
+          paneOrder: ["leaf-1"],
+        },
+      ],
+    });
+    const store = useSessionStatusStore.getState();
+    store.setAgent("leaf-1", "claude");
+    store.setSessionId("leaf-1", "session-a");
+    useTitlesStore.setState({
+      titles: {
+        [titleKey({ cwd: "/shared", agent: "claude", sessionId: "session-a" })]:
+          "Session A title",
+        [titleKey({ cwd: "/shared", agent: "claude", sessionId: "session-b" })]:
+          "Session B title",
+      },
+    });
+
+    const uninstall = installSessionNotifications();
+    try {
+      store.setStatus("leaf-1", "waiting-approval");
+      await waitFor(() =>
+        expect(notifyDesktop).toHaveBeenCalledWith(expect.any(String), "Session A title"),
+      );
+    } finally {
+      uninstall();
+    }
   });
 });

--- a/src/modules/claude-progress/lib/sessionNotifications.ts
+++ b/src/modules/claude-progress/lib/sessionNotifications.ts
@@ -7,8 +7,7 @@ import { findPaneContent } from "@/modules/terminal/lib/terminalLayout";
 import { basename } from "@/modules/explorer/lib/paths";
 import { agentLabel } from "@/modules/workspace/lib/agentLabel";
 import { selectCardTitle } from "@/modules/workspace/lib/cardTitle";
-import { progressKey } from "./progressStore";
-import { useTitlesStore } from "@/modules/workspace/lib/titlesStore";
+import { titleKey, useTitlesStore } from "@/modules/workspace/lib/titlesStore";
 import type { AgentKind } from "./codexNormalize";
 import { useSessionStatusStore } from "./sessionStatusStore";
 import type { SessionStatus } from "./sessionStatus";
@@ -68,8 +67,11 @@ function leafContextName(leafId: string, agent: AgentKind | undefined): string {
       continue;
     }
     const cwd = content.cwd ?? tab.cwd ?? null;
+    const sessionId = useSessionStatusStore.getState().sessionIds[leafId];
     const transcriptTitle =
-      cwd && agent ? useTitlesStore.getState().titles[progressKey(cwd, agent)] : undefined;
+      cwd && agent
+        ? useTitlesStore.getState().titles[titleKey({ cwd, agent, sessionId })]
+        : undefined;
     return resolvePaneLabel(tab, cwd, transcriptTitle);
   }
   return "";

--- a/src/modules/claude-progress/lib/sessionStatusStore.test.ts
+++ b/src/modules/claude-progress/lib/sessionStatusStore.test.ts
@@ -1,7 +1,14 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { useSessionStatusStore, aggregateSessionStatus } from "./sessionStatusStore";
 
-beforeEach(() => useSessionStatusStore.setState({ statuses: {}, agents: {} }));
+beforeEach(() =>
+  useSessionStatusStore.setState({
+    statuses: {},
+    agents: {},
+    sessionIds: {},
+    statusEpochs: {},
+  }),
+);
 
 describe("sessionStatusStore", () => {
   it("sets and overwrites a leaf's status", () => {
@@ -9,6 +16,38 @@ describe("sessionStatusStore", () => {
     expect(useSessionStatusStore.getState().statuses["leaf-1"]).toBe("active");
     useSessionStatusStore.getState().setStatus("leaf-1", "idle");
     expect(useSessionStatusStore.getState().statuses["leaf-1"]).toBe("idle");
+  });
+
+  it("bumps the status epoch only on title-relevant transitions", () => {
+    const store = useSessionStatusStore.getState();
+    // Entering thinking (first prompt) and idle (turn done) can expose a new
+    // transcript title; the active/waiting-approval churn between tool calls
+    // cannot, so it must not trigger title refetches.
+    store.setStatus("leaf-1", "thinking");
+    expect(useSessionStatusStore.getState().statusEpochs["leaf-1"]).toBe(1);
+
+    store.setStatus("leaf-1", "active");
+    store.setStatus("leaf-1", "waiting-approval");
+    store.setStatus("leaf-1", "active");
+    expect(useSessionStatusStore.getState().statusEpochs["leaf-1"]).toBe(1);
+
+    const epochs = useSessionStatusStore.getState().statusEpochs;
+    store.setStatus("leaf-1", "active");
+    expect(useSessionStatusStore.getState().statusEpochs).toBe(epochs);
+
+    store.setStatus("leaf-1", "idle");
+    expect(useSessionStatusStore.getState().statusEpochs["leaf-1"]).toBe(2);
+  });
+
+  it("records a session id and treats setting the same id as a no-op", () => {
+    const store = useSessionStatusStore.getState();
+    store.setSessionId("leaf-1", "session-a");
+    const sessionIds = useSessionStatusStore.getState().sessionIds;
+
+    store.setSessionId("leaf-1", "session-a");
+
+    expect(useSessionStatusStore.getState().sessionIds).toBe(sessionIds);
+    expect(useSessionStatusStore.getState().sessionIds["leaf-1"]).toBe("session-a");
   });
 
   it("clears a leaf", () => {
@@ -31,9 +70,9 @@ describe("sessionStatusStore", () => {
   });
 
   it("clearing an unknown leaf is a no-op", () => {
-    const before = useSessionStatusStore.getState().statuses;
+    const before = useSessionStatusStore.getState();
     useSessionStatusStore.getState().clear("missing");
-    expect(useSessionStatusStore.getState().statuses).toBe(before);
+    expect(useSessionStatusStore.getState()).toBe(before);
   });
 });
 
@@ -43,15 +82,21 @@ describe("sessionStatusStore agents", () => {
     expect(useSessionStatusStore.getState().agents["leaf-1"]).toBe("codex");
   });
 
-  it("clears a leaf's status and agent together when the session ends", () => {
+  it("clears all of a leaf's session state when the session ends", () => {
     const store = useSessionStatusStore.getState();
     store.setStatus("leaf-1", "thinking");
     store.setAgent("leaf-1", "claude");
+    store.setSessionId("leaf-1", "session-a");
 
     store.clear("leaf-1");
 
     const state = useSessionStatusStore.getState();
     expect(state.statuses["leaf-1"]).toBeUndefined();
     expect(state.agents["leaf-1"]).toBeUndefined();
+    expect(state.sessionIds["leaf-1"]).toBeUndefined();
+    // The status epoch goes too: title freshness compares fingerprints for
+    // equality, so removal is just one more fingerprint change — and keeping
+    // it would leak one entry per leaf ever seen.
+    expect(state.statusEpochs["leaf-1"]).toBeUndefined();
   });
 });

--- a/src/modules/claude-progress/lib/sessionStatusStore.ts
+++ b/src/modules/claude-progress/lib/sessionStatusStore.ts
@@ -6,6 +6,10 @@ import { probeStoreUpdate } from "@/lib/perfProbe";
 interface SessionStatusState {
   /** Live agent status per terminal leaf id; absence means no badge. */
   statuses: Record<string, SessionStatus>;
+  /** Claude session id per terminal leaf id, when reported by the local hook. */
+  sessionIds: Record<string, string>;
+  /** Counter bumped whenever a leaf's live status actually changes. */
+  statusEpochs: Record<string, number>;
   /**
    * Which agent (Claude or Codex) is running in each terminal leaf, derived from
    * the pane's foreground process. Lets a card label each pane's session even
@@ -13,6 +17,7 @@ interface SessionStatusState {
    */
   agents: Record<string, AgentKind>;
   setStatus: (leafId: string, status: SessionStatus) => void;
+  setSessionId: (leafId: string, sessionId: string) => void;
   setAgent: (leafId: string, agent: AgentKind) => void;
   clear: (leafId: string) => void;
 }
@@ -46,8 +51,30 @@ export function aggregateSessionStatus(
 export const selectSessionStatus = (state: SessionStatusState): SessionStatus | null =>
   aggregateSessionStatus(state.statuses);
 
+/** `map` without `key`; the same reference when the key is absent, so
+ *  subscribers comparing slice references still short-circuit. */
+function without<T>(map: Record<string, T>, key: string): Record<string, T> {
+  if (!(key in map)) {
+    return map;
+  }
+  const next = { ...map };
+  delete next[key];
+  return next;
+}
+
+/**
+ * The transitions after which a transcript's title may have changed: the first
+ * prompt lands with UserPromptSubmit (thinking) and ai-titles / renames are on
+ * disk by the turn's Stop (idle). The active/waiting-approval churn between
+ * tool calls never carries a title, so bumping the title epoch there would
+ * refetch whole transcripts several times per turn for nothing.
+ */
+const TITLE_EPOCH_STATUSES: SessionStatus[] = ["idle", "thinking"];
+
 export const useSessionStatusStore = create<SessionStatusState>((set) => ({
   statuses: {},
+  sessionIds: {},
+  statusEpochs: {},
   agents: {},
   setStatus: (leafId, status) =>
     set((s) => {
@@ -55,7 +82,20 @@ export const useSessionStatusStore = create<SessionStatusState>((set) => ({
         return s;
       }
       probeStoreUpdate("status");
-      return { statuses: { ...s.statuses, [leafId]: status } };
+      const statusEpochs = TITLE_EPOCH_STATUSES.includes(status)
+        ? { ...s.statusEpochs, [leafId]: (s.statusEpochs[leafId] ?? 0) + 1 }
+        : s.statusEpochs;
+      return {
+        statuses: { ...s.statuses, [leafId]: status },
+        statusEpochs,
+      };
+    }),
+  setSessionId: (leafId, sessionId) =>
+    set((s) => {
+      if (s.sessionIds[leafId] === sessionId) {
+        return s;
+      }
+      return { sessionIds: { ...s.sessionIds, [leafId]: sessionId } };
     }),
   setAgent: (leafId, agent) =>
     set((s) => {
@@ -67,24 +107,24 @@ export const useSessionStatusStore = create<SessionStatusState>((set) => ({
     }),
   clear: (leafId) =>
     set((s) => {
-      const hasStatus = leafId in s.statuses;
-      const hasAgent = leafId in s.agents;
-      if (!hasStatus && !hasAgent) {
+      if (
+        !(leafId in s.statuses) &&
+        !(leafId in s.sessionIds) &&
+        !(leafId in s.agents) &&
+        !(leafId in s.statusEpochs)
+      ) {
         return s;
       }
-      // Only rebuild the map the leaf is actually in, so clearing an
+      // `without` keeps an untouched map's reference, so clearing an
       // agent-only leaf doesn't churn the statuses ref the notifier watches.
-      const next: Partial<SessionStatusState> = {};
-      if (hasStatus) {
-        const statuses = { ...s.statuses };
-        delete statuses[leafId];
-        next.statuses = statuses;
-      }
-      if (hasAgent) {
-        const agents = { ...s.agents };
-        delete agents[leafId];
-        next.agents = agents;
-      }
-      return next;
+      // Deleting the status epoch is safe: title freshness compares
+      // fingerprints for equality (useWorkspaceTitles), so the removal is
+      // just one more fingerprint change — nothing orders epochs over time.
+      return {
+        statuses: without(s.statuses, leafId),
+        sessionIds: without(s.sessionIds, leafId),
+        agents: without(s.agents, leafId),
+        statusEpochs: without(s.statusEpochs, leafId),
+      };
     }),
 }));

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -352,7 +352,12 @@ export function TerminalView({
     // for SSH remote panes, which report in-band over the pty stream.
     let statusEventUnlisten: (() => void) | undefined;
     let statusEventDisposed = false;
-    void listen<{ paneId: number; kind: string; payload: string }>(
+    void listen<{
+      paneId: number;
+      kind: string;
+      payload: string;
+      sessionId?: string | null;
+    }>(
       "session-status",
       (event) => {
         if (event.payload.paneId !== ptyIdRef.current) return;
@@ -362,7 +367,13 @@ export function TerminalView({
           `tempoterm;${event.payload.kind};${event.payload.payload}`,
         );
         if (parsed?.kind === "status") {
-          useSessionStatusStore.getState().setStatus(leaf, parsed.status);
+          const store = useSessionStatusStore.getState();
+          // Store the id before the status transition so a notification raised
+          // by setStatus can resolve this exact session's title immediately.
+          if (event.payload.sessionId) {
+            store.setSessionId(leaf, event.payload.sessionId);
+          }
+          store.setStatus(leaf, parsed.status);
         } else if (parsed?.kind === "end") {
           useSessionStatusStore.getState().clear(leaf);
         }

--- a/src/modules/workspace/WorkspacePanel.test.tsx
+++ b/src/modules/workspace/WorkspacePanel.test.tsx
@@ -7,16 +7,21 @@ import { leaf } from "@/modules/terminal/lib/terminalLayout";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
 import { progressKey } from "@/modules/claude-progress/lib/progressStore";
 import { useWorktreeStore } from "./lib/worktreeStore";
-import { useTitlesStore } from "./lib/titlesStore";
+import { titleKey, useTitlesStore } from "./lib/titlesStore";
 import { usePrStore } from "./lib/prStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useEditorStore } from "@/modules/editor/store/editorStore";
 
 beforeEach(() => {
   useEditorStore.setState({ buffers: {} });
-  useSessionStatusStore.setState({ statuses: {}, agents: {} });
+  useSessionStatusStore.setState({
+    statuses: {},
+    agents: {},
+    sessionIds: {},
+    statusEpochs: {},
+  });
   useWorktreeStore.setState({ infos: {} });
-  useTitlesStore.setState({ titles: {} });
+  useTitlesStore.setState({ titles: {}, fetchedFingerprints: {}, inFlight: {} });
   usePrStore.setState({ prs: {}, fetchedAt: {} });
   useSettingsStore.setState({
     workspaceCard: { status: true, branch: true, cwd: true, pr: true },
@@ -151,6 +156,52 @@ describe("WorkspacePanel", () => {
     render(<WorkspacePanel />);
     expect(screen.getByText("Auto Alpha")).toBeInTheDocument();
     expect(screen.queryByText("alpha")).toBeNull();
+  });
+
+  it("shows each card's own Claude title when two sessions share one cwd", () => {
+    useTabsStore.setState({
+      ...useTabsStore.getState(),
+      tabs: [
+        {
+          id: "t1",
+          spaceId: "s1",
+          title: "alpha",
+          kind: "terminal",
+          paneTree: leaf("p1", { kind: "terminal", cwd: "/shared" }),
+          activeLeafId: "p1",
+          paneOrder: ["p1"],
+        },
+        {
+          id: "t2",
+          spaceId: "s1",
+          title: "beta",
+          kind: "terminal",
+          paneTree: leaf("p2", { kind: "terminal", cwd: "/shared" }),
+          activeLeafId: "p2",
+          paneOrder: ["p2"],
+        },
+      ],
+    });
+    useSessionStatusStore.setState({
+      statuses: { p1: "active", p2: "thinking" },
+      agents: { p1: "claude", p2: "claude" },
+      sessionIds: { p1: "session-a", p2: "session-b" },
+    });
+    useTitlesStore.setState({
+      titles: {
+        [titleKey({ cwd: "/shared", agent: "claude", sessionId: "session-a" })]:
+          "Session A title",
+        [titleKey({ cwd: "/shared", agent: "claude", sessionId: "session-b" })]:
+          "Session B title",
+      },
+    });
+
+    render(<WorkspacePanel />);
+
+    expect(screen.getByText("Session A title")).toBeInTheDocument();
+    expect(screen.getByText("Session B title")).toBeInTheDocument();
+    expect(screen.queryByText("alpha")).toBeNull();
+    expect(screen.queryByText("beta")).toBeNull();
   });
 
   it("lists every agent session when a tab is split across two panes", () => {

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -32,13 +32,12 @@ import { selectCardTitle } from "./lib/cardTitle";
 import { collectTabSessions, type TabSession } from "./lib/tabSessions";
 import { useWorktreeStore } from "./lib/worktreeStore";
 import { useWorktreeInfos } from "./lib/useWorktreeInfos";
-import { useTitlesStore } from "./lib/titlesStore";
+import { titleKey, useTitlesStore } from "./lib/titlesStore";
 import { useWorkspaceTitles } from "./lib/useWorkspaceTitles";
 import { usePrStore } from "./lib/prStore";
 import { useWorkspacePrs } from "./lib/useWorkspacePrs";
 import type { WorktreeInfo } from "./lib/worktreeBridge";
 import type { PrInfo } from "./lib/prBridge";
-import { progressKey } from "@/modules/claude-progress/lib/progressStore";
 import { agentLabel } from "./lib/agentLabel";
 import { probeCardRender } from "@/lib/perfProbe";
 
@@ -193,7 +192,9 @@ function basename(path: string): string {
 /** A session's display title: its transcript title, else its directory name. */
 function sessionTitle(session: TabSession, titles: Record<string, string>): string {
   if (session.agent && session.cwd) {
-    const auto = titles[progressKey(session.cwd, session.agent)];
+    const auto = titles[
+      titleKey({ cwd: session.cwd, agent: session.agent, sessionId: session.sessionId })
+    ];
     if (auto) {
       return auto;
     }
@@ -235,6 +236,7 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
   const { requestClose, confirmCloseDialog } = useTabCloseRequest(tab);
   const statuses = useSessionStatusStore((s) => s.statuses);
   const leafAgents = useSessionStatusStore((s) => s.agents);
+  const sessionIds = useSessionStatusStore((s) => s.sessionIds);
   const infos = useWorktreeStore((s) => s.infos);
   const titles = useTitlesStore((s) => s.titles);
   const prs = usePrStore((s) => s.prs);
@@ -247,14 +249,20 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
   const cwd = deriveTabCwd(tab);
   // Each pane running an agent is its own session. With two or more, the header
   // becomes the tab's identity and every session gets its own line below.
-  const sessions = collectTabSessions(tab, statuses, leafAgents);
+  const sessions = collectTabSessions(tab, statuses, leafAgents, sessionIds);
   const multi = sessions.length >= 2;
   const primary = sessions[0];
   const status = tabSessionStatus(tab, statuses);
   const info = cwd ? infos[cwd] : undefined;
   const autoTitle =
     !multi && primary?.cwd && primary?.agent
-      ? titles[progressKey(primary.cwd, primary.agent)]
+      ? titles[
+          titleKey({
+            cwd: primary.cwd,
+            agent: primary.agent,
+            sessionId: primary.sessionId,
+          })
+        ]
       : undefined;
   const title = selectCardTitle(tab, autoTitle);
   const pr = cwd ? prs[cwd] : undefined;
@@ -501,6 +509,7 @@ export function WorkspacePanel() {
   const prSource = useSettingsStore((s) => s.prSource);
   const statuses = useSessionStatusStore((s) => s.statuses);
   const leafAgents = useSessionStatusStore((s) => s.agents);
+  const sessionIds = useSessionStatusStore((s) => s.sessionIds);
   // Dedupe so multiple tabs in the same directory don't trigger redundant IPC
   // and network lookups for that directory.
   const cwds = useMemo(
@@ -513,16 +522,25 @@ export function WorkspacePanel() {
     [tabs],
   );
   useWorktreeInfos(cwds);
-  // Titles are per session (cwd + agent), so a directory running both Claude and
-  // Codex gets each one's own title fetched.
+  // Titles use the exact Claude session id when known, and retain the legacy
+  // cwd + agent key otherwise (including Codex).
   const titleTargets = useMemo(
     () =>
       tabs.flatMap((tab) =>
-        collectTabSessions(tab, statuses, leafAgents).flatMap((session) =>
-          session.cwd && session.agent ? [{ cwd: session.cwd, agent: session.agent }] : [],
+        collectTabSessions(tab, statuses, leafAgents, sessionIds).flatMap((session) =>
+          session.cwd && session.agent
+            ? [
+                {
+                  cwd: session.cwd,
+                  agent: session.agent,
+                  sessionId: session.sessionId,
+                  leafId: session.leafId,
+                },
+              ]
+            : [],
         ),
       ),
-    [tabs, statuses, leafAgents],
+    [tabs, statuses, leafAgents, sessionIds],
   );
   useWorkspaceTitles(titleTargets);
 

--- a/src/modules/workspace/lib/tabSessions.test.ts
+++ b/src/modules/workspace/lib/tabSessions.test.ts
@@ -32,16 +32,29 @@ describe("collectTabSessions", () => {
       tabWith(splitTree),
       { L1: "thinking", L2: "active" },
       { L1: "claude", L2: "codex" },
+      {},
     );
 
     expect(rows).toEqual([
-      { leafId: "L1", cwd: "/p", agent: "claude", status: "thinking" },
-      { leafId: "L2", cwd: "/p", agent: "codex", status: "active" },
+      {
+        leafId: "L1",
+        cwd: "/p",
+        agent: "claude",
+        sessionId: undefined,
+        status: "thinking",
+      },
+      {
+        leafId: "L2",
+        cwd: "/p",
+        agent: "codex",
+        sessionId: undefined,
+        status: "active",
+      },
     ]);
   });
 
   it("skips panes that have no live status", () => {
-    const rows = collectTabSessions(tabWith(splitTree), { L2: "active" }, {});
+    const rows = collectTabSessions(tabWith(splitTree), { L2: "active" }, {}, {});
     expect(rows.map((r) => r.leafId)).toEqual(["L2"]);
   });
 
@@ -55,13 +68,29 @@ describe("collectTabSessions", () => {
         { kind: "leaf", id: "E1", pane: { kind: "editor", path: "/p/a.ts" } },
       ],
     };
-    const rows = collectTabSessions(tabWith(tree), { L1: "thinking", E1: "active" }, {});
+    const rows = collectTabSessions(tabWith(tree), { L1: "thinking", E1: "active" }, {}, {});
     expect(rows.map((r) => r.leafId)).toEqual(["L1"]);
   });
 
   it("falls back to the tab cwd when the pane has not reported one", () => {
     const tree: LayoutNode = { kind: "leaf", id: "L1", pane: { kind: "terminal" } };
-    const rows = collectTabSessions(tabWith(tree, "/tab-cwd"), { L1: "idle" }, { L1: "claude" });
+    const rows = collectTabSessions(
+      tabWith(tree, "/tab-cwd"),
+      { L1: "idle" },
+      { L1: "claude" },
+      {},
+    );
     expect(rows[0].cwd).toBe("/tab-cwd");
+  });
+
+  it("carries the pane's Claude session id from the per-leaf map", () => {
+    const rows = collectTabSessions(
+      tabWith(splitTree),
+      { L1: "active" },
+      { L1: "claude" },
+      { L1: "session-a" },
+    );
+
+    expect(rows[0].sessionId).toBe("session-a");
   });
 });

--- a/src/modules/workspace/lib/tabSessions.ts
+++ b/src/modules/workspace/lib/tabSessions.ts
@@ -8,6 +8,7 @@ export interface TabSession {
   leafId: string;
   cwd: string | null;
   agent: AgentKind | undefined;
+  sessionId: string | undefined;
   status: SessionStatus;
 }
 
@@ -15,12 +16,14 @@ export interface TabSession {
  * The live agent sessions in a tab, one per terminal pane that currently has a
  * status. A pane's own cwd wins, falling back to the tab's starting cwd. The
  * agent comes from the per-leaf agent map; it may be undefined until the
- * foreground poll classifies the pane. Panes are returned in layout order.
+ * foreground poll classifies the pane. A locally reported Claude session id is
+ * carried from its own per-leaf map. Panes are returned in layout order.
  */
 export function collectTabSessions(
   tab: Tab,
   statuses: Record<string, SessionStatus>,
   agents: Record<string, AgentKind>,
+  sessionIds: Record<string, string>,
 ): TabSession[] {
   const sessions: TabSession[] = [];
   for (const pane of computeLayout(tab.paneTree)) {
@@ -35,6 +38,7 @@ export function collectTabSessions(
       leafId: pane.id,
       cwd: pane.content.cwd ?? tab.cwd ?? null,
       agent: agents[pane.id],
+      sessionId: sessionIds[pane.id],
       status,
     });
   }

--- a/src/modules/workspace/lib/titlesBridge.ts
+++ b/src/modules/workspace/lib/titlesBridge.ts
@@ -1,8 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 
-/** The auto title for a directory's newest Claude session, or null if none. */
-export function claudeSessionTitle(cwd: string): Promise<string | null> {
-  return invoke<string | null>("claude_session_title", { cwd });
+/** The requested Claude session's auto title, or the directory fallback. */
+export function claudeSessionTitle(cwd: string, sessionId?: string): Promise<string | null> {
+  return invoke<string | null>("claude_session_title", { cwd, sessionId });
 }
 
 /** The auto title for a directory's newest Codex session, or null if none. */

--- a/src/modules/workspace/lib/titlesStore.test.ts
+++ b/src/modules/workspace/lib/titlesStore.test.ts
@@ -1,25 +1,36 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { progressKey } from "@/modules/claude-progress/lib/progressStore";
-import { claudeSessionTitle, codexSessionTitle } from "./titlesBridge";
 
-vi.mock("./titlesBridge", () => ({
-  claudeSessionTitle: vi.fn(async () => "Claude title"),
-  codexSessionTitle: vi.fn(async () => "Codex title"),
-}));
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
 
-import { useTitlesStore } from "./titlesStore";
+import { titleKey, useTitlesStore } from "./titlesStore";
 
 beforeEach(() => {
-  useTitlesStore.setState({ titles: {}, fetchedEpochs: {} });
-  vi.mocked(claudeSessionTitle).mockClear();
-  vi.mocked(codexSessionTitle).mockClear();
+  useTitlesStore.setState({ titles: {}, fetchedFingerprints: {}, inFlight: {} });
+  invoke.mockReset();
+  invoke.mockImplementation(async (command: string) =>
+    command === "codex_session_title" ? "Codex title" : "Claude title",
+  );
+});
+
+describe("titleKey", () => {
+  it("uses the legacy progress key when there is no session id", () => {
+    expect(titleKey({ cwd: "/p", agent: "claude" })).toBe(progressKey("/p", "claude"));
+  });
+
+  it("appends the session id when one is known", () => {
+    expect(titleKey({ cwd: "/p", agent: "claude", sessionId: "session-a" })).toBe(
+      "claude:/p:session-a",
+    );
+  });
 });
 
 describe("titlesStore", () => {
   it("keys a Claude and a Codex title for the same cwd separately", async () => {
     await useTitlesStore.getState().refresh([
-      { cwd: "/p", agent: "claude", epoch: 0 },
-      { cwd: "/p", agent: "codex", epoch: 0 },
+      { cwd: "/p", agent: "claude", fingerprint: "0|0" },
+      { cwd: "/p", agent: "codex", fingerprint: "0|0" },
     ]);
 
     const { titles } = useTitlesStore.getState();
@@ -27,33 +38,234 @@ describe("titlesStore", () => {
     expect(titles[progressKey("/p", "codex")]).toBe("Codex title");
   });
 
-  it("skips bridge calls for targets already fetched at the same epoch", async () => {
-    await useTitlesStore.getState().refresh([{ cwd: "/p", agent: "claude", epoch: 1 }]);
-    vi.mocked(claudeSessionTitle).mockClear();
-    await useTitlesStore.getState().refresh([{ cwd: "/p", agent: "claude", epoch: 1 }]);
-    expect(claudeSessionTitle).not.toHaveBeenCalled();
+  it("fetches and stores distinct Claude titles for sessions sharing one cwd", async () => {
+    invoke.mockImplementation(
+      async (command: string, args: { sessionId?: string } | undefined) => {
+        if (command !== "claude_session_title") {
+          return "Codex title";
+        }
+        return args?.sessionId === "session-a" ? "Title A" : "Title B";
+      },
+    );
+
+    const sessionA = { cwd: "/p", agent: "claude" as const, sessionId: "session-a" };
+    const sessionB = { cwd: "/p", agent: "claude" as const, sessionId: "session-b" };
+    await useTitlesStore.getState().refresh([
+      { ...sessionA, fingerprint: "0|0" },
+      { ...sessionB, fingerprint: "0|0" },
+    ]);
+
+    expect(invoke).toHaveBeenCalledWith("claude_session_title", {
+      cwd: "/p",
+      sessionId: "session-a",
+    });
+    expect(invoke).toHaveBeenCalledWith("claude_session_title", {
+      cwd: "/p",
+      sessionId: "session-b",
+    });
+    const { titles } = useTitlesStore.getState();
+    expect(titles[titleKey(sessionA)]).toBe("Title A");
+    expect(titles[titleKey(sessionB)]).toBe("Title B");
   });
 
-  it("refetches a target when its epoch changes (new session started)", async () => {
-    await useTitlesStore.getState().refresh([{ cwd: "/p", agent: "claude", epoch: 1 }]);
-    vi.mocked(claudeSessionTitle).mockClear();
-    await useTitlesStore.getState().refresh([{ cwd: "/p", agent: "claude", epoch: 2 }]);
-    expect(claudeSessionTitle).toHaveBeenCalledTimes(1);
+  it("skips IPC calls for targets already fetched at the same fingerprint", async () => {
+    await useTitlesStore
+      .getState()
+      .refresh([{ cwd: "/p", agent: "claude", fingerprint: "1|2" }]);
+    invoke.mockClear();
+    await useTitlesStore
+      .getState()
+      .refresh([{ cwd: "/p", agent: "claude", fingerprint: "1|2" }]);
+    expect(invoke).not.toHaveBeenCalled();
   });
 
-  it("collapses multiple title fetches into a single store update", async () => {
-    let setCount = 0;
-    const unsub = useTitlesStore.subscribe(() => {
-      setCount += 1;
+  it("refetches once on any fingerprint change, in either direction", async () => {
+    // Fingerprints are compared for equality, never ordered: a pane leaving a
+    // shared key can shrink the stamp, and that still means exactly one
+    // refetch — not a suppression window, not a loop.
+    await useTitlesStore
+      .getState()
+      .refresh([{ cwd: "/p", agent: "claude", fingerprint: "0|44" }]);
+    invoke.mockClear();
+
+    await useTitlesStore
+      .getState()
+      .refresh([{ cwd: "/p", agent: "claude", fingerprint: "0|6" }]);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    invoke.mockClear();
+
+    await useTitlesStore
+      .getState()
+      .refresh([{ cwd: "/p", agent: "claude", fingerprint: "0|6" }]);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("does not launch a second fetch for the same fingerprint while in flight", async () => {
+    let release: (value: string) => void = () => {};
+    const slow = new Promise<string>((resolve) => {
+      release = resolve;
+    });
+    invoke.mockImplementationOnce(() => slow);
+
+    const target = { cwd: "/p", agent: "claude" as const, sessionId: "s" };
+    const first = useTitlesStore.getState().refresh([{ ...target, fingerprint: "a" }]);
+    const second = useTitlesStore.getState().refresh([{ ...target, fingerprint: "a" }]);
+    await second;
+    expect(invoke).toHaveBeenCalledTimes(1);
+    release("Title");
+    await first;
+    expect(useTitlesStore.getState().titles[titleKey(target)]).toBe("Title");
+  });
+
+  it("a fingerprint change supersedes the fetch in flight", async () => {
+    // Landings never re-fire the caller's effect, so if a changed fingerprint
+    // were merely skipped while the old fetch is in flight, nothing would ever
+    // fetch it — the old fetch would land its stale stamp and the title would
+    // stay wrong until some unrelated later transition.
+    let releaseOld: (value: string) => void = () => {};
+    const old = new Promise<string>((resolve) => {
+      releaseOld = resolve;
+    });
+    invoke
+      .mockImplementationOnce(() => old)
+      .mockImplementationOnce(async () => "New");
+
+    const target = { cwd: "/p", agent: "claude" as const, sessionId: "s" };
+    const first = useTitlesStore.getState().refresh([{ ...target, fingerprint: "a" }]);
+    const second = useTitlesStore.getState().refresh([{ ...target, fingerprint: "b" }]);
+    await second;
+    expect(invoke).toHaveBeenCalledTimes(2);
+
+    releaseOld("Old");
+    await first;
+
+    const state = useTitlesStore.getState();
+    expect(state.titles[titleKey(target)]).toBe("New");
+    expect(state.fetchedFingerprints[titleKey(target)]).toBe("b");
+  });
+
+  it("cancels an in-flight fetch when the fingerprint reverts to the cached one", async () => {
+    // Cache holds f1; a fetch for f2 is in flight; the pane that produced f2
+    // leaves again so the current stamp is back to f1. The cache answers f1,
+    // and the unwanted f2 fetch must not land its bookkeeping later.
+    const target = { cwd: "/p", agent: "claude" as const, sessionId: "s" };
+    await useTitlesStore.getState().refresh([{ ...target, fingerprint: "f1" }]);
+
+    let releaseF2: (value: string) => void = () => {};
+    invoke.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          releaseF2 = resolve;
+        }),
+    );
+    const flight = useTitlesStore.getState().refresh([{ ...target, fingerprint: "f2" }]);
+    await useTitlesStore.getState().refresh([{ ...target, fingerprint: "f1" }]);
+    releaseF2("Poison");
+    await flight;
+
+    const state = useTitlesStore.getState();
+    expect(state.titles[titleKey(target)]).toBe("Claude title");
+    expect(state.fetchedFingerprints[titleKey(target)]).toBe("f1");
+    expect(state.inFlight[titleKey(target)]).toBeUndefined();
+  });
+
+  it("drops a fetch that resolves after its session was pruned", async () => {
+    let release: (value: string) => void = () => {};
+    const slow = new Promise<string>((resolve) => {
+      release = resolve;
+    });
+    invoke.mockImplementationOnce(() => slow);
+
+    const target = { cwd: "/p", agent: "claude" as const, sessionId: "gone" };
+    const inFlight = useTitlesStore.getState().refresh([{ ...target, fingerprint: "0|0" }]);
+    useTitlesStore.getState().prune(new Set());
+    release("Zombie");
+    await inFlight;
+
+    const state = useTitlesStore.getState();
+    expect(state.titles[titleKey(target)]).toBeUndefined();
+    expect(state.fetchedFingerprints[titleKey(target)]).toBeUndefined();
+  });
+
+  it("a pruned-then-relaunched key only accepts the relaunched fetch", async () => {
+    // ABA: the key is pruned while a fetch is in flight, then becomes live
+    // again and refetches. The relaunch has a fresh generation, so the stale
+    // first fetch must not land even though the key is live again.
+    let releaseZombie: (value: string) => void = () => {};
+    const zombie = new Promise<string>((resolve) => {
+      releaseZombie = resolve;
+    });
+    invoke
+      .mockImplementationOnce(() => zombie)
+      .mockImplementationOnce(async () => "Fresh");
+
+    const target = { cwd: "/p", agent: "claude" as const, sessionId: "aba" };
+    const first = useTitlesStore.getState().refresh([{ ...target, fingerprint: "0|0" }]);
+    useTitlesStore.getState().prune(new Set());
+    await useTitlesStore.getState().refresh([{ ...target, fingerprint: "0|0" }]);
+    expect(useTitlesStore.getState().titles[titleKey(target)]).toBe("Fresh");
+
+    releaseZombie("Zombie");
+    await first;
+    expect(useTitlesStore.getState().titles[titleKey(target)]).toBe("Fresh");
+  });
+
+  it("records the fingerprint of a titleless fetch so siblings do not retrigger it", async () => {
+    invoke.mockImplementation(async () => null);
+    const target = { cwd: "/p", agent: "claude" as const, sessionId: "fresh" };
+
+    await useTitlesStore.getState().refresh([{ ...target, fingerprint: "0|3" }]);
+    invoke.mockClear();
+    await useTitlesStore.getState().refresh([{ ...target, fingerprint: "0|3" }]);
+
+    expect(invoke).not.toHaveBeenCalled();
+    const state = useTitlesStore.getState();
+    expect(state.titles[titleKey(target)]).toBeUndefined();
+    expect(state.fetchedFingerprints[titleKey(target)]).toBe("0|3");
+  });
+
+  it("keeps the titles reference stable when a batch lands no text change", async () => {
+    // Every open card subscribes to `titles`; a bookkeeping-only landing
+    // (titleless fetch) must not re-render them all.
+    invoke.mockImplementation(async () => null);
+    const before = useTitlesStore.getState().titles;
+
+    await useTitlesStore
+      .getState()
+      .refresh([{ cwd: "/p", agent: "claude", sessionId: "s", fingerprint: "0|1" }]);
+
+    expect(useTitlesStore.getState().titles).toBe(before);
+  });
+
+  it("keeps an existing title when a later fetch finds none", async () => {
+    const target = { cwd: "/p", agent: "claude" as const, sessionId: "s" };
+    await useTitlesStore.getState().refresh([{ ...target, fingerprint: "a" }]);
+    expect(useTitlesStore.getState().titles[titleKey(target)]).toBe("Claude title");
+
+    invoke.mockImplementation(async () => null);
+    await useTitlesStore.getState().refresh([{ ...target, fingerprint: "b" }]);
+
+    expect(useTitlesStore.getState().titles[titleKey(target)]).toBe("Claude title");
+    expect(useTitlesStore.getState().fetchedFingerprints[titleKey(target)]).toBe("b");
+  });
+
+  it("collapses a batch into one titles update", async () => {
+    let titlesChanges = 0;
+    let previous = useTitlesStore.getState().titles;
+    const unsub = useTitlesStore.subscribe((state) => {
+      if (state.titles !== previous) {
+        titlesChanges += 1;
+        previous = state.titles;
+      }
     });
     await useTitlesStore.getState().refresh([
-      { cwd: "/a", agent: "claude", epoch: 0 },
-      { cwd: "/b", agent: "claude", epoch: 0 },
-      { cwd: "/c", agent: "codex", epoch: 0 },
+      { cwd: "/a", agent: "claude", fingerprint: "0|0" },
+      { cwd: "/b", agent: "claude", fingerprint: "0|0" },
+      { cwd: "/c", agent: "codex", fingerprint: "0|0" },
     ]);
     unsub();
-    // Three fetches must collapse into one store update, not three.
-    expect(setCount).toBe(1);
+    // Three fetches must land as one titles change, not three.
+    expect(titlesChanges).toBe(1);
     const { titles } = useTitlesStore.getState();
     expect(titles[progressKey("/a", "claude")]).toBe("Claude title");
     expect(titles[progressKey("/b", "claude")]).toBe("Claude title");
@@ -61,16 +273,58 @@ describe("titlesStore", () => {
   });
 
   it("still caches successful titles when another fetch in the batch fails", async () => {
-    vi.mocked(claudeSessionTitle).mockImplementation(async (cwd: string) => {
-      if (cwd === "/bad") throw new Error("no transcript");
-      return "Claude title";
-    });
+    invoke.mockImplementation(
+      async (command: string, args: { cwd?: string } | undefined) => {
+        if (command === "claude_session_title" && args?.cwd === "/bad") {
+          throw new Error("no transcript");
+        }
+        return command === "codex_session_title" ? "Codex title" : "Claude title";
+      },
+    );
     await useTitlesStore.getState().refresh([
-      { cwd: "/good", agent: "claude", epoch: 0 },
-      { cwd: "/bad", agent: "claude", epoch: 0 },
+      { cwd: "/good", agent: "claude", fingerprint: "0|0" },
+      { cwd: "/bad", agent: "claude", fingerprint: "0|0" },
     ]);
     const { titles } = useTitlesStore.getState();
     expect(titles[progressKey("/good", "claude")]).toBe("Claude title");
     expect(titles[progressKey("/bad", "claude")]).toBeUndefined();
+  });
+
+  it("prunes cached entries whose session is no longer visible", async () => {
+    const live = { cwd: "/p", agent: "claude" as const, sessionId: "live" };
+    const dead = { cwd: "/p", agent: "claude" as const, sessionId: "dead" };
+    await useTitlesStore.getState().refresh([
+      { ...live, fingerprint: "0|0" },
+      { ...dead, fingerprint: "0|0" },
+    ]);
+
+    useTitlesStore.getState().prune(new Set([titleKey(live)]));
+
+    const state = useTitlesStore.getState();
+    expect(state.titles[titleKey(live)]).toBe("Claude title");
+    expect(state.titles[titleKey(dead)]).toBeUndefined();
+    expect(state.fetchedFingerprints[titleKey(dead)]).toBeUndefined();
+  });
+
+  it("pruning with nothing dead keeps the state reference", async () => {
+    const live = { cwd: "/p", agent: "claude" as const, sessionId: "live" };
+    await useTitlesStore.getState().refresh([{ ...live, fingerprint: "0|0" }]);
+    const before = useTitlesStore.getState();
+
+    useTitlesStore.getState().prune(new Set([titleKey(live)]));
+
+    expect(useTitlesStore.getState()).toBe(before);
+  });
+
+  it("pruning bookkeeping-only entries keeps the titles reference", async () => {
+    invoke.mockImplementation(async () => null);
+    const dead = { cwd: "/p", agent: "claude" as const, sessionId: "dead" };
+    await useTitlesStore.getState().refresh([{ ...dead, fingerprint: "0|0" }]);
+    const before = useTitlesStore.getState().titles;
+
+    useTitlesStore.getState().prune(new Set());
+
+    expect(useTitlesStore.getState().titles).toBe(before);
+    expect(useTitlesStore.getState().fetchedFingerprints[titleKey(dead)]).toBeUndefined();
   });
 });

--- a/src/modules/workspace/lib/titlesStore.ts
+++ b/src/modules/workspace/lib/titlesStore.ts
@@ -8,26 +8,61 @@ import { probeStoreUpdate } from "@/lib/perfProbe";
 export interface TitleTarget {
   cwd: string;
   agent: AgentKind;
+  sessionId?: string;
   /**
-   * Caller-provided session epoch. Used to invalidate the cache: when a new
-   * session starts the epoch bumps and we refetch this target. Targets whose
-   * cached epoch already matches are skipped entirely (no IPC).
+   * Opaque freshness stamp built by the caller from every input that can
+   * change the title (the progress epoch plus the contributing panes' status
+   * epochs). Compared for EQUALITY only — any change, in any direction, is one
+   * refetch. Equality is what makes pane membership changes safe: epochs from
+   * different panes are not comparable, so no ordering may ever be assumed.
    */
-  epoch: number;
+  fingerprint: string;
+}
+
+/** Cache key for one exact session, with the legacy per-cwd key as fallback. */
+export function titleKey(t: {
+  cwd: string;
+  agent: AgentKind;
+  sessionId?: string;
+}): string {
+  return t.sessionId ? `${t.agent}:${t.cwd}:${t.sessionId}` : progressKey(t.cwd, t.agent);
 }
 
 interface TitlesStoreState {
-  /** Auto session title per session, keyed by `progressKey(cwd, agent)`. */
+  /** Auto session title per session, keyed by {@link titleKey}. */
   titles: Record<string, string>;
-  /** Last successfully fetched epoch per session key. */
-  fetchedEpochs: Record<string, number>;
   /**
-   * Fetch and cache titles for a batch of sessions. Targets whose cached epoch
-   * already matches `target.epoch` are skipped (no IPC). All successful fetches
-   * collapse into ONE store update so subscribers re-render once, not N times.
-   * Missing titles or errors are ignored per-target.
+   * Fingerprint each key was last fetched at — recorded even when the fetch
+   * found no title, so a titleless session is not re-fetched on every sibling
+   * bump. Its keyset is a superset of `titles`' (every landing writes it).
+   */
+  fetchedFingerprints: Record<string, string>;
+  /**
+   * The fetch currently in flight per key: its process-unique generation and
+   * the fingerprint it was launched for. A result only lands while its
+   * generation is still the current one — a fingerprint change during flight
+   * launches a superseding fetch (new generation), a revert to the cached
+   * stamp cancels the entry, and prune removes it, so a landing only ever
+   * happens for a stamp somebody still wants: a stale fetch can neither
+   * overwrite a newer result, leave a changed fingerprint unfetched, nor
+   * resurrect a pruned key (ABA-safe).
+   */
+  inFlight: Record<string, { generation: number; fingerprint: string }>;
+  /**
+   * Fetch and cache titles for a batch of sessions. Targets whose cached
+   * fingerprint matches, or that already have a fetch in flight, are skipped
+   * (no IPC). Results land in one store update, and the `titles` reference
+   * only changes when some title text actually changed — every open card
+   * subscribes to it, so a bookkeeping-only update must not re-render them.
    */
   refresh: (targets: TitleTarget[]) => Promise<void>;
+  /**
+   * Drop cached entries whose key is not in `liveKeys`. Session-scoped keys
+   * are minted per Claude session, so without pruning the cache would grow for
+   * the app's lifetime (progressStore.syncSessions plays the same role for
+   * progress).
+   */
+  prune: (liveKeys: ReadonlySet<string>) => void;
 }
 
 async function fetchTitle(target: TitleTarget): Promise<string | null> {
@@ -35,47 +70,137 @@ async function fetchTitle(target: TitleTarget): Promise<string | null> {
     if (target.agent === "codex") {
       return (await codexSessionTitle(target.cwd)) ?? null;
     }
-    return (await claudeSessionTitle(target.cwd)) ?? null;
+    return (await claudeSessionTitle(target.cwd, target.sessionId)) ?? null;
   } catch {
     // No transcript yet, or no backend in tests/web preview; keep last value.
     return null;
   }
 }
 
+/** Process-wide fetch counter. Never reused, even across prune-and-relaunch of
+ *  the same key — that uniqueness is what defeats the ABA race. */
+let nextGeneration = 1;
+
 export const useTitlesStore = create<TitlesStoreState>((set, get) => ({
   titles: {},
-  fetchedEpochs: {},
+  fetchedFingerprints: {},
+  inFlight: {},
 
   refresh: async (targets) => {
-    const { fetchedEpochs } = get();
-    const stale = targets.filter(
-      (t) => fetchedEpochs[progressKey(t.cwd, t.agent)] !== t.epoch,
-    );
-    if (stale.length === 0) {
+    const { fetchedFingerprints, inFlight } = get();
+    const stale: TitleTarget[] = [];
+    const cancels: string[] = [];
+    for (const t of targets) {
+      const key = titleKey(t);
+      if (fetchedFingerprints[key] === t.fingerprint) {
+        // The cache already answers this stamp, so any fetch still in flight
+        // is for some other, no-longer-wanted stamp (a landing records the
+        // stamp and clears the entry together, so cache and in-flight can
+        // never hold the same one). Cancel it — e.g. the fingerprint
+        // reverted because a pane briefly joined and left a shared key — so
+        // its landing cannot displace the already-correct bookkeeping.
+        if (inFlight[key] !== undefined) {
+          cancels.push(key);
+        }
+        continue;
+      }
+      // A fetch in flight for a different stamp does not block a launch: the
+      // new one supersedes it (the old landing is dropped by the generation
+      // check), because nothing else would ever refetch the changed
+      // fingerprint — landings don't re-fire the caller's effect. Only an
+      // in-flight fetch for this exact stamp dedupes.
+      if (inFlight[key]?.fingerprint !== t.fingerprint) {
+        stale.push(t);
+      }
+    }
+    if (stale.length === 0 && cancels.length === 0) {
+      return;
+    }
+
+    const launches = stale.map((target) => ({
+      target,
+      key: titleKey(target),
+      generation: nextGeneration++,
+    }));
+    set((state) => {
+      const next = { ...state.inFlight };
+      for (const key of cancels) {
+        delete next[key];
+      }
+      for (const launch of launches) {
+        next[launch.key] = {
+          generation: launch.generation,
+          fingerprint: launch.target.fingerprint,
+        };
+      }
+      return { inFlight: next };
+    });
+    if (launches.length === 0) {
       return;
     }
 
     const results = await Promise.all(
-      stale.map(async (target) => ({ target, title: await fetchTitle(target) })),
+      launches.map(async (launch) => ({ ...launch, title: await fetchTitle(launch.target) })),
     );
-
-    const fetched = results.filter(
-      (r): r is { target: TitleTarget; title: string } => r.title !== null,
-    );
-    if (fetched.length === 0) {
-      return;
-    }
 
     set((state) => {
-      const nextTitles = { ...state.titles };
-      const nextEpochs = { ...state.fetchedEpochs };
-      for (const { target, title } of fetched) {
-        const key = progressKey(target.cwd, target.agent);
-        nextTitles[key] = title;
-        nextEpochs[key] = target.epoch;
+      let titles = state.titles;
+      const fingerprints = { ...state.fetchedFingerprints };
+      const nextInFlight = { ...state.inFlight };
+      let landed = false;
+      let titlesChanged = false;
+      for (const { target, key, generation, title } of results) {
+        // Superseded, pruned, or pruned-and-relaunched fetches must not land.
+        if (nextInFlight[key]?.generation !== generation) {
+          continue;
+        }
+        delete nextInFlight[key];
+        fingerprints[key] = target.fingerprint;
+        landed = true;
+        // A titleless fetch still records its fingerprint (negative cache) but
+        // keeps any existing title — a transcript never loses a title it had.
+        if (title !== null && titles[key] !== title) {
+          if (!titlesChanged) {
+            titles = { ...titles };
+          }
+          titles[key] = title;
+          titlesChanged = true;
+        }
+      }
+      if (!landed) {
+        return state;
+      }
+      if (!titlesChanged) {
+        return { fetchedFingerprints: fingerprints, inFlight: nextInFlight };
       }
       probeStoreUpdate("title");
-      return { titles: nextTitles, fetchedEpochs: nextEpochs };
+      return { titles, fetchedFingerprints: fingerprints, inFlight: nextInFlight };
     });
   },
+
+  prune: (liveKeys) =>
+    set((state) => {
+      // fetchedFingerprints covers every landed key (titles included);
+      // inFlight covers first fetches that have not landed yet.
+      const dead = Object.keys(state.fetchedFingerprints)
+        .concat(Object.keys(state.inFlight))
+        .filter((key) => !liveKeys.has(key));
+      if (dead.length === 0) {
+        return state;
+      }
+      const fetchedFingerprints = { ...state.fetchedFingerprints };
+      const inFlight = { ...state.inFlight };
+      // Only reclone titles when a dead key actually holds one, so a prune of
+      // bookkeeping-only entries cannot re-render every card.
+      const titlesDead = dead.some((key) => key in state.titles);
+      const titles = titlesDead ? { ...state.titles } : state.titles;
+      for (const key of dead) {
+        delete fetchedFingerprints[key];
+        delete inFlight[key];
+        if (titlesDead) {
+          delete titles[key];
+        }
+      }
+      return { titles, fetchedFingerprints, inFlight };
+    }),
 }));

--- a/src/modules/workspace/lib/useWorkspaceTitles.test.ts
+++ b/src/modules/workspace/lib/useWorkspaceTitles.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { progressKey, useProgressStore } from "@/modules/claude-progress/lib/progressStore";
+import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
+import { useTitlesStore } from "./titlesStore";
+import { useWorkspaceTitles, type VisibleSession } from "./useWorkspaceTitles";
+
+const refresh = vi.fn(async () => {});
+
+beforeEach(() => {
+  refresh.mockClear();
+  useProgressStore.setState({ sessions: {}, sessionEpochs: {} });
+  useSessionStatusStore.setState({
+    statuses: {},
+    agents: {},
+    sessionIds: {},
+    statusEpochs: {},
+  });
+  useTitlesStore.setState({ titles: {}, fetchedFingerprints: {}, inFlight: {}, refresh });
+});
+
+describe("useWorkspaceTitles", () => {
+  it("stamps a new fingerprint when a leaf's status epoch changes", async () => {
+    const target: VisibleSession = {
+      cwd: "/p",
+      agent: "claude",
+      sessionId: "session-a",
+      leafId: "leaf-1",
+    };
+    useProgressStore.setState({
+      sessionEpochs: { [progressKey("/p", "claude")]: 2 },
+    });
+    renderHook(() => useWorkspaceTitles([target]));
+
+    await waitFor(() =>
+      expect(refresh).toHaveBeenLastCalledWith([
+        { cwd: "/p", agent: "claude", sessionId: "session-a", fingerprint: "2|leaf-1:0" },
+      ]),
+    );
+
+    act(() => useSessionStatusStore.getState().setStatus("leaf-1", "idle"));
+
+    await waitFor(() => {
+      expect(refresh).toHaveBeenCalledTimes(2);
+      expect(refresh).toHaveBeenLastCalledWith([
+        { cwd: "/p", agent: "claude", sessionId: "session-a", fingerprint: "2|leaf-1:1" },
+      ]);
+    });
+  });
+
+  it("stamps every contributing pane's epoch when panes share one legacy key", async () => {
+    // Two codex panes in one cwd share the legacy key but carry their own
+    // status epochs. The fingerprint carries the whole multiset, so a bump in
+    // either pane — or one pane leaving — changes the stamp and refetches
+    // exactly once; no ordering between the panes is ever assumed.
+    useSessionStatusStore.setState({
+      statusEpochs: { "leaf-a": 1, "leaf-b": 4 },
+    });
+    const shared = { cwd: "/p", agent: "codex" as const };
+    const { rerender } = renderHook(
+      ({ sessions }: { sessions: VisibleSession[] }) => useWorkspaceTitles(sessions),
+      {
+        initialProps: {
+          sessions: [
+            { ...shared, leafId: "leaf-a" },
+            { ...shared, leafId: "leaf-b" },
+          ] as VisibleSession[],
+        },
+      },
+    );
+
+    await waitFor(() =>
+      expect(refresh).toHaveBeenLastCalledWith([
+        { cwd: "/p", agent: "codex", sessionId: undefined, fingerprint: "0|leaf-a:1,leaf-b:4" },
+      ]),
+    );
+
+    // The higher-epoch pane closes: the stamp shrinks, which is still a
+    // change — one refetch, not a suppression window.
+    rerender({ sessions: [{ ...shared, leafId: "leaf-a" }] });
+    await waitFor(() => {
+      expect(refresh).toHaveBeenCalledTimes(2);
+      expect(refresh).toHaveBeenLastCalledWith([
+        { cwd: "/p", agent: "codex", sessionId: undefined, fingerprint: "0|leaf-a:1" },
+      ]);
+    });
+  });
+
+  it("deduplicates visible sessions that share one title key", async () => {
+    const target: VisibleSession = {
+      cwd: "/p",
+      agent: "claude",
+      sessionId: "session-a",
+      leafId: "leaf-1",
+    };
+    renderHook(() => useWorkspaceTitles([target, { ...target }]));
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+    expect(refresh).toHaveBeenCalledWith([
+      { cwd: "/p", agent: "claude", sessionId: "session-a", fingerprint: "0|leaf-1:0" },
+    ]);
+  });
+
+  it("prunes keys that leave the visible set", async () => {
+    const prune = vi.fn();
+    useTitlesStore.setState({ prune });
+    const target: VisibleSession = {
+      cwd: "/p",
+      agent: "claude",
+      sessionId: "session-a",
+      leafId: "leaf-1",
+    };
+    const { rerender } = renderHook(
+      ({ sessions }: { sessions: VisibleSession[] }) => useWorkspaceTitles(sessions),
+      { initialProps: { sessions: [target] as VisibleSession[] } },
+    );
+
+    await waitFor(() =>
+      expect(prune).toHaveBeenLastCalledWith(new Set(["claude:/p:session-a"])),
+    );
+
+    rerender({ sessions: [] });
+    await waitFor(() => expect(prune).toHaveBeenLastCalledWith(new Set()));
+  });
+});

--- a/src/modules/workspace/lib/useWorkspaceTitles.ts
+++ b/src/modules/workspace/lib/useWorkspaceTitles.ts
@@ -1,52 +1,83 @@
 import { useEffect, useMemo } from "react";
 import { progressKey, useProgressStore } from "@/modules/claude-progress/lib/progressStore";
+import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
 import type { AgentKind } from "@/modules/claude-progress/lib/codexNormalize";
-import { useTitlesStore, type TitleTarget } from "./titlesStore";
+import { titleKey, useTitlesStore, type TitleTarget } from "./titlesStore";
 
-/** Caller-facing target: just cwd + agent. The epoch is stamped inside the hook. */
+/** Caller-facing target: cwd + agent, plus the pane identity when known. The
+ *  freshness fingerprint is stamped inside the hook. */
 export interface VisibleSession {
   cwd: string;
   agent: AgentKind;
+  sessionId?: string;
+  leafId?: string;
 }
 
 /**
- * Fetches the auto session title for each visible session (cwd + agent), and
- * refetches one when its session epoch changes (a new session starts), so titles
- * track the latest transcript.
+ * Fetches the auto session title for each visible session and refetches one
+ * when its freshness fingerprint changes — a new session in its directory, or
+ * a title-relevant status transition of any pane contributing to its key.
  *
  * The whole visible set is handed to the store as a single batched call, so:
- *   - sessions whose cached epoch already matches are skipped (no IPC)
- *   - N successful fetches collapse into one store update, not N re-renders
+ *   - sessions whose cached fingerprint already matches are skipped (no IPC)
+ *   - successful fetches collapse into one store update, not N re-renders
  * Per-target failures are swallowed by the store.
  */
 export function useWorkspaceTitles(targets: VisibleSession[]): void {
-  const epochs = useProgressStore((s) => s.sessionEpochs);
+  const progressEpochs = useProgressStore((s) => s.sessionEpochs);
+  const statusEpochs = useSessionStatusStore((s) => s.statusEpochs);
   const refresh = useTitlesStore((s) => s.refresh);
+  const prune = useTitlesStore((s) => s.prune);
 
-  // Dedupe by session key and stamp each session's current epoch.
+  // Group by title key, collecting each contributing pane's status epoch.
   const enriched = useMemo<TitleTarget[]>(() => {
-    const seen = new Set<string>();
-    const out: TitleTarget[] = [];
+    const byKey = new Map<
+      string,
+      { cwd: string; agent: AgentKind; sessionId?: string; leafEpochs: Map<string, number> }
+    >();
     for (const t of targets) {
-      const key = progressKey(t.cwd, t.agent);
-      if (seen.has(key)) {
-        continue;
-      }
-      seen.add(key);
-      out.push({ cwd: t.cwd, agent: t.agent, epoch: epochs[key] ?? 0 });
+      const key = titleKey(t);
+      const entry = byKey.get(key) ?? {
+        cwd: t.cwd,
+        agent: t.agent,
+        sessionId: t.sessionId,
+        leafEpochs: new Map<string, number>(),
+      };
+      entry.leafEpochs.set(t.leafId ?? "", t.leafId ? (statusEpochs[t.leafId] ?? 0) : 0);
+      byKey.set(key, entry);
     }
-    out.sort((a, b) =>
-      progressKey(a.cwd, a.agent).localeCompare(progressKey(b.cwd, b.agent)),
-    );
+    const out: TitleTarget[] = [];
+    for (const entry of byKey.values()) {
+      const progressEpoch = progressEpochs[progressKey(entry.cwd, entry.agent)] ?? 0;
+      // The fingerprint is compared for equality only (see TitleTarget): any
+      // change — a bump, a pane joining, leaving, or being swapped for
+      // another on a shared legacy key — means one refetch. Epochs of
+      // different panes are never ordered against each other; carrying the
+      // leaf id keeps an equal-epoch pane swap visible, and sorting just
+      // makes the stamp canonical.
+      const fingerprint = `${progressEpoch}|${[...entry.leafEpochs.entries()]
+        .map(([leafId, epoch]) => `${leafId}:${epoch}`)
+        .sort()
+        .join(",")}`;
+      out.push({
+        cwd: entry.cwd,
+        agent: entry.agent,
+        sessionId: entry.sessionId,
+        fingerprint,
+      });
+    }
+    out.sort((a, b) => titleKey(a).localeCompare(titleKey(b)));
     return out;
-  }, [targets, epochs]);
+  }, [targets, progressEpochs, statusEpochs]);
 
-  // Stable string key so the effect only re-fires when the set or an epoch changes.
-  const depKey = enriched
-    .map((t) => `${progressKey(t.cwd, t.agent)}@${t.epoch}`)
-    .join("\n");
+  // Stable string key so the effect only re-fires when the set or a
+  // fingerprint changes.
+  const depKey = enriched.map((t) => `${titleKey(t)}@${t.fingerprint}`).join("\n");
 
   useEffect(() => {
+    // Session-scoped cache keys are minted per Claude session; drop the ones
+    // no longer visible so the cache stays bounded over a long-lived app.
+    prune(new Set(enriched.map((t) => titleKey(t))));
     if (enriched.length === 0) {
       return;
     }
@@ -54,5 +85,5 @@ export function useWorkspaceTitles(targets: VisibleSession[]): void {
     // `enriched` is already encoded in depKey; depending on it directly would
     // refetch on every render because WorkspacePanel rebuilds the array.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [depKey, refresh]);
+  }, [depKey, refresh, prune]);
 }


### PR DESCRIPTION
## 摘要（正體中文）

同一目錄同時跑多個 Claude session 時，workspace 卡片標題會互相覆蓋（多張卡顯示同一個 session 的標題）。根因是標題管線整條以 (cwd, agent) 為鍵：後端只回目錄裡 mtime 最新 transcript 的標題，前端也只有一格快取。本 PR 把 Claude Code hook stdin 裡的 `session_id` 經 status IPC 帶進前端，標題查詢與快取改以 session 為鍵；順帶讓 ai-title／`/rename` 在 session 進行中就能更新。無 session id 的窗格（SSH 遠端、codex）維持原本 per-cwd 行為。

## Root cause

`claude_session_title(cwd)` returned the title of the directory's newest transcript, and the frontend cached it under one `progressKey(cwd, agent)` slot shared by every card in that directory — so concurrent sessions kept overwriting each other's titles (and a session's ai-title/rename never refreshed mid-session).

## Fix

- **Hook shim** (`status_ipc`): every hook event now reads stdin (bounded at 512 KiB, remainder drained to avoid EPIPE) and extracts `session_id`; the wire format gains an optional fifth field, legacy four-field lines still parse.
- **Backend** (`claude_progress`): `claude_session_title` takes an optional `session_id`, validated against `[A-Za-z0-9_-]{1,128}` before touching the filesystem, reading `<id>.jsonl` directly and falling back to the newest transcript when unknown.
- **Frontend**: `sessionStatusStore` maps each leaf to its session id and bumps a per-leaf epoch on real status transitions; `titlesStore` keys the cache per session (`titleKey`); cards, session rows, and desktop notification labels all resolve per-session titles. Panes without a session id keep the exact previous behavior.

## Testing

- Rust: 431/431 green (`cargo test`), `cargo check` warning-free; new tests cover the 5-field wire format round-trip, session-id validation (path traversal rejected), and `session_title_for` returning the requested session's title rather than the newest.
- Frontend: 1765/1765 green across 202 files, `tsc --noEmit` clean; new regression tests include “shows each card's own Claude title when two sessions share one cwd”, which reproduces this bug and fails against the old keying.
- Fail-then-pass verified: degrading `titleKey` back to per-cwd keying turns 3 regression tests red.
- Reviewed by a Tauri security pass (loopback trust boundary, path traversal, stdin DoS): no critical/high findings.

## Known limitation

SSH remote panes (OSC 6973 in-band path) and codex sessions have no session-id source, so multiple such sessions in one directory still share a title — same as before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016n4BJZ34KdvBtkgopw2deN