### PR TITLE
fix(git-graph): keep branch tail in its own lane instead of overlaying the trunk

### DIFF
--- a/src/modules/git-graph/lib/graphLayout.test.ts
+++ b/src/modules/git-graph/lib/graphLayout.test.ts
@@ -213,6 +213,25 @@ describe("edgePath", () => {
     expect(path.startsWith("M 20 20 C")).toBe(true);
     expect(path).toContain("L 34 92");
   });
+
+  it("keeps a branch tail in its own lane and bends into the trunk only at the parent", () => {
+    // Child on lane 1 (px < cx) merging back down to the trunk two rows below.
+    const edge: GraphEdge = {
+      cx: 34,
+      cy: 20,
+      px: 20,
+      py: 92,
+      lane: 1,
+      childIndex: 0,
+      parentIndex: 2,
+      colorIndex: 1,
+    };
+    const path = edgePath(edge, 36);
+    // Goes straight down the child's own lane first (no immediate bend that
+    // would overlay the trunk), then curves into the parent's lane at the end.
+    expect(path.startsWith("M 34 20 L 34 56")).toBe(true);
+    expect(path.trimEnd().endsWith("20 92")).toBe(true);
+  });
 });
 
 describe("firstParentRowIndex", () => {

--- a/src/modules/git-graph/lib/graphLayout.ts
+++ b/src/modules/git-graph/lib/graphLayout.ts
@@ -256,9 +256,19 @@ export function edgePath(edge: GraphEdge, rowHeight: number): string {
   if (px === cx) {
     return `M ${cx} ${cy} L ${px} ${py}`;
   }
-  // Bend out of the child node into the parent's lane within the first row,
-  // then a straight vertical track down to the parent.
   const bend = Math.min(rowHeight, py - cy);
+  if (px < cx) {
+    // Branch tail merging back down to a lower lane (typically the trunk):
+    // keep the line in the branch's own lane going straight down, and only
+    // bend into the parent's lane in the last row, right at the parent node.
+    // Bending immediately (as the merge-in case does) would run the branch's
+    // colour straight down the parent's lane and paint over the trunk line.
+    const ty = py - bend;
+    return `M ${cx} ${cy} L ${cx} ${ty} C ${cx} ${ty + bend * 0.5}, ${px} ${py - bend * 0.5}, ${px} ${py}`;
+  }
+  // Merge-in: the parent is on a higher lane (the merged-in branch). Bend out
+  // of the child node into that lane within the first row, then run a straight
+  // vertical track down the branch's own lane to the parent.
   const by = cy + bend;
   return `M ${cx} ${cy} C ${cx} ${cy + bend * 0.5}, ${px} ${by - bend * 0.5}, ${px} ${by} L ${px} ${py}`;
 }


### PR DESCRIPTION
## Problem

When a branch merged back into a lower lane (typically the trunk), its coloured line was drawn straight down the trunk lane, so the branch colour painted over the trunk line — the two colours visibly stacked on top of each other.

## Root cause

`edgePath` always bent out of the child node into the parent lane within the first row, then ran a straight vertical track down the parent lane. For a branch tail merging down to the trunk, that vertical track sat directly on the trunk line, drawn in the branch colour.

## Changes

- `edgePath`: when the parent is on a lower lane (`px < cx`), keep the line in the child branch lane going straight down and only bend into the parent lane in the last row, right at the parent node — matching how mhutchie/vscode-git-graph keeps each lane's vertical line in its own colour and curves only at the junction. The merge-in case (parent on a higher lane) is unchanged.
- Add a test asserting the branch tail runs down its own lane first and bends into the trunk only at the parent.

## Test plan

- [x] `pnpm typecheck` (`tsc --noEmit`) — 0 errors
- [x] `pnpm test` (vitest, graphLayout) — 23 passed
- [x] Manual: Git Graph tab — branch merges no longer overlay the trunk line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
