### PR TITLE
feat(source-control): collapsible Staged/Changes/Recent commits sections

### DIFF
--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ChevronDown,
@@ -513,6 +513,42 @@ function FileList({
   );
 }
 
+/**
+ * Collapsible section heading. The whole row is the click target for toggling;
+ * `action` (e.g. the "stage all" button) sits at the trailing edge and must
+ * stop propagation so its own click doesn't also toggle the section. `action`
+ * stays visible while collapsed, so e.g. staging everything doesn't require
+ * expanding the section first.
+ */
+function SectionHeader({
+  label,
+  collapsed,
+  onToggle,
+  action,
+}: {
+  label: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  action?: ReactNode;
+}) {
+  return (
+    <div
+      onClick={onToggle}
+      className="flex cursor-pointer items-center justify-between px-3 py-1 text-fg-subtle hover:bg-bg-elevated/60 hover:text-fg"
+    >
+      <span className="flex min-w-0 items-center gap-1 text-[11px] font-semibold uppercase tracking-wide">
+        {collapsed ? (
+          <ChevronRight size={12} className="shrink-0" />
+        ) : (
+          <ChevronDown size={12} className="shrink-0" />
+        )}
+        <span className="truncate">{label}</span>
+      </span>
+      {action}
+    </div>
+  );
+}
+
 export function SourceControlView() {
   const { t } = useTranslation("sourceControl");
   const { t: tCommon } = useTranslation("common");
@@ -526,6 +562,20 @@ export function SourceControlView() {
   const [pushing, setPushing] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("flat");
   const [refreshing, setRefreshing] = useState(false);
+  // Section headers the user has collapsed (keyed by "staged" | "changes" |
+  // "history"). Component-local, like viewMode — resets when the view remounts.
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
+  const toggleSection = useCallback((key: string) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
   const providerId = useChatStore((s) => s.providerId);
   const model = useChatStore((s) => s.model);
   const customBaseUrl = useChatStore((s) => s.customBaseUrl);
@@ -727,83 +777,96 @@ export function SourceControlView() {
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="min-h-0 flex-1 overflow-y-auto">
         {(status?.staged.length ?? 0) > 0 && (
           <section className="mb-2">
-            <h3 className="px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-fg-subtle">
-              {t("stagedChanges")}
-            </h3>
-            <FileList
-              files={status!.staged}
-              viewMode={viewMode}
-              actionIcon={Minus}
-              actionLabel={t("unstage")}
-              folderActionLabel={t("unstageFolder")}
-              onFileAction={(path) => void withRepo((repo) => gitUnstage(repo, path))}
-              onFolderAction={(paths) =>
-                void withRepo(async (repo) => {
-                  for (const path of paths) {
-                    await gitUnstage(repo, path);
-                  }
-                })
-              }
-              onFileOpen={(path) => openDiff(path, true)}
-              repoPath={repoPath ?? ""}
+            <SectionHeader
+              label={t("stagedChanges")}
+              collapsed={collapsedSections.has("staged")}
+              onToggle={() => toggleSection("staged")}
             />
+            {!collapsedSections.has("staged") && (
+              <FileList
+                files={status!.staged}
+                viewMode={viewMode}
+                actionIcon={Minus}
+                actionLabel={t("unstage")}
+                folderActionLabel={t("unstageFolder")}
+                onFileAction={(path) => void withRepo((repo) => gitUnstage(repo, path))}
+                onFolderAction={(paths) =>
+                  void withRepo(async (repo) => {
+                    for (const path of paths) {
+                      await gitUnstage(repo, path);
+                    }
+                  })
+                }
+                onFileOpen={(path) => openDiff(path, true)}
+                repoPath={repoPath ?? ""}
+              />
+            )}
           </section>
         )}
 
         <section className="mb-2">
-          <div className="flex items-center justify-between px-3 py-1">
-            <h3 className="text-[11px] font-semibold uppercase tracking-wide text-fg-subtle">
-              {t("changes")}
-            </h3>
-            {(status?.unstaged.length ?? 0) > 0 && (
-              <button
-                type="button"
-                onClick={() =>
+          <SectionHeader
+            label={t("changes")}
+            collapsed={collapsedSections.has("changes")}
+            onToggle={() => toggleSection("changes")}
+            action={
+              (status?.unstaged.length ?? 0) > 0 ? (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void withRepo(async (repo) => {
+                      for (const file of status!.unstaged) {
+                        await gitStage(repo, file.path);
+                      }
+                    });
+                  }}
+                  className="text-[11px] text-accent hover:underline"
+                >
+                  {t("stageAll")}
+                </button>
+              ) : undefined
+            }
+          />
+          {!collapsedSections.has("changes") &&
+            ((status?.unstaged.length ?? 0) === 0 ? (
+              <p className="px-3 py-1 text-xs text-fg-subtle">{t("noChanges")}</p>
+            ) : (
+              <FileList
+                files={status!.unstaged}
+                viewMode={viewMode}
+                actionIcon={Plus}
+                actionLabel={t("stage")}
+                folderActionLabel={t("stageFolder")}
+                onFileAction={(path) => void withRepo((repo) => gitStage(repo, path))}
+                onFolderAction={(paths) =>
                   void withRepo(async (repo) => {
-                    for (const file of status!.unstaged) {
-                      await gitStage(repo, file.path);
+                    for (const path of paths) {
+                      await gitStage(repo, path);
                     }
                   })
                 }
-                className="text-[11px] text-accent hover:underline"
-              >
-                {t("stageAll")}
-              </button>
-            )}
-          </div>
-          {(status?.unstaged.length ?? 0) === 0 ? (
-            <p className="px-3 py-1 text-xs text-fg-subtle">{t("noChanges")}</p>
-          ) : (
-            <FileList
-              files={status!.unstaged}
-              viewMode={viewMode}
-              actionIcon={Plus}
-              actionLabel={t("stage")}
-              folderActionLabel={t("stageFolder")}
-              onFileAction={(path) => void withRepo((repo) => gitStage(repo, path))}
-              onFolderAction={(paths) =>
-                void withRepo(async (repo) => {
-                  for (const path of paths) {
-                    await gitStage(repo, path);
-                  }
-                })
-              }
-              onFileOpen={(path) => openDiff(path, false)}
-              onRequestDiscard={setDiscardTarget}
-              repoPath={repoPath ?? ""}
-            />
-          )}
+                onFileOpen={(path) => openDiff(path, false)}
+                onRequestDiscard={setDiscardTarget}
+                repoPath={repoPath ?? ""}
+              />
+            ))}
         </section>
 
-        {history.length > 0 && (
-          <section>
-            <h3 className="px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-fg-subtle">
-              {t("history")}
-            </h3>
-            <div className="flex gap-1 px-3">
+        {/* Expanded: history lives in the normal scroll flow below Changes, so
+            it never eats into or covers the Changes area — you just scroll. */}
+        {history.length > 0 && !collapsedSections.has("history") && (
+          <section className="mt-2 border-t border-border pt-1">
+            <SectionHeader
+              label={t("history")}
+              collapsed={false}
+              onToggle={() => toggleSection("history")}
+            />
+            <div className="flex gap-1 px-3 pb-2">
               <HistoryGraphColumn commits={history} />
               <ul className="min-w-0 flex-1">
                 {history.map((commit) => (
@@ -811,6 +874,18 @@ export function SourceControlView() {
                 ))}
               </ul>
             </div>
+          </section>
+        )}
+        </div>
+
+        {/* Collapsed: just the header, pinned to the very bottom of the panel. */}
+        {history.length > 0 && collapsedSections.has("history") && (
+          <section className="shrink-0 border-t border-border">
+            <SectionHeader
+              label={t("history")}
+              collapsed
+              onToggle={() => toggleSection("history")}
+            />
           </section>
         )}
       </div>


### PR DESCRIPTION
## Problem

The Source Control panel stacks Staged changes, Changes, and Recent commits in one scroll region. With a long changeset or history, there's no way to fold a section away, and the commit list competes with the file lists for the same scrollbar.

## Changes

- Each section header (Staged changes / Changes / Recent commits) is now a collapsible row. The **whole header row** is the click target, not just a chevron.
- The Changes section's **"stage all"** button stays visible even while the section is collapsed, and stops click propagation so pressing it stages without toggling the section.
- **Recent commits** is pinned to the bottom of the panel while collapsed. When expanded it returns to the normal scroll flow below Changes, so it never covers or squeezes the Changes list — you scroll down to reach it.
- Collapse state is component-local (like the existing flat/folder view toggle); it resets when the view remounts.

## Test plan

- [x] `pnpm typecheck` (tsc --noEmit) — clean
- [x] `pnpm test` (vitest run) — 1898 passed / 216 files
- [x] Manual: collapse/expand all three sections in the running app; verified whole-row click, stage-all while collapsed stages without toggling, and expanded Recent commits sits below Changes without covering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)