### PR TITLE
fix(workspace): tell the tab and pane close buttons apart

### DIFF
--- a/src/components/PaneHeader.tsx
+++ b/src/components/PaneHeader.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { X } from "lucide-react";
+import { SquareMinus } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
 
 /**
@@ -29,6 +29,17 @@ export function PaneHeader({
       {left ?? <span />}
       <div className="flex shrink-0 items-center gap-0.5">
         {actions}
+        {/*
+          Deliberately not a ✕, and deliberately not the danger hover. This
+          button sits one row below the tab bar's own ✕, and the two used to be
+          near-identical glyphs a few pixels apart — with the colours the wrong
+          way round, since the tab ✕ destroys the whole tab (shells included, no
+          undo) while this one only peels off a split. So: the destructive close
+          keeps the ✕ and takes the danger hover, and this one reads as
+          "remove this cell" instead. The Panel and Columns icon families are
+          out: they already mean the sidebar toggles and the editor's split
+          mode.
+        */}
         {showClose && (
           <Tooltip label={t("workspace.closePane")}>
             <button
@@ -38,9 +49,9 @@ export function PaneHeader({
                 e.stopPropagation();
                 onClose();
               }}
-              className="rounded p-1 text-fg-muted transition-colors hover:bg-danger/15 hover:text-danger"
+              className="rounded p-1 text-fg-muted transition-colors hover:bg-border-strong hover:text-fg"
             >
-              <X size={14} />
+              <SquareMinus size={14} />
             </button>
           </Tooltip>
         )}

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -64,14 +64,16 @@ describe("TabBar global file search trigger", () => {
 });
 
 describe("TabBar close button tooltip", () => {
-  it("shows no tooltip on a clean tab's close button (the ✕ is self-explanatory)", () => {
+  // A split tab shows a second close button in each pane header one row below,
+  // so the ✕ cannot stand on its own — it has to name the level it acts on.
+  it("names the tab on a clean tab's close button", () => {
     vi.useFakeTimers();
     try {
       render(<TabBar />);
       const close = screen.getByLabelText("Close Tab");
       fireEvent.mouseEnter(close.parentElement!);
       act(() => vi.advanceTimersByTime(1000));
-      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Close Tab");
     } finally {
       vi.useRealTimers();
     }

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -173,8 +173,15 @@ function TabItem({ id }: { id: string }) {
           <span className="max-w-[160px] truncate">{tab.title}</span>
         </Tooltip>
       )}
-      {/* The ✕ glyph is self-explanatory; only the dirty dot needs a hint. */}
-      <Tooltip label={dirty ? t("editor:unsaved") : undefined} side="bottom">
+      {/*
+        Always labelled, and the only close button in the window that hovers to
+        danger. A split tab also shows a close button in each pane header one
+        row below; that one used to be the ✕-shaped red one even though it just
+        peels off a split, while this ✕ — which drops the whole tab, shells and
+        all, with no undo — hovered to plain grey. The weight now matches the
+        cost, and the tooltip names which is which.
+      */}
+      <Tooltip label={dirty ? t("editor:unsaved") : t("actions.closeTab")} side="bottom">
         <button
           type="button"
           aria-label={dirty ? t("editor:unsaved") : t("actions.closeTab")}
@@ -183,7 +190,7 @@ function TabItem({ id }: { id: string }) {
             e.stopPropagation();
             requestClose();
           }}
-          className="group/close rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
+          className="group/close rounded p-0.5 text-fg-subtle hover:bg-danger/15 hover:text-danger"
         >
           {dirty ? (
             <>


### PR DESCRIPTION
## Problem

Closes #296.

A split tab stacks two close buttons one row apart: the tab bar's, and the pane header's. Both rendered a bare lucide `X` at 13/14px, and the hover colours ran **backwards**:

| | tab close (`TabBar.tsx`) | pane close (`PaneHeader.tsx`) |
|---|---|---|
| glyph | `X` 13px | `X` 14px |
| hover | `bg-border-strong` / `text-fg` (grey) | `bg-danger/15` / `text-danger` (red) |
| cost | whole tab, every pane and its shell, **no undo** | peels off one split |

So the cheap action wore the alarming colour and the destructive one wore the neutral one. Reaching for the red button and landing on the grey one costs you the tab, which is exactly what the reporter hit.

The keyboard path was already fine (`closePaneOrTab` collapses a pane first and only closes the tab at one pane left) — this was purely a mouse-affordance problem.

## Fix

- **Pane header gets `SquareMinus` instead of `X`** — "remove this cell", not "close this thing".
- **Hover weights swap** so they track the cost: the tab `X` is now the only close button in the window that hovers to danger; the pane button hovers neutral.
- **The tab `X` is always labelled.** Its tooltip was suppressed on a clean tab under the reasoning that "the ✕ glyph is self-explanatory" — true only while it is the only close button on screen, which a split tab is exactly not.

### Why not a directional icon

`PanelRightClose` and friends read better in a 2-pane row split, but `PaneHeader` has no idea where it sits: the position would have to be threaded from `PaneTabContent` through all seven content components to reach it, and "which edge does this fold toward" has no honest answer in a nested or 3-way split. A single non-directional glyph keeps this to one file.

`Panel*` and `Columns*` are also spoken for — `PanelLeft`/`PanelRight` are the sidebar toggles in this same tab bar, and `Columns2` is the editor's split mode.

### Why not a confirm dialog

It was the reporter's suggestion and the first thing considered, but it taxes every intentional close to catch the rare accident, trains people to click through it, and dilutes `ConfirmDialog`, which this repo currently reserves for "you would lose unsaved work". It also leaves two identical buttons sitting next to each other. Scoping it to "only when a foreground process is running" does not rescue it either: `foreground_pid` is a stub off unix (`pty/session.rs:380`), so the guard would silently do nothing on Windows.

## Tests

`TabBar.test.tsx` had a test asserting the clean-tab close button shows **no** tooltip — that is the behaviour being changed, so it now asserts the tooltip names the tab, with the reasoning in a comment.

Full frontend suite green: 217 files / 1923 passed. `tsc --noEmit` clean. No Rust, capability, or `tauri.conf.json` changes.

## Follow-ups (not in this PR)

- `closeTab` has no undo of any kind and terminal panes kill their PTY on unmount, so an accidental tab close is unrecoverable. A reopen-closed-tab path is the real safety net, with the honest caveat that it re-launches rather than restores.
- Opening a file from the explorer always splits (`splitPaneWith(..., "row")`), which is the root cause the reporter also named. Worth asking them what they actually wanted before adding a setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
