### PR TITLE
feat(setup): probe CLIs through the user's login shell first

### DIFF
--- a/spec/deep-cli-detection/detection.md
+++ b/spec/deep-cli-detection/detection.md
@@ -1,0 +1,126 @@
+# Deep CLI Detection: Task Breakdown (shell-first design)
+
+All backend work is in `src-tauri/src/modules/setup/mod.rs`; tests join the existing `#[cfg(test)] mod tests` block. Sequential TDD: pure functions get their named test first (red), then the implementation (green). Spawn wrappers get an `#[ignore]` real-env test in the style of `real_env_finds_nvm_installed_claude`.
+
+Legend: (TF) = test-first pure function, (FS) = spawn wrapper, (WIRE) = integration, (FE) = frontend.
+
+---
+
+## Task 1 (TF): `tool_verdict`
+
+Pull the installed / meets_min decision into a pure function encoding the exists-but-unprobeable fallback.
+
+```rust
+/// The (installed, meets_min) verdict for one tool. A resolved-but-unversioned
+/// tool counts as installed; it satisfies meets_min only when the spec has no
+/// minimum (fail closed: an unknown version must not be assumed new enough).
+fn tool_verdict(version: Option<&str>, resolved: bool, min_version: Option<&str>) -> (bool, bool)
+```
+
+| version | resolved | min_version | installed | meets_min |
+|---------|----------|-------------|-----------|-----------|
+| Some(v) | (either) | Some(min)   | true      | meets_min(v, min) |
+| Some(v) | (either) | None        | true      | true |
+| None    | true     | None        | true      | true (the #232 outcome) |
+| None    | true     | Some(min)   | true      | false (fail closed) |
+| None    | false    | (either)    | false     | false |
+
+Tests: `tool_verdict_absent_tool_is_not_installed`, `tool_verdict_probed_version_applies_min`, `tool_verdict_exists_but_unprobeable_no_min_is_ready`, `tool_verdict_exists_but_unprobeable_with_min_fails_closed`.
+
+## Task 2 (TF): `shell_binary`
+
+```rust
+/// The shell to spawn for the batch probe: `$SHELL` when set, else the per-OS
+/// fallback (`/bin/zsh` on macOS, `/bin/sh` elsewhere). Pure.
+fn shell_binary(shell_env: Option<&str>, macos: bool) -> String
+```
+
+Test: `shell_binary_prefers_shell_env_then_os_fallback`.
+
+## Task 3 (TF): `shell_probe_script`
+
+One script probing every tool in a single shell spawn, each result sentinel-delimited so rc noise can't corrupt parsing:
+
+```rust
+const TOOL_SENTINEL_START: &str = "__TEMPO_TOOL_START__"; // followed by <id>__
+const TOOL_SENTINEL_END: &str = "__TEMPO_TOOL_END__";
+
+/// Build the batch probe script: for each (id, bin) emit
+/// `printf '__TEMPO_TOOL_START__<id>__'; <bin> --version 2>/dev/null; printf '__TEMPO_TOOL_END__'`.
+/// stderr is dropped (command-not-found noise); a missing tool yields an empty
+/// block. Ids and bins come from the static TOOLS registry only — never user
+/// input — so no quoting hazard. Pure.
+fn shell_probe_script(tools: &[(&str, &str)]) -> String
+```
+
+Test: `shell_probe_script_wraps_every_tool_in_sentinels` — script contains one start marker per id, each bin followed by `--version`, `2>/dev/null` present.
+
+## Task 4 (TF): `parse_shell_probe_output`
+
+```rust
+/// Per-tool version parsed out of the batch probe's stdout: for each sentinel
+/// block, the first dotted numeric token (parse_version) of its body, or None
+/// when the block is empty/garbage. Tolerates rc banners outside the blocks and
+/// a truncated final block (timeout kill). Pure.
+fn parse_shell_probe_output(output: &str) -> HashMap<String, Option<String>>
+```
+
+Tests:
+- `parse_shell_probe_output_reads_versions_per_tool` — two blocks (`claude` → "2.1.195 (Claude Code)", `codex` → "codex-cli 0.144.5") parse to their versions; a third empty block (`agy`) is None.
+- `parse_shell_probe_output_survives_rc_noise_and_truncation` — banner text before the first block is ignored; a block missing its end marker (killed shell) contributes nothing and does not corrupt earlier blocks.
+
+## Task 5 (FS): `run_shell_probe`
+
+```rust
+/// Run the batch probe in the user's login shell: `shell_binary(...) -ilc <script>`,
+/// stdin null, bounded by SHELL_PROBE_TIMEOUT (10s — one shell startup plus six
+/// probes; killed on overrun like probe_version), then parse_shell_probe_output.
+/// None on Windows or on any failure — detection then falls back per tool to the
+/// directory scan. Called once per detect_tools run.
+fn run_shell_probe(windows: bool) -> Option<HashMap<String, Option<String>>>
+```
+
+Reuses `tool_command` (CREATE_NO_WINDOW) and the `wait_timeout` kill pattern. Test: `real_shell_probe_reports_installed_tools`, `#[ignore]` env-dependent.
+
+## Task 6 (WIRE): rewire `detect_tools_blocking`
+
+```rust
+let shell_versions = run_shell_probe(cfg!(windows));   // None on Windows/failed
+let tools = TOOLS.iter().map(|spec| {
+    let shell_version = shell_versions.as_ref().and_then(|m| m.get(spec.id).cloned().flatten());
+    // Fallback (and disk evidence for the verdict) via the existing machinery.
+    let resolved = find_tool(spec.bin);
+    let version = shell_version.or_else(|| resolved.as_ref().and_then(|exe| /* existing probe */));
+    let (installed, meets_min) = tool_verdict(version.as_deref(), resolved.is_some() || /* shell saw it */, spec.min_version);
+    ...
+});
+```
+
+Notes:
+- A tool the shell answered for skips the fallback probe (no double spawn); `resolved` is still computed for the verdict's disk evidence — cheap, pure fs.
+- "Shell saw it" (a version came back via the shell) counts as resolved for the verdict even when the dir scan misses the file (an install method we don't enumerate).
+- brew/winget detection unchanged.
+- Optional cleanup while here: `tool_search_dirs()` is recomputed per `tool_command`/`find_tool` call (#236 shape); hoisting it once per run is nice-to-have, not required.
+
+## Task 7 (FE): unknown-version display check
+
+Backend can now emit `installed=true, version=null`:
+- No-min tools (claude/codex/agy): renders as "Installed", version span skipped — correct, no change.
+- Min-required tools (node/git/gh): renders as "Version too old" (fail closed but mislabeled). **Open decision**: accept as-is, or add `status.unknownVersion` copy (en + zh-Hant) and a `phaseFor` guard for `installed && !meetsMin && version == null`. Default recommendation: add the copy (one string, one guard, one test in `setupTools.test.ts`).
+
+---
+
+## Manual test script
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Machine with codex under a custom npm prefix, GUI launch | Codex "Installed" |
+| 2 | `SHELL=/bin/false` (broken shell) | Fallback path still detects nvm/homebrew installs |
+| 3 | Rename node away, keep codex shim | Codex "Installed" (verdict layer), node fail-closed |
+| 4 | Remove codex entirely | "Not installed" |
+| 5 | Windows CI + manual wizard smoke | Shell probe skipped, fallback works, no console flash |
+
+## Superseded from the previous plan revision
+
+- Static-dir enumeration (npmrc prefix parser, bun/pnpm/deno/~/bin) — dropped; the shell probe covers these. `search_dirs` remains the seam if a targeted addition is ever needed.
+- Login-shell **PATH capture** — superseded by probing inside the shell directly (same spawn cost, no PATH round-trip).

--- a/spec/deep-cli-detection/overview.md
+++ b/spec/deep-cli-detection/overview.md
@@ -1,0 +1,40 @@
+# Deep CLI Detection for the First-Run Setup Wizard
+
+Fixes GitHub issue #232 (Codex CLI installed under a custom npm prefix reported as "not installed") — the general case, beyond the probe-PATH fix that already landed in #236.
+
+## Design: ask the user's shell, fall back to directory scanning
+
+The wizard's real question is "does this command work in the user's terminal?" — so the primary detection path now asks the user's login shell directly instead of enumerating install locations:
+
+```
+$SHELL -ilc '<probe script running every tool's --version, sentinel-delimited>'
+```
+
+The shell loads the user's rc files, so its PATH covers every install method automatically (nvm, fnm, volta, asdf, Homebrew, custom npm prefix, bun, pnpm, deno, standalone installers, anything future). One shell spawn probes all tools.
+
+The pre-existing directory-scan machinery (search_dirs + version-manager dirs + enriched child PATH, hardened by #236 and #237) is demoted to the **fallback path**:
+
+- **Windows always** — there is no login shell; the GUI inherits the registry PATH and the dir scan covers npm/scoop/choco/fnm layouts.
+- **Unix when the shell probe fails** — `$SHELL` unset, broken rc files, timeout, or a tool missing from the shell's output (each tool falls back individually).
+
+A final verdict layer keeps the semantics honest: an executable found on disk whose `--version` still cannot be read counts as **installed** (version unknown), never "not installed" — the wizard's job is deciding whether to run the installer, and a present binary must not be reinstalled.
+
+## Why this shape
+
+- Root cause of #232 was never "can't find the file" (the shim was in `~/.local/bin`, already scanned); it was the probe running with the GUI's minimal PATH so the `#!/usr/bin/env node` shebang failed. #236 fixed that probe; the shell-first design goes further and makes the whole question match the user's terminal reality.
+- The previously planned static-dir enumeration (npmrc prefix, bun, pnpm, deno, ~/bin) is dropped: the shell already knows all of it. If field reports ever show a popular setup the shell path misses on a broken-rc machine, individual dirs can still be added to `search_dirs` — the seam stays.
+- Install commands (`install_tool`) keep #236's enriched `command_path` PATH; that is orthogonal to detection and already shipped.
+
+## Constraints
+
+- No new Tauri commands, no capability or permission changes; `detect_tools` / `install_tool` signatures unchanged.
+- Pure, parameter-injected helpers (script builder, output parser, shell selection, verdict) with fs/env/spawn isolated in thin wrappers — every branch unit-testable on the macOS CI runner.
+- Any new spawn goes through `tool_command` (CREATE_NO_WINDOW per the windows-tauri skill), bounded by a timeout and killed on overrun, degrading to the fallback silently.
+
+Full task breakdown: [detection.md](./detection.md)
+
+## Status
+
+- #236 (merged): fallback probe/install PATH enrichment + codex standalone installer.
+- #237: hardening follow-up (empty PATH entry filter, `| bash`).
+- This spec: the shell-first probe + verdict layer, to be implemented next.

--- a/src-tauri/src/modules/setup/mod.rs
+++ b/src-tauri/src/modules/setup/mod.rs
@@ -568,7 +568,9 @@ fn parse_shell_probe_output(output: &str) -> HashMap<String, Option<String>> {
     while let Some(start) = rest.find(TOOL_SENTINEL_START) {
         rest = &rest[start + TOOL_SENTINEL_START.len()..];
         let Some(id_end) = rest.find('\n') else { break };
-        let id = rest[..id_end].to_string();
+        // Trimmed so a shell that sneaks in a \r or padding can't make the
+        // id miss its registry lookup.
+        let id = rest[..id_end].trim().to_string();
         rest = &rest[id_end + 1..];
         let Some(body_end) = rest.find(TOOL_SENTINEL_END) else { break };
         versions.insert(id, parse_version(&rest[..body_end]));
@@ -657,15 +659,21 @@ fn detect_tools_blocking() -> DetectResult {
                 .as_ref()
                 .and_then(|versions| versions.get(spec.id).cloned())
                 .flatten();
-            // The scan still runs even when the shell answered: it supplies
-            // the disk evidence for the verdict (a present-but-unprobeable
-            // binary counts as installed, never "not installed") and the exe
-            // for the fallback probe.
-            let resolved = find_tool(spec.bin);
-            let version =
-                shell_version.or_else(|| resolved.as_deref().and_then(probe_version));
+            // A shell answer settles the tool outright, so the disk scan (a
+            // stack of directory reads) only runs as the fallback: it supplies
+            // the exe for the direct probe and the disk evidence for the
+            // verdict (a present-but-unprobeable binary counts as installed,
+            // never "not installed").
+            let (version, resolved) = match shell_version {
+                Some(version) => (Some(version), true),
+                None => {
+                    let exe = find_tool(spec.bin);
+                    let version = exe.as_deref().and_then(probe_version);
+                    (version, exe.is_some())
+                }
+            };
             let (installed, meets_min) =
-                tool_verdict(version.as_deref(), resolved.is_some(), spec.min_version);
+                tool_verdict(version.as_deref(), resolved, spec.min_version);
             ToolStatus {
                 id: spec.id.to_string(),
                 installed,
@@ -894,9 +902,11 @@ mod tests {
 
     #[test]
     fn parse_shell_probe_output_reads_versions_per_tool() {
+        // The codex id carries a \r: a CRLF-minded shell must not break the
+        // registry lookup (the parser trims the id).
         let output = format!(
             "{TOOL_SENTINEL_START}claude\n2.1.195 (Claude Code)\n{TOOL_SENTINEL_END}\
-             {TOOL_SENTINEL_START}codex\ncodex-cli 0.144.5\n{TOOL_SENTINEL_END}\
+             {TOOL_SENTINEL_START}codex\r\ncodex-cli 0.144.5\n{TOOL_SENTINEL_END}\
              {TOOL_SENTINEL_START}antigravity\n{TOOL_SENTINEL_END}"
         );
         let versions = parse_shell_probe_output(&output);

--- a/src-tauri/src/modules/setup/mod.rs
+++ b/src-tauri/src/modules/setup/mod.rs
@@ -4,6 +4,7 @@
 //! wizard. The tool registry is data-driven so adding or tweaking a tool is a
 //! one-line change; version comparison is a pure function for easy testing.
 
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -467,13 +468,13 @@ fn tool_command(exe: &std::path::Path) -> Command {
     command
 }
 
-/// Resolve and run `<tool> --version`, returning the parsed version or None if
-/// the tool is absent, errors, or outruns PROBE_TIMEOUT (killed so a hung binary
-/// never lingers). Reads output only after the process exits — `--version` is a
-/// few bytes, well under the pipe buffer, so this cannot deadlock.
-fn probe_version(stem: &str) -> Option<String> {
-    let exe = find_tool(stem)?;
-    let mut child = tool_command(&exe)
+/// Run `<exe> --version`, returning the parsed version or None if it errors
+/// or outruns PROBE_TIMEOUT (killed so a hung binary never lingers). Takes the
+/// already-resolved exe so callers sharing a detection run resolve each tool
+/// once. Reads output only after the process exits — `--version` is a few
+/// bytes, well under the pipe buffer, so this cannot deadlock.
+fn probe_version(exe: &Path) -> Option<String> {
+    let mut child = tool_command(exe)
         .arg("--version")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -498,6 +499,134 @@ fn probe_version(stem: &str) -> Option<String> {
     parse_version(&text)
 }
 
+/// The (installed, meets_min) verdict for one tool. `version` is the probe
+/// result, `resolved` is whether an executable file was found on disk, and
+/// `min_version` is the spec's minimum. Encodes the exists-but-unprobeable
+/// fallback: a resolved-but-unversioned tool counts as installed — the
+/// wizard's job is deciding whether to run the installer, and a present
+/// binary must not be reinstalled — but it satisfies meets_min only when the
+/// spec has no minimum (fail closed: an unknown version must never be
+/// assumed new enough). Pure.
+fn tool_verdict(version: Option<&str>, resolved: bool, min_version: Option<&str>) -> (bool, bool) {
+    match (version, resolved) {
+        (Some(v), _) => (true, min_version.is_none_or(|min| meets_min(v, min))),
+        (None, true) => (true, min_version.is_none()),
+        (None, false) => (false, false),
+    }
+}
+
+/// Marks a tool's block inside the login-shell batch probe output, followed by
+/// the tool id and a newline; the block body runs to [`TOOL_SENTINEL_END`].
+/// Sentinels let the parser ignore whatever rc files print around the blocks.
+const TOOL_SENTINEL_START: &str = "__TEMPO_TOOL_START__";
+const TOOL_SENTINEL_END: &str = "__TEMPO_TOOL_END__";
+
+/// Ceiling on the whole login-shell batch probe: one shell startup (rc files,
+/// lazy nvm hooks) plus every tool's `--version`, so it gets more room than a
+/// single PROBE_TIMEOUT; killed on overrun, falling back to the dir scan.
+const SHELL_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The shell to spawn for the batch probe: `$SHELL` when set, else the per-OS
+/// fallback (`/bin/zsh` on macOS, `/bin/sh` elsewhere). Pure.
+fn shell_binary(shell_env: Option<&str>, macos: bool) -> String {
+    match shell_env {
+        Some(shell) if !shell.is_empty() => shell.to_string(),
+        _ => if macos { "/bin/zsh" } else { "/bin/sh" }.to_string(),
+    }
+}
+
+/// The batch probe script: for each (id, bin), print the start sentinel plus
+/// the id, run `<bin> --version` with stderr dropped (an absent tool's
+/// command-not-found noise must leave its block empty, not corrupt it), then
+/// print the end sentinel. Ids and bins come from the static TOOLS registry
+/// only — never user input — so quoting is not a concern. Pure.
+fn shell_probe_script(tools: &[(&str, &str)]) -> String {
+    tools
+        .iter()
+        .map(|(id, bin)| {
+            // The bin is quoted so a future registry entry containing a space
+            // or metacharacter can never silently become shell-parsed.
+            format!(
+                "printf '{TOOL_SENTINEL_START}%s\\n' '{id}'; \
+                 '{bin}' --version 2>/dev/null; \
+                 printf '{TOOL_SENTINEL_END}'"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Per-tool versions parsed out of the batch probe's stdout: for each sentinel
+/// block, the id keys the first dotted numeric token of the body (None when
+/// the body is empty or garbage — the tool answered nothing usable). Text
+/// outside the blocks (rc banners) is ignored, and a block missing its end
+/// sentinel (the shell was killed mid-write) contributes nothing rather than
+/// garbage. Pure.
+fn parse_shell_probe_output(output: &str) -> HashMap<String, Option<String>> {
+    let mut versions = HashMap::new();
+    let mut rest = output;
+    while let Some(start) = rest.find(TOOL_SENTINEL_START) {
+        rest = &rest[start + TOOL_SENTINEL_START.len()..];
+        let Some(id_end) = rest.find('\n') else { break };
+        let id = rest[..id_end].to_string();
+        rest = &rest[id_end + 1..];
+        let Some(body_end) = rest.find(TOOL_SENTINEL_END) else { break };
+        versions.insert(id, parse_version(&rest[..body_end]));
+        rest = &rest[body_end + TOOL_SENTINEL_END.len()..];
+    }
+    versions
+}
+
+/// Run the batch probe in the user's login shell and return per-tool versions,
+/// or None on Windows (no login shell) or any failure — detection then falls
+/// back per tool to the directory scan. `-ilc` loads the rc files, so the
+/// shell's PATH matches the user's terminal and every install method (nvm,
+/// custom npm prefix, bun, pnpm, standalone installers) is covered without
+/// enumeration. Bounded by SHELL_PROBE_TIMEOUT and killed on overrun; an
+/// output with no sentinel blocks (a shell that choked on -i or -l) also
+/// falls back. Called once per detect_tools run.
+fn run_shell_probe(windows: bool) -> Option<HashMap<String, Option<String>>> {
+    if windows {
+        return None;
+    }
+    let shell = shell_binary(
+        std::env::var("SHELL").ok().as_deref(),
+        cfg!(target_os = "macos"),
+    );
+    let tools: Vec<(&str, &str)> = TOOLS.iter().map(|spec| (spec.id, spec.bin)).collect();
+    let script = shell_probe_script(&tools);
+    let mut child = tool_command(Path::new(&shell))
+        .arg("-ilc")
+        .arg(&script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        // Never read, so a pipe would only add a way for a noisy rc to block
+        // the shell on a full buffer before the probes even run.
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    // Bounded read, same 512 KiB ceiling as the status_ipc stdin path: the
+    // shell exiting does not mean stdout hit EOF — an rc-backgrounded writer
+    // inheriting the pipe would stall an unbounded `wait_with_output` forever
+    // and let a hostile rc grow the buffer without limit. The deadline doubles
+    // as the probe's whole clock.
+    let stdout = child.stdout.take()?;
+    let text = crate::modules::status_ipc::read_bounded_with_deadline(
+        stdout,
+        512 * 1024,
+        SHELL_PROBE_TIMEOUT,
+    );
+    // Whatever the read produced, never leave the shell running.
+    let _ = child.kill();
+    let _ = child.wait();
+    let versions = parse_shell_probe_output(&text?);
+    if versions.is_empty() {
+        None
+    } else {
+        Some(versions)
+    }
+}
+
 /// The install command string for `spec` on the current OS ("" when none).
 fn install_command(spec: &ToolSpec) -> &'static str {
     if cfg!(target_os = "windows") {
@@ -517,16 +646,26 @@ pub async fn detect_tools() -> Result<DetectResult, String> {
 }
 
 fn detect_tools_blocking() -> DetectResult {
+    // One login-shell batch probe answers every tool the user's terminal can
+    // see; each miss falls back per tool to the directory scan below (which is
+    // the only path on Windows).
+    let shell_versions = run_shell_probe(cfg!(windows));
     let tools = TOOLS
         .iter()
         .map(|spec| {
-            let version = probe_version(spec.bin);
-            let installed = version.is_some();
-            let meets_min = match (&version, spec.min_version) {
-                (Some(v), Some(min)) => meets_min(v, min),
-                (Some(_), None) => true,
-                (None, _) => false,
-            };
+            let shell_version = shell_versions
+                .as_ref()
+                .and_then(|versions| versions.get(spec.id).cloned())
+                .flatten();
+            // The scan still runs even when the shell answered: it supplies
+            // the disk evidence for the verdict (a present-but-unprobeable
+            // binary counts as installed, never "not installed") and the exe
+            // for the fallback probe.
+            let resolved = find_tool(spec.bin);
+            let version =
+                shell_version.or_else(|| resolved.as_deref().and_then(probe_version));
+            let (installed, meets_min) =
+                tool_verdict(version.as_deref(), resolved.is_some(), spec.min_version);
             ToolStatus {
                 id: spec.id.to_string(),
                 installed,
@@ -702,6 +841,85 @@ mod tests {
         assert!(dirs.contains(&PathBuf::from("/home/me/.asdf/shims")));
         assert!(dirs.contains(&PathBuf::from("/home/me/.nvm/versions/node/v22.14.0/bin")));
         assert!(dirs.contains(&PathBuf::from("/home/me/.nvm/versions/node/v20.11.0/bin")));
+    }
+
+    #[test]
+    fn tool_verdict_absent_tool_is_not_installed() {
+        assert_eq!(tool_verdict(None, false, Some("18")), (false, false));
+        assert_eq!(tool_verdict(None, false, None), (false, false));
+    }
+
+    #[test]
+    fn tool_verdict_probed_version_applies_min() {
+        assert_eq!(tool_verdict(Some("22.14.0"), true, Some("18")), (true, true));
+        assert_eq!(tool_verdict(Some("16.0.0"), true, Some("18")), (true, false));
+        assert_eq!(tool_verdict(Some("0.144.5"), true, None), (true, true));
+    }
+
+    #[test]
+    fn tool_verdict_exists_but_unprobeable_no_min_is_ready() {
+        // The #232 outcome: a codex/claude shim found on disk whose probe
+        // failed (its node interpreter unreachable) is installed, not missing.
+        assert_eq!(tool_verdict(None, true, None), (true, true));
+    }
+
+    #[test]
+    fn tool_verdict_exists_but_unprobeable_with_min_fails_closed() {
+        // An unknown version must never be assumed to satisfy a minimum.
+        assert_eq!(tool_verdict(None, true, Some("18")), (true, false));
+    }
+
+    #[test]
+    fn shell_binary_prefers_shell_env_then_os_fallback() {
+        assert_eq!(shell_binary(Some("/bin/fish"), true), "/bin/fish");
+        assert_eq!(shell_binary(Some("/bin/fish"), false), "/bin/fish");
+        assert_eq!(shell_binary(None, true), "/bin/zsh");
+        assert_eq!(shell_binary(None, false), "/bin/sh");
+        // An empty SHELL is as good as unset.
+        assert_eq!(shell_binary(Some(""), true), "/bin/zsh");
+    }
+
+    #[test]
+    fn shell_probe_script_wraps_every_tool_in_sentinels() {
+        let script = shell_probe_script(&[("claude", "claude"), ("antigravity", "agy")]);
+        // One start marker per id, the probed bin between the markers, and
+        // command-not-found noise dropped so an absent tool yields an empty block.
+        assert_eq!(script.matches(TOOL_SENTINEL_START).count(), 2);
+        assert_eq!(script.matches(TOOL_SENTINEL_END).count(), 2);
+        assert!(script.contains("'claude'"));
+        assert!(script.contains("'antigravity'"));
+        assert!(script.contains("'claude' --version 2>/dev/null"));
+        assert!(script.contains("'agy' --version 2>/dev/null"));
+    }
+
+    #[test]
+    fn parse_shell_probe_output_reads_versions_per_tool() {
+        let output = format!(
+            "{TOOL_SENTINEL_START}claude\n2.1.195 (Claude Code)\n{TOOL_SENTINEL_END}\
+             {TOOL_SENTINEL_START}codex\ncodex-cli 0.144.5\n{TOOL_SENTINEL_END}\
+             {TOOL_SENTINEL_START}antigravity\n{TOOL_SENTINEL_END}"
+        );
+        let versions = parse_shell_probe_output(&output);
+        assert_eq!(versions.get("claude"), Some(&Some("2.1.195".to_string())));
+        assert_eq!(versions.get("codex"), Some(&Some("0.144.5".to_string())));
+        // An absent tool leaves its block empty: reported as seen-but-no-version.
+        assert_eq!(versions.get("antigravity"), Some(&None));
+    }
+
+    #[test]
+    fn parse_shell_probe_output_survives_rc_noise_and_truncation() {
+        // rc banners print outside the sentinel blocks; a timeout kill can
+        // truncate the final block. Neither may corrupt the parsed results.
+        let output = format!(
+            "welcome to zsh!\n\
+             {TOOL_SENTINEL_START}git\ngit version 2.50.1 (Apple Git-155)\n{TOOL_SENTINEL_END}\
+             {TOOL_SENTINEL_START}node\nv22.14"
+        );
+        let versions = parse_shell_probe_output(&output);
+        assert_eq!(versions.get("git"), Some(&Some("2.50.1".to_string())));
+        // The truncated node block contributes nothing rather than garbage.
+        assert!(!versions.contains_key("node"));
+        assert_eq!(versions.len(), 1);
     }
 
     #[test]
@@ -926,6 +1144,17 @@ mod tests {
             .ends_with(PathBuf::from("installation").join("claude.cmd")));
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    #[ignore = "env-dependent: run manually on a machine with a real login shell"]
+    fn real_shell_probe_reports_installed_tools() {
+        // Proof on the real machine: the login-shell batch probe returns a
+        // non-empty map and sees at least one real tool. Run with:
+        //   cargo test -p tempo-term real_shell_probe -- --ignored --nocapture
+        let versions = run_shell_probe(false);
+        println!("shell probe versions: {versions:?}");
+        assert!(versions.is_some(), "expected the login shell probe to produce blocks");
     }
 
     #[test]

--- a/src-tauri/src/modules/status_ipc/mod.rs
+++ b/src-tauri/src/modules/status_ipc/mod.rs
@@ -191,8 +191,10 @@ const STDIN_TIMEOUT: Duration = Duration::from_millis(200);
 /// The thread drains any remainder as a courtesy, but only for as long as the
 /// shim process lives — a writer still going when the shim exits gets EPIPE,
 /// which hook runners already tolerated (pre-session-id shims never read stdin
-/// on most events at all).
-fn read_bounded_with_deadline<R>(reader: R, limit: u64, deadline: Duration) -> Option<String>
+/// on most events at all). On timeout the helper thread stays blocked on the
+/// read and is leaked; callers in long-lived processes (setup's shell probe)
+/// accept that as the cost of never stalling on a pipe held open.
+pub(crate) fn read_bounded_with_deadline<R>(reader: R, limit: u64, deadline: Duration) -> Option<String>
 where
     R: Read + Send + 'static,
 {

--- a/src/i18n/locales/en/onboarding.json
+++ b/src/i18n/locales/en/onboarding.json
@@ -22,6 +22,7 @@
     "checking": "Checking…",
     "missing": "Not installed",
     "outdated": "Version too old",
+    "unknownVersion": "Installed, version unknown",
     "ready": "Installed",
     "installing": "Installing…",
     "failed": "Install failed"

--- a/src/i18n/locales/zh-Hant/onboarding.json
+++ b/src/i18n/locales/zh-Hant/onboarding.json
@@ -22,6 +22,7 @@
     "checking": "偵測中…",
     "missing": "尚未安裝",
     "outdated": "版本過舊",
+    "unknownVersion": "已安裝，版本未知",
     "ready": "已安裝",
     "installing": "安裝中…",
     "failed": "安裝失敗"

--- a/src/modules/setup/SetupWizard.tsx
+++ b/src/modules/setup/SetupWizard.tsx
@@ -197,7 +197,7 @@ export function SetupWizard() {
             {status?.version ? (
               <span className="text-xs text-fg-subtle">v{status.version}</span>
             ) : null}
-            <StatusPill phase={phase} t={t} />
+            <StatusPill phase={phase} versionUnknown={status?.version == null} t={t} />
           </div>
           <p className="mt-2 text-sm leading-relaxed text-fg-muted">{t(`desc.${meta.name}`)}</p>
 
@@ -310,7 +310,19 @@ function Stepper({
   );
 }
 
-function StatusPill({ phase, t }: { phase: RowPhase; t: (k: string) => string }) {
+function StatusPill({
+  phase,
+  versionUnknown = false,
+  t,
+}: {
+  phase: RowPhase;
+  /** True when the tool's version could not be read (backend reports
+   *  installed with a null version). Only affects the "outdated" phase: the
+   *  fail-closed verdict is right, but "Version too old" would be a lie —
+   *  the version is unknown, not old. */
+  versionUnknown?: boolean;
+  t: (k: string) => string;
+}) {
   const map: Record<RowPhase, { key: string; cls: string }> = {
     checking: { key: "status.checking", cls: "text-fg-subtle" },
     missing: { key: "status.missing", cls: "border border-border text-fg-muted" },
@@ -320,7 +332,8 @@ function StatusPill({ phase, t }: { phase: RowPhase; t: (k: string) => string })
     failed: { key: "status.failed", cls: "border border-danger/40 text-danger" },
   };
   const { key, cls } = map[phase];
-  return <span className={`ml-auto rounded-full px-2 py-0.5 text-[11px] ${cls}`}>{t(key)}</span>;
+  const labelKey = phase === "outdated" && versionUnknown ? "status.unknownVersion" : key;
+  return <span className={`ml-auto rounded-full px-2 py-0.5 text-[11px] ${cls}`}>{t(labelKey)}</span>;
 }
 
 function ActionButton({


### PR DESCRIPTION
## Summary

Closes #232 — the general fix, on top of the probe-PATH repair that landed in #236/#237.

The wizard's real question is "does this command work in the user's terminal?", so detection now asks the user's login shell directly instead of enumerating install locations:

- **One `$SHELL -ilc` spawn probes every tool** (`--version`), sentinel-delimited per tool so rc banners can't corrupt parsing. The shell's rc files make its PATH match the user's terminal, so nvm, fnm, volta, custom npm prefixes, bun, pnpm, standalone installers — anything — is covered without enumeration.
- **Bounded on every axis**: 10s deadline, kill-on-overrun, 512 KiB stdout ceiling via `status_ipc`'s shared bounded reader (the shell exiting doesn't guarantee pipe EOF — an rc-backgrounded writer can hold stdout open), stderr nulled, `stdin` nulled. Any failure degrades silently to the fallback.
- **Fallback per tool**: the existing directory scan + enriched-PATH probe (#236, hardened in #237) — the only path on Windows, which has no login shell.
- **`tool_verdict`**: a binary found on disk whose version can't be read now reports **installed** (the wizard must never re-run an installer over a present binary) with `version: null`; tools with a version floor fail closed on `meetsMin`. The wizard shows a new "Installed, version unknown" pill for that state instead of the misleading "Version too old".

Plan: `spec/deep-cli-detection/` (included).

## Tests

- TDD red-then-green on all pure pieces: `tool_verdict` (5-row behavior table), `shell_binary`, `shell_probe_script` (quoting locked), `parse_shell_probe_output` (per-tool versions, rc noise, truncated-block tolerance).
- New `#[ignore]` real-env test; verified on a real machine: one shell spawn returns all six tools' versions.
- Full suites green: Rust 446, frontend 1778, `tsc --noEmit` and `cargo check` clean.
- Tauri security review on the diff: PASS — both LOW hardening notes (bounded stdout read, quoted bin interpolation) are applied in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)