### PR TITLE
fix(pty): start PowerShell instead of cmd.exe in UNC working directories

### DIFF
--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -10,7 +10,10 @@ use std::sync::{Arc, Mutex, RwLock};
 use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtyPair, PtySize};
 use tauri::ipc::{Channel, Response};
 
-use super::shell::{autosuggest_env, login_args, resolve_shell_with, terminal_env, usable_cwd};
+use super::shell::{
+    adjust_shell_for_unc_cwd, autosuggest_env, login_args, resolve_shell_with, terminal_env,
+    usable_cwd,
+};
 
 /// A single live terminal session.
 pub struct Session {
@@ -66,14 +69,26 @@ fn build_shell_command(
     shell_override: Option<String>,
     status_env: Vec<(String, String)>,
 ) -> (CommandBuilder, String) {
-    let shell = resolve_shell_with(shell_override);
+    // Resolve the start directory before picking the shell: on Windows the
+    // choice depends on it (cmd.exe cannot start in a UNC directory).
+    let cwd = usable_cwd(cwd);
+    let override_present = shell_override
+        .as_deref()
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false);
+    let shell = adjust_shell_for_unc_cwd(
+        resolve_shell_with(shell_override),
+        override_present,
+        cwd.as_deref(),
+        cfg!(windows),
+    );
     let mut cmd = CommandBuilder::new(&shell);
     // Run as a login shell so it sources the user's profile and inherits the
     // full PATH (Homebrew etc.); a GUI-launched non-login shell misses those.
     for arg in login_args(&shell) {
         cmd.arg(arg);
     }
-    if let Some(dir) = usable_cwd(cwd) {
+    if let Some(dir) = cwd {
         cmd.cwd(dir);
     }
     // Windows has no OS-level cwd backend (no /proc, no lsof — see

--- a/src-tauri/src/modules/pty/shell.rs
+++ b/src-tauri/src/modules/pty/shell.rs
@@ -342,6 +342,30 @@ pub fn windows_integration_env(
     )]
 }
 
+/// True for a UNC path (`\\server\share`, or the `//server/share` form Win32
+/// also accepts).
+fn is_unc_path(path: &str) -> bool {
+    path.starts_with(r"\\") || path.starts_with("//")
+}
+
+/// cmd.exe refuses to start in a UNC directory — it prints "UNC paths are not
+/// supported" and silently falls back to C:\Windows — while PowerShell handles
+/// UNC fine. When the shell is the cmd.exe default and the session starts in a
+/// UNC directory, swap in PowerShell. An explicit user override is respected
+/// as-is: the user chose that shell knowingly. `windows` is passed in (not
+/// cfg-gated) so the Windows behaviour stays unit-testable from any platform.
+pub fn adjust_shell_for_unc_cwd(
+    shell: String,
+    override_present: bool,
+    cwd: Option<&str>,
+    windows: bool,
+) -> String {
+    if windows && !override_present && is_cmd(&shell) && cwd.map(is_unc_path).unwrap_or(false) {
+        return "powershell.exe".to_string();
+    }
+    shell
+}
+
 /// Keep a start directory only when it is a real, existing directory. A restored
 /// session may point at a folder that has since been deleted; spawning there
 /// would fail, so fall back (the caller drops to the default) instead.
@@ -398,6 +422,65 @@ mod tests {
     fn blank_override_falls_through_to_shell_env() {
         assert_eq!(
             resolve_shell_from(Some("   ".to_string()), Some("/bin/zsh".to_string())),
+            "/bin/zsh"
+        );
+    }
+
+    #[test]
+    fn swaps_default_cmd_for_powershell_in_a_unc_cwd() {
+        assert_eq!(
+            adjust_shell_for_unc_cwd(
+                r"C:\Windows\system32\cmd.exe".to_string(),
+                false,
+                Some(r"\\vm.local\workspace\project"),
+                true,
+            ),
+            "powershell.exe"
+        );
+    }
+
+    #[test]
+    fn treats_forward_slash_unc_paths_the_same() {
+        assert_eq!(
+            adjust_shell_for_unc_cwd("cmd.exe".to_string(), false, Some("//server/share"), true),
+            "powershell.exe"
+        );
+    }
+
+    #[test]
+    fn respects_an_explicit_cmd_override_even_in_a_unc_cwd() {
+        assert_eq!(
+            adjust_shell_for_unc_cwd("cmd.exe".to_string(), true, Some(r"\\server\share"), true),
+            "cmd.exe"
+        );
+    }
+
+    #[test]
+    fn keeps_cmd_for_local_paths_and_other_shells_everywhere() {
+        assert_eq!(
+            adjust_shell_for_unc_cwd("cmd.exe".to_string(), false, Some(r"C:\work"), true),
+            "cmd.exe"
+        );
+        assert_eq!(
+            adjust_shell_for_unc_cwd("cmd.exe".to_string(), false, None, true),
+            "cmd.exe"
+        );
+        assert_eq!(
+            adjust_shell_for_unc_cwd(
+                "powershell.exe".to_string(),
+                false,
+                Some(r"\\server\share"),
+                true,
+            ),
+            "powershell.exe"
+        );
+    }
+
+    #[test]
+    fn never_swaps_shells_off_windows() {
+        // A POSIX path may legally start with a double slash; that is not UNC.
+        assert_eq!(
+            adjust_shell_for_unc_cwd("/bin/zsh".to_string(), false, Some("//net/share"), false),
             "/bin/zsh"
         );
     }


### PR DESCRIPTION
## Summary

Fixes #278.

On Windows the default shell resolves through `COMSPEC`, which is effectively always `cmd.exe` — and cmd.exe refuses a UNC start directory (`\\server\share\...`): it prints "UNC paths are not supported" and silently falls back to `C:\Windows`, so a workspace on a network share opens in the wrong place. PowerShell has no such limitation.

- When the resolved shell is the cmd.exe default and the session's start directory is UNC (`\\` or the `//` form Win32 also accepts), swap in `powershell.exe`
- An explicit custom-shell override is respected as-is: the user chose that shell knowingly, and pointing the setting at PowerShell was already the manual workaround
- The start directory is now resolved before the shell choice in `build_shell_command`, since the choice depends on it
- The OSC 7 cwd-reporting integration keys off the shell file name (`windows_integration_args`/`windows_integration_env`), so it switches to the PowerShell prompt wrapper automatically

The swap is a pure function parameterized on `windows`, following this module's convention of keeping Windows behavior unit-testable from any platform.

## Test plan

- 5 new unit tests in `shell.rs` (test-first): UNC backslash and forward-slash forms, explicit override respected, local paths and non-cmd shells untouched, no swapping off Windows
- `cargo test --lib modules::pty`: 33 pass; clippy introduces no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)