### PR TITLE
fix(breadcrumb): root a Windows drive crumb at C:\, not the drive's current directory

### DIFF
--- a/src/lib/breadcrumb.test.ts
+++ b/src/lib/breadcrumb.test.ts
@@ -115,4 +115,8 @@ describe("buildCrumbs", () => {
       { label: "muki", path: "C:\\Users\\muki" },
     ]);
   });
+
+  it("roots the ~ crumb too when home itself is a drive root", () => {
+    expect(buildCrumbs("C:\\", { homeDir: "C:\\" })).toEqual([{ label: "~", path: "C:\\" }]);
+  });
 });

--- a/src/lib/breadcrumb.test.ts
+++ b/src/lib/breadcrumb.test.ts
@@ -81,10 +81,38 @@ describe("buildCrumbs", () => {
       homeDir: "C:\\Users\\muki",
     });
 
+    // "C:" on its own means the *current directory* on drive C:, not its root.
+    // Only "C:\" reaches the root, so the crumb has to carry the separator —
+    // without doubling it into the paths built on top of it.
     expect(crumbs).toEqual([
-      { label: "C:", path: "C:" },
+      { label: "C:", path: "C:\\" },
       { label: "Windows", path: "C:\\Windows" },
       { label: "System32", path: "C:\\Windows\\System32" },
+    ]);
+  });
+
+  it("gives a bare Windows drive root a trailing separator", () => {
+    expect(buildCrumbs("C:\\", { homeDir: "C:\\Users\\muki" })).toEqual([
+      { label: "C:", path: "C:\\" },
+    ]);
+    expect(buildCrumbs("D:", { homeDir: "C:\\Users\\muki" })).toEqual([
+      { label: "D:", path: "D:\\" },
+    ]);
+  });
+
+  it("roots a Windows path even when home is unknown", () => {
+    expect(buildCrumbs("D:\\code", { homeDir: null })).toEqual([
+      { label: "D:", path: "D:\\" },
+      { label: "code", path: "D:\\code" },
+    ]);
+  });
+
+  it("leaves a drive-rooted home alone (the trail below it needs no re-rooting)", () => {
+    const crumbs = buildCrumbs("C:\\Users\\muki", { homeDir: "C:\\" });
+
+    expect(crumbs).toEqual([
+      { label: "Users", path: "C:\\Users" },
+      { label: "muki", path: "C:\\Users\\muki" },
     ]);
   });
 });

--- a/src/lib/breadcrumb.ts
+++ b/src/lib/breadcrumb.ts
@@ -22,6 +22,9 @@ export interface CrumbRoots {
 /** Match a run of either slash flavour, so Windows paths work too. */
 const SEPARATORS = /[\\/]+/;
 
+/** A Windows drive designator with nothing after it: "C:", "D:". */
+const DRIVE = /^[A-Za-z]:$/;
+
 function trimTrailing(path: string): string {
   const trimmed = path.replace(/[\\/]+$/, "");
   return trimmed.length > 0 ? trimmed : path;
@@ -31,9 +34,16 @@ function isInside(path: string, root: string): boolean {
   return path === root || path.startsWith(`${root}/`) || path.startsWith(`${root}\\`);
 }
 
-/** The separator the path itself uses, defaulting to "/". */
+/**
+ * The separator the path itself uses, defaulting to "/". A drive designator
+ * counts as a Windows path even before any separator shows up, so "C:" on its
+ * own still resolves to "\" rather than the default.
+ */
 function separatorOf(path: string): string {
-  return path.includes("\\") && !path.includes("/") ? "\\" : "/";
+  if (path.includes("/")) {
+    return "/";
+  }
+  return path.includes("\\") || DRIVE.test(path.slice(0, 2)) ? "\\" : "/";
 }
 
 export function buildCrumbs(path: string, roots: CrumbRoots): Crumb[] {
@@ -69,7 +79,11 @@ function crumbsBelow(root: string, target: string, sep: string): Crumb[] {
     } else {
       current = `${current}${sep}${segment}`;
     }
-    crumbs.push({ label: segment, path: current });
+    // A bare "C:" is the *current directory* on drive C:, which is per-drive
+    // process state — only "C:\" names the root. The separator goes on the
+    // crumb the user clicks, not on the accumulator, so the next segment
+    // still joins as "C:\Windows" rather than "C:\\Windows".
+    crumbs.push({ label: segment, path: DRIVE.test(current) ? `${current}${sep}` : current });
   }
   return crumbs;
 }

--- a/src/lib/breadcrumb.ts
+++ b/src/lib/breadcrumb.ts
@@ -22,8 +22,18 @@ export interface CrumbRoots {
 /** Match a run of either slash flavour, so Windows paths work too. */
 const SEPARATORS = /[\\/]+/;
 
-/** A Windows drive designator with nothing after it: "C:", "D:". */
+/** Matches a Windows drive designator and nothing else: "C:", "D:". */
 const DRIVE = /^[A-Za-z]:$/;
+
+/**
+ * A path a crumb can stand on. A bare "C:" cannot: on Windows it means the
+ * *current directory* on drive C:, which is per-drive process state, so only
+ * "C:\" names the root. Everything else is already a location and passes
+ * through untouched.
+ */
+function rooted(path: string, sep: string): string {
+  return DRIVE.test(path) ? `${path}${sep}` : path;
+}
 
 function trimTrailing(path: string): string {
   const trimmed = path.replace(/[\\/]+$/, "");
@@ -35,14 +45,15 @@ function isInside(path: string, root: string): boolean {
 }
 
 /**
- * The separator the path itself uses, defaulting to "/". A drive designator
- * counts as a Windows path even before any separator shows up, so "C:" on its
- * own still resolves to "\" rather than the default.
+ * The separator the path itself uses, defaulting to "/". A leading drive
+ * designator counts as a Windows path even before any separator shows up, so
+ * "C:" on its own still resolves to "\" rather than the default.
  */
 function separatorOf(path: string): string {
   if (path.includes("/")) {
     return "/";
   }
+  // slice(0, 2) is the drive head of "C:\Windows", or the whole of "C:".
   return path.includes("\\") || DRIVE.test(path.slice(0, 2)) ? "\\" : "/";
 }
 
@@ -55,7 +66,7 @@ export function buildCrumbs(path: string, roots: CrumbRoots): Crumb[] {
     // Home itself would otherwise be an empty trail; "~" keeps it visible
     // (and clickable) without spelling out the home prefix anywhere else.
     if (target === homeDir) {
-      return [{ label: "~", path: homeDir }];
+      return [{ label: "~", path: rooted(homeDir, sep) }];
     }
     return crumbsBelow(homeDir, target, sep);
   }
@@ -72,18 +83,15 @@ function crumbsBelow(root: string, target: string, sep: string): Crumb[] {
   for (const segment of rest.length > 0 ? rest.split(SEPARATORS) : []) {
     if (current.length === 0) {
       // Trail starting from nothing keeps the target's exact leading
-      // separators: "/opt" stays rooted, a UNC path keeps its "\\\\" prefix,
-      // and a Windows drive letter opens bare ("C:").
+      // separators: "/opt" stays rooted and a UNC path keeps its "\\\\" prefix.
       const leading = target.match(/^[\\/]+/)?.[0] ?? "";
       current = `${leading}${segment}`;
     } else {
       current = `${current}${sep}${segment}`;
     }
-    // A bare "C:" is the *current directory* on drive C:, which is per-drive
-    // process state — only "C:\" names the root. The separator goes on the
-    // crumb the user clicks, not on the accumulator, so the next segment
-    // still joins as "C:\Windows" rather than "C:\\Windows".
-    crumbs.push({ label: segment, path: DRIVE.test(current) ? `${current}${sep}` : current });
+    // `rooted` goes on the crumb the user clicks, not on the accumulator, so
+    // the next segment still joins as "C:\Windows", not "C:\\Windows".
+    crumbs.push({ label: segment, path: rooted(current, sep) });
   }
   return crumbs;
 }

--- a/src/modules/explorer/lib/paths.test.ts
+++ b/src/modules/explorer/lib/paths.test.ts
@@ -32,6 +32,13 @@ describe("dirname", () => {
   it("handles Windows separators", () => {
     expect(dirname("C:\\Users\\me\\file.txt")).toBe("C:\\Users\\me");
   });
+
+  it("keeps the separator on a Windows drive root", () => {
+    // A bare "C:" means the current directory on drive C:, not its root, so
+    // read_dir on it lists whatever folder the process happens to sit in.
+    expect(dirname("C:\\file.txt")).toBe("C:\\");
+    expect(dirname("C:\\Windows")).toBe("C:\\");
+  });
 });
 
 describe("joinPath", () => {

--- a/src/modules/explorer/lib/paths.test.ts
+++ b/src/modules/explorer/lib/paths.test.ts
@@ -54,6 +54,11 @@ describe("joinPath", () => {
   it("uses backslashes on Windows-style directories", () => {
     expect(joinPath("C:\\a\\b", "c.txt")).toBe("C:\\a\\b\\c.txt");
   });
+
+  it("recognises a drive designator as a Windows path before any separator", () => {
+    expect(joinPath("C:\\", "Windows")).toBe("C:\\Windows");
+    expect(joinPath("C:", "Windows")).toBe("C:\\Windows");
+  });
 });
 
 describe("relativePath", () => {

--- a/src/modules/explorer/lib/paths.ts
+++ b/src/modules/explorer/lib/paths.ts
@@ -8,6 +8,9 @@
 /** Match a run of either slash flavour, so the helpers work on both platforms. */
 const SEPARATORS = /[\\/]+/;
 
+/** A Windows drive designator with nothing after it: "C:", "D:". */
+const DRIVE = /^[A-Za-z]:$/;
+
 /** Whichever separator the path itself uses, defaulting to "/". */
 function separatorOf(path: string): string {
   return path.includes("\\") && !path.includes("/") ? "\\" : "/";
@@ -29,7 +32,11 @@ export function dirname(path: string): string {
     // No separator, or the only one is the leading root slash.
     return index === 0 ? trimmed.slice(0, 1) : trimmed;
   }
-  return trimmed.slice(0, index);
+  const parent = trimmed.slice(0, index);
+  // "C:\file.txt" sits at the root of drive C:, and the root only keeps that
+  // meaning with its separator — a bare "C:" means the drive's *current
+  // directory* instead, which is per-drive process state.
+  return DRIVE.test(parent) ? `${parent}${trimmed.charAt(index)}` : parent;
 }
 
 /** Join a directory and a child segment with the directory's own separator. */

--- a/src/modules/explorer/lib/paths.ts
+++ b/src/modules/explorer/lib/paths.ts
@@ -8,12 +8,22 @@
 /** Match a run of either slash flavour, so the helpers work on both platforms. */
 const SEPARATORS = /[\\/]+/;
 
-/** A Windows drive designator with nothing after it: "C:", "D:". */
+/** Matches a Windows drive designator and nothing else: "C:", "D:". */
 const DRIVE = /^[A-Za-z]:$/;
 
-/** Whichever separator the path itself uses, defaulting to "/". */
+/**
+ * Whichever separator the path itself uses, defaulting to "/". A leading drive
+ * designator counts as a Windows path even before any separator shows up, so
+ * "C:" on its own still resolves to "\". Kept in step with the same-named
+ * helper in `@/lib/breadcrumb` — two path helpers answering this differently
+ * is worse than the duplication.
+ */
 function separatorOf(path: string): string {
-  return path.includes("\\") && !path.includes("/") ? "\\" : "/";
+  if (path.includes("/")) {
+    return "/";
+  }
+  // slice(0, 2) is the drive head of "C:\Windows", or the whole of "C:".
+  return path.includes("\\") || DRIVE.test(path.slice(0, 2)) ? "\\" : "/";
 }
 
 /** The final path segment ("/a/b/c.txt" -> "c.txt"), ignoring trailing slashes. */


### PR DESCRIPTION
Closes #316

## The defect

On Windows a bare `C:` does not mean the root of drive C:. It means the *current directory* on drive C:, which is per-drive process state. Only `C:\` reaches the root.

`buildCrumbs` gave a drive root a crumb whose path was the bare `C:`, and nothing downstream normalised it — the crumb's path went straight through `fs_read_dir` to `std::fs::read_dir`, which listed whatever folder the process happened to sit in on that drive. The drive-relative entry paths that came back (`D:.claude`, not `D:\.claude`) then fed the next expansion and `onSelect`'s `setRoot`, so one bad crumb propagated through everything clicked afterwards.

Terminal pane headers have carried this since breadcrumbs landed, but a terminal's cwd is rarely parked at a drive root. #310 put the same breadcrumb on the explorer's path row, where opening a drive root is ordinary.

## The fix

A single `rooted()` helper decides whether a path can stand on its own as a location, and both the segment trail and the `~` crumb go through it. The separator lands on the crumb the user clicks, never on the accumulator, so the segments built on top stay `C:\Windows` rather than `C:\\Windows` — the trap the issue names.

`separatorOf` now recognises a leading drive designator as a Windows path before any separator appears, so a bare `C:` resolves to `\`.

## Also fixed here

`dirname` had the same defect from the other side: `dirname("C:\\Windows")` returned a bare `C:`. It is not an unrelated helper — the editor breadcrumb's sibling-file menu goes through it (`paneCrumbs.ts` → `listSiblingFiles` → `dirname`), so it is the same bug reached from the same click. It incidentally fixes explorer create/rename at a drive root too.

Keeping `separatorOf` in step across `lib/breadcrumb.ts` and `explorer/lib/paths.ts` is consistency work, not a bug fix: `joinPath("C:", "Windows")` went from `C:/Windows` to `C:\Windows`, and both are absolute. Two sibling helpers with the same name answering differently is the trap worth closing.

## Not covered

A UNC path's first crumb is still `\\server`, which is not a root the way `C:\` is — the shortest UNC root is `\\server\share`, so `read_dir("\\\\server")` errors and the menu opens empty. Pre-existing, not a regression from this change. Fixing it means merging two segments into one crumb, which raises a display question (what does that crumb read as?) that this fix should not answer on its own.

## Verification

macOS dev box, so none of this can be exercised by running it. The Windows behaviour lives entirely in pure string helpers with unit tests that run here, per the `windows-tauri` skill. The measured `read_dir` difference in the issue (verified by @yw-chan on Windows 11) is what the tests encode.

- `pnpm test` — 223 files, 1999 tests, green
- `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)