### PR TITLE
docs: add resume-with-launcher-flags feature to CHANGELOG-NEXT

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -4,6 +4,7 @@
 
 - 終端機支援原生 OSC 8 檔案超連結：Claude Code 等 CLI 印出的檔案連結，按住修飾鍵點擊就能直接在編輯器分割窗開啟，長路徑因換行斷開也不受影響；會向 shell 宣告支援讓 CLI 改輸出原生連結，並擋下偽裝成本機檔案的 UNC 與遠端目標 (#243, #280)
 - 版本控制面板的 Staged changes、Changes、Recent commits 三個區段可以收合：整條標題列都是點擊目標並支援鍵盤操作，Changes 收合時 Stage all 按鈕仍可直接使用，Recent commits 收合時會釘在面板底部 (#277, #282)
+- 接續 AI 對話時可以帶上啟動器預設參數：AI 對話恢復新增子選項，開啟後啟動時自動接續與 AI Sessions 面板的一鍵接續都會附上對應 agent 的參數；AI 對話恢復對新安裝改為預設啟用，既有使用者維持原本的選擇；Codex 參數的範例提示同步更新，不再建議新版 CLI 已移除的 --full-auto (#289)
 
 ### fix
 
@@ -18,6 +19,7 @@
 
 - The terminal now supports native OSC 8 file hyperlinks: file links printed by CLIs like Claude Code open directly in an editor split on modifier-click, unaffected by long paths wrapping across lines; the shell is told hyperlinks are supported so CLIs emit them, and UNC or remote targets disguised as local files are rejected (#243, #280)
 - The source control panel's Staged changes, Changes and Recent commits sections are collapsible: the whole header row is the click target and works from the keyboard, Stage all stays usable while Changes is collapsed, and Recent commits pins to the bottom of the panel while collapsed (#277, #282)
+- Resuming AI conversations can now carry the launcher default flags: a new sub-option under AI conversation recovery applies them to both startup auto-resume and the Sessions panel's one-click resume; AI conversation recovery is now enabled by default for fresh installs while existing users keep their choice, and the Codex flags placeholder no longer suggests --full-auto, which recent CLI versions removed (#289)
 
 ### fix
 


### PR DESCRIPTION
## Summary

Adds the bilingual changelog entry for #289 (apply launcher flags to resume commands, auto-resume default on, codex placeholder update), per the changelog-per-feature convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)