### PR TITLE
fix(fs): harden fs_read_file and surface real OSC 8 link targets

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,8 +4,8 @@ use tauri::Manager;
 
 use modules::fonts::fonts_report;
 use modules::fs::{
-    fs_create_dir, fs_create_file, fs_delete, fs_grep, fs_home_dir, fs_list_files, fs_read_dir,
-    fs_read_file, fs_rename, fs_reveal, fs_write_file,
+    fs_create_dir, fs_create_file, fs_delete, fs_grep, fs_home_dir, fs_is_file, fs_list_files,
+    fs_read_dir, fs_read_file, fs_rename, fs_reveal, fs_write_file,
 };
 use modules::ai::ai_chat;
 use modules::claude_progress::{
@@ -236,6 +236,7 @@ pub fn run() {
             fs_home_dir,
             fs_read_dir,
             fs_read_file,
+            fs_is_file,
             fs_write_file,
             fs_list_files,
             fs_grep,

--- a/src-tauri/src/modules/fs/mod.rs
+++ b/src-tauri/src/modules/fs/mod.rs
@@ -1,6 +1,8 @@
 //! File system module: directory listing, file reads and search for the
 //! explorer and editor.
 
+use std::io::Read;
+
 mod dir;
 mod ops;
 mod search;
@@ -18,9 +20,88 @@ pub fn fs_read_dir(path: String) -> Result<Vec<DirEntry>, String> {
     dir::read_dir(&path)
 }
 
+/// Ceiling for `fs_read_file`: bigger than any text file the editor should
+/// open, and a bound against pulling a multi-GB log into memory in one call.
+const MAX_READ_FILE_BYTES: u64 = 10 * 1024 * 1024;
+
+/// True for a path that names a DOS device (`NUL`, `CON`, `COM1`, also with
+/// an extension like `nul.txt`). On Windows `FileType::is_file` is merely
+/// "not a directory, not a symlink", so devices pass the regular-file check;
+/// reading one can block forever (e.g. a serial port). Pure string check so
+/// the Windows behaviour is unit-testable from any platform.
+fn is_dos_device_path(path: &str) -> bool {
+    let name = path
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(path)
+        .trim_end_matches([' ', '.']);
+    let stem = name.split('.').next().unwrap_or(name);
+    let upper = stem.to_ascii_uppercase();
+    matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL" | "CONIN$" | "CONOUT$")
+        || (upper.len() == 4
+            && (upper.starts_with("COM") || upper.starts_with("LPT"))
+            && upper[3..].chars().all(|c| c.is_ascii_digit()))
+}
+
+/// Read a file after metadata checks: only regular files and only up to
+/// `max_bytes`, enforced on the bytes actually read (a live log can outgrow
+/// its stat size). On unix `is_file` refuses devices, FIFOs and directories;
+/// on Windows it only refuses directories, so DOS device names are screened
+/// separately. A FIFO swapped in between stat and open can still block the
+/// read — accepted for a local single-user app.
+fn read_file_capped(path: &str, max_bytes: u64) -> Result<String, String> {
+    if cfg!(windows) && is_dos_device_path(path) {
+        return Err(format!("not a regular file: {path}"));
+    }
+    let meta = std::fs::metadata(path).map_err(|e| e.to_string())?;
+    if !meta.is_file() {
+        return Err(format!("not a regular file: {path}"));
+    }
+    if meta.len() > max_bytes {
+        return Err(format!(
+            "file too large to open ({} bytes, limit {max_bytes}): {path}",
+            meta.len()
+        ));
+    }
+    let file = std::fs::File::open(path).map_err(|e| e.to_string())?;
+    let mut buf = Vec::new();
+    std::io::Read::take(file, max_bytes + 1)
+        .read_to_end(&mut buf)
+        .map_err(|e| e.to_string())?;
+    if buf.len() as u64 > max_bytes {
+        return Err(format!(
+            "file too large to open (over {max_bytes} bytes): {path}"
+        ));
+    }
+    String::from_utf8(buf).map_err(|e| e.to_string())
+}
+
 #[tauri::command]
-pub fn fs_read_file(path: String) -> Result<String, String> {
-    std::fs::read_to_string(&path).map_err(|e| e.to_string())
+pub async fn fs_read_file(path: String) -> Result<String, String> {
+    // Off the main thread: a slow disk or network mount must not freeze the UI.
+    tauri::async_runtime::spawn_blocking(move || read_file_capped(&path, MAX_READ_FILE_BYTES))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Metadata-only probe: true when `path` names an openable file (a regular
+/// file on unix; on Windows anything that is not a directory or DOS device).
+/// Terminal links use this instead of reading the whole file just to decide
+/// whether a click should open an editor pane. Async for the same reason as
+/// `fs_read_file`: the path is attacker-choosable terminal output, and a
+/// stat on a dead network mount must not freeze the UI.
+fn is_openable_file(path: &str) -> bool {
+    if cfg!(windows) && is_dos_device_path(path) {
+        return false;
+    }
+    std::fs::metadata(path).map(|m| m.is_file()).unwrap_or(false)
+}
+
+#[tauri::command]
+pub async fn fs_is_file(path: String) -> Result<bool, String> {
+    tauri::async_runtime::spawn_blocking(move || is_openable_file(&path))
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -65,4 +146,74 @@ pub fn fs_rename(from: String, to: String) -> Result<(), String> {
 #[tauri::command]
 pub fn fs_reveal(path: String) -> Result<(), String> {
     ops::reveal(&path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("tempoterm-fs-test-{}-{}", std::process::id(), name));
+        dir
+    }
+
+    #[test]
+    fn reads_a_regular_file_within_the_cap() {
+        let path = temp_path("small.txt");
+        std::fs::write(&path, "hello").unwrap();
+
+        assert_eq!(
+            read_file_capped(&path.to_string_lossy(), 1024),
+            Ok("hello".to_string())
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn refuses_a_file_over_the_cap() {
+        let path = temp_path("big.txt");
+        std::fs::write(&path, "0123456789").unwrap();
+
+        let err = read_file_capped(&path.to_string_lossy(), 4).unwrap_err();
+        assert!(err.contains("too large"), "unexpected error: {err}");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn refuses_a_non_regular_file() {
+        let err = read_file_capped(&std::env::temp_dir().to_string_lossy(), u64::MAX).unwrap_err();
+        assert!(err.contains("not a regular file"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn probe_is_only_true_for_openable_files() {
+        let path = temp_path("probe.txt");
+        std::fs::write(&path, "x").unwrap();
+
+        assert!(is_openable_file(&path.to_string_lossy()));
+        assert!(!is_openable_file(&std::env::temp_dir().to_string_lossy()));
+        assert!(!is_openable_file(&temp_path("missing.txt").to_string_lossy()));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn detects_dos_device_paths_in_any_spelling() {
+        assert!(is_dos_device_path("NUL"));
+        assert!(is_dos_device_path("nul.txt"));
+        assert!(is_dos_device_path(r"C:\work\con.log"));
+        assert!(is_dos_device_path("/tmp/COM1"));
+        assert!(is_dos_device_path("LPT9.dat"));
+        assert!(is_dos_device_path("NUL  ")); // trailing spaces are stripped by Win32
+        assert!(is_dos_device_path("conout$"));
+
+        assert!(!is_dos_device_path("null.txt"));
+        assert!(!is_dos_device_path("console.log"));
+        assert!(!is_dos_device_path("COM10.txt"));
+        assert!(!is_dos_device_path("compare.rs"));
+        assert!(!is_dos_device_path(r"C:\nul\readme.md")); // device name as a directory, not the file
+    }
 }

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -7,6 +7,7 @@
   "closeUnsavedTitle": "Unsaved changes",
   "closeUnsavedMessage": "This tab has unsaved changes. Close without saving?",
   "discardClose": "Close without saving",
+  "loadError": "This file cannot be opened",
   "refresh": "Reload from disk",
   "reloadUnsavedTitle": "Unsaved changes",
   "reloadUnsavedMessage": "This file has unsaved changes. Reload from disk and discard them?",

--- a/src/i18n/locales/zh-Hant/editor.json
+++ b/src/i18n/locales/zh-Hant/editor.json
@@ -7,6 +7,7 @@
   "closeUnsavedTitle": "尚未儲存的變更",
   "closeUnsavedMessage": "這個分頁有未儲存的變更，確定要關閉嗎？",
   "discardClose": "不儲存直接關閉",
+  "loadError": "無法開啟這個檔案",
   "refresh": "從磁碟重新整理",
   "reloadUnsavedTitle": "尚未儲存的變更",
   "reloadUnsavedMessage": "這個檔案有未儲存的變更，要從磁碟重新載入並捨棄它們嗎？",

--- a/src/index.css
+++ b/src/index.css
@@ -205,6 +205,12 @@ textarea:focus-visible,
   z-index: 9999;
   display: none;
   pointer-events: none;
+  /* The text is an attacker-chosen link target: keep it inside a bounded box
+     and render it strictly left-to-right so bidi text can't reorder a path. */
+  max-width: min(600px, 80vw);
+  overflow-wrap: anywhere;
+  unicode-bidi: plaintext;
+  direction: ltr;
   font-size: 12px;
   line-height: 1rem;
   color: var(--color-fg);

--- a/src/modules/editor/EditorTabContent.loadError.test.tsx
+++ b/src/modules/editor/EditorTabContent.loadError.test.tsx
@@ -1,0 +1,87 @@
+// Regression test for the fabricated-empty-baseline bug: when the initial
+// read fails (file too large, unreadable, not a regular file), the editor
+// used to set an empty baseline — a clean-looking empty buffer — and a save
+// would then TRUNCATE the real file on disk. A failed load must show an
+// error state and block saving entirely.
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/i18n";
+import { EditorTabContent } from "./EditorTabContent";
+import { useEditorStore } from "./store/editorStore";
+import { useTabsStore } from "@/stores/tabsStore";
+import { leaf } from "@/modules/terminal/lib/terminalLayout";
+import { saveFocusedEditor } from "./lib/editorBus";
+
+const { mockFsWriteFile, mockFsReadFile } = vi.hoisted(() => ({
+  mockFsWriteFile: vi.fn().mockResolvedValue(undefined),
+  mockFsReadFile: vi.fn(),
+}));
+
+vi.mock("@/modules/explorer/lib/fsBridge", () => ({
+  fsReadFile: mockFsReadFile,
+  fsWriteFile: mockFsWriteFile,
+  // The toolbar's breadcrumb (paneCrumbs) resolves home + siblings on mount.
+  fsHomeDir: vi.fn().mockResolvedValue("/home/user"),
+  fsReadDir: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("@uiw/react-codemirror", () => ({
+  default: () => null,
+}));
+
+function fixtureTab(leafId: string, path: string) {
+  return {
+    id: "tab1",
+    spaceId: "s1",
+    title: "editor",
+    kind: "editor" as const,
+    paneTree: leaf(leafId, { kind: "editor" as const, path }),
+    activeLeafId: leafId,
+    paneOrder: [leafId],
+  };
+}
+
+describe("EditorTabContent failed load", () => {
+  beforeEach(() => {
+    mockFsWriteFile.mockClear();
+    mockFsReadFile.mockRejectedValue(
+      "file too large to open (52428800 bytes, limit 10485760): /big.log",
+    );
+    useEditorStore.setState({ buffers: {} });
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space" }],
+      activeSpaceId: "s1",
+      tabs: [fixtureTab("leaf1", "/big.log")],
+      activeId: "tab1",
+    });
+  });
+
+  it("shows an error state instead of a clean empty buffer", async () => {
+    render(<EditorTabContent path="/big.log" leafId="leaf1" />);
+    await act(async () => {});
+
+    expect(screen.getByText("This file cannot be opened")).toBeInTheDocument();
+    // No fabricated baseline: the buffer must simply not exist.
+    expect(useEditorStore.getState().buffers["/big.log"]).toBeUndefined();
+  });
+
+  it("refuses to save, so the real file is never truncated", async () => {
+    render(<EditorTabContent path="/big.log" leafId="leaf1" />);
+    await act(async () => {});
+
+    await act(async () => {
+      saveFocusedEditor();
+      await Promise.resolve();
+    });
+
+    expect(mockFsWriteFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -82,6 +82,11 @@ export function EditorTabContent({
   const [mode, setMode] = useState<EditorMode>("edit");
   const [confirmReload, setConfirmReload] = useState(false);
   const [externalChanged, setExternalChanged] = useState(false);
+  // Why the initial read failed (too large, unreadable, not a regular file).
+  // While set, the editor shows an error instead of an editable buffer: a
+  // fabricated empty baseline would look like a clean empty file, and saving
+  // it would truncate the real file on disk.
+  const [loadError, setLoadError] = useState<string | null>(null);
   const selfWrite = useRef<{ path: string; at: number } | null>(null);
   const effectiveMode: EditorMode = isMarkdown ? mode : "edit";
 
@@ -91,14 +96,27 @@ export function EditorTabContent({
   const languageCompartment = useRef(new Compartment());
 
   useEffect(() => {
+    setLoadError(null);
     // Re-read from disk whenever the file (re)opens so external edits show up;
     // skip only when there are unsaved local edits, to avoid clobbering them.
     if (!shouldReloadFromDisk(useEditorStore.getState().buffers[path])) {
       return;
     }
+    let cancelled = false;
     fsReadFile(path)
-      .then((text) => setBaseline(path, text))
-      .catch(() => setBaseline(path, ""));
+      .then((text) => {
+        if (!cancelled) {
+          setBaseline(path, text);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setLoadError(String(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [path, setBaseline]);
 
   const extensions = useMemo(() => {
@@ -145,6 +163,12 @@ export function EditorTabContent({
   }, [path, effectiveMode]);
 
   async function save() {
+    // Never write a buffer that has no successfully loaded baseline: it would
+    // replace the real file with the placeholder (e.g. truncate a file that
+    // was too large to open).
+    if (!useEditorStore.getState().buffers[path]) {
+      return;
+    }
     const current = useEditorStore.getState().contentOf(path);
     // Mark our own write BEFORE the async write: the OS watcher event can arrive
     // before fsWriteFile resolves, so setting the marker afterwards would race and
@@ -241,6 +265,15 @@ export function EditorTabContent({
     // reloadFromDisk closes over `path` and stable setters; re-subscribe on path.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [path]);
+
+  if (loadError) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-1 px-6 text-sm text-fg-subtle">
+        <span>{t("loadError")}</span>
+        <span className="max-w-full break-all text-xs">{loadError}</span>
+      </div>
+    );
+  }
 
   const editorPane = (
     <CodeMirror

--- a/src/modules/explorer/lib/fsBridge.test.ts
+++ b/src/modules/explorer/lib/fsBridge.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/modules/ssh/lib/sftp-bridge", () => ({
   sftpRename: (...a: unknown[]) => sftpRename(...a),
 }));
 
-import { canSearchRoot, fsCreateDir, fsCreateFile, fsDelete, fsReadDir, fsReadFile, fsRename, fsWriteFile } from "./fsBridge";
+import { canSearchRoot, fsCreateDir, fsCreateFile, fsDelete, fsIsFile, fsReadDir, fsReadFile, fsRename, fsWriteFile } from "./fsBridge";
 
 beforeEach(() => {
   invoke.mockReset();
@@ -70,6 +70,23 @@ describe("fsBridge routing", () => {
     invoke.mockResolvedValue(undefined);
     await fsWriteFile("/a.txt", "x");
     expect(invoke).toHaveBeenCalledWith("fs_write_file", { path: "/a.txt", contents: "x" });
+  });
+
+  it("probes a local file through fs_is_file without reading it", async () => {
+    invoke.mockResolvedValue(true);
+    expect(await fsIsFile("/a.txt")).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("fs_is_file", { path: "/a.txt" });
+  });
+
+  it("probes a remote file over sftp, mapping failure to false", async () => {
+    ensure.mockResolvedValue(7);
+    sftpReadFile.mockResolvedValue("body");
+    expect(await fsIsFile("ssh://c1/a.txt")).toBe(true);
+    expect(sftpReadFile).toHaveBeenCalledWith(7, "/a.txt");
+
+    sftpReadFile.mockRejectedValue(new Error("no such file"));
+    expect(await fsIsFile("ssh://c1/missing.txt")).toBe(false);
+    expect(invoke).not.toHaveBeenCalled();
   });
 });
 

--- a/src/modules/explorer/lib/fsBridge.ts
+++ b/src/modules/explorer/lib/fsBridge.ts
@@ -39,6 +39,27 @@ export async function fsReadFile(path: string): Promise<string> {
   return invoke<string>("fs_read_file", { path });
 }
 
+/**
+ * Metadata-only existence probe: true when `path` names a regular file.
+ * Terminal links use this instead of reading the whole file just to decide
+ * whether a click should open an editor pane. Remote (SFTP) paths fall back
+ * to a read — the only probe the SFTP bridge has — which downloads the whole
+ * remote file: the local size cap and file-type checks do NOT apply there.
+ */
+export async function fsIsFile(path: string): Promise<boolean> {
+  const remote = parseRemoteUri(path);
+  if (remote) {
+    try {
+      const id = await sftpSessionStore.getState().ensure(remote.connectionId);
+      await sftpReadFile(id, remote.path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return invoke<boolean>("fs_is_file", { path });
+}
+
 export async function fsWriteFile(path: string, contents: string): Promise<void> {
   const remote = parseRemoteUri(path);
   if (remote) {

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -78,7 +78,7 @@ import { applyTerminalPadding } from "./lib/terminalPadding";
 import { debounce } from "@/lib/debounce";
 import { dropOverlayClassName } from "@/components/EntryDropOverlay";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
-import { fsHomeDir, fsReadFile } from "@/modules/explorer/lib/fsBridge";
+import { fsHomeDir, fsIsFile } from "@/modules/explorer/lib/fsBridge";
 import { getDraggedEntry } from "@/modules/explorer/lib/dragEntry";
 import {
   STATUS_OSC_CODE,
@@ -731,8 +731,11 @@ export function TerminalView({
       }
       const abs = resolveFilePath(raw, resolvedCwd, await getHomeDir());
       try {
-        await fsReadFile(abs);
-        onOpenFileRef.current?.(abs);
+        // Metadata-only probe: don't read the whole file (the editor pane
+        // does that itself) just to know whether the click should open one.
+        if (await fsIsFile(abs)) {
+          onOpenFileRef.current?.(abs);
+        }
       } catch {
         // not a real file (e.g. a bare domain) — ignore the click
       }

--- a/src/modules/terminal/lib/createTerminal.test.ts
+++ b/src/modules/terminal/lib/createTerminal.test.ts
@@ -44,6 +44,23 @@ describe("createTerminal link handler", () => {
     expect(term.options.linkHandler?.allowNonHttpProtocols).toBe(true);
     term.dispose();
   });
+
+  it("shows the resolved target in the hover tooltip, not just the hint", () => {
+    const { term } = createTerminal({ linkHint: "Cmd-click to open" });
+    const event = new MouseEvent("mousemove", { clientX: 10, clientY: 20 });
+    const range = { start: { x: 1, y: 1 }, end: { x: 2, y: 1 } };
+
+    // OSC 8 display text can lie about its target, so the tooltip must show
+    // where the link really points.
+    term.options.linkHandler?.hover?.(event, "file:///Users/dev/notes.md", range);
+    const tooltip = document.querySelector(".terminal-link-tooltip");
+    expect(tooltip?.textContent).toBe("/Users/dev/notes.md (Cmd-click to open)");
+
+    term.options.linkHandler?.hover?.(event, "https://example.com/x", range);
+    expect(tooltip?.textContent).toBe("https://example.com/x (Cmd-click to open)");
+
+    term.dispose();
+  });
 });
 
 describe("createTerminal search", () => {

--- a/src/modules/terminal/lib/createTerminal.ts
+++ b/src/modules/terminal/lib/createTerminal.ts
@@ -111,10 +111,15 @@ export function createTerminal(options: CreateTerminalOptions = {}): TerminalHan
           }
         }
       },
-      hover: (event) => {
-        if (options.linkHint) {
-          showLinkTooltip(options.linkHint, event.clientX, event.clientY);
-        }
+      hover: (event, uri) => {
+        // OSC 8 display text can lie about its target, so always surface the
+        // real one (the resolved path for file links) alongside the hint.
+        const target = /^file:/i.test(uri) ? fileUriToPath(uri) || uri : uri;
+        showLinkTooltip(
+          options.linkHint ? `${target} (${options.linkHint})` : target,
+          event.clientX,
+          event.clientY,
+        );
       },
       leave: () => hideLinkTooltip(),
     },

--- a/src/modules/terminal/lib/linkTooltip.ts
+++ b/src/modules/terminal/lib/linkTooltip.ts
@@ -17,9 +17,26 @@ function ensureEl(): HTMLDivElement {
   return node;
 }
 
+/** Longest tooltip we render; enough for any sane path or URL. */
+const MAX_TOOLTIP_CHARS = 200;
+
+/**
+ * The tooltip's job is to show where a link REALLY points, and its input is
+ * attacker-chosen (OSC 8 URIs decode to arbitrary text). Strip control and
+ * format characters — a bidi override (U+202E) would visually reorder the
+ * shown path into a different one — and bound the length so a huge URI can't
+ * blanket the screen.
+ */
+function sanitizeTooltipText(text: string): string {
+  const cleaned = text.replace(/[\p{Cc}\p{Cf}]/gu, "");
+  return cleaned.length > MAX_TOOLTIP_CHARS
+    ? `${cleaned.slice(0, MAX_TOOLTIP_CHARS)}…`
+    : cleaned;
+}
+
 export function showLinkTooltip(text: string, x: number, y: number): void {
   const node = ensureEl();
-  node.textContent = text;
+  node.textContent = sanitizeTooltipText(text);
   node.style.left = `${x + 12}px`;
   node.style.top = `${y + 12}px`;
   node.style.display = "block";


### PR DESCRIPTION
## Summary

Fixes #281.

- **`fs_read_file` hardening**: rejects non-regular files (a terminal-link target can name anything — devices, FIFOs, directories), caps reads at 10 MB **enforced on the bytes actually read** (a live log can outgrow its stat size), and runs via `spawn_blocking` so a slow disk or dead network mount cannot freeze the UI.
- **Windows DOS device screening**: `FileType::is_file` on Windows is merely "not a directory, not a symlink", so `NUL`/`CON`/`COM1` (also with an extension like `nul.txt`) pass the regular-file check and reading e.g. a serial port blocks forever. A pure string check screens them, unit-tested from any platform.
- **New `fs_is_file` command**: metadata-only probe, also off the main thread; `openFromTerminal` uses it instead of reading the entire file just to decide whether a click should open an editor pane. SFTP paths keep the read-based probe (the only one the bridge has) — noted in the code that the local caps don't apply there.
- **Editor data-loss fix (found by the security review of this diff)**: on a failed initial read the editor used to fabricate an empty baseline — a clean-looking empty buffer — and one Cmd+S would truncate the real file on disk. With the new 10 MB cap, any large file would have hit this. A failed load now shows an error state, sets no baseline, and `save()` refuses to write without one. Regression-tested.
- **OSC 8 tooltip shows the resolved target** (display text can lie about where a link points), sanitized against bidi-override/control characters, length-bounded, and the tooltip box is width-capped so a huge URI can't blanket the screen.

## Deliberately not included (needs a maintainer decision)

The review also flagged that `fs_read_file` doesn't honor the assetProtocol deny list (`**/.ssh/**`, `**/.env*`, `**/*.pem`, ...). Applying that list here would break legitimate use — opening your own project's `.env` in the editor goes through the same command. The tooltip now showing the true target is a partial mitigation for disguised OSC 8 links; a per-link confirmation for sensitive targets could be a follow-up.

## Test plan

- Rust: 17 fs-module tests pass (new: capped read within/over limit, non-regular-file rejection, openable-file probe, DOS-device detection incl. negative cases)
- Frontend: full suite 1915 tests pass; new regression tests assert the failed-load error state, the absence of a fabricated baseline, and that save is blocked; fsBridge and tooltip tests updated
- Tauri security review ran on this diff: the one HIGH (editor truncation) is fixed here; MEDIUMs addressed (DOS devices, tooltip sanitization) or documented (deny list, SFTP probe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)