### PR TITLE
feat(explorer): preview images and PDFs from the file explorer

### DIFF
--- a/spec/media-preview/image-preview.md
+++ b/spec/media-preview/image-preview.md
@@ -1,0 +1,48 @@
+# Image Preview
+
+Render images (`png/jpg/jpeg/gif/webp/svg/bmp/ico`) in a new `media` pane inside the MAIN webview via `<img src={convertFileSrc(path)}>`.
+
+## User Stories
+
+### US-1: View an image in-app
+**As a** user
+**I want** clicking an image to show it in a viewer pane
+**So that** I do not get garbled binary text in the editor
+
+**Acceptance Criteria**:
+- [ ] The image renders fit-to-pane on `bg-bg`, filename shown in the pane header
+- [ ] A media pane splits/opens/reuses exactly like any other file pane
+- [ ] A broken/denied file shows a load-error message, not a blank pane
+- [ ] The tab icon is an image glyph; the tab title is the filename
+- [ ] All strings are i18n'd (en + zh-Hant)
+
+## Development Tasks
+
+### Rust Layer
+- [ ] None
+
+### IPC Layer (Capability + Permission)
+- [ ] No capability file changes
+- [ ] `tauri.conf.json` → `app.security.csp`: widen `img-src` only — `img-src 'self'` → `img-src 'self' asset: http://asset.localhost`
+- [ ] Security review (document in PR):
+  - Only `img-src` is widened (render-only). `connect-src` is NOT widened, so `fetch()` still cannot read file bytes
+  - The asset scope deny-list already blocks `.ssh`/`.aws`/`.env`/`*.key`/`*.pem`/`id_rsa*`
+  - `script-src 'self'` (no inline/remote scripts) keeps `<img>` injection hard
+  - SVG loaded via `<img>` runs no scripts and loads no external subresources
+  - Residual risk: an injected `<img src="asset://...">` could probe file existence via load/error timing — low, acceptable, least-privilege
+
+### Frontend Layer
+- [ ] `src/modules/terminal/lib/terminalLayout.ts`: add `| { kind: "media"; path: string }` to `PaneContent`
+- [ ] `src/stores/tabsStore.ts`: add `"media"` to `TabKind`; extend `singleLeafContentEquals` with a media path comparison (dedup parity)
+- [ ] New `src/modules/media/MediaTabContent.tsx` (mirror `PreviewTabContent` shell): `PaneHeader` with basename; `<img src={convertFileSrc(path)}>` centered, `object-contain`, on `bg-bg`; `onError` → `t("media:loadError")`; props `{ path, showClose?, onClose? }`
+- [ ] `PaneTabContent.tsx`: lazy `MediaTabContent`; render branch for `kind === "media"`
+- [ ] `TabBar.tsx` + `WorkspacePanel.tsx`: `case "media": return Image;` (lucide) in both `tabIcon` switches
+- [ ] i18n new `media` namespace (config.ts + en/media.json + zh-Hant/media.json)
+
+### Quality Assurance
+- [ ] `MediaTabContent.test.tsx`: renders `<img>` (convertFileSrc mocked to identity) + filename header; `onError` swaps to error text
+- [ ] Manual: click a `.png` → renders; a denied file (`~/.ssh/x.png`) → load-error, not a crash
+- [ ] Manual: temporarily revert the CSP edit → image fails (confirms CSP is the enabler)
+
+## Time Estimate
+- IPC/config: 0.5-1h, Frontend: 3-4h, Testing: 1h — **Subtotal 5-7h**

--- a/spec/media-preview/open-routing.md
+++ b/spec/media-preview/open-routing.md
@@ -1,0 +1,53 @@
+# Open Routing (shared foundation)
+
+Single branch point so every file-open path (sidebar click, file finder, source control, launcher picker, tab-bar drop, pane drop) opens images and PDFs in the right viewer instead of the text editor.
+
+## User Stories
+
+### US-1: One place decides the viewer
+**As a** developer maintaining the open paths
+**I want** file-type routing in one shared helper applied at the store boundary
+**So that** every current and future open path benefits without duplicating logic
+
+**Acceptance Criteria**:
+- [ ] `fileOpenContent(path)` returns `media` for image extensions, `preview` for `.pdf`, `editor` otherwise
+- [ ] Extension match is case-insensitive; a path with no extension opens in the editor
+- [ ] Remote `ssh://` paths are never remapped (they keep opening in the editor)
+- [ ] Clicking, finder-opening, source-control-opening, launcher-picking, and dropping an image or PDF all land in the correct viewer
+- [ ] Tab title for a routed image/PDF is the file basename
+
+## Development Tasks
+
+### Rust Layer
+- [ ] None
+
+### IPC Layer (Capability + Permission)
+- [ ] None (no command, no capability). Routing is pure frontend
+
+### Frontend Layer
+- [ ] New pure module `src/modules/explorer/lib/fileOpenContent.ts`:
+  - `extOf(path)`: lowercased extension without the dot, or "" when none (handles both separators)
+  - `isImagePath` / `isPdfPath` against `IMAGE_EXTS = png/jpg/jpeg/gif/webp/svg/bmp/ico`
+  - `fileOpenContent(path): PaneContent` — `isRemoteUri` → editor; image → `{kind:"media",path}`; pdf → `{kind:"preview", url: fileUrl(path)}`; else editor
+- [ ] `src/stores/tabsStore.ts`: private `resolveFileOpen(content)` remapping editor content; apply in `openFromSidebar` and `openInNewTab` — compute the basename title from the ORIGINAL editor path first, then remap, before the `!activeTab` branch and the split branch
+- [ ] `openEditorTab(path)` (LauncherPanel picker): classify first; `preview` delegates to `openPreviewTab(content.url)`; `media`/`editor` fall through (keep the dedup ONLY for editor)
+- [ ] `PaneTabContent.tsx` drop handlers: `handleDrop` cases editor/launcher/preview → `setPaneContent(tab.id, leafId, fileOpenContent(entry.path))`; split/wrap drop effect uses `fileOpenContent(pendingDrop.entry.path)`; `canDrop` adds `"media"` to the single-file group
+- [ ] Optional (nice-to-have): terminal `onOpenFile` and editor breadcrumb `onSwitchFile` also route through `fileOpenContent`
+
+### Quality Assurance
+- [ ] `fileOpenContent.test.ts`: `.png`/`.PNG`/`.jpeg`/`.svg`/`.ico` → media; `.pdf`/`.PDF` → preview with `file://` url; `.ts`/`README` (no ext) → editor; `ssh://c1/a.png` → editor
+- [ ] `tabsStore.test.ts`: `openFromSidebar` with `/a/pic.png` yields a media leaf + title `pic.png`; `/a/doc.pdf` yields a preview leaf url `file:///a/doc.pdf` + title `doc.pdf`; `openInNewTab` mirrors; `openEditorTab` routes both kinds
+- [ ] Extend `FileTree.test.tsx`: clicking an image row opens a media pane
+
+## Test Script
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Click `logo.png` in the explorer | Opens the image viewer pane, not garbled text |
+| 2 | Click `spec.pdf` | Opens the native PDF preview |
+| 3 | Cmd-P finder, open an image | Same image viewer |
+| 4 | Drop an image onto a terminal pane edge | Splits a media pane |
+| 5 | Click `main.ts` | Still opens the text editor |
+
+## Time Estimate
+- Frontend: 2-3h, Testing: 1h — **Subtotal 3.5-5h**

--- a/spec/media-preview/overview.md
+++ b/spec/media-preview/overview.md
@@ -1,0 +1,60 @@
+# Media Preview (Images + PDFs) Implementation Plan
+
+## Reference Documentation
+- Source: in-repo `src/modules/preview` (existing native-webview preview) and Tauri 2 asset protocol / `convertFileSrc`
+- Key patterns:
+  - `resolvePreviewSrc` builds `asset://localhost/%2F...` for the native child webview (relative-resource-safe)
+  - `convertFileSrc(path)` (from `@tauri-apps/api/core`) is the platform-correct way to reference a local file from the main webview (`asset://localhost/...` on macOS/Linux, `http://asset.localhost/...` on Windows); already mocked to identity in `src/test/setup.ts`
+  - `assetProtocol` is app-security config in `tauri.conf.json`, not a capability permission
+
+## Codebase Analysis
+- assetProtocol is already enabled (`tauri.conf.json` → `app.security.assetProtocol`) with `allow ["**","/**"]` and a secrets deny-list (`.ssh`, `.aws`, `.gnupg`, `.env*`, `*.pem`, `*.key`, `id_rsa*`), `requireLiteralLeadingDot: true`.
+- Main-window CSP has `img-src 'self'`, so an inline `<img src="asset://...">` in the main webview is blocked today.
+- All local file opens funnel through the tabs store:
+  - `openFromSidebar({kind:"editor",path})` → FileTree click, FileTree new-file, FileFinder, Source Control "Open File"
+  - `openInNewTab({kind:"editor",path})` → FileTree context menu, Source Control, tab-bar drop (`dragEntry.ts`)
+  - `openEditorTab(path)` → LauncherPanel file picker
+  - Pane drops → PaneTabContent `handleDrop` / split-drop effect / `onOpenFile`
+- `PaneContent` union lives in `src/modules/terminal/lib/terminalLayout.ts`; `TabKind` in `src/stores/tabsStore.ts`. Two exhaustive `tabIcon` switches (`TabBar.tsx`, `WorkspacePanel.tsx`) compile-force handling of any new kind.
+- `EditorTabContent` reads files as UTF-8 via `fs_read_file`; a binary image/PDF opened today shows garbled/empty text (baseline this feature fixes).
+- Remote files use SFTP (`ssh://` URIs); the asset protocol cannot serve them, so routing must only branch for local paths (`isRemoteUri` guard).
+- No shared `openFile` helper exists today; the store methods are the natural chokepoint.
+
+## Rust / Capability Layer
+- No new `#[tauri::command]` functions
+- No capability or permission JSON changes (assetProtocol is config-level, not a capability permission)
+- Only config edit is one line of CSP (`img-src`), for images. PDFs need no config change (they render in the existing native child webview)
+
+---
+
+## (1) Open Routing (shared foundation)
+Extension classifier + interception in `openFromSidebar` / `openInNewTab` / `openEditorTab` + PaneTabContent drops
+
+→ Details: [open-routing.md](./open-routing.md)
+
+## (2) Image Preview
+CSP `img-src` widening + `media` pane kind + `MediaTabContent` (main-webview `<img>` via `convertFileSrc`)
+
+→ Details: [image-preview.md](./image-preview.md)
+
+## (3) PDF Preview
+Route `.pdf` to the existing native preview webview; no CSP change, no new dependency
+
+→ Details: [pdf-preview.md](./pdf-preview.md)
+
+## Time Estimate Summary
+| Feature | Estimate |
+|---------|----------|
+| (1) Open Routing (shared) | 3.5-5h |
+| (2) Image Preview | 5-7h |
+| (3) PDF Preview | 2-2.5h |
+| **Total** | **10.5-14.5h** |
+
+Recommended implementation order: (2) first (it introduces the `media` pane kind the classifier returns), then (3), then (1) to wire every open path through them.
+
+## Decision Points (diverging from the initial leaning)
+1. PDFs remap to `{kind:"preview", url: fileUrl(path)}` at the shared store chokepoint instead of calling `openPreviewTab` — keeps routing at one branch point, honors caller open semantics, and sets a proper basename title (`openPreviewTab` would title the tab with the raw `file://` string). `openEditorTab` (LauncherPanel) still delegates to `openPreviewTab` for PDFs.
+2. Images stay in the main webview via `<img>` (rejected routing them through the native preview webview: heavier per-image native child webview, floating z-order / overlay-hiding / zoom-scaling baggage). The CSP cost is a single render-only directive widening.
+3. Scope guard: the classifier only branches for LOCAL paths; remote `ssh://` files keep opening in the editor (asset protocol cannot serve SFTP).
+
+Known cosmetic wart (accept or follow-up): a local-PDF preview tab shows the web `Globe` icon and an editable address bar containing the file path.

--- a/spec/media-preview/pdf-preview.md
+++ b/spec/media-preview/pdf-preview.md
@@ -1,0 +1,42 @@
+# PDF Preview
+
+Route `.pdf` to the existing native preview webview (WKWebView on macOS, WebView2 on Windows both render PDFs natively). No pdf.js, no CSP change.
+
+## User Stories
+
+### US-1: View a PDF in-app
+**As a** user
+**I want** clicking a PDF to open it in the native viewer
+**So that** I can read it without leaving the app or bundling pdf.js
+
+**Acceptance Criteria**:
+- [ ] Clicking a `.pdf` opens a `preview` pane that renders the document natively
+- [ ] The tab title is the PDF basename
+- [ ] No CSP change and no new dependency
+- [ ] Works on macOS and Windows
+
+## Development Tasks
+
+### Rust Layer
+- [ ] None (reuses the existing preview commands)
+
+### IPC Layer (Capability + Permission)
+- [ ] None. The native child webview renders the PDF; the main-window CSP does not apply to it
+
+### Frontend Layer
+- [ ] No new component. Routing remaps `.pdf` to `{ kind: "preview", url: fileUrl(path) }`; `resolvePreviewSrc` turns it into `asset://localhost/...`, identical to the existing drop-to-preview of a local file
+- [ ] Title: basename captured from the original path before remap; `useNativePreviewWebview` ignores `asset:` navigations so the title stays put
+- [ ] Known cosmetic (accept or follow-up): a local-PDF preview tab shows the `Globe` tab icon and an editable address bar containing the file path
+
+### Quality Assurance
+- [ ] Covered by the open-routing store tests (`.pdf` → preview url + basename title)
+- [ ] Manual (macOS): click a `.pdf` → WKWebView renders it
+- [ ] Manual (Windows CI build): click a `.pdf` → WebView2 renders it
+
+## Windows Pitfalls (applies to images + PDFs)
+- [ ] Images: always `convertFileSrc`, never hardcode `asset://` (Windows emits `http://asset.localhost/...`; CSP includes both)
+- [ ] PDFs: same path the existing drop-to-preview of a local file uses; if that is broken on Windows, PDFs inherit it — cross-check the `windows-tauri` skill release checklist
+- [ ] WebView2 renders PDF natively (Edge viewer); WKWebView renders PDF natively
+
+## Time Estimate
+- Frontend: 0.5-1h, Testing + Windows verify: 1-1.5h — **Subtotal 2-2.5h**

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost; font-src 'none'; media-src 'none'; worker-src 'none'; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'",
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost; font-src 'none'; media-src 'none'; worker-src 'none'; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'",
       "assetProtocol": {
         "enable": true,
         "scope": {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -7,6 +7,7 @@ import {
   GitCompare,
   Globe,
   History,
+  Image,
   LayoutGrid,
   PanelLeft,
   PanelRight,
@@ -61,6 +62,8 @@ function tabIcon(kind: Tab["kind"]): LucideIcon {
       return FileText;
     case "preview":
       return Globe;
+    case "media":
+      return Image;
     case "git-graph":
       return GitBranch;
     case "diff":

--- a/src/i18n/locales/en/preview.json
+++ b/src/i18n/locales/en/preview.json
@@ -1,5 +1,6 @@
 {
   "title": "Web Preview",
+  "mediaLoadError": "Couldn't load this file",
   "urlPlaceholder": "http://localhost:3000",
   "reload": "Reload",
   "back": "Back",

--- a/src/i18n/locales/zh-Hant/preview.json
+++ b/src/i18n/locales/zh-Hant/preview.json
@@ -1,5 +1,6 @@
 {
   "title": "網頁預覽",
+  "mediaLoadError": "無法載入這個檔案",
   "urlPlaceholder": "http://localhost:3000",
   "reload": "重新載入",
   "back": "上一頁",

--- a/src/modules/explorer/lib/fileOpenContent.test.ts
+++ b/src/modules/explorer/lib/fileOpenContent.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { extOf, fileOpenContent, isImagePath, isPdfPath } from "./fileOpenContent";
+
+describe("extOf", () => {
+  it("lowercases and strips the dot", () => {
+    expect(extOf("/a/Logo.PNG")).toBe("png");
+  });
+
+  it("returns empty for extensionless and dotfiles", () => {
+    expect(extOf("/a/README")).toBe("");
+    expect(extOf("/a/.env")).toBe("");
+  });
+
+  it("handles Windows separators", () => {
+    expect(extOf("C:\\pics\\shot.Jpg")).toBe("jpg");
+  });
+});
+
+describe("fileOpenContent", () => {
+  it("routes image extensions to the media viewer", () => {
+    for (const file of ["/a/x.png", "/a/x.JPEG", "/a/x.gif", "/a/x.webp", "/a/x.svg", "/a/x.ico"]) {
+      expect(fileOpenContent(file)).toEqual({ kind: "media", path: file });
+      expect(isImagePath(file)).toBe(true);
+    }
+  });
+
+  it("routes PDFs to the native preview with a file:// url", () => {
+    expect(fileOpenContent("/a/doc.pdf")).toEqual({ kind: "preview", url: "file:///a/doc.pdf" });
+    expect(isPdfPath("/a/DOC.PDF")).toBe(true);
+  });
+
+  it("routes everything else to the editor", () => {
+    expect(fileOpenContent("/a/main.ts")).toEqual({ kind: "editor", path: "/a/main.ts" });
+    expect(fileOpenContent("/a/README")).toEqual({ kind: "editor", path: "/a/README" });
+  });
+
+  it("never remaps remote ssh:// paths", () => {
+    expect(fileOpenContent("ssh://c1/pics/a.png")).toEqual({
+      kind: "editor",
+      path: "ssh://c1/pics/a.png",
+    });
+  });
+});

--- a/src/modules/explorer/lib/fileOpenContent.ts
+++ b/src/modules/explorer/lib/fileOpenContent.ts
@@ -1,0 +1,40 @@
+import { fileUrl } from "./dragEntry";
+import { isRemoteUri } from "@/modules/ssh/lib/remotePath";
+import type { PaneContent } from "@/modules/terminal/lib/terminalLayout";
+
+const IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico"]);
+
+/** Lowercased extension without the dot, or "" when there is none. */
+export function extOf(path: string): string {
+  const name = path.replace(/[\\/]+$/, "").split(/[\\/]/).pop() ?? "";
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(dot + 1).toLowerCase() : "";
+}
+
+export function isImagePath(path: string): boolean {
+  return IMAGE_EXTS.has(extOf(path));
+}
+
+export function isPdfPath(path: string): boolean {
+  return extOf(path) === "pdf";
+}
+
+/**
+ * Map a LOCAL file path to the pane content that should render it: images get
+ * the in-app media viewer, PDFs the native preview webview, everything else
+ * the text editor. Remote (ssh://) paths are never remapped — the asset
+ * protocol only serves local files, so SFTP images/PDFs keep opening in the
+ * editor.
+ */
+export function fileOpenContent(path: string): PaneContent {
+  if (isRemoteUri(path)) {
+    return { kind: "editor", path };
+  }
+  if (isImagePath(path)) {
+    return { kind: "media", path };
+  }
+  if (isPdfPath(path)) {
+    return { kind: "preview", url: fileUrl(path) };
+  }
+  return { kind: "editor", path };
+}

--- a/src/modules/media/MediaTabContent.test.tsx
+++ b/src/modules/media/MediaTabContent.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MediaTabContent } from "./MediaTabContent";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("MediaTabContent", () => {
+  it("renders the image through the asset url with the filename in the header", () => {
+    render(<MediaTabContent path="/pics/shot.png" showClose={false} />);
+    // convertFileSrc is mocked to identity in the test setup.
+    expect(screen.getByRole("img", { name: "shot.png" })).toHaveAttribute(
+      "src",
+      "/pics/shot.png",
+    );
+    expect(screen.getByText("shot.png")).toBeInTheDocument();
+  });
+
+  it("shows a load error instead of a blank pane when the file cannot render", () => {
+    render(<MediaTabContent path="/pics/broken.png" showClose={false} />);
+    fireEvent.error(screen.getByRole("img"));
+    expect(screen.getByText("mediaLoadError")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("folds the pane close button into the header row", () => {
+    const onClose = vi.fn();
+    render(<MediaTabContent path="/pics/shot.png" showClose onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/media/MediaTabContent.tsx
+++ b/src/modules/media/MediaTabContent.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { convertFileSrc } from "@tauri-apps/api/core";
+import { PaneHeader } from "@/components/PaneHeader";
+
+/**
+ * In-app viewer for a local image file, rendered in the main webview through
+ * the asset protocol (`convertFileSrc` emits the platform-correct URL). The
+ * existing asset-scope deny-list applies, so a blocked or unreadable file
+ * surfaces as the load-error message rather than a blank pane.
+ */
+export function MediaTabContent({
+  path,
+  showClose = false,
+  onClose,
+}: {
+  path: string;
+  showClose?: boolean;
+  onClose?: () => void;
+}) {
+  const { t } = useTranslation("preview");
+  const [failed, setFailed] = useState(false);
+  const name = path.split(/[\\/]/).pop() ?? path;
+
+  // A pane can be retargeted to another image; the error state is per file.
+  useEffect(() => {
+    setFailed(false);
+  }, [path]);
+
+  return (
+    <div className="flex h-full flex-col bg-bg">
+      <PaneHeader
+        left={<span className="min-w-0 truncate text-xs text-fg-muted">{name}</span>}
+        showClose={showClose}
+        onClose={() => onClose?.()}
+      />
+      {failed ? (
+        <p className="px-3 py-2 text-xs text-danger">{t("mediaLoadError")}</p>
+      ) : (
+        <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
+          <img
+            src={convertFileSrc(path)}
+            alt={name}
+            onError={() => setFailed(true)}
+            className="max-h-full max-w-full object-contain"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -38,6 +38,9 @@ const SessionsTabContent = lazy(() =>
     default: m.SessionsTabContent,
   })),
 );
+const MediaTabContent = lazy(() =>
+  import("@/modules/media/MediaTabContent").then((m) => ({ default: m.MediaTabContent })),
+);
 import { LauncherPanel } from "@/components/LauncherPanel";
 import { dropOverlayClassName, outerBandOverlayClassName } from "@/components/EntryDropOverlay";
 import { InfoDialog } from "@/components/InfoDialog";
@@ -49,6 +52,7 @@ import {
   useEntryDragStore,
   type DraggedEntry,
 } from "@/modules/explorer/lib/dragEntry";
+import { fileOpenContent } from "@/modules/explorer/lib/fileOpenContent";
 import { insertLinkIntoNote } from "@/modules/notes/lib/noteBus";
 import { useNoteDragStore } from "@/modules/notes/lib/noteDrag";
 import { useSshDragStore } from "@/modules/ssh/lib/sshDrag";
@@ -196,6 +200,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
     if (
       content.kind === "editor" ||
       content.kind === "preview" ||
+      content.kind === "media" ||
       content.kind === "launcher"
     ) {
       return !entry.isDir;
@@ -212,8 +217,9 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
         }
         break;
       case "editor":
+      case "media":
         if (!entry.isDir) {
-          setPaneContent(tab.id, leafId, { kind: "editor", path: entry.path });
+          setPaneContent(tab.id, leafId, fileOpenContent(entry.path));
         }
         break;
       case "note":
@@ -221,13 +227,20 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
         break;
       case "preview":
         if (!entry.isDir) {
-          setPaneContent(tab.id, leafId, { kind: "preview", url: fileUrl(entry.path) });
+          // A dropped image still replaces the preview with the media viewer;
+          // any other file keeps the existing show-in-preview behavior.
+          const routed = fileOpenContent(entry.path);
+          setPaneContent(
+            tab.id,
+            leafId,
+            routed.kind === "media" ? routed : { kind: "preview", url: fileUrl(entry.path) },
+          );
         }
         break;
       case "launcher":
         // Drop a file onto a freshly split pane to open it right there.
         if (!entry.isDir) {
-          setPaneContent(tab.id, leafId, { kind: "editor", path: entry.path });
+          setPaneContent(tab.id, leafId, fileOpenContent(entry.path));
         }
         break;
     }
@@ -279,7 +292,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
       useEntryDragStore.getState().clearPendingDrop();
       return;
     }
-    const newContent: PaneContent = { kind: "editor", path: pendingDrop.entry.path };
+    const newContent: PaneContent = fileOpenContent(pendingDrop.entry.path);
     if (zone.scope === "individual") {
       splitPaneWith(tab.id, pendingDrop.leafId, newContent, zone.direction, zone.anchor);
     } else {
@@ -490,6 +503,12 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                     })}
                     onNavigate={(url) => navigatePreview(tab.id, pane.id, url)}
                     onTitle={(title) => setPreviewTabTitle(tab.id, pane.id, title)}
+                    showClose={multiple}
+                    onClose={() => closePaneAndHistory(pane.id)}
+                  />
+                ) : pane.content.kind === "media" ? (
+                  <MediaTabContent
+                    path={pane.content.path}
                     showClose={multiple}
                     onClose={() => closePaneAndHistory(pane.id)}
                   />

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -17,6 +17,7 @@ export type PaneContent =
   | { kind: "editor"; path: string }
   | { kind: "note"; noteId: string }
   | { kind: "preview"; url: string }
+  | { kind: "media"; path: string }
   | { kind: "git-graph" }
   | { kind: "diff"; path: string; staged: boolean }
   | { kind: "sessions" }

--- a/src/modules/workspace/WorkspacePanel.tsx
+++ b/src/modules/workspace/WorkspacePanel.tsx
@@ -11,6 +11,7 @@ import {
   GitPullRequest,
   Globe,
   History,
+  Image,
   LayoutGrid,
   Pencil,
   Plus,
@@ -56,6 +57,8 @@ function tabIcon(kind: TabKind): LucideIcon {
       return FileText;
     case "preview":
       return Globe;
+    case "media":
+      return Image;
     case "git-graph":
       return GitBranch;
     case "diff":

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -71,11 +71,13 @@ describe("media/pdf open routing", () => {
     expect(activeTab().kind).toBe("media");
   });
 
-  it("openEditorTab delegates a pdf to the preview tab", () => {
-    useTabsStore.getState().openEditorTab("/a/doc.pdf");
+  it("openEditorTab opens a pdf as a preview tab titled by basename, deduped", () => {
+    const first = useTabsStore.getState().openEditorTab("/a/doc.pdf");
     const tab = activeTab();
     expect(tab.kind).toBe("preview");
+    expect(tab.title).toBe("doc.pdf");
     expect(firstLeafContent(tab)).toEqual({ kind: "preview", url: "file:///a/doc.pdf" });
+    expect(useTabsStore.getState().openEditorTab("/a/doc.pdf")).toBe(first);
   });
 
   it("keeps plain files in the editor", () => {

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -38,6 +38,52 @@ function firstLeafContent(tab: Tab) {
   return paneOf(node);
 }
 
+describe("media/pdf open routing", () => {
+  beforeEach(reset);
+
+  it("openFromSidebar routes an image to a media pane titled by basename", () => {
+    useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/a/pic.png" });
+    const tab = activeTab();
+    expect(tab.kind).toBe("media");
+    expect(tab.title).toBe("pic.png");
+    expect(firstLeafContent(tab)).toEqual({ kind: "media", path: "/a/pic.png" });
+  });
+
+  it("openFromSidebar routes a pdf to a native preview pane titled by basename", () => {
+    useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/a/doc.pdf" });
+    const tab = activeTab();
+    expect(tab.kind).toBe("preview");
+    expect(tab.title).toBe("doc.pdf");
+    expect(firstLeafContent(tab)).toEqual({ kind: "preview", url: "file:///a/doc.pdf" });
+  });
+
+  it("openInNewTab routes images and pdfs the same way", () => {
+    useTabsStore.getState().openInNewTab({ kind: "editor", path: "/a/pic.webp" });
+    expect(firstLeafContent(activeTab())).toEqual({ kind: "media", path: "/a/pic.webp" });
+    useTabsStore.getState().openInNewTab({ kind: "editor", path: "/a/doc.pdf" });
+    expect(firstLeafContent(activeTab()).kind).toBe("preview");
+  });
+
+  it("openEditorTab routes an image to a dedicated media tab and dedups it", () => {
+    const first = useTabsStore.getState().openEditorTab("/a/pic.png");
+    const again = useTabsStore.getState().openEditorTab("/a/pic.png");
+    expect(again).toBe(first);
+    expect(activeTab().kind).toBe("media");
+  });
+
+  it("openEditorTab delegates a pdf to the preview tab", () => {
+    useTabsStore.getState().openEditorTab("/a/doc.pdf");
+    const tab = activeTab();
+    expect(tab.kind).toBe("preview");
+    expect(firstLeafContent(tab)).toEqual({ kind: "preview", url: "file:///a/doc.pdf" });
+  });
+
+  it("keeps plain files in the editor", () => {
+    useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/a/main.ts" });
+    expect(activeTab().kind).toBe("editor");
+  });
+});
+
 describe("openEditorPaths", () => {
   beforeEach(reset);
 

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -545,12 +545,10 @@ export const useTabsStore = create<TabsState>()(
 
   openEditorTab: (path) => {
     const spaceId = get().ensureSpace();
-    // Images and PDFs picked from the launcher route to their viewers; the
-    // PDF case delegates to the preview tab (it manages its own dedup).
+    // Images and PDFs picked from the launcher route to their viewers. All
+    // three kinds share the same dedup and get the file basename as title
+    // (openPreviewTab would title a PDF with its raw file:// url instead).
     const content = fileOpenContent(path);
-    if (content.kind === "preview") {
-      return get().openPreviewTab(content.url);
-    }
     const existing = get().tabs.find(
       (t) =>
         t.kind === content.kind &&

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -6,6 +6,7 @@ import { perWindowStorage } from "@/lib/window";
 import { markFreshSshLeaf } from "@/modules/ssh/lib/freshSshLeaves";
 import { decideHtmlPreviewOpen, previewLocalPath } from "@/modules/preview/lib/htmlPreviewTarget";
 import { fileUrl } from "@/modules/explorer/lib/dragEntry";
+import { fileOpenContent } from "@/modules/explorer/lib/fileOpenContent";
 import {
   computeLayout,
   findPaneContent,
@@ -46,6 +47,7 @@ export type TabKind =
   | "editor"
   | "note"
   | "preview"
+  | "media"
   | "git-graph"
   | "diff"
   | "sessions"
@@ -276,6 +278,16 @@ function previewTitle(url: string): string {
   }
 }
 
+/**
+ * Editor opens re-route by file type (images → media viewer, PDFs → the
+ * native preview); every other content kind passes through untouched. Callers
+ * compute the tab title from the ORIGINAL path before remapping, so a routed
+ * PDF still gets its basename rather than a file:// url as title.
+ */
+function resolveFileOpen(content: PaneContent): PaneContent {
+  return content.kind === "editor" ? fileOpenContent(content.path) : content;
+}
+
 /** True when a tab is a single, unsplit leaf showing exactly `content`. */
 function singleLeafContentEquals(tab: Tab, content: PaneContent): boolean {
   if (tab.paneTree.kind !== "leaf") {
@@ -293,6 +305,9 @@ function singleLeafContentEquals(tab: Tab, content: PaneContent): boolean {
   }
   if (pane.kind === "preview" && content.kind === "preview") {
     return pane.url === content.url;
+  }
+  if (pane.kind === "media" && content.kind === "media") {
+    return pane.path === content.path;
   }
   if (pane.kind === "diff" && content.kind === "diff") {
     return pane.path === content.path && pane.staged === content.staged;
@@ -530,11 +545,17 @@ export const useTabsStore = create<TabsState>()(
 
   openEditorTab: (path) => {
     const spaceId = get().ensureSpace();
+    // Images and PDFs picked from the launcher route to their viewers; the
+    // PDF case delegates to the preview tab (it manages its own dedup).
+    const content = fileOpenContent(path);
+    if (content.kind === "preview") {
+      return get().openPreviewTab(content.url);
+    }
     const existing = get().tabs.find(
       (t) =>
-        t.kind === "editor" &&
+        t.kind === content.kind &&
         t.spaceId === spaceId &&
-        singleLeafContentEquals(t, { kind: "editor", path }),
+        singleLeafContentEquals(t, content),
     );
     if (existing) {
       set({ activeId: existing.id });
@@ -545,9 +566,9 @@ export const useTabsStore = create<TabsState>()(
     const tab: Tab = {
       id,
       spaceId,
-      kind: "editor",
+      kind: content.kind,
       title: basename(path),
-      paneTree: leaf(paneId, { kind: "editor", path }),
+      paneTree: leaf(paneId, content),
       activeLeafId: paneId,
       paneOrder: [paneId],
     };
@@ -697,6 +718,7 @@ export const useTabsStore = create<TabsState>()(
 
     const resolvedTitle =
       title ?? (content.kind === "editor" ? basename(content.path) : "Untitled");
+    content = resolveFileOpen(content);
     const activeTab = get().tabs.find((t) => t.id === get().activeId);
 
     if (!activeTab || activeTab.kind === "launcher") {
@@ -760,6 +782,7 @@ export const useTabsStore = create<TabsState>()(
 
     const resolvedTitle =
       title ?? (content.kind === "editor" ? basename(content.path) : "Untitled");
+    content = resolveFileOpen(content);
     const id = nextTabId();
     const paneId = nextPaneId();
     if (isFreshSsh) {


### PR DESCRIPTION
## Summary

Clicking an image (`png/jpg/jpeg/gif/webp/svg/bmp/ico`) or PDF in the file explorer now opens a proper viewer instead of garbled binary text in the editor.

- **Images**: a new `media` pane renders the file in the main webview via `convertFileSrc` — fit-to-pane, filename in the header, a localized load-error message when the file can't render. Tab icon is an image glyph.
- **PDFs**: routed to the existing native preview webview; WKWebView (macOS) and WebView2 (Windows) both render PDFs natively — **no pdf.js, no new dependency**.
- **Every open path routes**: file-tree click, context-menu "open in new tab", file finder, source control "Open File", launcher picker, tab-bar drop, and pane drops (center + edge-split) all branch through one `fileOpenContent` classifier. Remote `ssh://` files keep opening in the editor (the asset protocol cannot serve SFTP).

## Security

The only config change is one CSP directive: `img-src 'self'` → `img-src 'self' asset: http://asset.localhost` (render-only). The asset-protocol scope and its secrets deny-list (`.ssh`, `.aws`, `.env*`, `*.key`, …) are unchanged; `connect-src`/`script-src`/`object-src`/`frame-src` untouched, so no read-back or exfiltration channel is added.

A dedicated Tauri security review of the diff **passed** (0 critical/high/medium): the widening is least-privilege, no injection path controls the image src, SVG via `<img>` renders in secure static mode (no script execution), and cross-origin canvas tainting blocks pixel read-back. One informational LOW note (image-existence oracle, requires prior script execution in a hardened-CSP webview) — accepted.

## Size

No new dependencies; `MediaTabContent` is code-split like the other non-terminal panes. Bundle/installer size is unaffected.

## Details

Implementation plan in `spec/media-preview/` (three parts: open routing, image preview, PDF preview).

## Test plan

- `tsc --noEmit` passes
- Full `vitest run` — 1864 tests pass, including new suites: `fileOpenContent` classifier, `MediaTabContent`, and tabs-store routing (media pane + basename titles, PDF → preview delegation, dedup, plain files stay in the editor)
- Manual (macOS): click a `.png` → image renders; click a `.pdf` → native PDF viewer; click `.ts` → editor as before; drop an image onto a pane edge → media split
- Windows: covered by CI build; the PDF path reuses the exact asset URL flow the existing drop-to-preview feature uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)