### PR TITLE
feat(notes): add paste-to-terminal button on note code blocks

### DIFF
--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -36,6 +36,7 @@
   "preview": "Preview",
   "copy": "Copy",
   "copied": "Copied",
+  "paste": "Paste into terminal",
   "run": "Run in terminal",
   "language": "Language",
   "exitHint": "Cmd + Enter to exit",

--- a/src/i18n/locales/zh-Hant/notes.json
+++ b/src/i18n/locales/zh-Hant/notes.json
@@ -36,6 +36,7 @@
   "preview": "預覽",
   "copy": "複製",
   "copied": "已複製",
+  "paste": "貼到終端機",
   "run": "在終端機執行",
   "language": "語言",
   "exitHint": "Cmd + Enter 跳脫",

--- a/src/modules/notes/NoteEditor.tsx
+++ b/src/modules/notes/NoteEditor.tsx
@@ -18,10 +18,13 @@ import Link from "@tiptap/extension-link";
 import { Markdown } from "tiptap-markdown";
 import { common, createLowlight } from "lowlight";
 import { exitCode } from "@tiptap/pm/commands";
-import { Check, Copy, SquareTerminal } from "lucide-react";
+import { Check, ClipboardPaste, Copy, SquareTerminal } from "lucide-react";
 import { useMemo, useState } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { runCommandInTerminal } from "@/modules/terminal/lib/terminalBus";
+import {
+  pasteIntoActiveTerminal,
+  runCommandInTerminal,
+} from "@/modules/terminal/lib/terminalBus";
 import { isWebUrl } from "@/lib/url";
 import { createSlashCommand } from "./slashCommand";
 import { registerNoteInserter, unregisterNoteInserter } from "./lib/noteBus";
@@ -98,6 +101,16 @@ function CodeBlockView({ node, updateAttributes }: NodeViewProps) {
               className="rounded p-1 text-fg-subtle hover:bg-bg-elevated hover:text-fg"
             >
               {copied ? <Check size={14} className="text-success" /> : <Copy size={14} />}
+            </button>
+          </Tooltip>
+          <Tooltip label={t("paste")}>
+            <button
+              type="button"
+              aria-label={t("paste")}
+              onClick={() => pasteIntoActiveTerminal(node.textContent)}
+              className="rounded p-1 text-fg-subtle hover:bg-bg-elevated hover:text-accent"
+            >
+              <ClipboardPaste size={14} />
             </button>
           </Tooltip>
           {runnable && (

--- a/src/modules/terminal/lib/terminalBus.test.ts
+++ b/src/modules/terminal/lib/terminalBus.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   focusedTerminalOps,
+  pasteIntoActiveTerminal,
   readTerminalBuffer,
+  registerTerminal,
   registerTerminalOps,
   registerTerminalReader,
+  unregisterTerminal,
   unregisterTerminalOps,
   unregisterTerminalReader,
   type TerminalOps,
@@ -92,5 +95,66 @@ describe("terminal ops registry", () => {
     });
     expect(focusedTerminalOps()).toBeNull();
     unregisterTerminalOps("leaf-1");
+  });
+});
+
+describe("pasteIntoActiveTerminal", () => {
+  beforeEach(() => {
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space 1" }],
+      activeSpaceId: "s1",
+      tabs: [
+        {
+          id: "a",
+          spaceId: "s1",
+          title: "a",
+          kind: "terminal",
+          paneTree: leaf("leaf-1", { kind: "terminal" }),
+          activeLeafId: "leaf-1",
+          paneOrder: ["leaf-1"],
+        },
+      ],
+      activeId: "a",
+    });
+  });
+
+  it("pastes through the pane's xterm paste so bracketed paste applies", () => {
+    const ops = makeOps();
+    registerTerminalOps("leaf-1", ops);
+    pasteIntoActiveTerminal("echo hi");
+    expect(ops.paste).toHaveBeenCalledWith("echo hi");
+    unregisterTerminalOps("leaf-1");
+  });
+
+  it("strips trailing newlines so a shell never auto-executes the paste", () => {
+    const ops = makeOps();
+    registerTerminalOps("leaf-1", ops);
+    pasteIntoActiveTerminal("echo hi\n");
+    expect(ops.paste).toHaveBeenCalledWith("echo hi");
+    unregisterTerminalOps("leaf-1");
+  });
+
+  it("keeps interior newlines of a multi-line prompt", () => {
+    const ops = makeOps();
+    registerTerminalOps("leaf-1", ops);
+    pasteIntoActiveTerminal("line one\nline two\r\n");
+    expect(ops.paste).toHaveBeenCalledWith("line one\nline two");
+    unregisterTerminalOps("leaf-1");
+  });
+
+  it("falls back to a raw write when the pane has no ops registered", () => {
+    const write = vi.fn();
+    registerTerminal("leaf-1", write);
+    pasteIntoActiveTerminal("echo hi");
+    expect(write).toHaveBeenCalledWith("echo hi");
+    unregisterTerminal("leaf-1");
+  });
+
+  it("opens a new terminal tab when none exists", () => {
+    useTabsStore.setState({ tabs: [], activeId: null });
+    pasteIntoActiveTerminal("echo hi");
+    const state = useTabsStore.getState();
+    expect(state.tabs).toHaveLength(1);
+    expect(state.tabs[0].kind).toBe("terminal");
   });
 });

--- a/src/modules/terminal/lib/terminalBus.ts
+++ b/src/modules/terminal/lib/terminalBus.ts
@@ -164,32 +164,56 @@ function resolveActiveTerminal(): { tabId: string; leafId: string } | null {
 }
 
 /**
+ * Resolve like `resolveActiveTerminal`, focus the resolved tab, and open a new
+ * terminal tab when none exists anywhere. Returns the target leaf id, or null
+ * when even the freshly created tab is not a terminal.
+ */
+function focusOrCreateTerminal(): string | null {
+  const resolved = resolveActiveTerminal();
+  if (resolved) {
+    useTabsStore.getState().setActive(resolved.tabId);
+    return resolved.leafId;
+  }
+  const root = useWorkspaceStore.getState().rootPath ?? undefined;
+  useTabsStore.getState().newTerminalTab(root);
+  const created = useTabsStore.getState().tabs.find(
+    (t) => t.id === useTabsStore.getState().activeId,
+  );
+  if (!created || created.kind !== "terminal") {
+    return null;
+  }
+  return created.activeLeafId;
+}
+
+/**
  * Run a command in a terminal: reuse the active terminal tab if there is one,
  * otherwise the first terminal in the active space, otherwise open a new one.
  * The command is queued if the target pane's shell is still starting.
  */
 export function runCommandInTerminal(command: string): void {
-  const resolved = resolveActiveTerminal();
-  let leafId: string;
-  if (resolved) {
-    leafId = resolved.leafId;
-    useTabsStore.getState().setActive(resolved.tabId);
-  } else {
-    const root = useWorkspaceStore.getState().rootPath ?? undefined;
-    useTabsStore.getState().newTerminalTab(root);
-    const created = useTabsStore.getState().tabs.find(
-      (t) => t.id === useTabsStore.getState().activeId,
-    );
-    if (!created || created.kind !== "terminal") {
-      return;
-    }
-    leafId = created.activeLeafId;
+  const leafId = focusOrCreateTerminal();
+  if (!leafId) {
+    return;
   }
-
   // CR (`\r`), not LF — the byte Enter sends. Windows' PSReadLine treats LF as
   // a `>>` continuation (never submits); CR submits on every platform. Strip any
   // trailing CR/LF first so a caller-supplied newline can't yield `\n\r`.
   writeToTerminal(leafId, `${command.replace(/[\r\n]+$/, "")}\r`);
+}
+
+/**
+ * Paste text into a terminal for the user to edit and submit themselves,
+ * resolving the target like `runCommandInTerminal`. Goes through the pane's
+ * xterm paste (bracketed paste), so a multi-line prompt lands in an agent's
+ * input box instead of being submitted line by line. Trailing newlines are
+ * stripped so a shell never auto-executes the pasted text.
+ */
+export function pasteIntoActiveTerminal(text: string): void {
+  const leafId = focusOrCreateTerminal();
+  if (!leafId) {
+    return;
+  }
+  pasteToTerminal(leafId, text.replace(/[\r\n]+$/, ""));
 }
 
 /** Read the active terminal's scrollback as plain text, or null if there is


### PR DESCRIPTION
First of two PRs for #263 (quick clipboard for commands & prompts).

## What

- New `pasteIntoActiveTerminal` in the terminal bus: resolves the target like `runCommandInTerminal` (active terminal → first in space → first anywhere → create one), focuses it, and pastes through the pane's xterm `paste()` so bracketed paste applies — a multi-line prompt lands in an agent's input box instead of being submitted line by line. Trailing newlines are stripped so a shell never auto-executes the pasted text.
- Every note code block now shows a "Paste into terminal" button (all languages, so saved prompts work too). The existing run button (paste + submit) stays limited to shell languages.
- `runCommandInTerminal`'s resolve-or-create logic is extracted into a shared helper, no behavior change.

## Testing

- 5 new unit tests for `pasteIntoActiveTerminal` (bracketed paste path, trailing-newline strip, interior newlines kept, raw-write fallback, create-when-missing)
- `pnpm typecheck`, full `pnpm test` (214 files / 1884 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)