### PR TITLE
fix(settings): discard the background draft when settings close by any route

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -92,4 +92,39 @@ describe("SettingsModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /Live preview/ }));
     expect(screen.getByTestId("background-preview-panel")).toBeInTheDocument();
   });
+
+  it("drops the background draft when settings close without going through close() or Escape", () => {
+    useBackgroundImageDraftStore.getState().begin({
+      path: "/pictures/draft.png",
+      opacity: 40,
+      terminalOpacity: 50,
+      scope: "workspace",
+      textColor: null,
+    });
+    const { unmount } = render(<SettingsModal />);
+
+    // What AboutSettingsSection does: flip the store and let App unmount us.
+    useUiStore.getState().setSettingsOpen(false);
+    unmount();
+
+    expect(useBackgroundImageDraftStore.getState().draft).toBeNull();
+  });
+
+  it("leaves live preview when the modal unmounts mid-preview", () => {
+    useBackgroundImageDraftStore.getState().begin({
+      path: "/pictures/draft.png",
+      opacity: 40,
+      terminalOpacity: 50,
+      scope: "workspace",
+      textColor: null,
+    });
+    useBackgroundImageDraftStore.getState().enterPreview();
+    const { unmount } = render(<SettingsModal />);
+
+    unmount();
+
+    // Otherwise useBackgroundImage keeps serving the draft to the whole shell,
+    // with no panel left on screen to get out of it.
+    expect(useBackgroundImageDraftStore.getState().previewActive).toBe(false);
+  });
 });

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -39,6 +39,17 @@ export function SettingsModal() {
     return () => window.removeEventListener("keydown", onKey);
   }, [cancelBackgroundDraft, leaveBackgroundPreview, setSettingsOpen]);
 
+  // close() and Escape both drop the background draft, but they are not the
+  // only ways out: AboutSettingsSection closes settings to go elsewhere, and
+  // anything else flipping settingsOpen from outside skips them entirely. A
+  // draft left behind reopens holding last session's unapplied edits, and one
+  // left mid-preview keeps previewActive true with no panel on screen to leave
+  // it — the whole shell then renders someone's abandoned preview. Unmount is
+  // the one point every exit passes through.
+  useEffect(() => {
+    return () => useBackgroundImageDraftStore.getState().cancel();
+  }, []);
+
   if (previewActive) {
     return (
       <div


### PR DESCRIPTION
Follow-up to #305, found while reviewing it.

## Problem

`close()` and Escape both call `cancel()` on the background draft store, but they are not the only ways out of settings. `AboutSettingsSection.tsx:123` closes the modal to go elsewhere, and anything else flipping `settingsOpen` from outside skips both handlers.

Two consequences, one mild and one not:

- A draft that survives reopens holding last session's unapplied edits.
- A draft abandoned **mid-preview** leaves `previewActive` true after the modal unmounts. `useBackgroundImage` keeps serving the draft to the whole shell, and the panel that would let you leave preview went away with the modal — so reopening settings renders the preview layer again instead of the settings body.

## Fix

Cancel on unmount. Every exit route passes through it, so the two handlers no longer have to each remember.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/components/SettingsModal.test.tsx` — 7 passed
- [x] Verified both new tests fail with the effect removed (2 failed / 5 passed), so they pin the new behaviour rather than passing by accident

No changelog entry: #305 has not shipped yet, so there is no released behaviour to describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)