### PR TITLE
fix(tabs): stop a sidebar open from flattening a hand-arranged pane layout

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,10 @@ _Avoid_: panel, split, view
 The unified h-7 strip at the top of a pane. Full headers (terminal, editor, preview, diff) carry that pane's identity and actions plus the close button; minimal headers (launcher, git-graph, note, sessions) carry only the close button and render only while the tab is split.
 _Avoid_: toolbar (reserved for rows of actions inside content, like GitGraphToolbar)
 
+**Pane grid**:
+The arrangement a sidebar open gives a tab: up to four equal columns, each holding up to two stacked panes, recomputed for the pane count on every open. A tab is on the grid only until the user arranges the panes themselves (a stacked split, an edge drop) — from then on it keeps the shape they gave it, and a sidebar open adds one pane alongside rather than rebuilding.
+_Avoid_: tiling, auto-layout
+
 **Breadcrumb**:
 The location trail on the left of a terminal or editor pane header, and the explorer sidebar's path row under its title — always home-relative (absolute outside home). Clicking a segment opens its menu — the segment itself plus its subdirectories for a terminal or the explorer (directories expand in place), the files sharing the folder for an editor — and choosing an entry switches what that pane shows: the terminal cds, the editor swaps file, the explorer re-roots. It never opens a new tab.
 _Avoid_: path bar, address bar (that is the preview pane's URL row)

--- a/src/modules/terminal/lib/terminalLayout.test.ts
+++ b/src/modules/terminal/lib/terminalLayout.test.ts
@@ -5,6 +5,7 @@ import {
   findPaneContent,
   firstLeafId,
   gridLayout,
+  isGridLayout,
   leaf,
   leafIds,
   paneIdAt,
@@ -259,6 +260,41 @@ describe("gridLayout", () => {
       expect(top.rect.height).toBeCloseTo(50, 5);
       expect(bottom.rect.height).toBeCloseTo(50, 5);
     }
+  });
+});
+
+describe("isGridLayout", () => {
+  function order(n: number): string[] {
+    return Array.from({ length: n }, (_, i) => `p${i}`);
+  }
+
+  function grid(ids: string[]): LayoutNode {
+    return gridLayout(ids.map((id) => ({ id, content: { kind: "terminal" } as const })));
+  }
+
+  it("recognises the tree gridLayout itself builds, at every size", () => {
+    for (const n of [1, 2, 3, 4, 5, 8]) {
+      const ids = order(n);
+      expect(isGridLayout(grid(ids), ids)).toBe(true);
+    }
+  });
+
+  it("ignores split ratios, so dragging a splitter does not leave the grid", () => {
+    const ids = order(2);
+    const tree = grid(ids);
+    expect(isGridLayout(setSizesById(tree, splitId(tree), [0.8, 0.2]), ids)).toBe(true);
+  });
+
+  it("rejects a hand-stacked pair, which the grid would have laid out as columns", () => {
+    expect(isGridLayout(splitLeaf(leaf("a"), "a", "col", "b"), ["a", "b"])).toBe(false);
+  });
+
+  it("rejects a grid whose panes sit in a different add-order", () => {
+    expect(isGridLayout(grid(["a", "b"]), ["b", "a"])).toBe(false);
+  });
+
+  it("rejects an empty paneOrder rather than asking gridLayout to build nothing", () => {
+    expect(isGridLayout(leaf("a"), [])).toBe(false);
   });
 });
 

--- a/src/modules/terminal/lib/terminalLayout.test.ts
+++ b/src/modules/terminal/lib/terminalLayout.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  appendAlongside,
   computeLayout,
   computeSplitters,
   findPaneContent,
   firstLeafId,
   gridLayout,
-  isGridLayout,
   leaf,
   leafIds,
+  matchesGridLayout,
   paneIdAt,
   removeLeaf,
   resolveDropZone,
@@ -263,7 +264,7 @@ describe("gridLayout", () => {
   });
 });
 
-describe("isGridLayout", () => {
+describe("matchesGridLayout", () => {
   function order(n: number): string[] {
     return Array.from({ length: n }, (_, i) => `p${i}`);
   }
@@ -275,26 +276,61 @@ describe("isGridLayout", () => {
   it("recognises the tree gridLayout itself builds, at every size", () => {
     for (const n of [1, 2, 3, 4, 5, 8]) {
       const ids = order(n);
-      expect(isGridLayout(grid(ids), ids)).toBe(true);
+      expect(matchesGridLayout(grid(ids), ids)).toBe(true);
     }
   });
 
   it("ignores split ratios, so dragging a splitter does not leave the grid", () => {
     const ids = order(2);
     const tree = grid(ids);
-    expect(isGridLayout(setSizesById(tree, splitId(tree), [0.8, 0.2]), ids)).toBe(true);
+    expect(matchesGridLayout(setSizesById(tree, splitId(tree), [0.8, 0.2]), ids)).toBe(true);
   });
 
   it("rejects a hand-stacked pair, which the grid would have laid out as columns", () => {
-    expect(isGridLayout(splitLeaf(leaf("a"), "a", "col", "b"), ["a", "b"])).toBe(false);
+    expect(matchesGridLayout(splitLeaf(leaf("a"), "a", "col", "b"), ["a", "b"])).toBe(false);
+  });
+
+  it("accepts a hand-split pair laid out left/right — that is the grid", () => {
+    expect(matchesGridLayout(splitLeaf(leaf("a"), "a", "row", "b"), ["a", "b"])).toBe(true);
   });
 
   it("rejects a grid whose panes sit in a different add-order", () => {
-    expect(isGridLayout(grid(["a", "b"]), ["b", "a"])).toBe(false);
+    expect(matchesGridLayout(grid(["a", "b"]), ["b", "a"])).toBe(false);
   });
 
   it("rejects an empty paneOrder rather than asking gridLayout to build nothing", () => {
-    expect(isGridLayout(leaf("a"), [])).toBe(false);
+    expect(matchesGridLayout(leaf("a"), [])).toBe(false);
+  });
+});
+
+describe("appendAlongside", () => {
+  it("splits a lone pane left/right", () => {
+    const tree = appendAlongside(leaf("a"), "b", { kind: "terminal" });
+    const panes = computeLayout(tree);
+    expect(panes.map((p) => Math.round(p.rect.width))).toEqual([50, 50]);
+    expect(panes.every((p) => Math.round(p.rect.height) === 100)).toBe(true);
+  });
+
+  it("inherits the tree's own direction, so a stack keeps stacking", () => {
+    const stacked = splitLeaf(leaf("a"), "a", "col", "b");
+    const panes = computeLayout(appendAlongside(stacked, "c", { kind: "terminal" }));
+    expect(panes.every((p) => Math.round(p.rect.width) === 100)).toBe(true);
+  });
+
+  it("gives every pane an even share instead of halving what is already there", () => {
+    let tree: LayoutNode = splitLeaf(leaf("a"), "a", "col", "b");
+    tree = appendAlongside(tree, "c", { kind: "terminal" });
+    tree = appendAlongside(tree, "d", { kind: "terminal" });
+
+    for (const pane of computeLayout(tree)) {
+      expect(pane.rect.height).toBeCloseTo(25, 5);
+    }
+  });
+
+  it("leaves every existing split's direction and ratio untouched", () => {
+    const stacked = splitLeaf(leaf("a"), "a", "col", "b");
+    const tree = appendAlongside(stacked, "c", { kind: "terminal" });
+    expect(tree.kind === "split" && tree.children[0]).toEqual(stacked);
   });
 });
 

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -522,17 +522,46 @@ export function gridLayout(panes: OrderedPane[]): LayoutNode {
  * rebuilt, or every sidebar click would flatten their stack back into
  * columns.
  *
- * Shape alone can't tell a hand-built layout from a grid that a close left
- * off-canon (possible from 6 panes up, where removing a stacked pane leaves a
- * tree the current count would grid differently). Such a tab reads as
- * hand-built and stops re-gridding, which errs the safe way: panes stay where
- * they are instead of being rearranged.
+ * Two things it deliberately does not distinguish:
+ *
+ * - A hand-made split that happens to land on the grid (splitting a
+ *   single-pane tab left/right builds the very tree `gridLayout` would) reads
+ *   as a grid. Harmless: re-gridding it can't flip a direction the user chose.
+ * - A grid that a close left off-canon reads as hand-made. `closePane` only
+ *   collapses the removed leaf's parent, so from five panes up the survivors
+ *   can sit in slots the new count would assign differently, and that tab
+ *   stops re-gridding. It errs the safe way — panes stay where they are.
  */
-export function isGridLayout(tree: LayoutNode, paneOrder: string[]): boolean {
+export function matchesGridLayout(tree: LayoutNode, paneOrder: string[]): boolean {
   if (paneOrder.length === 0) {
     return false;
   }
+  // Only the shape is compared, so the content here is filler.
   return sameShape(tree, gridLayout(paneOrder.map((id) => ({ id, content: TERMINAL_PANE }))));
+}
+
+/**
+ * Add a pane alongside the whole tree, splitting on whichever direction the
+ * tree already uses (a single leaf has none, so side by side). Nothing
+ * existing is carved up and no existing split changes direction — the tab
+ * keeps the shape it had, with one more pane at the end.
+ *
+ * The tree keeps a share proportional to the panes it holds, so repeated
+ * appends divide the tab evenly rather than halving whatever is already there
+ * (which is the 50/25/12.5 shrink `gridLayout` exists to avoid).
+ */
+export function appendAlongside(
+  tree: LayoutNode,
+  newId: string,
+  newPane: PaneContent,
+): LayoutNode {
+  const existing = leafIds(tree).length;
+  return {
+    kind: "split",
+    direction: tree.kind === "split" ? tree.direction : "row",
+    children: [tree, leaf(newId, newPane)],
+    sizes: [existing / (existing + 1), 1 / (existing + 1)],
+  };
 }
 
 /** Same splits, same directions, same leaf ids. Sizes and pane content are not compared. */

--- a/src/modules/terminal/lib/terminalLayout.ts
+++ b/src/modules/terminal/lib/terminalLayout.ts
@@ -510,6 +510,43 @@ export function gridLayout(panes: OrderedPane[]): LayoutNode {
   return combineEqualRow(columns);
 }
 
+/**
+ * True when `tree` is exactly the grid `gridLayout` would build for
+ * `paneOrder`: same nesting, same directions, same leaf in every slot. Split
+ * ratios are not compared — dragging a splitter resizes the grid, it doesn't
+ * replace it.
+ *
+ * Sidebar opens rebuild the whole tab through `gridLayout`, which is only
+ * safe while the tab still *is* that grid. A layout the user built by hand —
+ * panes stacked with the split shortcut, say — has to be added to instead of
+ * rebuilt, or every sidebar click would flatten their stack back into
+ * columns.
+ *
+ * Shape alone can't tell a hand-built layout from a grid that a close left
+ * off-canon (possible from 6 panes up, where removing a stacked pane leaves a
+ * tree the current count would grid differently). Such a tab reads as
+ * hand-built and stops re-gridding, which errs the safe way: panes stay where
+ * they are instead of being rearranged.
+ */
+export function isGridLayout(tree: LayoutNode, paneOrder: string[]): boolean {
+  if (paneOrder.length === 0) {
+    return false;
+  }
+  return sameShape(tree, gridLayout(paneOrder.map((id) => ({ id, content: TERMINAL_PANE }))));
+}
+
+/** Same splits, same directions, same leaf ids. Sizes and pane content are not compared. */
+function sameShape(a: LayoutNode, b: LayoutNode): boolean {
+  if (a.kind === "leaf" || b.kind === "leaf") {
+    return a.kind === "leaf" && b.kind === "leaf" && a.id === b.id;
+  }
+  return (
+    a.direction === b.direction &&
+    sameShape(a.children[0], b.children[0]) &&
+    sameShape(a.children[1], b.children[1])
+  );
+}
+
 /** Nest `nodes` left to right as equal-width row splits ([1/n, (n-1)/n] at
  * each level, so `computeLayout` gives every node the same width). */
 function combineEqualRow(nodes: LayoutNode[]): LayoutNode {

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -1211,6 +1211,20 @@ describe("openFromSidebar", () => {
       expect(tab.paneOrder).toEqual([...before.map((b) => b.id), added.id]);
     });
 
+    it("keeps every pane an even share as more open into the stack", () => {
+      stackedTab();
+      useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/c.ts" });
+      useTabsStore.getState().openFromSidebar({ kind: "note", noteId: "/d.md" }, "d");
+
+      const panes = computeLayout(activeTab().paneTree);
+      expect(panes).toHaveLength(4);
+      // Appending must not halve whatever is already there (50, 25, 12.5, ...)
+      // — that is the shrink the grid was introduced to remove.
+      for (const pane of panes) {
+        expect(pane.rect.height).toBeCloseTo(25, 5);
+      }
+    });
+
     it("still honours the 8-pane cap", () => {
       stackedTab();
       for (let i = 3; i <= 8; i++) {

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -1170,6 +1170,61 @@ describe("openFromSidebar", () => {
       expect(computeLayout(after.paneTree)).toHaveLength(4);
     });
   });
+
+  describe("openFromSidebar into a layout the user arranged by hand", () => {
+    beforeEach(reset);
+
+    /** A tab split top/bottom with the split shortcut — a shape the grid never builds. */
+    function stackedTab() {
+      useTabsStore.getState().openEditorTab("/a.ts");
+      useTabsStore.getState().splitActivePane("col");
+      return activeTab();
+    }
+
+    it("leaves stacked panes stacked instead of re-gridding them into columns", () => {
+      const before = computeLayout(stackedTab().paneTree);
+      expect(before.every((p) => Math.round(p.rect.width) === 100)).toBe(true);
+
+      useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/b.ts" });
+
+      const panes = computeLayout(activeTab().paneTree);
+      expect(panes).toHaveLength(3);
+      // Nothing sits beside anything else: the tab is still one column.
+      expect(panes.every((p) => Math.round(p.rect.width) === 100)).toBe(true);
+      const original = panes.filter((p) => before.some((b) => b.id === p.id));
+      expect(original).toHaveLength(2);
+    });
+
+    it("adds the new pane below the existing ones and focuses it", () => {
+      const before = computeLayout(stackedTab().paneTree);
+      useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/b.ts" });
+
+      const tab = activeTab();
+      const panes = computeLayout(tab.paneTree);
+      const added = panes.find((p) => !before.some((b) => b.id === p.id))!;
+      const original = panes.filter((p) => before.some((b) => b.id === p.id));
+      expect(added.content).toMatchObject({ kind: "editor", path: "/b.ts" });
+      expect(added.rect.top).toBeGreaterThanOrEqual(
+        Math.max(...original.map((p) => p.rect.top + p.rect.height)),
+      );
+      expect(tab.activeLeafId).toBe(added.id);
+      expect(tab.paneOrder).toEqual([...before.map((b) => b.id), added.id]);
+    });
+
+    it("still honours the 8-pane cap", () => {
+      stackedTab();
+      for (let i = 3; i <= 8; i++) {
+        expect(useTabsStore.getState().openFromSidebar({ kind: "editor", path: `/${i}.ts` })).toEqual({
+          status: "opened",
+        });
+      }
+      const before = activeTab();
+      expect(useTabsStore.getState().openFromSidebar({ kind: "editor", path: "/9.ts" })).toEqual({
+        status: "at-capacity",
+      });
+      expect(activeTab().paneOrder).toEqual(before.paneOrder);
+    });
+  });
 });
 
 describe("openFromSidebar with ssh content", () => {

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -11,6 +11,7 @@ import {
   computeLayout,
   findPaneContent,
   gridLayout,
+  isGridLayout,
   leaf,
   leafIds,
   paneOf,
@@ -757,14 +758,28 @@ export const useTabsStore = create<TabsState>()(
     if (isFreshSsh) {
       markFreshSshLeaf(newId);
     }
-    const panes: OrderedPane[] = [
-      ...activeTab.paneOrder.map((id) => ({
-        id,
-        content: findPaneContent(activeTab.paneTree, id)!,
-      })),
-      { id: newId, content },
-    ];
-    const paneTree = gridLayout(panes);
+    // Recomputing the canonical grid is only right while the tab still is one.
+    // Once the user has arranged the panes themselves — stacked a pair with
+    // the split shortcut, dropped a file onto an edge — re-gridding would
+    // flatten every one of their splits back into columns on the next sidebar
+    // click. Such a tab gets the new pane appended alongside the whole tree,
+    // the same way the outer drop zone adds one, so no existing pane is
+    // carved up and no existing split changes direction.
+    const paneTree = isGridLayout(activeTab.paneTree, activeTab.paneOrder)
+      ? gridLayout([
+          ...activeTab.paneOrder.map((id) => ({
+            id,
+            content: findPaneContent(activeTab.paneTree, id)!,
+          })),
+          { id: newId, content },
+        ] satisfies OrderedPane[])
+      : wrapTree(
+          activeTab.paneTree,
+          newId,
+          content,
+          activeTab.paneTree.kind === "split" ? activeTab.paneTree.direction : "row",
+          "after",
+        );
     set((state) => ({
       tabs: state.tabs.map((t) =>
         t.id === activeTab.id
@@ -970,8 +985,10 @@ export const useTabsStore = create<TabsState>()(
             ? {
                 ...t,
                 // A fresh split shows the launcher so the user picks what goes in it.
-                // Directional and pane-specific (unlike openFromSidebar's grid rebuild)
-                // — the user is choosing exactly which pane to split and which way.
+                // Directional and pane-specific — the user is choosing exactly which
+                // pane to split and which way, so the tree is edited in place. That
+                // choice also takes the tab off the canonical grid, which is what
+                // stops a later sidebar open from rebuilding it (see isGridLayout).
                 paneTree: splitLeaf(t.paneTree, t.activeLeafId, direction, newId, {
                   kind: "launcher",
                 }),

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -8,12 +8,13 @@ import { decideHtmlPreviewOpen, previewLocalPath } from "@/modules/preview/lib/h
 import { fileUrl } from "@/modules/explorer/lib/dragEntry";
 import { fileOpenContent } from "@/modules/explorer/lib/fileOpenContent";
 import {
+  appendAlongside,
   computeLayout,
   findPaneContent,
   gridLayout,
-  isGridLayout,
   leaf,
   leafIds,
+  matchesGridLayout,
   paneOf,
   removeLeaf,
   setLeafPane,
@@ -101,8 +102,10 @@ interface TabsState {
   openSessionsTab: () => string;
   /**
    * Open sidebar content (explorer file, note, or SSH connection). When the
-   * active tab is a real working tab, this splits beside its current
-   * right-most pane. When there is no active tab, or the active tab is a
+   * active tab is a real working tab, this adds a pane to it: a tab still on
+   * the canonical grid is re-gridded for the new count, one the user arranged
+   * themselves keeps its shape and takes the pane alongside. When there is no
+   * active tab, or the active tab is a
    * Launcher tab (kind === "launcher" — TabsArea.tsx renders LauncherPanel
    * for those directly and ignores their paneTree), this opens a fresh tab
    * and, for the launcher case, closes the old one — the same two-step
@@ -762,24 +765,17 @@ export const useTabsStore = create<TabsState>()(
     // Once the user has arranged the panes themselves — stacked a pair with
     // the split shortcut, dropped a file onto an edge — re-gridding would
     // flatten every one of their splits back into columns on the next sidebar
-    // click. Such a tab gets the new pane appended alongside the whole tree,
-    // the same way the outer drop zone adds one, so no existing pane is
-    // carved up and no existing split changes direction.
-    const paneTree = isGridLayout(activeTab.paneTree, activeTab.paneOrder)
-      ? gridLayout([
-          ...activeTab.paneOrder.map((id) => ({
-            id,
-            content: findPaneContent(activeTab.paneTree, id)!,
-          })),
-          { id: newId, content },
-        ] satisfies OrderedPane[])
-      : wrapTree(
-          activeTab.paneTree,
-          newId,
-          content,
-          activeTab.paneTree.kind === "split" ? activeTab.paneTree.direction : "row",
-          "after",
-        );
+    // click. Such a tab gets the new pane appended alongside instead.
+    const regrid = (): OrderedPane[] => [
+      ...activeTab.paneOrder.map((id) => ({
+        id,
+        content: findPaneContent(activeTab.paneTree, id)!,
+      })),
+      { id: newId, content },
+    ];
+    const paneTree = matchesGridLayout(activeTab.paneTree, activeTab.paneOrder)
+      ? gridLayout(regrid())
+      : appendAlongside(activeTab.paneTree, newId, content);
     set((state) => ({
       tabs: state.tabs.map((t) =>
         t.id === activeTab.id
@@ -986,9 +982,11 @@ export const useTabsStore = create<TabsState>()(
                 ...t,
                 // A fresh split shows the launcher so the user picks what goes in it.
                 // Directional and pane-specific — the user is choosing exactly which
-                // pane to split and which way, so the tree is edited in place. That
-                // choice also takes the tab off the canonical grid, which is what
-                // stops a later sidebar open from rebuilding it (see isGridLayout).
+                // pane to split and which way, so the tree is edited in place rather
+                // than rebuilt. A stacked split also takes the tab off the canonical
+                // grid, so later sidebar opens stop rebuilding it (matchesGridLayout);
+                // a plain left/right split of a single pane *is* the grid, and
+                // re-gridding that can't flip a direction anyway.
                 paneTree: splitLeaf(t.paneTree, t.activeLeafId, direction, newId, {
                   kind: "launcher",
                 }),


### PR DESCRIPTION
Closes #311

## Root cause

Not the render layer, and not `splitLeaf` — both were cleared in the issue's first pass and both are innocent.

`openFromSidebar` rebuilt the active tab's *entire* pane tree through `gridLayout` on every open (`tabsStore.ts:767`), and `gridLayout` always lays panes out as up to four equal columns with a `row` split at the top. A tab the user had split top/bottom therefore flipped to side by side on the next sidebar click — and not just the pane being added, which is why the report said every stacked split in the tab was affected.

## The fix

Re-gridding is right while the tab still *is* the grid, so that stays: a new pure `matchesGridLayout(tree, paneOrder)` compares the tree against the grid its pane order would produce, ignoring split ratios so dragging a splitter doesn't count as leaving. A tab that no longer matches is one the user arranged themselves, and it keeps its shape — `appendAlongside` adds the new pane beside the whole tree along the tab's own root direction, so no existing pane is carved up and no existing split changes direction.

`appendAlongside` gives the existing tree a share proportional to the panes it holds, rather than the flat 50/50 `wrapTree` uses. Without that, each open halves whatever is already there (50, 25, 12.5, …) — the exact shrink `gridLayout` was introduced to remove. Appending onto a stacked pair now leaves all panes at an even share.

## Entry points

Files, notes, SSH connections, quick-open, and source-control all route through `openFromSidebar`, so all are fixed by the one change. Worktrees (`splitPaneWith` with a caller-chosen direction) and the launcher (`setPaneContent`) never re-gridded and never had the bug — the issue asked for that to be checked.

## Known boundary

Shape alone cannot tell a hand-built layout from a grid that a close left off-canon. `closePane` only collapses the removed leaf's parent, so from five panes up the survivors can sit in slots the new count would assign differently, and that tab stops re-gridding. It errs the safe way — panes stay where they are instead of being rearranged — and it is documented on `matchesGridLayout` rather than papered over. Re-gridding on close was considered and rejected: on the 5-pane case it would visibly teleport a pane from the first column to the last, which is worse than leaving it.

Separately, a tab migrated from the pre-`paneTree` (v1) persisted shape backfills `paneOrder` from `leafIds`, which is tree order rather than add order, so a 5+ pane grid restored from v1 reads as hand-built. Same benign direction, and v1 data is ancient.

## On the issue's "Expected"

> Opening a file or a note from the sidebar creates a new tab.

That part is a misreading — sidebar opens split into the active tab by design (see `CHANGELOG-0.0.13.md` and the phase-2 plan). The real defect is the direction rewrite, which is what this fixes. Worth correcting the issue text rather than the code.

## Verification

- New store tests reproduce the report's steps: a stacked tab stays stacked, the new pane lands below and focused, shares stay even across repeated opens, the 8-pane cap still holds
- `matchesGridLayout` and `appendAlongside` covered directly as pure functions
- `pnpm test` — 223 files, 2007 tests, green
- `pnpm typecheck` — clean

Adds "Pane grid" to `CONTEXT.md`, since the code now leans on the term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)