### PR TITLE
chore: release v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tempo-term",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-term"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-term"
-version = "0.3.0"
+version = "0.3.1"
 description = "TempoTerm - AI-powered terminal, editor and file explorer"
 authors = ["TempoTerm"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TempoTerm",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.tempoterm.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump to 0.3.1 across package.json, tauri.conf.json, Cargo.toml, and Cargo.lock.

Ships: AI conversation recovery (#260), notes quick command library (#268, #270), middle-click tab close (#269), OpenSSL launch-crash fix (#265), Windows exit-hang fix (#272).

CHANGELOG-NEXT.md stays until the Windows CI build finishes, then gets archived to docs/changelogs/CHANGELOG-0.3.1.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)