### PR TITLE
chore: release v0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tempo-term",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-term"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-term"
-version = "0.3.2"
+version = "0.3.3"
 description = "TempoTerm - AI-powered terminal, editor and file explorer"
 authors = ["TempoTerm"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TempoTerm",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "com.tempoterm.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump to 0.3.3 across the four version files (package.json, tauri.conf.json, Cargo.toml, Cargo.lock).

Ships the three changes already on master:

- #298 (fix) — tab and split-pane close buttons are no longer near-identical
- #300 (feat) — Cmd/Ctrl-click opens a file in its own tab
- #293 (fix) — Codex card titles resolve per session, not per directory

Release notes are already in CHANGELOG-NEXT.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)