### PR TITLE
feat: support native OSC 8 file hyperlinks

### DIFF
--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -102,6 +102,10 @@ fn build_shell_command(
     // so Claude sessions in other terminals never touch our UI.
     cmd.env("TEMPOTERM", "1");
 
+    // Tell CLI tools like Claude Code (via supports-hyperlinks) that we support OSC 8 hyperlinks natively.
+    cmd.env("FORCE_HYPERLINK", "1");
+    cmd.env("COLORTERM", "truecolor"); // Added for robustness
+
     // Point this pane's status-hook shim back at the app's loopback listener
     // and tag it with the pane's pty id (see status_ipc). Empty when the
     // listener failed to start.

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -307,6 +307,9 @@ export function TerminalView({
       theme: getTheme(useSettingsStore.getState().themeId).terminal,
       linkHint: linkHintRef.current,
       onOpenLocalUrl: (url) => onOpenPreviewRef.current?.(url),
+      onOpenFileUrl: (url) => {
+        void openFromTerminal(url);
+      },
     });
     handleRef.current = handle;
     const { term, fit } = handle;

--- a/src/modules/terminal/lib/createTerminal.ts
+++ b/src/modules/terminal/lib/createTerminal.ts
@@ -36,6 +36,10 @@ export interface CreateTerminalOptions {
    * external URLs always go to the browser.
    */
   onOpenLocalUrl?: (url: string) => void;
+  /**
+   * Fired when an OSC 8 file link (e.g., file:///...) is modifier-clicked.
+   */
+  onOpenFileUrl?: (url: string) => void;
 }
 
 export function createTerminal(options: CreateTerminalOptions = {}): TerminalHandle {
@@ -51,6 +55,34 @@ export function createTerminal(options: CreateTerminalOptions = {}): TerminalHan
     // Otherwise xterm consumes Alt+click to move the cursor, which swallows the
     // Alt+click that opens file links.
     altClickMovesCursor: false,
+    linkHandler: {
+      activate: (event, uri) => {
+        if (!matchesOpenModifier(event, IS_MAC)) {
+          return;
+        }
+        if (isWebUrl(uri)) {
+          if (options.onOpenLocalUrl && isLocalUrl(uri)) {
+            options.onOpenLocalUrl(uri);
+          } else {
+            void openUrl(uri);
+          }
+        } else if (uri.startsWith("file://") && options.onOpenFileUrl) {
+          try {
+            const raw = decodeURIComponent(new URL(uri).pathname);
+            options.onOpenFileUrl(raw);
+          } catch {
+            const raw = uri.replace(/^file:\/\/(?:localhost)?/i, "");
+            options.onOpenFileUrl(raw);
+          }
+        }
+      },
+      hover: (event) => {
+        if (options.linkHint) {
+          showLinkTooltip(options.linkHint, event.clientX, event.clientY);
+        }
+      },
+      leave: () => hideLinkTooltip(),
+    },
   });
 
   const fit = new FitAddon();


### PR DESCRIPTION
### 問題原因
1. `tempo-term` 目前沒有宣告支援「原生跳轉連結（OSC 8）」，導致 Node.js 的 CLI 工具（如 Claude Code 依賴的 `supports-hyperlinks` 套件）退而求其次輸出原始的 Markdown 格式路徑。
2. 原有的 `registerLinkProvider` 雖然能解析路徑，但當 Markdown 路徑過長被終端機強制斷行時，解析器就會失敗，導致使用者看的到卻點不開路徑。

### 解決方案
1. 在 `session.rs` 啟動時加入 `FORCE_HYPERLINK=1` 環境變數，確保 CLI 工具輸出乾淨的 OSC 8 原生連結。
2. 由於 xterm.js 5.0+ 已經內建 OSC 8 支援，我們只需在 `createTerminal.ts` 掛載 `linkHandler`。
3. 攔截 `file://` 協定的點擊事件（搭配 `matchesOpenModifier` 驗證），轉交給 `TerminalView.tsx` 既有的 `openFromTerminal` 處理，確保 `Cmd+點擊` 或 `Alt+點擊` 能夠安全開啟檔案。