### PR TITLE
fix(git): drop git2 network features to stop linking Homebrew OpenSSL

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2038,8 +2038,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
  "url",
 ]
 
@@ -2980,9 +2978,7 @@ checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -3012,20 +3008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -3625,27 +3607,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4769,7 +4733,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,10 @@ ignore = "0.4"
 grep-regex = "0.1"
 grep-searcher = "0.1"
 grep-matcher = "0.1"
-git2 = "0.19"
+# default-features = false drops the ssh/https transports (libssh2-sys +
+# openssl-sys), which dynamically linked the build machine's Homebrew OpenSSL
+# and crashed at launch on Macs without it (#262). All git2 usage is local-only.
+git2 = { version = "0.19", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "rt", "io-util", "net", "time"] }
 tauri-plugin-dialog = "2.7.1"


### PR DESCRIPTION
Fixes #262

## Root cause

The released macOS binary dynamically links `/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib` (and `libcrypto`), pulled in by git2's default `ssh`/`https` features via `libssh2-sys` → `openssl-sys`. On a Mac without Homebrew's openssl@3, dyld aborts at launch with "Library missing" before the app can show anything. This has been latent since the git integration landed — verified the v0.2.2 release binary carries the same linkage — and only surfaces on machines without Homebrew OpenSSL.

## Fix

Disable git2's default features. Every git2 call site in the app is local-only (`Repository::open`/`discover`, status, diff, log, branch listing — including remote-tracking branches, which read local refs — and commit creation), so libgit2's network transports were never used. `libssh2-sys` and `openssl-sys` drop out of the dependency tree entirely; the user-facing git operations in the terminal go through the git CLI and are unaffected.

## Verification

- `cargo check` and full `cargo test` pass (447 passed, 6 ignored)
- `otool -L target/release/tempo-term` shows no OpenSSL and zero `/opt/homebrew` references
- `openssl-sys` / `libssh2-sys` no longer present in `Cargo.lock`
- Windows: no code change; per-PR `windows-check.yml` gates compilation, and `windows-build.yml` was dispatched on this branch to verify the bundle links (native-crate change per the windows-tauri checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)