### PR TITLE
feat(notes): status-bar quick access to note code blocks

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -7,6 +7,7 @@ import { formatBytes, formatPercent, formatRate, ramPercent } from "@/modules/sy
 import { Tooltip } from "@/components/Tooltip";
 import { PortsIndicator } from "@/modules/ports/PortsIndicator";
 import { WorktreesIndicator } from "@/modules/worktrees/WorktreesIndicator";
+import { NotesQuickAccess } from "@/modules/notes/NotesQuickAccess";
 
 export function StatusBar() {
   const { t } = useTranslation();
@@ -57,6 +58,7 @@ export function StatusBar() {
       )}
 
       <div className="ml-auto flex items-center gap-1">
+        <NotesQuickAccess />
         <WorktreesIndicator />
         <PortsIndicator />
         {showIndicator && (

--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -62,5 +62,10 @@
     "quote": "Quote",
     "code": "Code block",
     "divider": "Divider"
+  },
+  "quickAccess": {
+    "title": "Quick commands",
+    "search": "Search commands and prompts…",
+    "empty": "No code blocks in your notes yet"
   }
 }

--- a/src/i18n/locales/en/notes.json
+++ b/src/i18n/locales/en/notes.json
@@ -36,6 +36,7 @@
   "preview": "Preview",
   "copy": "Copy",
   "copied": "Copied",
+  "paste": "Paste into terminal",
   "run": "Run in terminal",
   "language": "Language",
   "exitHint": "Cmd + Enter to exit",

--- a/src/i18n/locales/zh-Hant/notes.json
+++ b/src/i18n/locales/zh-Hant/notes.json
@@ -36,6 +36,7 @@
   "preview": "預覽",
   "copy": "複製",
   "copied": "已複製",
+  "paste": "貼到終端機",
   "run": "在終端機執行",
   "language": "語言",
   "exitHint": "Cmd + Enter 跳脫",

--- a/src/i18n/locales/zh-Hant/notes.json
+++ b/src/i18n/locales/zh-Hant/notes.json
@@ -62,5 +62,10 @@
     "quote": "引用",
     "code": "程式碼區塊",
     "divider": "分隔線"
+  },
+  "quickAccess": {
+    "title": "快捷命令",
+    "search": "搜尋命令與 prompt…",
+    "empty": "筆記裡還沒有程式碼區塊"
   }
 }

--- a/src/modules/notes/NoteEditor.tsx
+++ b/src/modules/notes/NoteEditor.tsx
@@ -18,10 +18,13 @@ import Link from "@tiptap/extension-link";
 import { Markdown } from "tiptap-markdown";
 import { common, createLowlight } from "lowlight";
 import { exitCode } from "@tiptap/pm/commands";
-import { Check, Copy, SquareTerminal } from "lucide-react";
+import { Check, ClipboardPaste, Copy, SquareTerminal } from "lucide-react";
 import { useMemo, useState } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { runCommandInTerminal } from "@/modules/terminal/lib/terminalBus";
+import {
+  pasteIntoActiveTerminal,
+  runCommandInTerminal,
+} from "@/modules/terminal/lib/terminalBus";
 import { isWebUrl } from "@/lib/url";
 import { createSlashCommand } from "./slashCommand";
 import { registerNoteInserter, unregisterNoteInserter } from "./lib/noteBus";
@@ -98,6 +101,16 @@ function CodeBlockView({ node, updateAttributes }: NodeViewProps) {
               className="rounded p-1 text-fg-subtle hover:bg-bg-elevated hover:text-fg"
             >
               {copied ? <Check size={14} className="text-success" /> : <Copy size={14} />}
+            </button>
+          </Tooltip>
+          <Tooltip label={t("paste")}>
+            <button
+              type="button"
+              aria-label={t("paste")}
+              onClick={() => pasteIntoActiveTerminal(node.textContent)}
+              className="rounded p-1 text-fg-subtle hover:bg-bg-elevated hover:text-accent"
+            >
+              <ClipboardPaste size={14} />
             </button>
           </Tooltip>
           {runnable && (

--- a/src/modules/notes/NoteEditor.tsx
+++ b/src/modules/notes/NoteEditor.tsx
@@ -29,6 +29,7 @@ import { isWebUrl } from "@/lib/url";
 import { createSlashCommand } from "./slashCommand";
 import { registerNoteInserter, unregisterNoteInserter } from "./lib/noteBus";
 import { bashCommandHighlight } from "./lib/bashCommandHighlight";
+import { SHELL_LANGS } from "./lib/codeBlocks";
 import { NoteSearchHighlight } from "./noteSearchHighlight";
 import { Combobox } from "@/components/Combobox";
 import { Tooltip } from "@/components/Tooltip";
@@ -38,7 +39,6 @@ const lowlight = createLowlight(common);
 // Override the stock bash grammar so leading command names (ssh, git, custom
 // scripts) get colored too, not only highlight.js's built-in whitelist.
 lowlight.register("bash", bashCommandHighlight);
-const SHELL_LANGS = new Set(["", "sh", "bash", "zsh", "shell", "console", "terminal"]);
 
 const CODE_LANGS = [
   "text",

--- a/src/modules/notes/NotesQuickAccess.test.tsx
+++ b/src/modules/notes/NotesQuickAccess.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/i18n";
+import { NotesQuickAccess } from "./NotesQuickAccess";
+import { useNotesStore } from "@/stores/notesStore";
+
+const busMocks = vi.hoisted(() => ({
+  pasteIntoActiveTerminal: vi.fn(),
+  runCommandInTerminal: vi.fn(),
+}));
+vi.mock("@/modules/terminal/lib/terminalBus", () => busMocks);
+
+const CONTENTS: Record<string, string> = {
+  "/notes/deploy.md": "```sh\nkubectl get pods\n```",
+  "/notes/prompts.md": "```\nSummarize this repo.\n```\n\n```python\nprint('hi')\n```",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useNotesStore.setState({
+    rootPath: "/notes",
+    tree: [
+      { kind: "note", name: "deploy.md", title: "deploy", path: "/notes/deploy.md", isConflict: false },
+      { kind: "note", name: "prompts.md", title: "prompts", path: "/notes/prompts.md", isConflict: false },
+    ],
+    readNote: (path: string) => Promise.resolve(CONTENTS[path]),
+  });
+});
+
+describe("NotesQuickAccess", () => {
+  it("renders nothing when no notes folder is configured", () => {
+    useNotesStore.setState({ rootPath: null });
+    render(<NotesQuickAccess />);
+    expect(screen.queryByLabelText("Quick commands")).toBeNull();
+  });
+
+  it("lists blocks grouped by note when opened", async () => {
+    render(<NotesQuickAccess />);
+    fireEvent.click(screen.getByLabelText("Quick commands"));
+    await waitFor(() => expect(screen.getByText("deploy")).toBeInTheDocument());
+    expect(screen.getByText("prompts")).toBeInTheDocument();
+    expect(screen.getByText("kubectl get pods")).toBeInTheDocument();
+    expect(screen.getByText("Summarize this repo.")).toBeInTheDocument();
+  });
+
+  it("pastes a block on row click and closes the panel", async () => {
+    render(<NotesQuickAccess />);
+    fireEvent.click(screen.getByLabelText("Quick commands"));
+    await waitFor(() => expect(screen.getByText("kubectl get pods")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("kubectl get pods"));
+    expect(busMocks.pasteIntoActiveTerminal).toHaveBeenCalledWith("kubectl get pods");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("offers paste-and-run only for shell blocks", async () => {
+    render(<NotesQuickAccess />);
+    fireEvent.click(screen.getByLabelText("Quick commands"));
+    await waitFor(() => expect(screen.getByText("kubectl get pods")).toBeInTheDocument());
+    // Two shell-runnable blocks: the sh one and the language-less prompt.
+    // The python block must not offer run.
+    expect(screen.getAllByLabelText("Run in terminal")).toHaveLength(2);
+    fireEvent.click(screen.getAllByLabelText("Run in terminal")[0]);
+    expect(busMocks.runCommandInTerminal).toHaveBeenCalledWith("kubectl get pods");
+  });
+
+  it("filters rows by search text", async () => {
+    render(<NotesQuickAccess />);
+    fireEvent.click(screen.getByLabelText("Quick commands"));
+    await waitFor(() => expect(screen.getByText("kubectl get pods")).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText("Search commands and prompts…"), {
+      target: { value: "summarize" },
+    });
+    expect(screen.queryByText("kubectl get pods")).toBeNull();
+    expect(screen.getByText("Summarize this repo.")).toBeInTheDocument();
+  });
+
+  it("closes on Escape", async () => {
+    render(<NotesQuickAccess />);
+    fireEvent.click(screen.getByLabelText("Quick commands"));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/src/modules/notes/NotesQuickAccess.tsx
+++ b/src/modules/notes/NotesQuickAccess.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ClipboardList, SquareTerminal } from "lucide-react";
+import { Tooltip } from "@/components/Tooltip";
+import { useNotesStore } from "@/stores/notesStore";
+import {
+  pasteIntoActiveTerminal,
+  runCommandInTerminal,
+} from "@/modules/terminal/lib/terminalBus";
+import {
+  collectQuickBlocks,
+  SHELL_LANGS,
+  type NoteQuickBlocks,
+} from "./lib/codeBlocks";
+
+/**
+ * StatusBar quick access to the code blocks saved in notes (#263): a floating
+ * panel over the status bar listing every block grouped by note, searchable.
+ * Clicking a row pastes the block into the active terminal for editing; shell
+ * blocks also offer paste-and-run. The notes files are the single source of
+ * truth — the panel re-scans them each time it opens, so there is no ambient
+ * polling and nothing to keep in sync.
+ */
+export function NotesQuickAccess() {
+  const { t } = useTranslation("notes");
+  const rootPath = useNotesStore((s) => s.rootPath);
+  const tree = useNotesStore((s) => s.tree);
+  const readNote = useNotesStore((s) => s.readNote);
+  const [open, setOpen] = useState(false);
+  const [notes, setNotes] = useState<NoteQuickBlocks[]>([]);
+  const [query, setQuery] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    let cancelled = false;
+    void collectQuickBlocks(tree, readNote).then((result) => {
+      if (!cancelled) {
+        setNotes(result);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, tree, readNote]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onDown = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // No notes folder configured: stay out of the status bar entirely, like the
+  // Ports and Worktrees indicators do when they have nothing to show.
+  if (!rootPath) {
+    return null;
+  }
+
+  const needle = query.trim().toLowerCase();
+  const filtered = notes
+    .map((note) => ({
+      ...note,
+      blocks:
+        needle === ""
+          ? note.blocks
+          : `${note.group} ${note.title}`.toLowerCase().includes(needle)
+            ? note.blocks
+            : note.blocks.filter((b) => b.text.toLowerCase().includes(needle)),
+    }))
+    .filter((note) => note.blocks.length > 0);
+
+  const dismissAnd = (action: () => void) => {
+    setOpen(false);
+    setQuery("");
+    action();
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Tooltip label={t("quickAccess.title")} side="top">
+        <button
+          type="button"
+          aria-label={t("quickAccess.title")}
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+          className={`flex h-5 items-center gap-1 rounded px-1.5 transition-colors hover:text-fg ${
+            open ? "text-fg" : "text-fg-subtle"
+          }`}
+        >
+          <ClipboardList size={14} strokeWidth={1.75} />
+        </button>
+      </Tooltip>
+      {open && (
+        <div
+          role="dialog"
+          aria-label={t("quickAccess.title")}
+          className="absolute bottom-7 right-0 z-50 flex max-h-96 w-96 flex-col overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-xl"
+        >
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t("quickAccess.search")}
+            className="m-2 rounded border border-border bg-bg px-2 py-1 text-xs text-fg outline-none focus:border-accent"
+          />
+          <div className="overflow-y-auto pb-1">
+            {filtered.length === 0 && (
+              <p className="px-3 py-4 text-center text-xs text-fg-subtle">
+                {t("quickAccess.empty")}
+              </p>
+            )}
+            {filtered.map((note) => (
+              <section key={note.path}>
+                <h3 className="truncate px-3 pb-0.5 pt-2 text-[11px] font-medium text-fg-subtle">
+                  {note.group ? `${note.group} / ${note.title}` : note.title}
+                </h3>
+                {note.blocks.map((block, i) => (
+                  <div
+                    key={`${note.path}:${i}`}
+                    className="group flex items-center gap-2 px-3 py-1 hover:bg-bg"
+                  >
+                    {/* Row click = paste for editing; the terminal icon on
+                        shell blocks is the explicit paste-and-run action. */}
+                    <button
+                      type="button"
+                      title={t("paste")}
+                      onClick={() => dismissAnd(() => pasteIntoActiveTerminal(block.text))}
+                      className="min-w-0 flex-1 truncate text-left font-mono text-xs text-fg-muted group-hover:text-fg"
+                    >
+                      {block.text.split("\n")[0]}
+                    </button>
+                    {block.text.includes("\n") && (
+                      <span aria-hidden className="text-[10px] text-fg-subtle">
+                        ⋮
+                      </span>
+                    )}
+                    {SHELL_LANGS.has(block.lang) && (
+                      <Tooltip label={t("run")} side="top">
+                        <button
+                          type="button"
+                          aria-label={t("run")}
+                          onClick={() => dismissAnd(() => runCommandInTerminal(block.text))}
+                          className="rounded p-0.5 text-fg-subtle opacity-0 transition-opacity hover:text-accent group-hover:opacity-100"
+                        >
+                          <SquareTerminal size={13} />
+                        </button>
+                      </Tooltip>
+                    )}
+                  </div>
+                ))}
+              </section>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/modules/notes/lib/codeBlocks.test.ts
+++ b/src/modules/notes/lib/codeBlocks.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { collectQuickBlocks, extractCodeBlocks, SHELL_LANGS } from "./codeBlocks";
+import type { NotesNode } from "./notesTree";
+
+describe("extractCodeBlocks", () => {
+  it("extracts fenced blocks with their language", () => {
+    const md = [
+      "# Title",
+      "",
+      "```bash",
+      "git status",
+      "```",
+      "",
+      "some prose",
+      "",
+      "```",
+      "You are a helpful reviewer.",
+      "Review the diff below.",
+      "```",
+    ].join("\n");
+    expect(extractCodeBlocks(md)).toEqual([
+      { lang: "bash", text: "git status" },
+      { lang: "", text: "You are a helpful reviewer.\nReview the diff below." },
+    ]);
+  });
+
+  it("skips empty and unterminated blocks", () => {
+    const md = ["```sh", "```", "", "```bash", "echo unterminated"].join("\n");
+    expect(extractCodeBlocks(md)).toEqual([]);
+  });
+
+  it("does not treat indented backticks inside a block as a closing fence", () => {
+    const md = ["```js", "const s = `template`;", "```"].join("\n");
+    expect(extractCodeBlocks(md)).toEqual([{ lang: "js", text: "const s = `template`;" }]);
+  });
+});
+
+describe("collectQuickBlocks", () => {
+  const tree: NotesNode[] = [
+    {
+      kind: "folder",
+      name: "ops",
+      path: "/notes/ops",
+      children: [
+        {
+          kind: "note",
+          name: "deploy.md",
+          title: "deploy",
+          path: "/notes/ops/deploy.md",
+          isConflict: false,
+        },
+      ],
+    },
+    { kind: "note", name: "prompts.md", title: "prompts", path: "/notes/prompts.md", isConflict: false },
+    { kind: "note", name: "empty.md", title: "empty", path: "/notes/empty.md", isConflict: false },
+  ];
+  const contents: Record<string, string> = {
+    "/notes/ops/deploy.md": "```sh\nkubectl get pods\n```",
+    "/notes/prompts.md": "```\nSummarize this file.\n```",
+    "/notes/empty.md": "no fences here",
+  };
+
+  it("walks folders, keeps only notes with blocks, and labels groups by folder", async () => {
+    const result = await collectQuickBlocks(tree, (path) => Promise.resolve(contents[path]));
+    expect(result).toEqual([
+      {
+        path: "/notes/ops/deploy.md",
+        title: "deploy",
+        group: "ops",
+        blocks: [{ lang: "sh", text: "kubectl get pods" }],
+      },
+      {
+        path: "/notes/prompts.md",
+        title: "prompts",
+        group: "",
+        blocks: [{ lang: "", text: "Summarize this file." }],
+      },
+    ]);
+  });
+
+  it("drops notes whose read fails instead of failing the whole scan", async () => {
+    const result = await collectQuickBlocks(tree, (path) =>
+      path === "/notes/prompts.md"
+        ? Promise.reject(new Error("gone"))
+        : Promise.resolve(contents[path]),
+    );
+    expect(result.map((n) => n.title)).toEqual(["deploy"]);
+  });
+});
+
+describe("SHELL_LANGS", () => {
+  it("treats the language-less block as runnable, matching the note editor", () => {
+    expect(SHELL_LANGS.has("")).toBe(true);
+    expect(SHELL_LANGS.has("bash")).toBe(true);
+    expect(SHELL_LANGS.has("python")).toBe(false);
+  });
+});

--- a/src/modules/notes/lib/codeBlocks.ts
+++ b/src/modules/notes/lib/codeBlocks.ts
@@ -1,0 +1,81 @@
+import type { NotesNode } from "./notesTree";
+
+/**
+ * Fenced code blocks harvested from notes, powering the status-bar quick
+ * access (#263): every block a note holds is a paste-able command/prompt.
+ * Extraction is pure string work so it stays unit-testable.
+ */
+
+/** Languages whose blocks are safe to paste-and-submit as shell commands.
+ *  The empty string covers blocks with no language set. */
+export const SHELL_LANGS = new Set(["", "sh", "bash", "zsh", "shell", "console", "terminal"]);
+
+export interface QuickBlock {
+  lang: string;
+  text: string;
+}
+
+export interface NoteQuickBlocks {
+  path: string;
+  title: string;
+  /** Folder path relative to the notes root ("" for top-level notes). */
+  group: string;
+  blocks: QuickBlock[];
+}
+
+/**
+ * Extract fenced code blocks (``` fences at line start, as tiptap-markdown
+ * writes them). Empty and unterminated blocks are skipped — a fence the user
+ * is still typing should not surface half a note as a "command".
+ */
+export function extractCodeBlocks(markdown: string): QuickBlock[] {
+  const blocks: QuickBlock[] = [];
+  const lines = markdown.split("\n");
+  let open: { lang: string; body: string[] } | null = null;
+  for (const line of lines) {
+    const fence = /^```(\S*)\s*$/.exec(line);
+    if (open) {
+      if (fence && fence[1] === "") {
+        const text = open.body.join("\n");
+        if (text.trim()) {
+          blocks.push({ lang: open.lang, text });
+        }
+        open = null;
+      } else {
+        open.body.push(line);
+      }
+    } else if (fence) {
+      open = { lang: fence[1].toLowerCase(), body: [] };
+    }
+  }
+  return blocks;
+}
+
+/**
+ * Walk the notes tree and read every note, returning the ones that contain at
+ * least one code block, in tree order. A note that fails to read (deleted
+ * mid-scan, cloud placeholder) is dropped rather than failing the whole scan.
+ */
+export async function collectQuickBlocks(
+  nodes: NotesNode[],
+  readNote: (path: string) => Promise<string>,
+  group = "",
+): Promise<NoteQuickBlocks[]> {
+  const results: NoteQuickBlocks[] = [];
+  for (const node of nodes) {
+    if (node.kind === "folder") {
+      const childGroup = group ? `${group} / ${node.name}` : node.name;
+      results.push(...(await collectQuickBlocks(node.children, readNote, childGroup)));
+    } else {
+      const content = await readNote(node.path).catch(() => null);
+      if (content === null) {
+        continue;
+      }
+      const blocks = extractCodeBlocks(content);
+      if (blocks.length > 0) {
+        results.push({ path: node.path, title: node.title, group, blocks });
+      }
+    }
+  }
+  return results;
+}

--- a/src/modules/terminal/lib/terminalBus.test.ts
+++ b/src/modules/terminal/lib/terminalBus.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   focusedTerminalOps,
+  pasteIntoActiveTerminal,
   readTerminalBuffer,
+  registerTerminal,
   registerTerminalOps,
   registerTerminalReader,
+  unregisterTerminal,
   unregisterTerminalOps,
   unregisterTerminalReader,
   type TerminalOps,
@@ -92,5 +95,66 @@ describe("terminal ops registry", () => {
     });
     expect(focusedTerminalOps()).toBeNull();
     unregisterTerminalOps("leaf-1");
+  });
+});
+
+describe("pasteIntoActiveTerminal", () => {
+  beforeEach(() => {
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space 1" }],
+      activeSpaceId: "s1",
+      tabs: [
+        {
+          id: "a",
+          spaceId: "s1",
+          title: "a",
+          kind: "terminal",
+          paneTree: leaf("leaf-1", { kind: "terminal" }),
+          activeLeafId: "leaf-1",
+          paneOrder: ["leaf-1"],
+        },
+      ],
+      activeId: "a",
+    });
+  });
+
+  it("pastes through the pane's xterm paste so bracketed paste applies", () => {
+    const ops = makeOps();
+    registerTerminalOps("leaf-1", ops);
+    pasteIntoActiveTerminal("echo hi");
+    expect(ops.paste).toHaveBeenCalledWith("echo hi");
+    unregisterTerminalOps("leaf-1");
+  });
+
+  it("strips trailing newlines so a shell never auto-executes the paste", () => {
+    const ops = makeOps();
+    registerTerminalOps("leaf-1", ops);
+    pasteIntoActiveTerminal("echo hi\n");
+    expect(ops.paste).toHaveBeenCalledWith("echo hi");
+    unregisterTerminalOps("leaf-1");
+  });
+
+  it("keeps interior newlines of a multi-line prompt", () => {
+    const ops = makeOps();
+    registerTerminalOps("leaf-1", ops);
+    pasteIntoActiveTerminal("line one\nline two\r\n");
+    expect(ops.paste).toHaveBeenCalledWith("line one\nline two");
+    unregisterTerminalOps("leaf-1");
+  });
+
+  it("falls back to a raw write when the pane has no ops registered", () => {
+    const write = vi.fn();
+    registerTerminal("leaf-1", write);
+    pasteIntoActiveTerminal("echo hi");
+    expect(write).toHaveBeenCalledWith("echo hi");
+    unregisterTerminal("leaf-1");
+  });
+
+  it("opens a new terminal tab when none exists", () => {
+    useTabsStore.setState({ tabs: [], activeId: null });
+    pasteIntoActiveTerminal("echo hi");
+    const state = useTabsStore.getState();
+    expect(state.tabs).toHaveLength(1);
+    expect(state.tabs[0].kind).toBe("terminal");
   });
 });

--- a/src/modules/terminal/lib/terminalBus.ts
+++ b/src/modules/terminal/lib/terminalBus.ts
@@ -164,32 +164,56 @@ function resolveActiveTerminal(): { tabId: string; leafId: string } | null {
 }
 
 /**
+ * Resolve like `resolveActiveTerminal`, focus the resolved tab, and open a new
+ * terminal tab when none exists anywhere. Returns the target leaf id, or null
+ * when even the freshly created tab is not a terminal.
+ */
+function focusOrCreateTerminal(): string | null {
+  const resolved = resolveActiveTerminal();
+  if (resolved) {
+    useTabsStore.getState().setActive(resolved.tabId);
+    return resolved.leafId;
+  }
+  const root = useWorkspaceStore.getState().rootPath ?? undefined;
+  useTabsStore.getState().newTerminalTab(root);
+  const created = useTabsStore.getState().tabs.find(
+    (t) => t.id === useTabsStore.getState().activeId,
+  );
+  if (!created || created.kind !== "terminal") {
+    return null;
+  }
+  return created.activeLeafId;
+}
+
+/**
  * Run a command in a terminal: reuse the active terminal tab if there is one,
  * otherwise the first terminal in the active space, otherwise open a new one.
  * The command is queued if the target pane's shell is still starting.
  */
 export function runCommandInTerminal(command: string): void {
-  const resolved = resolveActiveTerminal();
-  let leafId: string;
-  if (resolved) {
-    leafId = resolved.leafId;
-    useTabsStore.getState().setActive(resolved.tabId);
-  } else {
-    const root = useWorkspaceStore.getState().rootPath ?? undefined;
-    useTabsStore.getState().newTerminalTab(root);
-    const created = useTabsStore.getState().tabs.find(
-      (t) => t.id === useTabsStore.getState().activeId,
-    );
-    if (!created || created.kind !== "terminal") {
-      return;
-    }
-    leafId = created.activeLeafId;
+  const leafId = focusOrCreateTerminal();
+  if (!leafId) {
+    return;
   }
-
   // CR (`\r`), not LF — the byte Enter sends. Windows' PSReadLine treats LF as
   // a `>>` continuation (never submits); CR submits on every platform. Strip any
   // trailing CR/LF first so a caller-supplied newline can't yield `\n\r`.
   writeToTerminal(leafId, `${command.replace(/[\r\n]+$/, "")}\r`);
+}
+
+/**
+ * Paste text into a terminal for the user to edit and submit themselves,
+ * resolving the target like `runCommandInTerminal`. Goes through the pane's
+ * xterm paste (bracketed paste), so a multi-line prompt lands in an agent's
+ * input box instead of being submitted line by line. Trailing newlines are
+ * stripped so a shell never auto-executes the pasted text.
+ */
+export function pasteIntoActiveTerminal(text: string): void {
+  const leafId = focusOrCreateTerminal();
+  if (!leafId) {
+    return;
+  }
+  pasteToTerminal(leafId, text.replace(/[\r\n]+$/, ""));
 }
 
 /** Read the active terminal's scrollback as plain text, or null if there is


### PR DESCRIPTION
Closes #263

Second of two PRs for #263, **stacked on #268** (uses its `pasteIntoActiveTerminal`) — merge #268 first, then retarget/merge this one.

## What

- A ClipboardList indicator in the status bar (hidden until a notes folder is configured, like Ports/Worktrees) opens a floating panel listing every code block saved in notes: grouped by folder/note title, searchable, sourced by re-scanning the notes files on each open — no ambient polling, no new data model, no new dependency.
- Row click pastes the block into the active terminal for editing; shell-language blocks (including language-less ones, which is where saved prompts usually live) also offer an explicit paste-and-run action.
- `SHELL_LANGS` moves into the shared `codeBlocks` lib so the note editor and the panel agree on what is runnable.

## Testing

- 6 unit tests for the extraction/collection lib (fence parsing, unterminated fences, folder grouping, read-failure tolerance)
- 6 component tests (hidden without a notes root, grouping, paste on click, run only on shell blocks, search filter, Escape closes)
- `pnpm typecheck`, full `pnpm test` (216 files / 1896 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)