### PR TITLE
feat(explorer): open a file in its own tab on Cmd/Ctrl-click

### DIFF
--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { matchesOpenModifier, openModifierLabel } from "./platform";
+import {
+  matchesNewTabModifier,
+  matchesOpenModifier,
+  openModifierLabel,
+} from "./platform";
 
 type Mods = { altKey?: boolean; metaKey?: boolean; ctrlKey?: boolean };
 const ev = (m: Mods) => ({ altKey: false, metaKey: false, ctrlKey: false, ...m });
@@ -25,6 +29,33 @@ describe("matchesOpenModifier", () => {
   });
   it("non-mac: Cmd alone does not match", () => {
     expect(matchesOpenModifier(ev({ metaKey: true }), false)).toBe(false);
+  });
+});
+
+// Narrower than matchesOpenModifier on purpose: Alt activates a terminal link
+// but has never meant "new tab" anywhere, so it must not open one here.
+describe("matchesNewTabModifier", () => {
+  it("mac: Cmd matches", () => {
+    expect(matchesNewTabModifier(ev({ metaKey: true }), true)).toBe(true);
+  });
+  it("mac: Ctrl does not match", () => {
+    expect(matchesNewTabModifier(ev({ ctrlKey: true }), true)).toBe(false);
+  });
+  it("mac: Alt does not match", () => {
+    expect(matchesNewTabModifier(ev({ altKey: true }), true)).toBe(false);
+  });
+  it("non-mac: Ctrl matches", () => {
+    expect(matchesNewTabModifier(ev({ ctrlKey: true }), false)).toBe(true);
+  });
+  it("non-mac: Cmd does not match", () => {
+    expect(matchesNewTabModifier(ev({ metaKey: true }), false)).toBe(false);
+  });
+  it("non-mac: Alt does not match", () => {
+    expect(matchesNewTabModifier(ev({ altKey: true }), false)).toBe(false);
+  });
+  it("no modifier never matches", () => {
+    expect(matchesNewTabModifier(ev({}), true)).toBe(false);
+    expect(matchesNewTabModifier(ev({}), false)).toBe(false);
   });
 });
 

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -44,3 +44,24 @@ export function matchesOpenModifier(
 export function openModifierLabel(isMac: boolean = IS_MAC): string {
   return isMac ? "Alt / Cmd" : "Alt / Ctrl";
 }
+
+/**
+ * Whether a click (or Enter) asks for a new tab instead of the sidebar's
+ * default, which is to split the active tab.
+ *
+ * Deliberately not `matchesOpenModifier`: that one is the terminal's
+ * link-activation gesture and counts Alt, which nowhere means "new tab". This
+ * is the plain Cmd/Ctrl-click that browsers, editors and Finder all share.
+ *
+ * Splitting on mac rather than on `IS_WINDOWS` is intentional here (cf. the
+ * windows-tauri rule against mac-vs-everything-else gates): Ctrl-click is the
+ * new-tab gesture on Windows *and* Linux, so the non-mac arm is the real
+ * Windows path, not a fallback that leaves it without one. Both arms are
+ * asserted in platform.test.ts.
+ */
+export function matchesNewTabModifier(
+  event: ModifierEvent,
+  isMac: boolean = IS_MAC,
+): boolean {
+  return isMac ? event.metaKey : event.ctrlKey;
+}

--- a/src/modules/explorer/FileFinder.test.tsx
+++ b/src/modules/explorer/FileFinder.test.tsx
@@ -50,6 +50,35 @@ describe("FileFinder opening a file", () => {
     const tab = useTabsStore.getState().tabs[0];
     expect(tab.paneTree.kind).toBe("split");
   });
+
+  // Both modifiers fired for the same reason as in FileTree.test.tsx: jsdom is
+  // neither platform, so the mapping is pinned in platform.test.ts instead.
+  const MODS = { metaKey: true, ctrlKey: true };
+
+  it("opens a modifier-clicked result in its own tab instead of splitting", async () => {
+    useTabsStore.getState().openEditorTab("/p/main.ts");
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("util.ts"));
+
+    fireEvent.click(screen.getByText("util.ts"), MODS);
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(2);
+    expect(tabs.every((t) => t.paneTree.kind === "leaf")).toBe(true);
+  });
+
+  it("honours the modifier on Enter, not just on click", async () => {
+    useTabsStore.getState().openEditorTab("/p/main.ts");
+    render(<FileFinder root="/p" onClose={() => {}} />);
+    await waitFor(() => screen.getByText("util.ts"));
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "util" } });
+    await waitFor(() => screen.getByText("util.ts"));
+    fireEvent.keyDown(input, { key: "Enter", ...MODS });
+
+    expect(useTabsStore.getState().tabs).toHaveLength(2);
+  });
 });
 
 describe("FileFinder keyboard navigation", () => {

--- a/src/modules/explorer/FileFinder.tsx
+++ b/src/modules/explorer/FileFinder.tsx
@@ -8,6 +8,7 @@ import { useRecentFilesStore } from "./lib/recentFiles";
 import { FileIcon } from "./components/FileIcon";
 import { InfoDialog } from "@/components/InfoDialog";
 import { useOverlayGuard } from "@/lib/overlayGuard";
+import { matchesNewTabModifier } from "@/lib/platform";
 import { useTabsStore } from "@/stores/tabsStore";
 
 interface FileFinderProps {
@@ -33,6 +34,7 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const activeResultRef = useRef<HTMLButtonElement | null>(null);
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
+  const openInNewTab = useTabsStore((s) => s.openInNewTab);
   const recentPaths = useRecentFilesStore((s) => s.paths);
   const addRecent = useRecentFilesStore((s) => s.addRecent);
 
@@ -113,8 +115,11 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
     // still re-scrolls back to the active row.
   }, [activeIndex, results]);
 
-  function open(path: string) {
-    const result = openFromSidebar({ kind: "editor", path });
+  /** `newTab` mirrors the file tree's Cmd/Ctrl gesture, on click and on Enter. */
+  function open(path: string, newTab = false) {
+    const result = newTab
+      ? openInNewTab({ kind: "editor", path })
+      : openFromSidebar({ kind: "editor", path });
     if (result.status === "at-capacity") {
       setAtCapacity(true);
       return;
@@ -138,7 +143,7 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
       e.preventDefault();
       setActiveIndex((i) => (results.length ? (i - 1 + results.length) % results.length : 0));
     } else if (e.key === "Enter" && results[activeIndex]) {
-      open(results[activeIndex]);
+      open(results[activeIndex], matchesNewTabModifier(e));
     }
   }
 
@@ -194,7 +199,7 @@ export function FileFinder({ root, onClose }: FileFinderProps) {
                     <button
                       ref={active ? activeResultRef : undefined}
                       type="button"
-                      onClick={() => open(path)}
+                      onClick={(event) => open(path, matchesNewTabModifier(event))}
                       // mousemove, not mouseenter: keyboard-driven scrolling
                       // can slide a row under a stationary cursor, and a plain
                       // enter there would steal the selection from the keyboard.

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -66,6 +66,36 @@ describe("FileTree opening a file", () => {
     const tab = useTabsStore.getState().tabs[0];
     expect(tab.paneTree.kind).toBe("split");
   });
+
+  // The component reads the platform default, and jsdom is neither mac nor
+  // Windows, so these fire both modifiers rather than betting on the UA
+  // sniff. Which key maps to which platform is pinned in platform.test.ts.
+  const newTabClick = (el: Element) =>
+    fireEvent.click(el, { metaKey: true, ctrlKey: true });
+
+  it("opens a modifier-clicked file in its own tab instead of splitting", () => {
+    const entries = [
+      { name: "main.ts", path: "/p/main.ts", is_dir: false, size: 0 },
+      { name: "util.ts", path: "/p/util.ts", is_dir: false, size: 0 },
+    ];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.click(screen.getByText("main.ts"));
+    newTabClick(screen.getByText("util.ts"));
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(2);
+    expect(tabs.every((t) => t.paneTree.kind === "leaf")).toBe(true);
+  });
+
+  it("ignores the modifier on a directory, which expands rather than opens", () => {
+    const entries = [{ name: "dir", path: "/p/dir", is_dir: true, size: 0 }];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    newTabClick(screen.getByText("dir"));
+
+    expect(useTabsStore.getState().tabs).toHaveLength(0);
+  });
 });
 
 describe("FileTree at pane capacity", () => {

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -15,6 +15,7 @@ import {
   TerminalSquare,
   Trash2,
 } from "lucide-react";
+import { matchesNewTabModifier } from "@/lib/platform";
 import { FileIcon } from "./components/FileIcon";
 import {
   fsCreateDir,
@@ -173,9 +174,16 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
     setExpanded(true);
   }
 
-  async function toggle() {
+  /**
+   * `newTab` is the Cmd/Ctrl-click path onto the same action the context menu
+   * already offers, for people who never find the context menu. Directories
+   * ignore it — clicking one expands it in place, it opens nothing.
+   */
+  async function toggle(newTab = false) {
     if (!entry.is_dir) {
-      const result = openFromSidebar({ kind: "editor", path: entry.path });
+      const result = newTab
+        ? openInNewTab({ kind: "editor", path: entry.path })
+        : openFromSidebar({ kind: "editor", path: entry.path });
       if (result.status === "at-capacity") {
         setAtCapacity(true);
       }
@@ -383,11 +391,11 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
           <Tooltip label={entry.name} className="w-full">
             <button
               type="button"
-              onClick={() => {
+              onClick={(event) => {
                 if (consumeDragClick()) {
                   return;
                 }
-                void toggle();
+                void toggle(matchesNewTabModifier(event));
               }}
               onContextMenu={(event) => {
                 event.preventDefault();


### PR DESCRIPTION
## Problem

Relates to #296 (the close-button half is #298).

Clicking a file in the explorer splits the active tab. That is the root cause the reporter named in their third suggestion: they wanted a second file open, got a second pane, and were then left picking between two close buttons.

The escape hatch already exists. `openInNewTab` has been in the store all along, and **"Open in New Tab" is already a right-click menu item** in the file tree, the notes sidebar, the connections panel and source control. The capability was never missing — it was only reachable through a menu nobody thinks to open.

## Fix

Wire the conventional Cmd/Ctrl-click onto the action the context menu already calls:

- **File tree** — modifier-click a file opens it in its own tab.
- **File finder** — same on click *and* on Enter, so the keyboard path is not a second-class citizen.

A plain click still splits. Nothing that relies on the current behaviour changes, and no setting is introduced.

### Why a gesture and not a setting

A setting looked cheap — `openFromSidebar` (`tabsStore.ts:709`) is a single seam and `SettingsState` is a flat persisted slice — but that same seam is shared by notes, SSH connections and source control, so one "don't split" toggle silently changes four surfaces to fix one. It also forces a global answer ("new tab" or "replace the pane") to what is really a per-click decision. The modifier gives both outcomes without a settings row to maintain.

### Why not `matchesOpenModifier`

The existing helper also counts Alt, because it is the terminal's link-*activation* gesture. Alt-click has never meant "new tab" anywhere, so `matchesNewTabModifier` is deliberately narrower: Cmd on mac, Ctrl elsewhere.

### Windows

Checked against the `windows-tauri` pre-flight. The only item that applies is rule 8 (frontend platform gates). The mac-vs-rest split is deliberate rather than an `IS_WINDOWS` branch: Ctrl-click is the new-tab gesture on Windows **and** Linux, so the non-mac arm is Windows' real path, not a fallback that leaves it without one — which is the failure mode that rule guards against. Both arms are asserted explicitly in `platform.test.ts`. Nothing else in the checklist is touched: no subprocess, no cfg-gating, no path building, no native crate, no Rust at all.

The explorer had no modifier handling before this, so there is nothing for Ctrl-click to collide with.

## Tests

- `platform.test.ts` — the mapping pinned for both platforms, including that Alt matches `matchesOpenModifier` but never `matchesNewTabModifier`.
- `FileTree.test.tsx` — modifier-click opens a second tab instead of splitting; a directory ignores the modifier and still just expands.
- `FileFinder.test.tsx` — same for click, and for Enter.

The component tests fire both modifiers at once, because the components read the platform default and jsdom is neither platform; the per-platform mapping is pinned in `platform.test.ts` instead. Noted in a comment at both sites.

Red-then-green verified: with the two source files reverted, 3 of the 4 new behaviour tests fail. The directory test passes either way by design — it is a guard against a future change making directories respond to the modifier.

Full suite green: 217 files / 1934 passed. `tsc --noEmit` clean.

## Not in this PR

`ContextMenuItem` has no field for a shortcut hint, so the right-click entry cannot advertise the new gesture yet. Adding one is a wider change to a shared component than this fix warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
