### PR TITLE
fix(terminal): make OSC 8 file links activate and harden URI parsing

### DIFF
--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -106,7 +106,6 @@ fn build_shell_command(
 
     // Tell CLI tools like Claude Code (via supports-hyperlinks) that we support OSC 8 hyperlinks natively.
     cmd.env("FORCE_HYPERLINK", "1");
-    cmd.env("COLORTERM", "truecolor"); // Added for robustness
 
     // Point this pane's status-hook shim back at the app's loopback listener
     // and tag it with the pane's pty id (see status_ipc). Empty when the

--- a/src/modules/terminal/lib/createTerminal.test.ts
+++ b/src/modules/terminal/lib/createTerminal.test.ts
@@ -1,5 +1,50 @@
 import { describe, expect, it } from "vitest";
-import { createTerminal } from "./createTerminal";
+import { createTerminal, fileUriToPath } from "./createTerminal";
+
+describe("fileUriToPath", () => {
+  it("decodes a POSIX file URI", () => {
+    expect(fileUriToPath("file:///Users/dev/My%20File.md", false)).toBe("/Users/dev/My File.md");
+  });
+
+  it("strips the leading slash before a Windows drive letter", () => {
+    expect(fileUriToPath("file:///C:/Users/dev/notes.md", true)).toBe("C:/Users/dev/notes.md");
+  });
+
+  it("keeps rootless POSIX-looking paths intact on Windows", () => {
+    expect(fileUriToPath("file:///srv/share/readme.md", true)).toBe("/srv/share/readme.md");
+  });
+
+  it("falls back to prefix stripping when decoding fails", () => {
+    // %zz is invalid percent-encoding, so decodeURIComponent throws.
+    expect(fileUriToPath("file:///C:/bad%zz.md", true)).toBe("C:/bad%zz.md");
+  });
+
+  it("rejects UNC-shaped paths that would fire an SMB connection", () => {
+    expect(fileUriToPath("file:////attacker.example/share/x", true)).toBe("");
+    expect(fileUriToPath("file:////attacker.example/share/x", false)).toBe("");
+  });
+
+  it("rejects URIs with a remote host instead of silently dropping it", () => {
+    expect(fileUriToPath("file://evil.example/etc/passwd", false)).toBe("");
+  });
+
+  it("keeps accepting the localhost host form", () => {
+    expect(fileUriToPath("file://localhost/etc/hosts", false)).toBe("/etc/hosts");
+  });
+
+  it("rejects non-file protocols", () => {
+    expect(fileUriToPath("javascript:alert(1)", false)).toBe("");
+    expect(fileUriToPath("ssh://c1/x", false)).toBe("");
+  });
+});
+
+describe("createTerminal link handler", () => {
+  it("allows non-http protocols so OSC 8 file:// links reach the handler", () => {
+    const { term } = createTerminal();
+    expect(term.options.linkHandler?.allowNonHttpProtocols).toBe(true);
+    term.dispose();
+  });
+});
 
 describe("createTerminal search", () => {
   it("exposes a search addon that finds text already in the buffer", async () => {

--- a/src/modules/terminal/lib/createTerminal.ts
+++ b/src/modules/terminal/lib/createTerminal.ts
@@ -6,7 +6,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { buildTerminalFontFamily } from "@/modules/fonts/lib/fontChain";
 import { isLocalUrl, isWebUrl } from "@/lib/url";
-import { IS_MAC, matchesOpenModifier } from "@/lib/platform";
+import { IS_MAC, IS_WINDOWS, matchesOpenModifier } from "@/lib/platform";
 import { hideLinkTooltip, showLinkTooltip } from "./linkTooltip";
 import "@xterm/xterm/css/xterm.css";
 
@@ -22,6 +22,39 @@ export interface TerminalHandle {
   term: Terminal;
   fit: FitAddon;
   search: SearchAddon;
+}
+
+/**
+ * Convert a file:// URI from an OSC 8 link into a filesystem path, or "" when
+ * the URI doesn't name a plain local file. OSC 8 URIs are attacker-supplied
+ * (anything that prints to the terminal), so this rejects rather than guesses.
+ * On Windows the URL pathname keeps a leading slash before the drive letter
+ * (file:///C:/x -> /C:/x), which the fs commands reject.
+ */
+export function fileUriToPath(uri: string, isWindows: boolean = IS_WINDOWS): string {
+  let path: string;
+  try {
+    const url = new URL(uri);
+    if (url.protocol !== "file:") {
+      return "";
+    }
+    // A remote host would either vanish from pathname (file://host/x -> /x)
+    // or come back as a UNC target; reject rather than open something other
+    // than what the link claims to be.
+    if (url.host && url.host !== "localhost") {
+      return "";
+    }
+    path = decodeURIComponent(url.pathname);
+  } catch {
+    path = uri.replace(/^file:\/\/(?:localhost)?/i, "");
+  }
+  if (isWindows && /^\/[A-Za-z]:/.test(path)) {
+    path = path.slice(1);
+  }
+  // Accept only plain absolute paths. A leading double slash (or backslash)
+  // is a UNC host on Windows — opening one fires an SMB connection at an
+  // attacker-chosen machine — and anything relative is not a file link.
+  return /^(?:[A-Za-z]:[\\/]|\/(?![/\\]))/.test(path) ? path : "";
 }
 
 export interface CreateTerminalOptions {
@@ -56,6 +89,11 @@ export function createTerminal(options: CreateTerminalOptions = {}): TerminalHan
     // Alt+click that opens file links.
     altClickMovesCursor: false,
     linkHandler: {
+      // Without this xterm's built-in OSC 8 provider drops every non-http(s)
+      // URI before the handler runs, so file:// links would never activate.
+      // Safe to enable: activate only acts on web and file:// URIs, requires a
+      // modifier-click, and file links open read-only in the editor pane.
+      allowNonHttpProtocols: true,
       activate: (event, uri) => {
         if (!matchesOpenModifier(event, IS_MAC)) {
           return;
@@ -66,13 +104,10 @@ export function createTerminal(options: CreateTerminalOptions = {}): TerminalHan
           } else {
             void openUrl(uri);
           }
-        } else if (uri.startsWith("file://") && options.onOpenFileUrl) {
-          try {
-            const raw = decodeURIComponent(new URL(uri).pathname);
-            options.onOpenFileUrl(raw);
-          } catch {
-            const raw = uri.replace(/^file:\/\/(?:localhost)?/i, "");
-            options.onOpenFileUrl(raw);
+        } else if (/^file:/i.test(uri) && options.onOpenFileUrl) {
+          const path = fileUriToPath(uri);
+          if (path) {
+            options.onOpenFileUrl(path);
           }
         }
       },


### PR DESCRIPTION
## Summary

Follow-up to #243, which merged with the `file://` branch unreachable and a Windows path bug. This resolves the points raised in the review there:

- **Add `allowNonHttpProtocols: true` to the xterm `linkHandler`.** Without it, xterm's built-in OSC 8 provider drops every non-http(s) URI before the custom handler runs, so the file-link branch shipped in #243 never executed. Safe to enable: `activate` only acts on web URLs and `file://` URIs, requires a modifier-click, and file links open read-only in the editor pane — `javascript:` / `data:` / custom schemes fall through and do nothing.
- **Fix the Windows drive-letter form** (gemini's high finding on #243): `new URL("file:///C:/x").pathname` is `/C:/x`, and the leading slash makes the fs commands fail. Extracted a `fileUriToPath` helper (parameterized on `isWindows` so the Windows behavior is unit-tested from any platform).
- **Harden URI parsing.** OSC 8 URIs are attacker-supplied — anything that prints to the terminal chooses them, and the display text can lie about the target. The helper now rejects UNC-shaped paths (`file:////host/share` would fire an SMB connection at an attacker-chosen machine on Windows, leaking NTLM credentials), URIs with a remote host, non-file protocols, and relative leftovers, returning `""` which the caller skips.
- **Drop the redundant `COLORTERM` line** in the pty session setup; `terminal_env` in `shell.rs` already sets it (guarded by a test).

## Test plan

- 10 unit tests in `createTerminal.test.ts` pass, covering POSIX decoding, Windows drive-letter stripping, fallback on bad percent-encoding, UNC rejection, remote-host rejection, localhost acceptance, protocol rejection, and the `allowNonHttpProtocols` option being set
- `tsc --noEmit` clean, `cargo check` and pty module tests (28) pass
- Tauri security review ran on this diff: PASS (the remaining pre-existing finding about `fs_read_file` scope will be tracked in a separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)