### PR TITLE
test(git-graph): fix flaky retry test racing the selection effect

### DIFF
--- a/src/modules/git-graph/GitGraphTabContent.test.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.test.tsx
@@ -92,7 +92,10 @@ describe("GitGraphTabContent pending commit selection", () => {
     render(<GitGraphTabContent />);
 
     await waitFor(() => expect(screen.getByText("msg ddd4444")).toBeInTheDocument());
-    expect(usePendingGraphSelectionStore.getState().hash).toBeNull();
+    // The pending hash is consumed by a separate effect pass after the commit
+    // renders — assert it asynchronously like the sibling tests, or a slow
+    // runner (CI) sees the commit before the selection effect has run.
+    await waitFor(() => expect(usePendingGraphSelectionStore.getState().hash).toBeNull());
   });
 
   it("selects a second commit requested after the tab is already mounted with an unchanged commit list", async () => {


### PR DESCRIPTION
## Summary

The "retries even when hasMore is already false" test flaked on the PR #289 CI run (`expected 'ddd4444' to be null`). It waited for the commit to render, then asserted the pending-selection hash **synchronously** — but the hash is consumed by a separate effect pass, so a slow runner sees the commit before the selection effect has run. Every sibling test in the file already asserts this via `waitFor`; this one just missed it. One-line fix.

## Test plan

- The file passes locally (14 tests); the fix only relaxes a timing assumption, asserting the same final state

🤖 Generated with [Claude Code](https://claude.com/claude-code)