### PR TITLE
feat(terminal): report the cwd from Git Bash panes on Windows

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -2,6 +2,8 @@
 
 ### feat
 
+- Windows 上的 Git Bash 面板現在也會回報工作目錄，在裡面 `cd` 檔案總管會跟著切換；先前只有 PowerShell 和 cmd.exe 有這個同步 (#312)
+
 ### fix
 
 ### 貢獻者
@@ -9,6 +11,8 @@
 ## English
 
 ### feat
+
+- Git Bash panes on Windows now report their working directory, so `cd` moves the file explorer with them — previously only PowerShell and cmd.exe were wired up (#312)
 
 ### fix
 

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -94,15 +94,21 @@ fn build_shell_command(
     // Windows has no OS-level cwd backend (no /proc, no lsof — see
     // read_process_cwd below), so the shell itself reports its cwd via OSC 7 at
     // every prompt: PowerShell through an injected prompt wrapper, cmd.exe
-    // through a PROMPT prefix. The frontend parses the sequence (see
-    // src/modules/terminal/lib/osc7.ts). Unix keeps the poll backend.
+    // through a PROMPT prefix, bash through PROMPT_COMMAND. The frontend parses
+    // the sequence (see src/modules/terminal/lib/osc7.ts). Unix keeps the poll
+    // backend.
     #[cfg(windows)]
     {
         for arg in super::shell::windows_integration_args(&shell) {
             cmd.arg(arg);
         }
         let inherited_prompt = std::env::var("PROMPT").ok();
-        for (key, value) in super::shell::windows_integration_env(&shell, inherited_prompt) {
+        let inherited_prompt_command = std::env::var("PROMPT_COMMAND").ok();
+        for (key, value) in super::shell::windows_integration_env(
+            &shell,
+            inherited_prompt,
+            inherited_prompt_command,
+        ) {
             cmd.env(key, value);
         }
     }

--- a/src-tauri/src/modules/pty/shell.rs
+++ b/src-tauri/src/modules/pty/shell.rs
@@ -269,6 +269,24 @@ const POWERSHELL_OSC7_SNIPPET: &str = r#"if ($env:TEMPOTERM_OSC7 -ne '1') {
   }
 }"#;
 
+/// The bash counterpart of the PowerShell snippet, run through `PROMPT_COMMAND`
+/// (bash executes it before printing each prompt). This is what makes the
+/// explorer follow `cd` in a Git Bash / MSYS2 pane, which until now reported
+/// nothing at all: Windows has no cwd backend to poll, and the PowerShell and
+/// cmd hooks only cover their own shells.
+///
+/// The path needs converting because bash reports MSYS paths (`/d/code`) while
+/// the frontend parser only accepts drive-lettered ones — deliberately, so a
+/// cwd leaking from a remote shell inside the pane can't move the explorer to a
+/// directory that doesn't exist here (see `parseOsc7Cwd`). The common case, a
+/// path under a drive mount, is rewritten with a bash regex and costs no
+/// process; only MSYS-virtual locations (`/tmp`, `/usr/bin`) fall back to
+/// `cygpath -w`. An empty result — no `cygpath`, as under WSL's `bash.exe`,
+/// whose `/mnt/d` paths this shell integration cannot describe anyway — reports
+/// nothing rather than a wrong directory.
+#[cfg_attr(not(windows), allow(dead_code))]
+const BASH_OSC7_PROMPT_COMMAND: &str = r#"__tempoterm_d="$PWD"; if [[ $__tempoterm_d =~ ^/([A-Za-z])(/.*)?$ ]]; then __tempoterm_d="${BASH_REMATCH[1]^^}:${BASH_REMATCH[2]}"; else __tempoterm_d="$(cygpath -w "$__tempoterm_d" 2>/dev/null)"; fi; if [ -n "$__tempoterm_d" ]; then printf '\033]7;file://localhost/%s\033\\' "$__tempoterm_d"; fi"#;
+
 /// The last path component, split on both separators so a Windows path still
 /// resolves when this code is unit-tested on Unix, lowercased for matching.
 #[cfg_attr(not(windows), allow(dead_code))]
@@ -295,6 +313,15 @@ fn is_cmd(shell: &str) -> bool {
     shell_file_name(shell).trim_end_matches(".exe") == "cmd"
 }
 
+/// True for Git Bash / MSYS2 bash, and for `sh.exe` — which Git for Windows
+/// ships as bash under another name. A shell that only *looks* like this and
+/// ignores `PROMPT_COMMAND` (a real POSIX `sh`) simply reports no cwd; the
+/// variable is never read, so nothing breaks.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn is_bash(shell: &str) -> bool {
+    matches!(shell_file_name(shell).trim_end_matches(".exe"), "bash" | "sh")
+}
+
 /// PowerShell's `-EncodedCommand` payload: base64 of the UTF-16LE script bytes.
 #[cfg_attr(not(windows), allow(dead_code))]
 fn encoded_command(script: &str) -> String {
@@ -319,27 +346,51 @@ pub fn windows_integration_args(shell: &str) -> Vec<String> {
     ]
 }
 
-/// Extra environment that wires up cwd reporting on Windows. cmd.exe has no
-/// prompt function to wrap, but its `PROMPT` string expands `$e` to ESC and
-/// `$p` to the current directory, so prefixing the user's prompt (default
-/// `$P$G`, i.e. `C:\dir>`) with an OSC 7 report does the same job. The path
-/// arrives raw — unencoded spaces and backslashes — which the frontend parser
-/// tolerates. Other shells get nothing.
+/// Extra environment that wires up cwd reporting on Windows.
+///
+/// cmd.exe has no prompt function to wrap, but its `PROMPT` string expands `$e`
+/// to ESC and `$p` to the current directory, so prefixing the user's prompt
+/// (default `$P$G`, i.e. `C:\dir>`) with an OSC 7 report does the same job. The
+/// path arrives raw — unencoded spaces and backslashes — which the frontend
+/// parser tolerates.
+///
+/// bash (Git Bash / MSYS2) gets the same report from `PROMPT_COMMAND`, which it
+/// runs before every prompt. Both values wrap whatever the user already had —
+/// Git for Windows' own profile sets neither, but a `PROMPT_COMMAND` inherited
+/// from the environment would otherwise be lost. Any other shell gets nothing.
 #[cfg_attr(not(windows), allow(dead_code))]
 pub fn windows_integration_env(
     shell: &str,
     current_prompt: Option<String>,
+    current_prompt_command: Option<String>,
 ) -> Vec<(String, String)> {
-    if !is_cmd(shell) {
-        return Vec::new();
+    if is_cmd(shell) {
+        let user_prompt = current_prompt
+            .filter(|p| !p.trim().is_empty())
+            .unwrap_or_else(|| "$P$G".to_string());
+        return vec![(
+            "PROMPT".to_string(),
+            format!("$e]7;file://localhost/$P$e\\{user_prompt}"),
+        )];
     }
-    let user_prompt = current_prompt
-        .filter(|p| !p.trim().is_empty())
-        .unwrap_or_else(|| "$P$G".to_string());
-    vec![(
-        "PROMPT".to_string(),
-        format!("$e]7;file://localhost/$P$e\\{user_prompt}"),
-    )]
+    if is_bash(shell) {
+        let user_command = current_prompt_command.filter(|c| !c.trim().is_empty());
+        // Already wrapped (a shell spawned from inside a tempo-term pane
+        // inherits the wrapped value): leave it alone rather than reporting the
+        // cwd twice per prompt.
+        if user_command
+            .as_deref()
+            .is_some_and(|c| c.contains("__tempoterm_d"))
+        {
+            return Vec::new();
+        }
+        let value = match user_command {
+            Some(user) => format!("{BASH_OSC7_PROMPT_COMMAND}; {user}"),
+            None => BASH_OSC7_PROMPT_COMMAND.to_string(),
+        };
+        return vec![("PROMPT_COMMAND".to_string(), value)];
+    }
+    Vec::new()
 }
 
 /// True for a UNC path (`\\server\share`, or the `//server/share` form Win32
@@ -664,7 +715,7 @@ mod tests {
     #[test]
     fn cmd_gets_an_osc7_prompt_prefix_keeping_the_default_prompt() {
         for shell in ["cmd.exe", r"C:\Windows\System32\cmd.exe", "cmd"] {
-            let env = windows_integration_env(shell, None);
+            let env = windows_integration_env(shell, None, None);
             assert_eq!(
                 env,
                 vec![(
@@ -675,19 +726,57 @@ mod tests {
             );
         }
         // A blank inherited PROMPT falls back to the default too.
-        let env = windows_integration_env("cmd.exe", Some("   ".to_string()));
+        let env = windows_integration_env("cmd.exe", Some("   ".to_string()), None);
         assert_eq!(env[0].1, r"$e]7;file://localhost/$P$e\$P$G");
     }
 
     #[test]
     fn cmd_prompt_prefix_preserves_a_custom_prompt() {
-        let env = windows_integration_env("cmd.exe", Some("$D $P$G".to_string()));
+        let env = windows_integration_env("cmd.exe", Some("$D $P$G".to_string()), None);
         assert_eq!(env[0].1, r"$e]7;file://localhost/$P$e\$D $P$G");
     }
 
     #[test]
-    fn non_cmd_shells_get_no_integration_env() {
-        assert!(windows_integration_env("powershell.exe", None).is_empty());
-        assert!(windows_integration_env("/bin/zsh", None).is_empty());
+    fn bash_gets_an_osc7_prompt_command() {
+        for shell in [
+            r"C:\Program Files\Git\bin\bash.exe",
+            "C:/Program Files/Git/usr/bin/sh.exe",
+            "bash",
+        ] {
+            let env = windows_integration_env(shell, None, None);
+            assert_eq!(env.len(), 1, "{shell}");
+            assert_eq!(env[0].0, "PROMPT_COMMAND", "{shell}");
+            // Reports OSC 7, and rewrites the MSYS path into the drive-lettered
+            // form the frontend parser accepts.
+            assert!(env[0].1.contains(r"\033]7;file://localhost/%s"), "{shell}");
+            assert!(env[0].1.contains("BASH_REMATCH"), "{shell}");
+            assert!(env[0].1.contains("cygpath -w"), "{shell}");
+        }
+    }
+
+    #[test]
+    fn bash_prompt_command_keeps_an_inherited_one() {
+        let env = windows_integration_env("bash.exe", None, Some("history -a".to_string()));
+        assert!(env[0].1.starts_with(BASH_OSC7_PROMPT_COMMAND));
+        assert!(env[0].1.ends_with("; history -a"));
+
+        // Blank is the same as unset, not something worth appending.
+        let env = windows_integration_env("bash.exe", None, Some("  ".to_string()));
+        assert_eq!(env[0].1, BASH_OSC7_PROMPT_COMMAND);
+    }
+
+    #[test]
+    fn bash_prompt_command_is_not_wrapped_twice() {
+        // A shell launched from inside a pane inherits the wrapped value; adding
+        // ours again would report the cwd twice per prompt.
+        let already = format!("{BASH_OSC7_PROMPT_COMMAND}; history -a");
+        assert!(windows_integration_env("bash.exe", None, Some(already)).is_empty());
+    }
+
+    #[test]
+    fn shells_without_an_integration_get_no_env() {
+        assert!(windows_integration_env("powershell.exe", None, None).is_empty());
+        assert!(windows_integration_env("/bin/zsh", None, None).is_empty());
+        assert!(windows_integration_env("/usr/bin/nu", None, None).is_empty());
     }
 }

--- a/src/modules/terminal/lib/osc7.test.ts
+++ b/src/modules/terminal/lib/osc7.test.ts
@@ -16,6 +16,19 @@ describe("parseOsc7Cwd", () => {
     );
   });
 
+  it("parses Git Bash's PROMPT_COMMAND report", () => {
+    // The injected PROMPT_COMMAND (see windows_integration_env in
+    // src-tauri/src/modules/pty/shell.rs) rewrites MSYS "/d/code" into the
+    // drive-lettered form before printing, so forward slashes arrive here.
+    expect(parseOsc7Cwd("file://localhost/D:/code/tempo-term")).toBe("D:\\code\\tempo-term");
+    // A drive root reports as a bare "D:" (BASH_REMATCH[2] is empty there).
+    expect(parseOsc7Cwd("file://localhost/D:")).toBe("D:\\");
+    // MSYS-virtual locations come from `cygpath -w`, i.e. already backslashed.
+    expect(parseOsc7Cwd("file://localhost/C:\\Users\\muki\\AppData\\Local\\Temp")).toBe(
+      "C:\\Users\\muki\\AppData\\Local\\Temp",
+    );
+  });
+
   it("decodes percent-encoded non-ASCII (CJK folder names) back to UTF-8", () => {
     expect(parseOsc7Cwd("file:///D:/%E5%B0%88%E6%A1%88/app")).toBe("D:\\專案\\app");
   });


### PR DESCRIPTION
## Problem

On Windows the explorer-follows-terminal sync only works in PowerShell and cmd.exe panes. In a Git Bash / MSYS2 pane, `cd` never moves the file explorer — the sync is one-way there (the explorer can still cd the shell, but not the reverse).

## Root cause

Windows has no OS-level cwd backend (no `/proc`, no `lsof`), so `TerminalView`'s Windows branch relies entirely on an OSC 7 report from the shell. That report comes from injected shell integration, and `windows_integration_args` / `windows_integration_env` only cover PowerShell (a prompt-function wrapper) and cmd.exe (a `PROMPT` prefix) — "Other shells get nothing".

## Changes

- `windows_integration_env` now also returns a `PROMPT_COMMAND` for bash (`bash.exe`, and `sh.exe` — which Git for Windows ships as bash), which bash runs before each prompt. Git for Windows' own profile sets neither `PROMPT` nor `PROMPT_COMMAND`, so the injected value survives into the interactive shell.
- The snippet rewrites the path before reporting: bash reports MSYS paths (`/d/code`) while `parseOsc7Cwd` only accepts drive-lettered ones — deliberately, so a cwd leaking from a remote shell inside the pane can't move the explorer somewhere that doesn't exist locally. A bash regex covers the common drive-mount case with no extra process; only MSYS-virtual locations (`/tmp`, `/usr/bin`) fall back to `cygpath -w`.
- An empty conversion reports nothing rather than a wrong directory. That is also what WSL's `bash.exe` gets: its `/mnt/d` paths are outside what this integration can describe, so such a pane stays silent instead of guessing.
- An inherited `PROMPT_COMMAND` is preserved (ours runs first, then theirs), and a value that already carries the injection is left alone, so a shell started from inside a pane doesn't report twice per prompt.
- No frontend parser change was needed — the emitted forms are already what `parseOsc7Cwd` accepts; a test pins that.

## Test plan

- [x] `cargo test` — new `shell.rs` tests cover the bash env, the inherited-value wrap, the no-double-wrap guard, and that other shells still get nothing
- [x] `RUSTFLAGS="-D warnings" cargo check` (what Windows Check CI runs)
- [x] `pnpm typecheck`, `pnpm test` for `osc7.test.ts` — new cases for the Git Bash payloads (`file://localhost/D:/code/tempo-term`, the bare `D:` drive root, and a `cygpath -w` backslashed path)
- [x] Ran the exact injected snippet through Git Bash (5.3, MINGW64) and captured the emitted bytes:
      `cd /d/code` → `ESC]7;file://localhost/D:/code ESC\`, `cd /tmp` → `.../C:\Users\...\AppData\Local\Temp`, `cd /d` → `.../D:`
- [x] Verified `$?` survives `PROMPT_COMMAND`, so a user prompt showing the last exit status is unaffected
- [x] Manual: set the custom shell path to `C:\Program Files\Git\bin\bash.exe`, open a pane, `cd` around — the explorer root should follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)