### PR TITLE
docs: fill in the contributors section and correct the OSC 7 comments

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -8,6 +8,8 @@
 
 ### 貢獻者
 
+- @yw-chan (#312)
+
 ## English
 
 ### feat
@@ -17,3 +19,5 @@
 ### fix
 
 ### Contributors
+
+- @yw-chan (#312)

--- a/src-tauri/src/modules/pty/shell.rs
+++ b/src-tauri/src/modules/pty/shell.rs
@@ -284,6 +284,25 @@ const POWERSHELL_OSC7_SNIPPET: &str = r#"if ($env:TEMPOTERM_OSC7 -ne '1') {
 /// `cygpath -w`. An empty result — no `cygpath`, as under WSL's `bash.exe`,
 /// whose `/mnt/d` paths this shell integration cannot describe anyway — reports
 /// nothing rather than a wrong directory.
+///
+/// Two things the other two hooks never have to deal with. The uppercase drive
+/// letter is load-bearing rather than cosmetic: `shouldCdToRoot` compares the
+/// reported cwd against the explorer root as plain strings, so a lowercase
+/// `d:\code` never matches a `D:\code` root and the two keep cd-ing at each
+/// other; PowerShell's `System.Uri` and cmd's `$P` both report uppercase
+/// already. And `${var^^}` needs bash 4.0+ — on an older one it is a runtime
+/// `bad substitution` that aborts the rest of the command, leaving the pane
+/// printing an error line at every prompt and reporting nothing. Git for
+/// Windows ships 5.x, but `is_bash` also matches `sh`.
+///
+/// This is also the only one of the three a user can override: a
+/// `PROMPT_COMMAND` assignment in `~/.bashrc` wins over the value we put in the
+/// environment. Windows panes run bash non-login (`login_args` splits on `/`
+/// alone, so a `C:\...\bash.exe` never matches it), so `/etc/profile` and its
+/// `profile.d` scripts never run — but `/etc/bash.bashrc` and `~/.bashrc` do.
+/// PowerShell's snippet arrives as an `-EncodedCommand` that runs after the
+/// profile, and cmd has no rc file at all. Losing this hook degrades to the old
+/// behaviour, no report, rather than to a wrong one.
 #[cfg_attr(not(windows), allow(dead_code))]
 const BASH_OSC7_PROMPT_COMMAND: &str = r#"__tempoterm_d="$PWD"; if [[ $__tempoterm_d =~ ^/([A-Za-z])(/.*)?$ ]]; then __tempoterm_d="${BASH_REMATCH[1]^^}:${BASH_REMATCH[2]}"; else __tempoterm_d="$(cygpath -w "$__tempoterm_d" 2>/dev/null)"; fi; if [ -n "$__tempoterm_d" ]; then printf '\033]7;file://localhost/%s\033\\' "$__tempoterm_d"; fi"#;
 

--- a/src/modules/terminal/lib/osc7.ts
+++ b/src/modules/terminal/lib/osc7.ts
@@ -4,10 +4,11 @@
  *
  * macOS/Linux read the shell's cwd from the OS (lsof / /proc — see
  * `read_process_cwd` in src-tauri/src/modules/pty/session.rs); Windows has no
- * such backend, so the injected shell integration (a PowerShell prompt wrapper
- * / a cmd.exe PROMPT prefix — see `windows_integration_args` /
- * `windows_integration_env` in src-tauri/src/modules/pty/shell.rs) makes the
- * shell announce its cwd in an OSC 7 sequence at every prompt instead.
+ * such backend, so the injected shell integration (a PowerShell prompt wrapper,
+ * a cmd.exe PROMPT prefix, a bash PROMPT_COMMAND — see
+ * `windows_integration_args` / `windows_integration_env` in
+ * src-tauri/src/modules/pty/shell.rs) makes the shell announce its cwd in an
+ * OSC 7 sequence at every prompt instead.
  */
 
 /**
@@ -18,9 +19,11 @@
  * shell (`ssh` run inside the pane, WSL) whose directories don't exist here —
  * matching macOS, where a pane running ssh keeps the explorer on the local dir.
  *
- * Tolerates both local emitters: PowerShell sends a percent-encoded URI
+ * Tolerates all three local emitters: PowerShell sends a percent-encoded URI
  * (`file:///C:/Users/f%20o`), while cmd.exe's PROMPT expands `$P` raw
- * (`file://localhost/C:\Users\f o` — spaces, backslashes and `%` unencoded).
+ * (`file://localhost/C:\Users\f o` — spaces, backslashes and `%` unencoded) and
+ * bash's PROMPT_COMMAND prints an equally raw drive-lettered path, rewritten
+ * from the MSYS form it starts out in (`file://localhost/D:/code`).
  */
 export function parseOsc7Cwd(payload: string): string | null {
   // Cap the raw input before any decoding or regex work: a hostile or runaway


### PR DESCRIPTION
Follow-ups to #312. Comments and changelog only, no behaviour change.

## Changes

- **`CHANGELOG-NEXT.md`** — the 貢獻者/Contributors headings were left empty. Filling them is the reason #306 added them, and `checkChangelog.mjs` rejects an empty section at release time, so the cycle's first community PR should fill them rather than leave it for the release.
- **`osc7.ts`** — the file comment and `parseOsc7Cwd`'s doc still described two emitters. Bash is a third, and its payload is raw like cmd's rather than percent-encoded like PowerShell's, which is the part a reader of the parser needs.
- **`BASH_OSC7_PROMPT_COMMAND`** — records the two constraints that are invisible from the snippet itself:
  - The uppercase drive letter is load-bearing, not cosmetic. `shouldCdToRoot` compares the reported cwd to the explorer root as plain strings, so a lowercase `d:\code` against a `D:\code` root never matches and the two keep cd-ing at each other. Worth writing down before someone drops `${var^^}` to widen bash compatibility.
  - `${var^^}` needs bash 4.0+. On an older one it is a runtime `bad substitution` that aborts the rest of the command, so the pane prints an error line at every prompt and reports nothing. Git for Windows ships 5.x, but `is_bash` also matches `sh`.
  - Also notes that this is the only one of the three hooks a user can override (a `PROMPT_COMMAND` in `~/.bashrc` wins over the environment value), and that Windows panes run bash non-login, so it is `/etc/bash.bashrc` and `~/.bashrc` that matter here, not `/etc/profile`.

## Test plan

- [x] `pnpm typecheck`
- [x] `cargo check`
- [x] `node scripts/checkChangelog.mjs CHANGELOG-NEXT.md` — the contributors sections no longer come up empty (`fix` still does, as expected mid-cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)