### PR TITLE
fix(workspace): make the whole space header row toggle collapse

### DIFF
--- a/src/modules/workspace/WorkspacePanel.test.tsx
+++ b/src/modules/workspace/WorkspacePanel.test.tsx
@@ -90,6 +90,13 @@ describe("WorkspacePanel", () => {
     expect(screen.queryByText("beta")).not.toBeInTheDocument();
   });
 
+  it("puts the chevron and folder inside the collapse toggle so the whole row toggles", () => {
+    render(<WorkspacePanel />);
+    const toggle = screen.getByRole("button", { name: /Salon/ });
+    // Chevron + folder icons — clicking them must hit the toggle button.
+    expect(toggle.querySelectorAll("svg").length).toBeGreaterThanOrEqual(2);
+  });
+
   it("shows a Claude status badge on a card whose cwd has a running session", () => {
     useSessionStatusStore.setState({ statuses: { p1: "active" } });
     render(<WorkspacePanel />);

--- a/src/modules/workspace/WorkspacePanel.test.tsx
+++ b/src/modules/workspace/WorkspacePanel.test.tsx
@@ -97,6 +97,22 @@ describe("WorkspacePanel", () => {
     expect(toggle.querySelectorAll("svg").length).toBeGreaterThanOrEqual(2);
   });
 
+  it("keeps the active space and tab untouched when another group is toggled", () => {
+    useTabsStore.setState({
+      ...useTabsStore.getState(),
+      spaces: [
+        { id: "s1", name: "Salon" },
+        { id: "s2", name: "Studio" },
+      ],
+      activeSpaceId: "s2",
+      activeId: "t1",
+    });
+    render(<WorkspacePanel />);
+    fireEvent.click(screen.getByRole("button", { name: /Salon/ }));
+    expect(useTabsStore.getState().activeSpaceId).toBe("s2");
+    expect(useTabsStore.getState().activeId).toBe("t1");
+  });
+
   it("shows a Claude status badge on a card whose cwd has a running session", () => {
     useSessionStatusStore.setState({ statuses: { p1: "active" } });
     render(<WorkspacePanel />);

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -453,10 +453,9 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
             <button
               type="button"
               aria-expanded={!collapsed}
-              onClick={() => {
-                setActiveSpace(id);
-                setCollapsed((c) => !c);
-              }}
+              // Collapse/expand only — activating the space here would yank
+              // the main view over to this group's tab.
+              onClick={() => setCollapsed((c) => !c)}
               className="flex min-w-0 flex-1 items-center gap-1 text-left"
             >
               {collapsed ? (

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -426,37 +426,47 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
   return (
     <section className="space-y-1.5">
       <div className="group flex items-center gap-1 rounded-md px-1.5 py-1 hover:bg-bg-elevated">
-        {collapsed ? (
-          <ChevronRight size={13} className="shrink-0 text-fg-subtle" />
-        ) : (
-          <ChevronDown size={13} className="shrink-0 text-fg-subtle" />
-        )}
-        <Folder size={14} className="shrink-0 text-fg-subtle" />
-
         {editing ? (
-          <input
-            autoFocus
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onBlur={commitRename}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") commitRename();
-              if (e.key === "Escape") setEditing(false);
-            }}
-            className="min-w-0 flex-1 rounded border border-accent bg-bg px-1 text-xs text-fg outline-none"
-          />
+          <>
+            {collapsed ? (
+              <ChevronRight size={13} className="shrink-0 text-fg-subtle" />
+            ) : (
+              <ChevronDown size={13} className="shrink-0 text-fg-subtle" />
+            )}
+            <Folder size={14} className="shrink-0 text-fg-subtle" />
+            <input
+              autoFocus
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onBlur={commitRename}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitRename();
+                if (e.key === "Escape") setEditing(false);
+              }}
+              className="min-w-0 flex-1 rounded border border-accent bg-bg px-1 text-xs text-fg outline-none"
+            />
+          </>
         ) : (
+          // The chevron and folder live inside the toggle button so the whole
+          // row (not just the name text) collapses/expands the group.
           <Tooltip label={nameTruncated && name} className="min-w-0 flex-1">
             <button
-              ref={nameRef}
               type="button"
               onClick={() => {
                 setActiveSpace(id);
                 setCollapsed((c) => !c);
               }}
-              className="min-w-0 flex-1 truncate text-left text-xs font-semibold text-fg"
+              className="flex min-w-0 flex-1 items-center gap-1 text-left"
             >
-              {name}
+              {collapsed ? (
+                <ChevronRight size={13} className="shrink-0 text-fg-subtle" />
+              ) : (
+                <ChevronDown size={13} className="shrink-0 text-fg-subtle" />
+              )}
+              <Folder size={14} className="shrink-0 text-fg-subtle" />
+              <span ref={nameRef} className="min-w-0 flex-1 truncate text-xs font-semibold text-fg">
+                {name}
+              </span>
             </button>
           </Tooltip>
         )}

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -452,6 +452,7 @@ function SpaceGroup({ id, name, filter }: { id: string; name: string; filter: St
           <Tooltip label={nameTruncated && name} className="min-w-0 flex-1">
             <button
               type="button"
+              aria-expanded={!collapsed}
               onClick={() => {
                 setActiveSpace(id);
                 setCollapsed((c) => !c);


### PR DESCRIPTION
## Summary

Clicking the chevron (or anywhere on the space header row other than the name text) did not collapse/expand the group — the chevron and folder icons sat outside the name button, so the natural click target was dead.

This moves the chevron and folder icons inside the toggle button, making the entire header row (chevron + folder + name) the collapse toggle. The rename/delete/add-tab action buttons on the right are unchanged.

Two follow-ups from review and testing:

- The toggle no longer activates the group's space — previously collapsing a group also yanked the main view over to that group's tab. Switching spaces stays with tab cards and the add-tab button.
- The toggle exposes its state via `aria-expanded` for screen readers.

## Test plan

- `tsc --noEmit` passes
- `vitest run src/modules/workspace` — 82 tests pass, including structural coverage for the row-wide toggle and a regression test that toggling a group leaves the active space/tab untouched
- Manual: click the chevron or the empty area next to the group name and confirm the group collapses without the main view switching tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)