### PR TITLE
docs: add fs hardening and codex hook fixes to CHANGELOG-NEXT

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -9,6 +9,8 @@
 
 - 修正 git graph 裡分支尾端併回主線時，分支的線會蓋在主線上的問題：分支現在沿自己的軌道畫到底、貼著匯入的 commit 才彎進去，多條分支併進同一個 commit 也各走各的軌道 (#274)
 - 修正 Windows 上工作目錄在網路共享（UNC 路徑）時終端機開錯位置的問題：cmd.exe 不支援 UNC 起始目錄會退回 C:\Windows，現在這種情況自動改用 PowerShell 啟動；有自訂 shell 設定時仍尊重使用者的選擇 (#284)
+- 強化終端機連結的開檔安全：拒絕裝置與非一般檔案、單次讀取上限 10 MB 且改在背景執行緒跑（慢速磁碟或網路掛載不再凍住畫面），連結的懸浮提示會顯示解析後的真實目標，防止 OSC 8 連結文字偽裝；同時修正編輯器在檔案讀取失敗時誤存而把原檔清空的資料毀損風險 (#286)
+- 修正 Windows 上 Codex hook 安裝失敗與 session 卡片誤顯示 Claude 圖示的問題：config.toml 編碼有問題（如 PowerShell 存成 UTF-16）不再擋住 hooks.json 升級且會給出明確錯誤，無法辨識來源的狀態回報改為清掉舊的 agent 標籤，設定頁開關失敗也會顯示原因而不是默默彈回 (#287)
 
 ## English
 
@@ -21,3 +23,5 @@
 
 - Fix branch tails overdrawing the trunk in the git graph when merging back: a branch now runs down its own lane and only bends in right at its parent commit, and multiple branches joining the same commit each keep their own lane (#274)
 - Fix terminals opening in the wrong place on Windows when the working directory is a network share (UNC path): cmd.exe rejects a UNC start directory and falls back to C:\Windows, so PowerShell is started instead in that case; a custom shell setting is still respected as-is (#284)
+- Harden file opening from terminal links: devices and non-regular files are refused, reads are capped at 10 MB and run off the main thread (a slow disk or network mount no longer freezes the UI), and the link hover tooltip shows the resolved real target so OSC 8 link text cannot disguise it; also fixes a data-loss risk where saving after a failed read would truncate the original file (#286)
+- Fix Codex hook install failures and session cards wearing the Claude icon on Windows: a config.toml encoding problem (e.g. UTF-16 from PowerShell) no longer blocks the hooks.json upgrade and reports a clear error, status reports that cannot name their agent now clear the stale label, and the settings toggle shows the failure reason instead of silently snapping back (#287)


### PR DESCRIPTION
## Summary

Adds the bilingual changelog entries for #286 (fs_read_file hardening + OSC 8 tooltip target) and #287 (Windows codex hook install order + stale agent label), per the changelog-per-feature convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)