### PR TITLE
chore: release v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tempo-term",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-term"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-term"
-version = "0.2.2"
+version = "0.3.0"
 description = "TempoTerm - AI-powered terminal, editor and file explorer"
 authors = ["TempoTerm"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TempoTerm",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "identifier": "com.tempoterm.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Bump the four version files to 0.3.0 (package.json, tauri.conf.json, Cargo.toml, Cargo.lock via `cargo update -p tempo-term --offline`).

Minor bump (0.2.2 → 0.3.0): this release ships new feature surfaces — diff review comments for agent sessions, image/PDF preview, sidebar card redesign with AI CLI logomarks, and the new active-tab style. `CHANGELOG-NEXT.md` is fully populated for the release notes.

## Release checklist (after merge)

- [ ] `source ~/.zshrc && ./scripts/release.sh` on master
- [ ] Close milestone v0.3.0
- [ ] Archive the changelog only after Windows CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)