### PR TITLE
feat(tabs): middle-click closes a tab

### DIFF
--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -78,6 +78,23 @@ describe("TabBar close button tooltip", () => {
   });
 });
 
+describe("TabBar middle-click close", () => {
+  const auxClick = (el: Element, button: number) =>
+    fireEvent(el, new MouseEvent("auxclick", { bubbles: true, button }));
+
+  it("closes the tab on middle-click (no unsaved changes)", () => {
+    render(<TabBar />);
+    auxClick(screen.getByRole("tab"), 1);
+    expect(useTabsStore.getState().tabs).toHaveLength(0);
+  });
+
+  it("leaves the tab alone on other aux buttons", () => {
+    render(<TabBar />);
+    auxClick(screen.getByRole("tab"), 2);
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+  });
+});
+
 describe("TabBar tab context menu", () => {
   it("opens a context menu with a rename item on right-click", () => {
     render(<TabBar />);

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -125,6 +125,14 @@ function TabItem({ id }: { id: string }) {
       aria-selected={active}
       onClick={() => setActive(tab.id)}
       onDoubleClick={startRename}
+      onAuxClick={(e) => {
+        // Middle-click closes the tab (browser/editor convention). Routed
+        // through requestClose so a dirty editor still gets its confirm dialog.
+        if (e.button === 1) {
+          e.preventDefault();
+          requestClose();
+        }
+      }}
       onContextMenu={(e) => {
         // Right-clicks on the rename input skip the tab menu and bubble to the
         // window-level InputContextMenu, like every other text field.


### PR DESCRIPTION
Closes #85

Middle-clicking a tab now closes it, matching browser/VS Code convention. The handler routes through the same `requestClose` as the tab's ✕ button, so a dirty editor still gets its confirm dialog. Other aux buttons are ignored.

Per the issue discussion, the other requests were resolved as: F2 rename is covered by the existing double-click rename, custom keybindings are out of scope for now (a dedicated issue is welcome if demand grows), and the global summon hotkey is declined (new plugin dependency + conflicts with VS Code).

## Testing

- 2 new TabBar tests (middle-click closes; other aux buttons ignored)
- `pnpm typecheck`, full `pnpm test` (214 files / 1881 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)