### PR TITLE
feat(explorer): make the sidebar path row a clickable breadcrumb

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -4,6 +4,7 @@
 
 - Windows 上的 Git Bash 面板現在也會回報工作目錄，在裡面 `cd` 檔案總管會跟著切換；先前只有 PowerShell 和 cmd.exe 有這個同步 (#312)
 - 外觀設定新增自訂背景圖片，可預覽、保存或拖曳替換 PNG、JPEG、WebP，調整介面與終端機圖片透明度、文字顏色，並選擇只套用於工作區或延伸至整個視窗 (#305)
+- 檔案總管的路徑列改成可點選的麵包屑，跟終端機標題列一樣：點任一段會列出該目錄的子目錄、可就地展開下一層，選一個就把檔案總管切換到那裡（作用中的終端機也會一併 cd）；遠端 (SSH) 根目錄同樣適用 (#310)
 
 ### fix
 
@@ -11,7 +12,7 @@
 
 ### 貢獻者
 
-- @yw-chan (#312)
+- @yw-chan (#312, #310)
 - @mark22013333 (#305)
 
 ## English
@@ -20,6 +21,7 @@
 
 - Git Bash panes on Windows now report their working directory, so `cd` moves the file explorer with them — previously only PowerShell and cmd.exe were wired up (#312)
 - Add app-managed PNG, JPEG, or WebP background images in Appearance settings, with pre-commit preview, drag-to-replace, separate interface and terminal opacity, custom text colour, and workspace or whole-window scope (#305)
+- The explorer's path row is now a clickable breadcrumb, like a terminal pane header's: click a segment to list that directory's subdirectories, expand a level in place, and pick one to re-root the explorer there (the active terminal cds along); remote (SSH) roots work the same way (#310)
 
 ### fix
 
@@ -27,5 +29,5 @@
 
 ### Contributors
 
-- @yw-chan (#312)
+- @yw-chan (#312, #310)
 - @mark22013333 (#305)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,5 +13,5 @@ The unified h-7 strip at the top of a pane. Full headers (terminal, editor, prev
 _Avoid_: toolbar (reserved for rows of actions inside content, like GitGraphToolbar)
 
 **Breadcrumb**:
-The location trail on the left of a terminal or editor pane header, always home-relative (absolute outside home). Clicking a segment opens its menu — the segment itself plus its subdirectories for a terminal (directories expand in place), the files sharing the folder for an editor — and choosing an entry switches what this pane shows; it never opens a new tab.
+The location trail on the left of a terminal or editor pane header, and the explorer sidebar's path row under its title — always home-relative (absolute outside home). Clicking a segment opens its menu — the segment itself plus its subdirectories for a terminal or the explorer (directories expand in place), the files sharing the folder for an editor — and choosing an entry switches what that pane shows: the terminal cds, the editor swaps file, the explorer re-roots. It never opens a new tab.
 _Avoid_: path bar, address bar (that is the preview pane's URL row)

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -33,6 +33,8 @@ interface BreadcrumbProps {
   onSelect: (path: string) => void;
   /** Which segments open a menu. An editor only offers its filename segment. */
   clickable?: "all" | "last";
+  /** "sm" for the explorer sidebar's path row, whose text sits below pane-header size. */
+  size?: "sm" | "md";
   menu: BreadcrumbMenu;
 }
 
@@ -41,7 +43,13 @@ interface BreadcrumbProps {
  * "Breadcrumb"). Aligned to the trail's end so a narrow pane clips the head,
  * keeping the segments closest to the cwd/file visible.
  */
-export function Breadcrumb({ crumbs, onSelect, clickable = "all", menu }: BreadcrumbProps) {
+export function Breadcrumb({
+  crumbs,
+  onSelect,
+  clickable = "all",
+  size = "md",
+  menu,
+}: BreadcrumbProps) {
   const [openFor, setOpenFor] = useState<{ crumb: Crumb; x: number; y: number } | null>(null);
 
   function openMenu(e: MouseEvent<HTMLButtonElement>, crumb: Crumb) {
@@ -51,7 +59,11 @@ export function Breadcrumb({ crumbs, onSelect, clickable = "all", menu }: Breadc
   }
 
   return (
-    <div className="flex min-w-0 items-center justify-end overflow-hidden text-[13px] text-fg-muted">
+    <div
+      className={`flex min-w-0 items-center justify-end overflow-hidden text-fg-muted ${
+        size === "sm" ? "text-[11px]" : "text-[13px]"
+      }`}
+    >
       {crumbs.map((crumb, index) => {
         const isLast = index === crumbs.length - 1;
         const isClickable = clickable === "all" || isLast;

--- a/src/modules/explorer/ExplorerView.test.tsx
+++ b/src/modules/explorer/ExplorerView.test.tsx
@@ -1,8 +1,13 @@
-import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, act, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/i18n";
 
-vi.mock("./lib/fsBridge", () => ({ fsReadDir: vi.fn().mockResolvedValue([]) }));
+// fsHomeDir backs the path breadcrumb's home-relative trail; rejecting keeps the
+// home unknown so these tests read the plain absolute segments.
+vi.mock("./lib/fsBridge", () => ({
+  fsReadDir: vi.fn().mockResolvedValue([]),
+  fsHomeDir: vi.fn().mockRejectedValue(new Error("no home in tests")),
+}));
 
 import { ExplorerView } from "./ExplorerView";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -16,7 +21,11 @@ describe("ExplorerView remote root", () => {
     useWorkspaceStore.setState({ rootPath: "ssh://c1/home/me" });
     render(<ExplorerView />);
     expect(screen.queryByLabelText("Open folder")).toBeNull();
-    expect(screen.getByText("/home/me")).toBeInTheDocument();
+    // The path renders as breadcrumb segments of the remote path, never the raw
+    // ssh:// uri.
+    expect(screen.getByRole("button", { name: "home" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "me" })).toBeInTheDocument();
+    expect(screen.queryByText(/ssh:\/\//)).toBeNull();
   });
 
   it("keeps the open-folder button for a local root", () => {
@@ -31,6 +40,59 @@ describe("ExplorerView remote root", () => {
     useWorkspaceStore.setState({ rootPath: "/home/me" });
     render(<ExplorerView />);
     expect(screen.queryByLabelText("Find files")).toBeNull();
+  });
+});
+
+describe("ExplorerView path breadcrumb", () => {
+  it("re-roots the explorer at a directory picked from a path segment's menu", async () => {
+    const { fsReadDir } = await import("./lib/fsBridge");
+    vi.mocked(fsReadDir).mockImplementation(async (path: string) => {
+      if (path === "/work") {
+        return [
+          { name: "app", path: "/work/app", is_dir: true, size: 0 },
+          { name: "docs", path: "/work/docs", is_dir: true, size: 0 },
+        ];
+      }
+      if (path === "/work/app") {
+        return [{ name: "main.ts", path: "/work/app/main.ts", is_dir: false, size: 0 }];
+      }
+      return [];
+    });
+
+    useWorkspaceStore.setState({ rootPath: "/work/app" });
+    render(<ExplorerView />);
+    await screen.findByText("main.ts");
+
+    // Clicking the parent segment lists its subdirectories, headed by itself.
+    fireEvent.click(screen.getByRole("button", { name: "work" }));
+    const menu = await screen.findByRole("menu");
+    await within(menu).findByRole("menuitem", { name: "docs" });
+
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "docs" }));
+
+    await waitFor(() => expect(useWorkspaceStore.getState().rootPath).toBe("/work/docs"));
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("keeps a remote root remote when a segment is picked", async () => {
+    const { fsReadDir } = await import("./lib/fsBridge");
+    vi.mocked(fsReadDir).mockImplementation(async (path: string) => {
+      if (path === "ssh://c1/srv") {
+        return [{ name: "logs", path: "ssh://c1/srv/logs", is_dir: true, size: 0 }];
+      }
+      return [];
+    });
+
+    useWorkspaceStore.setState({ rootPath: "ssh://c1/srv/app" });
+    render(<ExplorerView />);
+
+    fireEvent.click(screen.getByRole("button", { name: "srv" }));
+    const menu = await screen.findByRole("menu");
+    fireEvent.click(await within(menu).findByRole("menuitem", { name: "logs" }));
+
+    // The picked path comes back as a plain remote path; the root must be
+    // rebuilt as an ssh:// uri or the tree would read it as a local folder.
+    await waitFor(() => expect(useWorkspaceStore.getState().rootPath).toBe("ssh://c1/srv/logs"));
   });
 });
 

--- a/src/modules/explorer/ExplorerView.tsx
+++ b/src/modules/explorer/ExplorerView.tsx
@@ -3,10 +3,13 @@ import { useTranslation } from "react-i18next";
 import { ChevronsDownUp, ChevronsUpDown, FolderOpen, RotateCw } from "lucide-react";
 import { FileTree } from "./FileTree";
 import { Tooltip } from "@/components/Tooltip";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { buildCrumbs } from "@/lib/breadcrumb";
+import { listSubdirectories, useHomeDir } from "@/components/paneCrumbs";
 import { fsReadDir, type DirEntry } from "./lib/fsBridge";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { pickFolder } from "@/lib/dialog";
-import { isRemoteUri, parseRemoteUri } from "@/modules/ssh/lib/remotePath";
+import { buildRemoteUri, isRemoteUri, parseRemoteUri } from "@/modules/ssh/lib/remotePath";
 
 export function ExplorerView() {
   const { t } = useTranslation("explorer");
@@ -31,7 +34,16 @@ export function ExplorerView() {
   // A remote (SFTP) root hides local-only controls and shows the remote path
   // rather than the raw ssh:// uri.
   const remote = rootPath ? isRemoteUri(rootPath) : false;
-  const displayRoot = rootPath ? (parseRemoteUri(rootPath)?.path ?? rootPath) : null;
+  const remoteRoot = rootPath ? parseRemoteUri(rootPath) : null;
+  const displayRoot = rootPath ? (remoteRoot?.path ?? rootPath) : null;
+
+  // The root's path row is a breadcrumb, same as a terminal pane header's:
+  // clicking a segment lists its subdirectories, and picking one re-roots the
+  // explorer there. Because the workspace root is two-way bound to the active
+  // terminal (see terminal/lib/cwdSync), that also cds the shell — exactly what
+  // opening another folder does today.
+  const homeDir = useHomeDir(remoteRoot?.connectionId);
+  const crumbs = displayRoot ? buildCrumbs(displayRoot, { homeDir }) : [];
 
   async function openFolder() {
     const folder = await pickFolder();
@@ -138,9 +150,30 @@ export function ExplorerView() {
       </div>
 
       {rootPath && (
-        <div className="border-b border-border px-3 py-1">
-          <Tooltip label={displayRoot ?? rootPath} className="max-w-full">
-            <span className="block truncate text-[11px] text-fg-subtle">{displayRoot}</span>
+        // The wrapper is a flex row and the tooltip span a min-w-0 item, so the
+        // trail sits left while it fits and only starts clipping its head — the
+        // segments furthest from the current folder — once the sidebar is too
+        // narrow for it.
+        <div className="flex border-b border-border px-3 py-1">
+          <Tooltip label={displayRoot ?? rootPath} className="min-w-0">
+            {crumbs.length > 0 ? (
+              <Breadcrumb
+                crumbs={crumbs}
+                size="sm"
+                menu={{
+                  kind: "tree",
+                  loadChildren: (path) => listSubdirectories(path, remoteRoot?.connectionId),
+                }}
+                onSelect={(path) =>
+                  setRoot(remoteRoot ? buildRemoteUri(remoteRoot.connectionId, path) : path)
+                }
+              />
+            ) : (
+              // A filesystem root ("/") has no segments below it to walk. Same
+              // size and colour as the Breadcrumb above, so the row does not
+              // change shade with the folder it is showing.
+              <span className="block truncate text-[11px] text-fg-muted">{displayRoot}</span>
+            )}
           </Tooltip>
         </div>
       )}


### PR DESCRIPTION
## Problem

A terminal pane header shows its cwd as a clickable breadcrumb — click a segment, get that directory's subdirectories, pick one and the pane follows. The file explorer's root path, right under the sidebar title, was still plain truncated text: it told you where you were but you could not go anywhere from it. Moving up one level meant reopening the folder picker.

## Changes

- The explorer's path row now renders the shared `Breadcrumb` with the terminal's `tree` menu: clicking a segment lists that directory's subdirectories (expandable in place) and picking one re-roots the explorer there. Since the workspace root is already two-way bound to the active terminal (`terminal/lib/cwdSync`), a pick also cds that shell — the same thing "open folder" does today.
- `Breadcrumb` gains `size="sm"` so the sidebar keeps its 11px row; pane headers stay at 13px.
- Remote (SFTP) roots keep working: subdirectories are listed over that connection, and the picked plain path is rebuilt into an `ssh://` uri so the tree does not read it as a local folder.
- A filesystem root (`/`) has no segments below it to walk, so it falls back to the plain text row.
- The row is a flex container holding a `min-w-0` item, so the trail sits left while it fits and clips its head — not its tail — once the sidebar is too narrow. The current folder stays visible.
- CONTEXT.md's Breadcrumb glossary entry now covers this third location.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 218 files, 1946 tests passing
- [x] New `ExplorerView` tests: picking a directory from a segment's menu re-roots the explorer, and a remote root stays remote (`ssh://c1/srv/logs`)
- [x] `pnpm tauri dev` builds and launches with the change in place
- [x] Manual: click a parent segment in the explorer path row, expand a subdirectory, pick it — the tree re-roots and the active terminal cds there

🤖 Generated with [Claude Code](https://claude.com/claude-code)