### PR TITLE
fix(shortcuts): stop bare Ctrl+letter combos firing app actions on macOS

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -9,6 +9,7 @@
 ### fix
 
 - 修正整個視窗模式下終端機重複套用遮罩的問題 (#305)
+- 修正 macOS 上 `Ctrl+T`、`Ctrl+P`、`Ctrl+,`、`Ctrl+D` 會誤觸應用程式功能的問題。這幾組在終端機裡是控制碼，先前按一次會同時送出控制碼並執行應用程式動作，例如 `Ctrl+D` 送出 EOF 的同時把窗格分割掉；現在一律留給終端機，應用程式快捷鍵維持用 `Cmd` (#317)
 
 ### 貢獻者
 
@@ -26,6 +27,7 @@
 ### fix
 
 - Fix duplicate terminal wallpaper masks in whole-window mode (#305)
+- Fix `Ctrl+T`, `Ctrl+P`, `Ctrl+,` and `Ctrl+D` firing app actions on macOS. They are terminal control codes, so a single press used to send the byte and run the app action together — `Ctrl+D` sent EOF to the shell while splitting the pane. They now belong to the terminal; the app's shortcuts stay on `Cmd` (#317)
 
 ### Contributors
 

--- a/src/App.mac.test.tsx
+++ b/src/App.mac.test.tsx
@@ -152,4 +152,48 @@ describe("App shell — macOS keyboard shortcuts", () => {
     const tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
     expect(tab?.paneTree).toEqual(paneTree);
   });
+
+  it("leaves bare Ctrl+letter combos alone on macOS", () => {
+    // The app's modifier here is Cmd. Every one of these is a terminal control
+    // code or a readline binding — ^D is EOF, ^P walks history, ^T transposes,
+    // and ^B is tmux's prefix — so a focused terminal sends the byte and then
+    // lets the event bubble up to this handler (see the attachCustomKeyEventHandler
+    // comment in TerminalView). Acting on it here fires the app action *as well
+    // as* the control code, on every press.
+    const paneTree = splitLeaf(
+      leaf("left-leaf", { kind: "launcher" }),
+      "left-leaf",
+      "row",
+      "right-leaf",
+      { kind: "launcher" },
+    );
+    useTabsStore.setState({
+      spaces: [{ id: "s1", name: "Space 1" }],
+      activeSpaceId: "s1",
+      tabs: [
+        {
+          id: "a",
+          spaceId: "s1",
+          title: "a",
+          kind: "launcher" as const,
+          paneTree,
+          activeLeafId: "left-leaf",
+          paneOrder: ["left-leaf", "right-leaf"],
+        },
+      ],
+      activeId: "a",
+    });
+    render(<App />);
+
+    fireEvent.keyDown(window, { code: "KeyD", key: "d", ctrlKey: true });
+    fireEvent.keyDown(window, { code: "KeyP", key: "p", ctrlKey: true });
+    fireEvent.keyDown(window, { code: "KeyT", key: "t", ctrlKey: true });
+    fireEvent.keyDown(window, { code: "Comma", key: ",", ctrlKey: true });
+
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
+    expect(tab?.paneTree).toEqual(paneTree);
+    expect(useUiStore.getState().fileFinderOpen).toBe(false);
+    expect(useUiStore.getState().settingsOpen).toBe(false);
+    expect(useTabsStore.getState().tabs.length).toBe(1);
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -535,6 +535,15 @@ function App() {
         return;
       }
 
+      // The four below match on `key` instead of `code`, and until now sat
+      // outside the primaryMod gate — only the `metaKey || ctrlKey` check far
+      // above stood between them and a keypress. On macOS that let a bare
+      // Ctrl+T/P/,/D fire the app action even though Cmd is the modifier here,
+      // and a focused terminal had already sent the control byte by then (^D is
+      // EOF, ^P walks history), so one press did both things at once.
+      if (!primaryMod) {
+        return;
+      }
       const key = e.key.toLowerCase();
       if (key === "t") {
         e.preventDefault();


### PR DESCRIPTION
Reported by @chuangmaster on #313.

## Problem

The four handlers at the end of `App.tsx`'s keydown effect match on `key` rather than `code`, and sit outside the `primaryMod` gate every handler above them uses:

```js
const primaryMod = IS_WINDOWS ? e.ctrlKey : e.metaKey;
if (primaryMod && !e.altKey) { /* KeyW, Backquote, KeyN, KeyL */ }
if (e.code === "KeyB" && primaryMod) { /* dock */ }

const key = e.key.toLowerCase();       // ← nothing gates these four
if (key === "t") { ... }
else if (key === "p") { ... }
else if (key === ",") { ... }
else if (key === "d") { ... }
```

The only check between them and a keypress is `if (!(e.metaKey || e.ctrlKey)) return;` far above, which passes for **either** modifier on **either** platform. So on macOS a bare `Ctrl+T`, `Ctrl+P`, `Ctrl+,` or `Ctrl+D` fires the app action even though Cmd is the modifier there.

In a focused terminal it is worse than a stray action. `isAppShortcut` returns false for these on macOS, so xterm sends the control byte and then lets the event bubble to this handler — its `attachCustomKeyEventHandler` comment says so explicitly. One `Ctrl+D` sends EOF to the shell **and** splits the pane. `Ctrl+P` walks readline history **and** opens the file finder.

The block's own comment already claimed to be "gated on each platform's primary modifier ... so the two gates never overlap". These four were the exception.

## Test plan

- [x] Added `leaves bare Ctrl+letter combos alone on macOS` to `App.mac.test.tsx`, asserting the pane tree, file finder, settings and tab count all stay put across `Ctrl+D/P/T/,`
- [x] Confirmed it **fails before the fix** (the pane tree came back split), so it pins the behaviour rather than passing by accident
- [x] `pnpm typecheck`
- [x] `pnpm test` — 223 files, 1989 tests

## Notes

Alt handling is left alone. The `primaryMod` block excludes it, the `KeyB` handler deliberately uses it for the right dock, and these four never checked it — so `Cmd+Alt+D` still splits. Worth tidying, but a separate question from the gate.

This is the macOS half of the modifier-gating problem in #313; the Windows half (Ctrl+letter being swallowed *instead of* reaching the terminal) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)