### PR TITLE
feat(shortcuts): hand Ctrl+B/P/N back to the shell on Windows

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -5,6 +5,7 @@
 - Windows 上的 Git Bash 面板現在也會回報工作目錄，在裡面 `cd` 檔案總管會跟著切換；先前只有 PowerShell 和 cmd.exe 有這個同步 (#312)
 - 外觀設定新增自訂背景圖片，可預覽、保存或拖曳替換 PNG、JPEG、WebP，調整介面與終端機圖片透明度、文字顏色，並選擇只套用於工作區或延伸至整個視窗 (#305)
 - 檔案總管的路徑列改成可點選的麵包屑，跟終端機標題列一樣：點任一段會列出該目錄的子目錄、可就地展開下一層，選一個就把檔案總管切換到那裡（作用中的終端機也會一併 cd）；遠端 (SSH) 根目錄同樣適用 (#310)
+- Windows 上的 `Ctrl+B`、`Ctrl+P`、`Ctrl+N` 改為交給終端機。這三組在終端機裡本來就有用途，`Ctrl+B` 是 tmux 的 prefix 與 Claude Code 的背景執行，`Ctrl+P` 與 `Ctrl+N` 是 readline 的上下一筆歷史，先前會被應用程式攔走。對應功能改用 `Ctrl+Shift+B` 開關左側欄、`Ctrl+Shift+P` 搜尋檔案、`Ctrl+Shift+N` 開新視窗；`Ctrl+W`、`Ctrl+T`、`Ctrl+D` 的 Shift 位置已有其他功能，這次維持原狀。macOS 不受影響 (#318)
 
 ### fix
 
@@ -23,6 +24,7 @@
 - Git Bash panes on Windows now report their working directory, so `cd` moves the file explorer with them — previously only PowerShell and cmd.exe were wired up (#312)
 - Add app-managed PNG, JPEG, or WebP background images in Appearance settings, with pre-commit preview, drag-to-replace, separate interface and terminal opacity, custom text colour, and workspace or whole-window scope (#305)
 - The explorer's path row is now a clickable breadcrumb, like a terminal pane header's: click a segment to list that directory's subdirectories, expand a level in place, and pick one to re-root the explorer there (the active terminal cds along); remote (SSH) roots work the same way (#310)
+- `Ctrl+B`, `Ctrl+P` and `Ctrl+N` now reach the shell on Windows instead of being claimed by the app. All three already mean something in a terminal — `Ctrl+B` is tmux's prefix and Claude Code's background-run key, `Ctrl+P` and `Ctrl+N` walk readline history. The app actions moved to `Ctrl+Shift+B` (left sidebar), `Ctrl+Shift+P` (find files) and `Ctrl+Shift+N` (new window). `Ctrl+W`, `Ctrl+T` and `Ctrl+D` keep their bindings for now, since their Shift slots are already taken. macOS is unaffected (#318)
 
 ### fix
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -458,8 +458,10 @@ function App() {
           useTabsStore.getState().focusNextPane();
           return;
         }
-        // N opens a new window (mirrors File > New Window).
-        if (e.code === "KeyN" && !e.shiftKey) {
+        // N opens a new window (mirrors File > New Window). Windows moved it to
+        // Ctrl+Shift+N so a bare Ctrl+N reaches the shell (readline's
+        // next-history); macOS keeps Cmd+N, which never collides.
+        if (e.code === "KeyN" && (IS_WINDOWS ? e.shiftKey : !e.shiftKey)) {
           e.preventDefault();
           void invoke("open_new_window").catch(() => {});
           return;
@@ -530,6 +532,12 @@ function App() {
       // bare Ctrl+B on macOS still reaches the terminal (readline/tmux). Read
       // `code` (not `key`) because ⌥ rewrites `e.key` on macOS (⌥B → "∫").
       if (e.code === "KeyB" && primaryMod) {
+        // The left dock moved to Ctrl+Shift+B on Windows so a bare Ctrl+B
+        // reaches the shell (tmux's prefix, Claude Code's background-run key).
+        // The right dock keeps Alt, which is not a control code anywhere.
+        if (IS_WINDOWS && !e.altKey && !e.shiftKey) {
+          return;
+        }
         e.preventDefault();
         useUiStore.getState().toggleSide(e.altKey ? "right" : "left");
         return;
@@ -555,7 +563,9 @@ function App() {
         } else {
           useTabsStore.getState().openLauncherTab();
         }
-      } else if (key === "p") {
+      } else if (key === "p" && (!IS_WINDOWS || e.shiftKey)) {
+        // Windows moved Find Files to Ctrl+Shift+P so a bare Ctrl+P reaches the
+        // shell (readline's previous-history).
         e.preventDefault();
         useUiStore.getState().openFileFinder();
       } else if (key === ",") {

--- a/src/App.windows.test.tsx
+++ b/src/App.windows.test.tsx
@@ -168,4 +168,34 @@ describe("App shell — Windows keyboard shortcuts", () => {
     const tab = useTabsStore.getState().tabs.find((t) => t.id === "a");
     expect(tab?.activeLeafId).toBe("right-leaf");
   });
+
+  it("leaves bare Ctrl+B/P to the shell and answers to the Shift variants", () => {
+    // ^B is tmux's prefix and Claude Code's background-run key, ^P walks
+    // readline history. Windows has no Cmd to hide behind, so the app action
+    // moved up to Ctrl+Shift rather than swallowing the control code (#313).
+    // A searchable root is required: App closes the finder again when there is
+    // no local folder to search (see the canSearchRoot effect).
+    useWorkspaceStore.setState({ rootPath: "/work" });
+    render(<App />);
+
+    const dockBefore = useUiStore.getState().visible.left;
+    fireEvent.keyDown(window, { code: "KeyB", key: "b", ctrlKey: true });
+    fireEvent.keyDown(window, { code: "KeyP", key: "p", ctrlKey: true });
+    expect(useUiStore.getState().visible.left).toBe(dockBefore);
+    expect(useUiStore.getState().fileFinderOpen).toBe(false);
+
+    fireEvent.keyDown(window, { code: "KeyB", key: "B", ctrlKey: true, shiftKey: true });
+    fireEvent.keyDown(window, { code: "KeyP", key: "P", ctrlKey: true, shiftKey: true });
+    expect(useUiStore.getState().visible.left).toBe(!dockBefore);
+    expect(useUiStore.getState().fileFinderOpen).toBe(true);
+  });
+
+  it("keeps the right dock on Ctrl+Alt+B", () => {
+    // Alt is not a control code, so the right dock never had to move.
+    render(<App />);
+
+    const rightBefore = useUiStore.getState().visible.right;
+    fireEvent.keyDown(window, { code: "KeyB", key: "b", ctrlKey: true, altKey: true });
+    expect(useUiStore.getState().visible.right).toBe(!rightBefore);
+  });
 });

--- a/src/components/menuBarMenus.ts
+++ b/src/components/menuBarMenus.ts
@@ -114,7 +114,7 @@ export function buildMenus(ctx: MenuContext): MenuDef[] {
       items: [
         { id: "new-tab", labelKey: "menuBar.newTab", group: 0, shortcut: { mac: "⌘T", win: "Ctrl+T" }, action: { kind: "event", event: "menu:new-tab" } },
         { id: "new-terminal-tab", labelKey: "menuBar.newTerminalTab", group: 0, shortcut: { mac: "⇧⌘T", win: "Ctrl+Shift+T" }, action: { kind: "event", event: "menu:new-terminal-tab" } },
-        { id: "new-window", labelKey: "menuBar.newWindow", group: 0, shortcut: { mac: "⌘N", win: "Ctrl+N" }, action: { kind: "newWindow" } },
+        { id: "new-window", labelKey: "menuBar.newWindow", group: 0, shortcut: { mac: "⌘N", win: "Ctrl+Shift+N" }, action: { kind: "newWindow" } },
         { id: "save", labelKey: "menuBar.save", group: 1, shortcut: { mac: "⌘S", win: "Ctrl+S" }, action: { kind: "event", event: "menu:save" }, disabled: notEditor },
         { id: "close-tab", labelKey: "menuBar.closeTab", group: 2, shortcut: { mac: "⌘W", win: "Ctrl+W" }, action: { kind: "event", event: "menu:close-tab" } },
         { id: "close-window", labelKey: "menuBar.closeWindow", group: 2, shortcut: { mac: "⇧⌘W", win: "Ctrl+Shift+W" }, action: { kind: "window", op: "close" } },
@@ -130,14 +130,14 @@ export function buildMenus(ctx: MenuContext): MenuDef[] {
         { id: "paste", labelKey: "menuBar.paste", group: 0, shortcut: { mac: "⌘V", win: "Ctrl+V" }, action: { kind: "event", event: "menu:paste" } },
         { id: "select-all", labelKey: "menuBar.selectAll", group: 0, shortcut: { mac: "⌘A", win: "Ctrl+A" }, action: { kind: "event", event: "menu:select-all" } },
         { id: "find-in-terminal", labelKey: "menuBar.findInTerminal", group: 1, shortcut: { mac: "⌘F", win: "Ctrl+Shift+F" }, action: { kind: "event", event: "menu:find-in-terminal" }, disabled: notTerminal },
-        { id: "find-files", labelKey: "menuBar.findFiles", group: 1, shortcut: { mac: "⌘P", win: "Ctrl+P" }, action: { kind: "event", event: "menu:find-files" } },
+        { id: "find-files", labelKey: "menuBar.findFiles", group: 1, shortcut: { mac: "⌘P", win: "Ctrl+Shift+P" }, action: { kind: "event", event: "menu:find-files" } },
       ],
     },
     {
       id: "view",
       labelKey: "menuBar.view",
       items: [
-        { id: "toggle-sidebar", labelKey: "menuBar.toggleSidebar", group: 0, shortcut: { mac: "⌘B", win: "Ctrl+B" }, action: { kind: "event", event: "menu:toggle-sidebar" } },
+        { id: "toggle-sidebar", labelKey: "menuBar.toggleSidebar", group: 0, shortcut: { mac: "⌘B", win: "Ctrl+Shift+B" }, action: { kind: "event", event: "menu:toggle-sidebar" } },
         { id: "toggle-right-sidebar", labelKey: "menuBar.toggleRightSidebar", group: 0, shortcut: { mac: "⌥⌘B", win: "Ctrl+Alt+B" }, action: { kind: "event", event: "menu:toggle-right-sidebar" } },
         {
           id: "sidebar-panel",

--- a/src/modules/settings/ShortcutsSettingsSection.tsx
+++ b/src/modules/settings/ShortcutsSettingsSection.tsx
@@ -25,8 +25,17 @@ const GROUPS: ShortcutGroup[] = [
       { labelKey: "shortcutsList.closeTab", keys: `${MOD} W` },
       { labelKey: "shortcutsList.switchTab", keys: `${MOD} 1–9` },
       { labelKey: "shortcutsList.switchSidebar", keys: `${ALT} 1–8` },
-      { labelKey: "shortcutsList.findFiles", keys: `${MOD} P` },
-      { labelKey: "shortcutsList.toggleSidebar", keys: `${MOD} B` },
+      // Windows moved these to Ctrl+Shift so the bare Ctrl+<letter> reaches the
+      // shell (^P/^N walk readline history, ^B is tmux's prefix). macOS has no
+      // collision because its modifier is Cmd.
+      {
+        labelKey: "shortcutsList.findFiles",
+        keys: IS_MAC ? `${MOD} P` : `${MOD} ${SHIFT} P`,
+      },
+      {
+        labelKey: "shortcutsList.toggleSidebar",
+        keys: IS_MAC ? `${MOD} B` : `${MOD} ${SHIFT} B`,
+      },
       { labelKey: "shortcutsList.toggleRightSidebar", keys: `${MOD} ${ALT} B` },
       { labelKey: "shortcutsList.zoomIn", keys: `${MOD} +` },
       { labelKey: "shortcutsList.zoomOut", keys: `${MOD} -` },

--- a/src/modules/terminal/lib/terminalKeymap.test.ts
+++ b/src/modules/terminal/lib/terminalKeymap.test.ts
@@ -79,18 +79,31 @@ describe("isAppShortcut", () => {
     }
   });
 
-  it("routes the Windows Ctrl+letter shortcuts to the app so the shell can't eat them", () => {
-    // These collide with terminal control codes (Ctrl+T=^T, Ctrl+D=EOF, ...);
-    // on Windows the app must win. Shift variants of W/T/D are valid too.
+  it("keeps Ctrl+W/T/D for the app on Windows, Shift variants included", () => {
+    // Their Ctrl+Shift slots are already taken (Close Window, New Terminal Tab,
+    // Split Down), so these three have nowhere to move to yet and the app still
+    // wins. See #313.
     for (const code of ["KeyW", "KeyT", "KeyD"]) {
       expect(win({ code, ctrlKey: true })).toBe(true);
       expect(win({ code, ctrlKey: true, shiftKey: true })).toBe(true);
     }
-    for (const code of ["KeyP", "KeyB", "KeyN", "Comma"]) {
-      expect(win({ code, ctrlKey: true })).toBe(true);
-      // No Shift variant for these — Ctrl+Shift+P etc. stay with the terminal.
-      expect(win({ code, ctrlKey: true, shiftKey: true })).toBe(false);
+  });
+
+  it("hands Ctrl+B/P/N to the shell on Windows and claims the Shift variants", () => {
+    // ^B is tmux's prefix and Claude Code's background-run key, ^P and ^N walk
+    // readline history — a terminal app has no business eating those, so the
+    // app action moved to Ctrl+Shift+<letter>.
+    for (const code of ["KeyP", "KeyB", "KeyN"]) {
+      expect(win({ code, ctrlKey: true })).toBe(false);
+      expect(win({ code, ctrlKey: true, shiftKey: true })).toBe(true);
     }
+  });
+
+  it("keeps Ctrl+, for Settings on Windows (no shell binds it)", () => {
+    // Comma is not a control code and none of Claude Code, bash or pwsh binds
+    // it, so there is nothing to yield to and it stays on the bare combo.
+    expect(win({ code: "Comma", ctrlKey: true })).toBe(true);
+    expect(win({ code: "Comma", ctrlKey: true, shiftKey: true })).toBe(false);
   });
 
   it("does NOT claim those Ctrl+letter keys off Windows (macOS uses Cmd, no collision)", () => {

--- a/src/modules/terminal/lib/terminalKeymap.ts
+++ b/src/modules/terminal/lib/terminalKeymap.ts
@@ -71,10 +71,16 @@ export function isAppShortcut(event: AppShortcutEvent, isWindows: boolean): bool
       case "KeyT":
       case "KeyD":
         return true;
-      // Find Files, Toggle Sidebar, New Window, Settings — no Shift variant.
+      // Find Files, Toggle Sidebar and New Window moved to Ctrl+Shift+<letter>
+      // so the bare combo reaches the shell: ^B is tmux's prefix and Claude
+      // Code's background-run key, ^P and ^N walk readline history. The app
+      // action now lives on the Shift variant, so that is what we claim.
       case "KeyP":
       case "KeyB":
       case "KeyN":
+        return event.shiftKey;
+      // Settings keeps the bare combo. Ctrl+, is not a control code and no
+      // shell binds it, so there is nothing here to yield to.
       case "Comma":
         return !event.shiftKey;
       default:


### PR DESCRIPTION
Part of #313, reported by @yw-chan.

## Problem

On Windows the app's shortcut modifier is Ctrl, which is also where terminal control codes come from, so `isAppShortcut` claimed a block of `Ctrl+<letter>` combos and the shell never saw them. All six letters happen to be Claude Code bindings — and this app is a terminal.

## What moves

| Key | Before | After (Windows) | Why |
|---|---|---|---|
| `Ctrl+B` | Toggle Sidebar | goes to the shell; sidebar on `Ctrl+Shift+B` | tmux prefix, Claude Code's background-run |
| `Ctrl+P` | Find Files | goes to the shell; Find Files on `Ctrl+Shift+P` | readline `previous-history` |
| `Ctrl+N` | New Window | goes to the shell; New Window on `Ctrl+Shift+N` | readline `next-history` |

## What stays

`Ctrl+W`, `Ctrl+T` and `Ctrl+D` keep the app action. Their `Ctrl+Shift` slots are already Close Window, New Terminal Tab and Split Down, so there is nowhere to move them without rearranging the whole table — its own piece of work, tracked in #313.

`Ctrl+,` keeps the bare combo for the opposite reason: comma is not a control code, and neither Claude Code, bash nor pwsh binds it, so there is nothing to yield to.

The right dock keeps `Ctrl+Alt+B` — Alt is not a control code either.

**macOS is untouched.** Its modifier is Cmd, which never collides with a control code, so every branch here reads `IS_WINDOWS`.

## Display follows behaviour

Both places that spell shortcuts out were updated for the Windows column only: `ShortcutsSettingsSection.tsx` and the self-drawn Windows menu bar (`menuBarMenus.ts`). A settings list that disagrees with the handler is worse than no list.

## Test plan

- [x] `App.windows.test.tsx` — bare `Ctrl+B`/`Ctrl+P` leave the dock and finder alone, the Shift variants act; `Ctrl+Alt+B` still toggles the right dock
- [x] `terminalKeymap.test.ts` — split into three cases: W/T/D still claimed (Shift included), B/P/N inverted, Comma unchanged
- [x] Confirmed both new tests **fail without the change** (2 failed / 19 passed with the implementation stashed)
- [x] `App.mac.test.tsx` unchanged and green, so macOS really is untouched
- [x] `pnpm typecheck`, `pnpm test` — 223 files, 1993 tests

## Windows pre-flight

Frontend-only: no `src-tauri`, no subprocess spawn, no cfg-gated API, no new crate. Every platform branch reads `IS_WINDOWS` rather than `IS_MAC`, and both platforms are exercised on the mac runner through the platform mock — so the Windows path has real coverage even though the dev box cannot run it.

Behaviour on a real Windows machine is still unverified; the failure mode is a shortcut doing nothing, not data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)