### PR TITLE
feat: add note selection formatting

### DIFF
--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -40,6 +40,16 @@
   "language": "Language",
   "exitHint": "Cmd + Enter to exit",
   "linkHint": "Cmd / Ctrl-click to open",
+  "format": {
+    "bold": "Bold",
+    "italic": "Italic",
+    "strike": "Strikethrough",
+    "code": "Inline code",
+    "link": "Link",
+    "linkUrl": "Link URL",
+    "linkPlaceholder": "Paste a URL",
+    "removeLink": "Remove link"
+  },
   "slash": {
     "text": "Text",
     "h1": "Heading 1",

--- a/src/i18n/locales/zh-Hant/notes.json
+++ b/src/i18n/locales/zh-Hant/notes.json
@@ -40,6 +40,16 @@
   "language": "語言",
   "exitHint": "Cmd + Enter 跳脫",
   "linkHint": "Cmd / Ctrl + 點擊開啟連結",
+  "format": {
+    "bold": "粗體",
+    "italic": "斜體",
+    "strike": "刪除線",
+    "code": "行內程式碼",
+    "link": "連結",
+    "linkUrl": "連結網址",
+    "linkPlaceholder": "貼上網址",
+    "removeLink": "移除連結"
+  },
   "slash": {
     "text": "文字",
     "h1": "標題 1",

--- a/src/modules/notes/NoteEditor.tsx
+++ b/src/modules/notes/NoteEditor.tsx
@@ -29,6 +29,7 @@ import { bashCommandHighlight } from "./lib/bashCommandHighlight";
 import { NoteSearchHighlight } from "./noteSearchHighlight";
 import { Combobox } from "@/components/Combobox";
 import { Tooltip } from "@/components/Tooltip";
+import { SelectionCommandMenu } from "./SelectionCommandMenu";
 
 const lowlight = createLowlight(common);
 // Override the stock bash grammar so leading command names (ssh, git, custom
@@ -227,5 +228,10 @@ export function NoteEditor({ content, onChange, noteId, onEditorReady }: NoteEdi
     return () => unregisterNoteInserter(noteId);
   }, [editor, noteId]);
 
-  return <EditorContent editor={editor} className="h-full" />;
+  return (
+    <>
+      {editor && <SelectionCommandMenu editor={editor} />}
+      <EditorContent editor={editor} className="h-full" />
+    </>
+  );
 }

--- a/src/modules/notes/SelectionCommandMenu.tsx
+++ b/src/modules/notes/SelectionCommandMenu.tsx
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import type { Editor } from "@tiptap/react";
+import {
+  Bold,
+  CodeXml,
+  Italic,
+  Link as LinkIcon,
+  Strikethrough,
+  Unlink,
+  type LucideIcon,
+} from "lucide-react";
+import { SlashCommandList, type SlashListHandle } from "./SlashCommandList";
+import { createBlockCommandItems } from "./slashCommand";
+
+interface SelectionCommandMenuProps {
+  editor: Editor;
+}
+
+interface MenuAnchor {
+  left: number;
+  top: number;
+  selectionKey: string;
+}
+
+const MENU_WIDTH = 256;
+const MENU_MAX_HEIGHT = 288;
+const VIEWPORT_MARGIN = 8;
+
+interface FormatButtonProps {
+  label: string;
+  active: boolean;
+  icon: LucideIcon;
+  onClick: () => void;
+}
+
+function FormatButton({ label, active, icon: Icon, onClick }: FormatButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onClick}
+      className={`rounded p-1.5 ${
+        active ? "bg-bg text-fg" : "text-fg-muted hover:bg-bg hover:text-fg"
+      }`}
+    >
+      <Icon size={15} />
+    </button>
+  );
+}
+
+/** Reuses the slash-command panel to transform selected blocks in place. */
+export function SelectionCommandMenu({ editor }: SelectionCommandMenuProps) {
+  const { t } = useTranslation("notes");
+  const items = useMemo(() => createBlockCommandItems(t, false), [t]);
+  const [anchor, setAnchor] = useState<MenuAnchor | null>(null);
+  const [linkEditing, setLinkEditing] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+  const dismissedSelection = useRef<string | null>(null);
+  const listRef = useRef<SlashListHandle>(null);
+  const linkInputRef = useRef<HTMLInputElement>(null);
+  const hide = useCallback(() => setAnchor(null), []);
+  const handleEditorBlur = useCallback(() => {
+    window.setTimeout(() => {
+      const activeElement = document.activeElement as HTMLElement | null;
+      if (!activeElement?.closest("[data-selection-command-menu]")) {
+        hide();
+      }
+    }, 0);
+  }, [hide]);
+
+  const update = useCallback(() => {
+    const { selection } = editor.state;
+    if (selection.empty || editor.isActive("codeBlock")) {
+      dismissedSelection.current = null;
+      setAnchor(null);
+      return;
+    }
+
+    const selectionKey = `${selection.from}:${selection.to}`;
+    if (dismissedSelection.current === selectionKey) {
+      setAnchor(null);
+      return;
+    }
+
+    let left = VIEWPORT_MARGIN;
+    let top = VIEWPORT_MARGIN;
+    try {
+      const start = editor.view.coordsAtPos(selection.from);
+      const end = editor.view.coordsAtPos(selection.to);
+      left = Math.min(start.left, end.left);
+      top = Math.max(start.bottom, end.bottom) + 6;
+      if (top + MENU_MAX_HEIGHT > window.innerHeight - VIEWPORT_MARGIN) {
+        top = Math.max(
+          VIEWPORT_MARGIN,
+          Math.min(start.top, end.top) - MENU_MAX_HEIGHT - 6,
+        );
+      }
+    } catch {
+      // jsdom has no text layout. Keeping a deterministic fallback makes the
+      // selection behavior testable; real webviews use ProseMirror geometry.
+    }
+    left = Math.max(
+      VIEWPORT_MARGIN,
+      Math.min(left, window.innerWidth - MENU_WIDTH - VIEWPORT_MARGIN),
+    );
+    setAnchor({ left, top, selectionKey });
+  }, [editor]);
+
+  useEffect(() => {
+    editor.on("selectionUpdate", update);
+    editor.on("transaction", update);
+    editor.on("focus", update);
+    editor.on("blur", handleEditorBlur);
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    update();
+    return () => {
+      editor.off("selectionUpdate", update);
+      editor.off("transaction", update);
+      editor.off("focus", update);
+      editor.off("blur", handleEditorBlur);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [editor, handleEditorBlur, update]);
+
+  useEffect(() => {
+    if (linkEditing) {
+      linkInputRef.current?.focus();
+    }
+  }, [linkEditing]);
+
+  useEffect(() => {
+    if (!anchor) {
+      return;
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        editor.commands.setTextSelection(editor.state.selection.to);
+      } else if (listRef.current?.onKeyDown(event)) {
+        event.preventDefault();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [anchor, editor]);
+
+  if (!anchor) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      data-selection-command-menu
+      className="fixed z-[1000]"
+      style={{ left: anchor.left, top: anchor.top }}
+    >
+      <SlashCommandList
+        ref={listRef}
+        items={items}
+        header={
+          <div className="border-b border-border px-2 pb-1">
+            <div className="flex items-center gap-1">
+              <FormatButton
+                label={t("format.bold")}
+                active={editor.isActive("bold")}
+                icon={Bold}
+                onClick={() => editor.chain().focus().toggleBold().run()}
+              />
+              <FormatButton
+                label={t("format.italic")}
+                active={editor.isActive("italic")}
+                icon={Italic}
+                onClick={() => editor.chain().focus().toggleItalic().run()}
+              />
+              <FormatButton
+                label={t("format.strike")}
+                active={editor.isActive("strike")}
+                icon={Strikethrough}
+                onClick={() => editor.chain().focus().toggleStrike().run()}
+              />
+              <FormatButton
+                label={t("format.code")}
+                active={editor.isActive("code")}
+                icon={CodeXml}
+                onClick={() => editor.chain().focus().toggleCode().run()}
+              />
+              <FormatButton
+                label={t("format.link")}
+                active={editor.isActive("link")}
+                icon={LinkIcon}
+                onClick={() => {
+                  setLinkUrl((editor.getAttributes("link").href as string | undefined) ?? "");
+                  setLinkEditing(true);
+                }}
+              />
+            </div>
+            {linkEditing && (
+              <div className="mt-1">
+                <input
+                  ref={linkInputRef}
+                  type="url"
+                  value={linkUrl}
+                  aria-label={t("format.linkUrl")}
+                  placeholder={t("format.linkPlaceholder")}
+                  onChange={(event) => setLinkUrl(event.target.value)}
+                  onKeyDown={(event) => {
+                    event.stopPropagation();
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      const href = linkUrl.trim();
+                      const chain = editor.chain().focus();
+                      if (href) {
+                        chain.setLink({ href }).run();
+                      } else {
+                        chain.unsetLink().run();
+                      }
+                      setLinkEditing(false);
+                    }
+                  }}
+                  className="w-full rounded border border-border-strong bg-bg px-2 py-1 text-xs text-fg outline-none placeholder:text-fg-subtle focus:border-accent"
+                />
+                {editor.isActive("link") && (
+                  <button
+                    type="button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => {
+                      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+                      setLinkEditing(false);
+                    }}
+                    className="mt-1 flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs text-danger hover:bg-bg"
+                  >
+                    <Unlink size={14} />
+                    {t("format.removeLink")}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        }
+        command={(item) => {
+          dismissedSelection.current = anchor.selectionKey;
+          setAnchor(null);
+          const { from, to } = editor.state.selection;
+          item.run(editor, { from, to });
+          editor.commands.setTextSelection(editor.state.selection.to);
+        }}
+      />
+    </div>,
+    document.body,
+  );
+}

--- a/src/modules/notes/SelectionCommandMenu.tsx
+++ b/src/modules/notes/SelectionCommandMenu.tsx
@@ -62,9 +62,14 @@ export function SelectionCommandMenu({ editor }: SelectionCommandMenuProps) {
   const dismissedSelection = useRef<string | null>(null);
   const listRef = useRef<SlashListHandle>(null);
   const linkInputRef = useRef<HTMLInputElement>(null);
+  const blurTimeoutRef = useRef<number | null>(null);
   const hide = useCallback(() => setAnchor(null), []);
   const handleEditorBlur = useCallback(() => {
-    window.setTimeout(() => {
+    if (blurTimeoutRef.current !== null) {
+      window.clearTimeout(blurTimeoutRef.current);
+    }
+    blurTimeoutRef.current = window.setTimeout(() => {
+      blurTimeoutRef.current = null;
       const activeElement = document.activeElement as HTMLElement | null;
       if (!activeElement?.closest("[data-selection-command-menu]")) {
         hide();
@@ -111,20 +116,38 @@ export function SelectionCommandMenu({ editor }: SelectionCommandMenuProps) {
   }, [editor]);
 
   useEffect(() => {
+    let animationFrameId: number | null = null;
+    const scheduleUpdate = () => {
+      if (animationFrameId !== null) {
+        return;
+      }
+      animationFrameId = window.requestAnimationFrame(() => {
+        animationFrameId = null;
+        update();
+      });
+    };
+
     editor.on("selectionUpdate", update);
     editor.on("transaction", update);
     editor.on("focus", update);
     editor.on("blur", handleEditorBlur);
-    window.addEventListener("resize", update);
-    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", scheduleUpdate);
+    window.addEventListener("scroll", scheduleUpdate, true);
     update();
     return () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      if (blurTimeoutRef.current !== null) {
+        window.clearTimeout(blurTimeoutRef.current);
+        blurTimeoutRef.current = null;
+      }
       editor.off("selectionUpdate", update);
       editor.off("transaction", update);
       editor.off("focus", update);
       editor.off("blur", handleEditorBlur);
-      window.removeEventListener("resize", update);
-      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", scheduleUpdate);
+      window.removeEventListener("scroll", scheduleUpdate, true);
     };
   }, [editor, handleEditorBlur, update]);
 
@@ -220,6 +243,9 @@ export function SelectionCommandMenu({ editor }: SelectionCommandMenuProps) {
                       } else {
                         chain.unsetLink().run();
                       }
+                      setLinkEditing(false);
+                    } else if (event.key === "Escape") {
+                      event.preventDefault();
                       setLinkEditing(false);
                     }
                   }}

--- a/src/modules/notes/SlashCommandList.tsx
+++ b/src/modules/notes/SlashCommandList.tsx
@@ -4,6 +4,7 @@ import {
   useImperativeHandle,
   useState,
   type KeyboardEvent,
+  type ReactNode,
 } from "react";
 import type { Editor, Range } from "@tiptap/react";
 import type { LucideIcon } from "lucide-react";
@@ -22,10 +23,11 @@ export interface SlashListHandle {
 interface SlashCommandListProps {
   items: SlashItem[];
   command: (item: SlashItem) => void;
+  header?: ReactNode;
 }
 
 export const SlashCommandList = forwardRef<SlashListHandle, SlashCommandListProps>(
-  function SlashCommandList({ items, command }, ref) {
+  function SlashCommandList({ items, command, header }, ref) {
     const [selected, setSelected] = useState(0);
 
     useEffect(() => {
@@ -57,12 +59,14 @@ export const SlashCommandList = forwardRef<SlashListHandle, SlashCommandListProp
 
     return (
       <div className="max-h-72 w-64 overflow-y-auto rounded-lg border border-border-strong bg-bg-elevated py-1 shadow-xl">
+        {header}
         {items.map((item, index) => {
           const Icon = item.icon;
           return (
             <button
               key={item.title}
               type="button"
+              onMouseDown={(event) => event.preventDefault()}
               onMouseEnter={() => setSelected(index)}
               onClick={() => command(item)}
               className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm ${

--- a/src/modules/notes/slashCommand.test.tsx
+++ b/src/modules/notes/slashCommand.test.tsx
@@ -119,6 +119,21 @@ describe("note slash command", () => {
     expect(editor.getText()).toBe("plain text");
   });
 
+  it("cancels link editing with Escape without closing the command panel", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "format.link" }));
+    const input = await screen.findByRole("textbox", { name: "format.linkUrl" });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(screen.queryByRole("textbox", { name: "format.linkUrl" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "slash.text" })).toBeInTheDocument();
+    expect(editor.state.selection.empty).toBe(false);
+  });
+
   it("removes a link from selected text without deleting the text", async () => {
     const editor = await renderEditorAtEnd("plain text");
     act(() => {

--- a/src/modules/notes/slashCommand.test.tsx
+++ b/src/modules/notes/slashCommand.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { Editor } from "@tiptap/react";
 import { describe, expect, it, vi } from "vitest";
 import { NoteEditor } from "./NoteEditor";
@@ -44,5 +44,139 @@ describe("note slash command", () => {
 
     expect(await screen.findByText("slash.text")).toBeInTheDocument();
     expect(screen.getByText("slash.code")).toBeInTheDocument();
+  });
+
+  it("shows the existing block command menu when note text is selected", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+
+    expect(await screen.findByText("slash.text")).toBeInTheDocument();
+    expect(screen.getByText("slash.quote")).toBeInTheDocument();
+  });
+
+  it("formats selected text as bold from the same command panel", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "format.bold" }));
+
+    expect(editor.getHTML()).toBe("<p><strong>plain</strong> text</p>");
+    expect(screen.getByRole("button", { name: "slash.text" })).toBeInTheDocument();
+  });
+
+  it("formats selected text as italic from the same command panel", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "format.italic" }));
+
+    expect(editor.getHTML()).toBe("<p><em>plain</em> text</p>");
+  });
+
+  it("formats selected text with strikethrough from the same command panel", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "format.strike" }));
+
+    expect(editor.getHTML()).toBe("<p><s>plain</s> text</p>");
+  });
+
+  it("formats selected text as inline code from the same command panel", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "format.code" }));
+
+    expect(editor.getHTML()).toBe("<p><code>plain</code> text</p>");
+  });
+
+  it("adds a link to selected text from the same command panel", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "format.link" }));
+    const input = await screen.findByRole("textbox", { name: "format.linkUrl" });
+    fireEvent.change(input, { target: { value: "https://example.com" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const link = editor.view.dom.querySelector("a");
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveTextContent("plain");
+    expect(editor.getText()).toBe("plain text");
+  });
+
+  it("removes a link from selected text without deleting the text", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+      editor.commands.setLink({ href: "https://example.com" });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "format.link" }));
+    fireEvent.click(await screen.findByRole("button", { name: "format.removeLink" }));
+
+    expect(editor.view.dom.querySelector("a")).toBeNull();
+    expect(editor.getText()).toBe("plain text");
+  });
+
+  it("changes the selected block style without deleting its text", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "slash.h1" }));
+
+    expect(editor.getText()).toBe("plain text");
+    expect(editor.getHTML()).toBe("<h1>plain text</h1>");
+    expect(screen.queryByRole("button", { name: "slash.h1" })).not.toBeInTheDocument();
+  });
+
+  it("closes the selection command menu with Escape", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+    await screen.findByRole("button", { name: "slash.text" });
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(screen.queryByRole("button", { name: "slash.text" })).not.toBeInTheDocument();
+    expect(editor.state.selection.empty).toBe(true);
+  });
+
+  it("keeps deleting the slash trigger when a typed slash command runs", async () => {
+    const editor = await renderEditorAtEnd("/");
+
+    fireEvent.click(await screen.findByRole("button", { name: "slash.h2" }));
+
+    expect(editor.getText()).toBe("");
+    expect(editor.getHTML()).toBe("<h2></h2>");
+  });
+
+  it("preserves selected text when inserting a divider from the selection menu", async () => {
+    const editor = await renderEditorAtEnd("plain text");
+    act(() => {
+      editor.commands.setTextSelection({ from: 1, to: 6 });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "slash.divider" }));
+
+    expect(editor.getText()).toContain("plain text");
+    expect(editor.getHTML()).toContain("<hr>");
   });
 });

--- a/src/modules/notes/slashCommand.ts
+++ b/src/modules/notes/slashCommand.ts
@@ -20,7 +20,7 @@ interface SlashCommandSpec {
   key: string;
   keywords: string;
   icon: LucideIcon;
-  run: (editor: Editor, range: Range) => void;
+  run: (chain: BlockChain) => boolean;
 }
 
 /**
@@ -31,6 +31,7 @@ interface SlashCommandSpec {
 interface BlockChain {
   focus(): BlockChain;
   deleteRange(range: Range): BlockChain;
+  setTextSelection(position: number): BlockChain;
   setParagraph(): BlockChain;
   toggleHeading(attrs: { level: 1 | 2 | 3 | 4 | 5 | 6 }): BlockChain;
   toggleBulletList(): BlockChain;
@@ -42,8 +43,9 @@ interface BlockChain {
   run(): boolean;
 }
 
-function blockChain(editor: Editor, range: Range): BlockChain {
-  return (editor.chain() as unknown as BlockChain).focus().deleteRange(range);
+function blockChain(editor: Editor, range?: Range): BlockChain {
+  const chain = (editor.chain() as unknown as BlockChain).focus();
+  return range ? chain.deleteRange(range) : chain;
 }
 
 const SPECS: SlashCommandSpec[] = [
@@ -51,63 +53,87 @@ const SPECS: SlashCommandSpec[] = [
     key: "text",
     keywords: "text paragraph 文字 段落",
     icon: Type,
-    run: (editor, range) => blockChain(editor, range).setParagraph().run(),
+    run: (chain) => chain.setParagraph().run(),
   },
   {
     key: "h1",
     keywords: "h1 heading title 標題",
     icon: Heading1,
-    run: (editor, range) => blockChain(editor, range).toggleHeading({ level: 1 }).run(),
+    run: (chain) => chain.toggleHeading({ level: 1 }).run(),
   },
   {
     key: "h2",
     keywords: "h2 heading subtitle 標題",
     icon: Heading2,
-    run: (editor, range) => blockChain(editor, range).toggleHeading({ level: 2 }).run(),
+    run: (chain) => chain.toggleHeading({ level: 2 }).run(),
   },
   {
     key: "h3",
     keywords: "h3 heading 標題",
     icon: Heading3,
-    run: (editor, range) => blockChain(editor, range).toggleHeading({ level: 3 }).run(),
+    run: (chain) => chain.toggleHeading({ level: 3 }).run(),
   },
   {
     key: "bullet",
     keywords: "bullet unordered list 項目 清單",
     icon: List,
-    run: (editor, range) => blockChain(editor, range).toggleBulletList().run(),
+    run: (chain) => chain.toggleBulletList().run(),
   },
   {
     key: "ordered",
     keywords: "ordered numbered list 編號 清單",
     icon: ListOrdered,
-    run: (editor, range) => blockChain(editor, range).toggleOrderedList().run(),
+    run: (chain) => chain.toggleOrderedList().run(),
   },
   {
     key: "todo",
     keywords: "todo task checkbox 待辦 清單",
     icon: ListChecks,
-    run: (editor, range) => blockChain(editor, range).toggleTaskList().run(),
+    run: (chain) => chain.toggleTaskList().run(),
   },
   {
     key: "quote",
     keywords: "quote blockquote 引用",
     icon: Quote,
-    run: (editor, range) => blockChain(editor, range).toggleBlockquote().run(),
+    run: (chain) => chain.toggleBlockquote().run(),
   },
   {
     key: "code",
     keywords: "code codeblock snippet 程式碼",
     icon: Code2,
-    run: (editor, range) => blockChain(editor, range).toggleCodeBlock().run(),
+    run: (chain) => chain.toggleCodeBlock().run(),
   },
   {
     key: "divider",
     keywords: "divider hr rule separator 分隔線",
     icon: Minus,
-    run: (editor, range) => blockChain(editor, range).setHorizontalRule().run(),
+    run: (chain) => chain.setHorizontalRule().run(),
   },
 ];
+
+/** The same command set can delete a typed slash trigger or transform the
+ * current selection in place. */
+export function createBlockCommandItems(
+  t: TFunction<"notes">,
+  deleteSlashTrigger: boolean,
+): SlashItem[] {
+  return SPECS.map((spec) => ({
+    title: t(`slash.${spec.key}`),
+    keywords: spec.keywords,
+    icon: spec.icon,
+    run: (editor, range) => {
+      let chain = blockChain(editor, deleteSlashTrigger ? range : undefined);
+      // A divider inserts content rather than transforming the current block.
+      // Collapse to the end of the selected textblock first so its text is
+      // neither replaced nor split around the new horizontal rule.
+      if (!deleteSlashTrigger && spec.key === "divider") {
+        const blockEnd = editor.state.doc.resolve(range.to).end();
+        chain = chain.setTextSelection(blockEnd);
+      }
+      return spec.run(chain);
+    },
+  }));
+}
 
 /** Builds the `/` slash command extension with localized labels. */
 export function createSlashCommand(t: TFunction<"notes">): Extension {
@@ -123,16 +149,10 @@ export function createSlashCommand(t: TFunction<"notes">): Extension {
           startOfLine: false,
           items: ({ query }) => {
             const q = query.toLowerCase().trim();
-            return SPECS.filter((spec) => {
+            return createBlockCommandItems(t, true).filter((item) => {
               if (!q) return true;
-              const title = t(`slash.${spec.key}`).toLowerCase();
-              return title.includes(q) || spec.keywords.toLowerCase().includes(q);
-            }).map((spec) => ({
-              title: t(`slash.${spec.key}`),
-              keywords: spec.keywords,
-              icon: spec.icon,
-              run: spec.run,
-            }));
+              return item.title.toLowerCase().includes(q) || item.keywords.toLowerCase().includes(q);
+            });
           },
           command: ({ editor, range, props }) => {
             props.run(editor, range);


### PR DESCRIPTION
## Summary

- open the existing block command panel when note text is selected
- add inline bold, italic, strikethrough, code, and link formatting to the same panel
- support adding, editing, and removing links without deleting selected text
- preserve the existing `/` slash-command behavior and selected text during block transformations

## Why

The note editor previously exposed block formatting only through `/`, so users could not restyle selected text or apply inline formatting without a separate toolbar.

## Impact

Selected note text can now be formatted from one contextual command panel, while the original slash-command workflow remains unchanged.

## Validation

- `pnpm test` — 206 files, 1808 tests passed
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
