### PR TITLE
chore: release v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tempo-term",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-term"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-term"
-version = "0.3.1"
+version = "0.3.2"
 description = "TempoTerm - AI-powered terminal, editor and file explorer"
 authors = ["TempoTerm"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TempoTerm",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.tempoterm.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Version bump to 0.3.2 across the four version files (package.json, tauri.conf.json, Cargo.toml, Cargo.lock via `cargo update -p tempo-term --offline`).

Release contents (CHANGELOG-NEXT.md, already on master):
- feat: native OSC 8 file hyperlinks (#243, #280)
- feat: collapsible source control sections (#277, #282)
- feat: launcher flags on resume + auto-resume default on (#289)
- fix: git graph branch tail overlaying the trunk (#274)
- fix: PowerShell fallback for UNC working directories (#284)
- fix: fs_read_file hardening + editor truncation fix (#286)
- fix: Windows codex hook install + stale agent label (#287)

🤖 Generated with [Claude Code](https://claude.com/claude-code)