### PR TITLE
docs: add media preview PR #256 to CHANGELOG-NEXT

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -8,6 +8,7 @@
 - 側邊欄的分頁卡片、群組名稱與 session 名稱被截斷時，滑鼠移到卡片任一處會以提示框顯示完整名稱，未截斷時不會出現 (#248)
 - 分頁列的使用中分頁改用新樣式：分頁撐滿分頁列並貼齊底部框線，以強調色底線加上 10% 透明度的同色背景標示，取代原本的圓點 (#252)
 - Diff 分頁可以留評論給 AI agent：滑到某一行點行號左側的 +，在該行下方留下評論；按標頭的紙飛機按鈕，所有評論會按檔案分組、附上行號與程式碼，一次貼進正在執行 Claude 或 Codex 的終端機面板，內容先落在輸入框、確認後才送出；送過的評論會標示已送出並保留供驗收，檔案重新載入時評論依行內容自動跟到新位置，第一次打開 diff 分頁會顯示一次性操作指引 (#254)
+- 檔案總管可以直接預覽圖片與 PDF：點擊圖片（png、jpg、gif、webp、svg 等）會開啟圖片檢視分頁，點擊 PDF 會以系統內建的檢視器開啟；檔案搜尋、source control、launcher 選檔與拖放也都套用相同行為，一般文字檔照舊進編輯器，不新增任何相依套件 (#256)
 
 ### fix
 
@@ -23,6 +24,7 @@
 - Hovering anywhere on a sidebar card reveals the full tab, group, or session name in a tooltip when it is truncated, and stays quiet when it is not (#248)
 - The active tab in the tab bar gets a new look: the tab stretches flush to the bar's bottom border and is marked by an accent underline plus a 10% accent background fill, replacing the leading dot (#252)
 - Diff tabs now take review comments for AI agents: hover a line and click the + left of its line number to comment under it. The paper-plane button in the header batch-sends every comment — grouped by file with line numbers and code anchors — into a terminal pane running Claude or Codex; the prompt lands in the input box for confirmation before sending. Sent comments stay visible (marked "Sent") for verification, comments re-anchor by line content when the file reloads, and a one-time hint introduces the flow on the first diff tab (#254)
+- Images and PDFs now open in proper viewers from the file explorer: clicking an image (png, jpg, gif, webp, svg, …) opens an in-app image pane, and PDFs render in the system's built-in viewer; the file finder, source control, launcher picker, and drag-and-drop all follow the same routing, plain text files keep opening in the editor, and no new dependency is added (#256)
 
 ### fix
 


### PR DESCRIPTION
## Summary

Add the image/PDF preview feature (#256) to `CHANGELOG-NEXT.md` in both languages: in-app image viewer, native PDF rendering, unified routing across all open paths, no new dependency.

## Test plan

- Docs-only change; format matches the existing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)