### PR TITLE
feat(workspace): show full name on hover for truncated sidebar titles

### DIFF
--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -75,4 +75,67 @@ describe("Tooltip", () => {
     act(() => vi.advanceTimersByTime(1000));
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
+
+  it("suppresses an ancestor tooltip while a nested one is hovered", () => {
+    const { container } = render(
+      <Tooltip label="card">
+        <div>
+          <Tooltip label="badge">
+            <button type="button">x</button>
+          </Tooltip>
+        </div>
+      </Tooltip>,
+    );
+    const outer = container.firstElementChild!;
+    const inner = screen.getByRole("button").parentElement!;
+
+    fireEvent.mouseEnter(outer);
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("card");
+
+    // Entering the nested tooltip hides the ancestor's immediately, and only
+    // the nested label shows after the delay.
+    fireEvent.mouseEnter(inner);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    act(() => vi.advanceTimersByTime(300));
+    const tips = screen.getAllByRole("tooltip");
+    expect(tips).toHaveLength(1);
+    expect(tips[0]).toHaveTextContent("badge");
+
+    // Leaving the nested one (pointer still over the ancestor — relatedTarget
+    // points inside it, so no leave fires on the ancestor) brings the
+    // ancestor's tooltip back after its delay.
+    fireEvent.mouseLeave(inner, { relatedTarget: outer });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("card");
+
+    // Leaving the ancestor too cancels everything.
+    fireEvent.mouseLeave(outer);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("releases the suppression when the nested tooltip unmounts mid-hover", () => {
+    const { container, rerender } = render(
+      <Tooltip label="card">
+        <div>
+          <Tooltip label="badge">
+            <button type="button">x</button>
+          </Tooltip>
+        </div>
+      </Tooltip>,
+    );
+    const outer = container.firstElementChild!;
+
+    fireEvent.mouseEnter(outer);
+    fireEvent.mouseEnter(screen.getByRole("button").parentElement!);
+    rerender(
+      <Tooltip label="card">
+        <div />
+      </Tooltip>,
+    );
+    // The ancestor is no longer suppressed, so it can show again.
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("card");
+  });
 });

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,4 +1,14 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { createPortal } from "react-dom";
 
 interface TooltipProps {
@@ -14,6 +24,13 @@ interface TooltipProps {
 
 const MARGIN = 6;
 const DEFAULT_DELAY_MS = 300;
+
+/**
+ * Lets a nested Tooltip silence its nearest ancestor Tooltip while hovered, so
+ * wrapping a whole card in a Tooltip doesn't stack a second tooltip on top of
+ * the ones already inside it (PR badge, session rows).
+ */
+const TooltipNestingContext = createContext<{ suppress(): void; release(): void } | null>(null);
 
 /**
  * A hover tooltip rendered through a portal with fixed positioning, clamped to
@@ -36,6 +53,11 @@ export function Tooltip({
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [anchor, setAnchor] = useState<DOMRect | null>(null);
   const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  const parent = useContext(TooltipNestingContext);
+  // Count of hovered nested tooltips; while positive this one stays hidden.
+  const suppressedRef = useRef(0);
+  // Whether this tooltip currently holds a suppression on its parent.
+  const holdRef = useRef(false);
 
   const cancel = useCallback(() => {
     if (timerRef.current !== null) {
@@ -56,8 +78,8 @@ export function Tooltip({
     }
   }, [label, cancel]);
 
-  function arm() {
-    if (!label || timerRef.current !== null) {
+  const arm = useCallback(() => {
+    if (!label || suppressedRef.current > 0 || timerRef.current !== null) {
       return;
     }
     timerRef.current = setTimeout(() => {
@@ -67,7 +89,38 @@ export function Tooltip({
       const el = anchorRef.current?.firstElementChild ?? anchorRef.current;
       setAnchor(el?.getBoundingClientRect() ?? null);
     }, delayMs);
-  }
+  }, [label, delayMs]);
+
+  const nesting = useMemo(
+    () => ({
+      suppress() {
+        suppressedRef.current += 1;
+        cancel();
+      },
+      release() {
+        suppressedRef.current = Math.max(0, suppressedRef.current - 1);
+        // Re-arm for the case where the pointer moved off the nested tooltip
+        // but is still over this one. If it left both, this wrapper's own
+        // mouseleave fires right after (leave events go bottom-up) and cancels.
+        if (suppressedRef.current === 0) {
+          arm();
+        }
+      },
+    }),
+    [arm, cancel],
+  );
+
+  // A nested tooltip unmounting mid-hover (e.g. its row disappears) never
+  // fires mouseleave, so give the suppression back here instead.
+  useEffect(
+    () => () => {
+      if (holdRef.current) {
+        holdRef.current = false;
+        parent?.release();
+      }
+    },
+    [parent],
+  );
 
   // Measure the rendered tooltip, then place it and clamp to the viewport.
   useLayoutEffect(() => {
@@ -97,12 +150,24 @@ export function Tooltip({
   return (
     <span
       ref={anchorRef}
-      onMouseEnter={arm}
-      onMouseLeave={cancel}
+      onMouseEnter={() => {
+        if (parent && !holdRef.current) {
+          holdRef.current = true;
+          parent.suppress();
+        }
+        arm();
+      }}
+      onMouseLeave={() => {
+        if (parent && holdRef.current) {
+          holdRef.current = false;
+          parent.release();
+        }
+        cancel();
+      }}
       onMouseDownCapture={cancel}
       className={className ? `inline-flex ${className}` : "inline-flex"}
     >
-      {children}
+      <TooltipNestingContext.Provider value={nesting}>{children}</TooltipNestingContext.Provider>
       {label &&
         anchor &&
         createPortal(

--- a/src/components/useIsTruncated.test.tsx
+++ b/src/components/useIsTruncated.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useIsTruncated } from "./useIsTruncated";
+
+function Probe({ text }: { text: string }) {
+  const [ref, truncated] = useIsTruncated(text);
+  return (
+    <span ref={ref} data-testid="probe" data-truncated={truncated}>
+      {text}
+    </span>
+  );
+}
+
+describe("useIsTruncated", () => {
+  // jsdom does no layout, so fake the overflow measurements the hook reads.
+  let scrollWidth = 0;
+  let clientWidth = 0;
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      get: () => scrollWidth,
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      get: () => clientWidth,
+    });
+  });
+  afterEach(() => {
+    delete (HTMLElement.prototype as { scrollWidth?: number }).scrollWidth;
+    delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth;
+  });
+
+  it("is true when the content overflows the element", () => {
+    scrollWidth = 200;
+    clientWidth = 100;
+    render(<Probe text="long title" />);
+    expect(screen.getByTestId("probe")).toHaveAttribute("data-truncated", "true");
+  });
+
+  it("is false when the content fits", () => {
+    scrollWidth = 100;
+    clientWidth = 100;
+    render(<Probe text="short" />);
+    expect(screen.getByTestId("probe")).toHaveAttribute("data-truncated", "false");
+  });
+
+  it("re-measures when the text changes", () => {
+    scrollWidth = 100;
+    clientWidth = 100;
+    const { rerender } = render(<Probe text="short" />);
+    expect(screen.getByTestId("probe")).toHaveAttribute("data-truncated", "false");
+
+    scrollWidth = 300;
+    rerender(<Probe text="a much longer title" />);
+    expect(screen.getByTestId("probe")).toHaveAttribute("data-truncated", "true");
+  });
+});

--- a/src/components/useIsTruncated.ts
+++ b/src/components/useIsTruncated.ts
@@ -1,0 +1,40 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * Whether an element's content overflows horizontally (its `truncate` ellipsis
+ * is showing). Attach the returned callback ref to the truncating element; the
+ * flag follows element resizes (ResizeObserver) and text changes, so a tooltip
+ * gated on it only appears when the full text is actually hidden.
+ */
+export function useIsTruncated(text: string): [(el: HTMLElement | null) => void, boolean] {
+  const [truncated, setTruncated] = useState(false);
+  const elRef = useRef<HTMLElement | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const attach = useCallback((el: HTMLElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    elRef.current = el;
+    if (!el) {
+      setTruncated(false);
+      return;
+    }
+    const check = () => setTruncated(el.scrollWidth > el.clientWidth);
+    check();
+    // jsdom has no ResizeObserver; there the initial check (0 > 0) stands.
+    if (typeof ResizeObserver !== "undefined") {
+      observerRef.current = new ResizeObserver(check);
+      observerRef.current.observe(el);
+    }
+  }, []);
+
+  // Re-measure when the text changes without the element remounting.
+  useLayoutEffect(() => {
+    const el = elRef.current;
+    if (el) {
+      setTruncated(el.scrollWidth > el.clientWidth);
+    }
+  }, [text]);
+
+  return [attach, truncated];
+}

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { useTabsStore, type Tab, type TabKind } from "@/stores/tabsStore";
 import { Tooltip } from "@/components/Tooltip";
+import { useIsTruncated } from "@/components/useIsTruncated";
 import { ContextMenu } from "@/components/ContextMenu";
 import { tabContextMenuItems } from "@/components/tabContextMenuItems";
 import { useTabCloseRequest } from "@/components/useTabCloseRequest";
@@ -217,12 +218,15 @@ function SessionRow({
 }) {
   const label = agentLabel(session.agent);
   const title = sessionTitle(session, titles);
+  const [titleRef, truncated] = useIsTruncated(title);
   return (
     <span className="flex items-center gap-1.5">
       {showStatus && <StatusBadge status={session.status} />}
       {label && <span className="shrink-0 text-[11px] text-fg-subtle">{label}</span>}
-      <Tooltip label={title} className="min-w-0 flex-1">
-        <span className="min-w-0 flex-1 truncate text-[11px] text-fg-muted">{title}</span>
+      <Tooltip label={truncated && title} className="min-w-0 flex-1">
+        <span ref={titleRef} className="min-w-0 flex-1 truncate text-[11px] text-fg-muted">
+          {title}
+        </span>
       </Tooltip>
     </span>
   );
@@ -269,6 +273,9 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
   const pr = cwd ? prs[cwd] : undefined;
   const Icon = tabIcon(tab.kind);
   const label = agentLabel(primary?.agent);
+  // The rename input replaces the title span while editing, which detaches the
+  // ref and turns the flag (and so the card tooltip) off on its own.
+  const [titleRef, titleTruncated] = useIsTruncated(title);
 
   function startRename() {
     setDraft(title);
@@ -293,84 +300,89 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
   }, [editing]);
 
   return (
-    <button
-      type="button"
-      onClick={() => setActive(tab.id)}
-      onContextMenu={(event) => {
-        // Right-clicks on the rename input skip the card menu and bubble to
-        // the window-level InputContextMenu, like every other text field.
-        if (event.target instanceof HTMLInputElement) return;
-        event.preventDefault();
-        setMenu({ x: event.clientX, y: event.clientY });
-      }}
-      className={`flex w-full items-stretch gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors ${
-        active
-          ? "border-accent bg-accent/10 text-fg"
-          : "border-border bg-bg-inset text-fg-muted hover:bg-bg-elevated"
-      }`}
-    >
-      <span className="flex shrink-0 flex-col items-center justify-start gap-1">
-        <Icon size={14} className="text-fg-subtle" />
-        <span className="text-[10px] font-medium leading-none text-fg-subtle">{index}</span>
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="flex items-center gap-1.5">
-          {editing ? (
-            <input
-              ref={inputRef}
-              value={draft}
-              onChange={(event) => setDraft(event.target.value)}
-              onBlur={commitRename}
-              onClick={(event) => event.stopPropagation()}
-              onPointerDown={(event) => event.stopPropagation()}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") commitRename();
-                if (event.key === "Escape") setEditing(false);
-              }}
-              className="min-w-0 flex-1 rounded border border-accent bg-bg px-1 text-xs text-fg outline-none"
-            />
-          ) : (
-            <Tooltip label={title} className="min-w-0 flex-1">
-              <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">{title}</span>
-            </Tooltip>
+    // The whole card reveals the full title on hover, but only while the title
+    // is actually truncated. Tooltips inside the card (PR badge, session rows)
+    // suppress this one while hovered, so they never stack.
+    <Tooltip label={titleTruncated && title} className="w-full">
+      <button
+        type="button"
+        onClick={() => setActive(tab.id)}
+        onContextMenu={(event) => {
+          // Right-clicks on the rename input skip the card menu and bubble to
+          // the window-level InputContextMenu, like every other text field.
+          if (event.target instanceof HTMLInputElement) return;
+          event.preventDefault();
+          setMenu({ x: event.clientX, y: event.clientY });
+        }}
+        className={`flex w-full items-stretch gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors ${
+          active
+            ? "border-accent bg-accent/10 text-fg"
+            : "border-border bg-bg-inset text-fg-muted hover:bg-bg-elevated"
+        }`}
+      >
+        <span className="flex shrink-0 flex-col items-center justify-start gap-1">
+          <Icon size={14} className="text-fg-subtle" />
+          <span className="text-[10px] font-medium leading-none text-fg-subtle">{index}</span>
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-1.5">
+            {editing ? (
+              <input
+                ref={inputRef}
+                value={draft}
+                onChange={(event) => setDraft(event.target.value)}
+                onBlur={commitRename}
+                onClick={(event) => event.stopPropagation()}
+                onPointerDown={(event) => event.stopPropagation()}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") commitRename();
+                  if (event.key === "Escape") setEditing(false);
+                }}
+                className="min-w-0 flex-1 rounded border border-accent bg-bg px-1 text-xs text-fg outline-none"
+              />
+            ) : (
+              <span ref={titleRef} className="min-w-0 flex-1 truncate text-xs font-medium text-fg">
+                {title}
+              </span>
+            )}
+            {!multi && card.status && status && <StatusBadge status={status} />}
+            {!multi && card.status && status && label && (
+              <span className="shrink-0 text-[11px] text-fg-subtle">{label}</span>
+            )}
+          </span>
+          {multi && (
+            <span className="mt-1 block space-y-0.5">
+              {sessions.map((session) => (
+                <SessionRow
+                  key={session.leafId}
+                  session={session}
+                  titles={titles}
+                  showStatus={card.status}
+                />
+              ))}
+            </span>
           )}
-          {!multi && card.status && status && <StatusBadge status={status} />}
-          {!multi && card.status && status && label && (
-            <span className="shrink-0 text-[11px] text-fg-subtle">{label}</span>
+          <BranchBlock info={info} cwd={cwd} showBranch={card.branch} showCwd={card.cwd} />
+          {card.pr && pr && (
+            <span className="mt-0.5 block">
+              <PrBadge pr={pr} />
+            </span>
           )}
         </span>
-        {multi && (
-          <span className="mt-1 block space-y-0.5">
-            {sessions.map((session) => (
-              <SessionRow
-                key={session.leafId}
-                session={session}
-                titles={titles}
-                showStatus={card.status}
-              />
-            ))}
-          </span>
+        {menu && (
+          <ContextMenu
+            x={menu.x}
+            y={menu.y}
+            onClose={() => setMenu(null)}
+            items={tabContextMenuItems(t, {
+              onRename: startRename,
+              onClose: requestClose,
+            })}
+          />
         )}
-        <BranchBlock info={info} cwd={cwd} showBranch={card.branch} showCwd={card.cwd} />
-        {card.pr && pr && (
-          <span className="mt-0.5 block">
-            <PrBadge pr={pr} />
-          </span>
-        )}
-      </span>
-      {menu && (
-        <ContextMenu
-          x={menu.x}
-          y={menu.y}
-          onClose={() => setMenu(null)}
-          items={tabContextMenuItems(t, {
-            onRename: startRename,
-            onClose: requestClose,
-          })}
-        />
-      )}
-      {confirmCloseDialog}
-    </button>
+        {confirmCloseDialog}
+      </button>
+    </Tooltip>
   );
 }
 
@@ -397,6 +409,7 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
   // ⌘1-9. O(1) lookup per card (vs an O(n) indexOf), memoized on the slice so a
   // rename keystroke or status update doesn't rebuild the map.
   const tabNumberById = useMemo(() => new Map(allTabs.map((tab, i) => [tab.id, i + 1])), [allTabs]);
+  const [nameRef, nameTruncated] = useIsTruncated(name);
 
   // Under an active filter a group with no matching cards adds only noise.
   if (filter !== "all" && tabs.length === 0) {
@@ -433,8 +446,9 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
             className="min-w-0 flex-1 rounded border border-accent bg-bg px-1 text-xs text-fg outline-none"
           />
         ) : (
-          <Tooltip label={name} className="min-w-0 flex-1">
+          <Tooltip label={nameTruncated && name} className="min-w-0 flex-1">
             <button
+              ref={nameRef}
               type="button"
               onClick={() => {
                 setActiveSpace(id);

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -216,13 +216,14 @@ function SessionRow({
   showStatus: boolean;
 }) {
   const label = agentLabel(session.agent);
+  const title = sessionTitle(session, titles);
   return (
     <span className="flex items-center gap-1.5">
       {showStatus && <StatusBadge status={session.status} />}
       {label && <span className="shrink-0 text-[11px] text-fg-subtle">{label}</span>}
-      <span className="min-w-0 flex-1 truncate text-[11px] text-fg-muted">
-        {sessionTitle(session, titles)}
-      </span>
+      <Tooltip label={title} className="min-w-0 flex-1">
+        <span className="min-w-0 flex-1 truncate text-[11px] text-fg-muted">{title}</span>
+      </Tooltip>
     </span>
   );
 }
@@ -329,7 +330,9 @@ function TabCard({ tab, index }: { tab: Tab; index: number }) {
               className="min-w-0 flex-1 rounded border border-accent bg-bg px-1 text-xs text-fg outline-none"
             />
           ) : (
-            <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">{title}</span>
+            <Tooltip label={title} className="min-w-0 flex-1">
+              <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">{title}</span>
+            </Tooltip>
           )}
           {!multi && card.status && status && <StatusBadge status={status} />}
           {!multi && card.status && status && label && (
@@ -430,16 +433,18 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
             className="min-w-0 flex-1 rounded border border-accent bg-bg px-1 text-xs text-fg outline-none"
           />
         ) : (
-          <button
-            type="button"
-            onClick={() => {
-              setActiveSpace(id);
-              setCollapsed((c) => !c);
-            }}
-            className="min-w-0 flex-1 truncate text-left text-xs font-semibold text-fg"
-          >
-            {name}
-          </button>
+          <Tooltip label={name} className="min-w-0 flex-1">
+            <button
+              type="button"
+              onClick={() => {
+                setActiveSpace(id);
+                setCollapsed((c) => !c);
+              }}
+              className="min-w-0 flex-1 truncate text-left text-xs font-semibold text-fg"
+            >
+              {name}
+            </button>
+          </Tooltip>
         )}
 
         {!editing && (


### PR DESCRIPTION
## Summary

Long titles in the workspace sidebar truncate with an ellipsis (e.g. `Debug undef...`) and there was no way to read the full name. This PR shows the full title in a tooltip when hovering the card, with two refinements from review:

- **Card-wide hover**: the tooltip triggers from anywhere on the tab card, not just the title text.
- **Only when truncated**: the tooltip appears only when the title is actually cut off; titles that fit stay quiet.

Space (group) names and per-session rows in multi-agent cards get the same treatment.

## Implementation

- `Tooltip` gains a nesting context: a nested tooltip (PR badge, session rows) suppresses its nearest ancestor tooltip while hovered, so wrapping the whole card in a `Tooltip` never stacks two tooltips. The suppression is released (and the ancestor re-arms) when the pointer moves off the nested element, including when it unmounts mid-hover.
- New `useIsTruncated` hook reports horizontal overflow via a callback ref + `ResizeObserver`, re-measuring on text changes, and gates the tooltip label (falsy label = no tooltip, which `Tooltip` already supports).
- Native `title` attributes are intentionally not used: the macOS WebView often ignores them (documented in `Tooltip.tsx`).

## Test plan

- `tsc --noEmit` passes
- Full `vitest run` — 207 files / 1814 tests pass, including new tests for tooltip nesting suppression and `useIsTruncated`
- Manual: hover a truncated card title anywhere on the card and confirm the full name appears; short titles show no tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)