### PR TITLE
feat(editor): VS Code-style scrollbars for the editor and diff views

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -147,6 +147,46 @@ body {
  */
 
 /*
+ * Editor/diff proxy scrollbars (Windows only, where classic scrollbars are
+ * always-on): the scroller's own bars are hidden and replaced with thin
+ * overflow strips that the browser renders real native scrollbars for,
+ * positioned VS Code style — the horizontal bar pinned to the pane's bottom
+ * starting after the line-number gutter, the vertical one at the right edge.
+ * attachProxyScrollbars (lib/proxyScrollbar.ts) creates the strips and keeps
+ * them two-way synced with the editor's scroller.
+ */
+.proxy-scrollbar-host {
+  /* The strips anchor to the host (the editor's wrapper), which is a plain
+     unpositioned div in the editor tab. */
+  position: relative;
+}
+.proxy-scrollbar-host .cm-scroller {
+  scrollbar-width: none;
+}
+.proxy-scrollbar {
+  position: absolute;
+  z-index: 10;
+}
+.proxy-scrollbar.horizontal {
+  bottom: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.proxy-scrollbar.horizontal > div {
+  height: 1px;
+}
+.proxy-scrollbar.vertical {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+.proxy-scrollbar.vertical > div {
+  width: 1px;
+}
+
+/*
  * The terminal is different: xterm 6.0 ships its own VS Code-style scrollbar
  * (.xterm-scrollable-element) instead of using the native overlay one, so the
  * policy above never reaches it. Its width is JS-measured, and on macOS overlay

--- a/src/lib/proxyScrollbar.ts
+++ b/src/lib/proxyScrollbar.ts
@@ -81,7 +81,15 @@ export function attachProxyScrollbars({
 
   // Cache the applied geometry so scroll handlers can call refresh every
   // frame without causing style churn.
-  const last = { left: NaN, width: NaN, bottom: NaN, hSpacer: NaN, vSpacer: NaN, hShown: true };
+  const last = {
+    left: NaN,
+    width: NaN,
+    bottom: NaN,
+    hSpacer: NaN,
+    vSpacer: NaN,
+    hShown: true,
+    vShown: true,
+  };
   const refresh = () => {
     // Re-assert the host class: React rewrites className when e.g. the theme
     // class on the editor wrapper changes, wiping foreign classes.
@@ -132,6 +140,15 @@ export function attachProxyScrollbars({
       h.spacer.style.width = `${hSpacer}px`;
     }
     if (v) {
+      // Hide outright when nothing really overflows: layout heights are
+      // fractional but the spacer is set from the integer scrollHeight, and
+      // that sub-pixel difference alone is enough to make the browser draw
+      // a (pointless, full-thumb) scrollbar.
+      const vShown = vOverflow;
+      if (vShown !== last.vShown) {
+        last.vShown = vShown;
+        v.strip.style.display = vShown ? "" : "none";
+      }
       const vSpacer = scroller.scrollHeight;
       if (vSpacer !== last.vSpacer) {
         last.vSpacer = vSpacer;

--- a/src/lib/proxyScrollbar.ts
+++ b/src/lib/proxyScrollbar.ts
@@ -1,0 +1,233 @@
+import type { Extension } from "@codemirror/state";
+import { ViewPlugin } from "@codemirror/view";
+import { IS_WINDOWS } from "@/lib/platform";
+
+/**
+ * Native proxy scrollbars for the CodeMirror surfaces, VS Code layout.
+ *
+ * The real scrollbars have two problems the CSS can't fix: the horizontal
+ * bar spans the whole scroller, running beneath the sticky line-number
+ * gutter; and in the diff view the editors are auto-height (the outer
+ * .cm-mergeView owns vertical scrolling), so the horizontal bar sits at the
+ * bottom of the whole document, out of sight. So the scroller's own bars are
+ * hidden and replaced with thin overflow strips — the browser renders real
+ * native scrollbars for them — pinned where VS Code puts them: horizontal at
+ * the pane's bottom starting after the gutter, vertical at the right edge.
+ * Strip and scroller get equal scroll ranges, so positions map 1:1 with no
+ * math on scroll events.
+ *
+ * Windows only: WebView2's classic scrollbars are always visible, making the
+ * misplaced bars a real problem there. macOS/Linux keep the stock behaviour
+ * and their native overlay scrollbars.
+ */
+
+export interface ProxyScrollbarsHandle {
+  /** Re-measure and reposition the strips (call on geometry changes). */
+  refresh(): void;
+  destroy(): void;
+}
+
+interface ProxyScrollbarsOptions {
+  /** Element whose scrollLeft/scrollTop moves. */
+  scroller: HTMLElement;
+  /** Positioned ancestor the strips live in; the pane the bars pin to. */
+  host: HTMLElement;
+  /** "x" when vertical scrolling lives on an outer container (the diff view),
+   * "xy" for self-scrolling editors. */
+  axes: "x" | "xy";
+}
+
+const NOOP: ProxyScrollbarsHandle = { refresh() {}, destroy() {} };
+
+/** Native classic scrollbar thickness, measured once with a probe element. */
+let barThickness = -1;
+function scrollbarThickness(): number {
+  if (barThickness < 0) {
+    const probe = document.createElement("div");
+    probe.style.cssText =
+      "position:absolute;visibility:hidden;width:60px;height:60px;overflow:scroll";
+    document.body.appendChild(probe);
+    barThickness = probe.offsetWidth - probe.clientWidth;
+    probe.remove();
+  }
+  return barThickness;
+}
+
+export function attachProxyScrollbars({
+  scroller,
+  host,
+  axes,
+}: ProxyScrollbarsOptions): ProxyScrollbarsHandle {
+  if (!IS_WINDOWS) {
+    return NOOP;
+  }
+  // The class both scopes the CSS that hides the scroller's own bars and
+  // marks that replacements exist.
+  host.classList.add("proxy-scrollbar-host");
+
+  const makeStrip = (direction: "horizontal" | "vertical") => {
+    const strip = document.createElement("div");
+    strip.className = `proxy-scrollbar ${direction}`;
+    const spacer = document.createElement("div");
+    strip.appendChild(spacer);
+    host.appendChild(strip);
+    return { strip, spacer };
+  };
+  const h = makeStrip("horizontal");
+  const v = axes === "xy" ? makeStrip("vertical") : null;
+  if (v) {
+    v.strip.style.width = `${scrollbarThickness()}px`;
+  }
+
+  // Cache the applied geometry so scroll handlers can call refresh every
+  // frame without causing style churn.
+  const last = { left: NaN, width: NaN, bottom: NaN, hSpacer: NaN, vSpacer: NaN, hShown: true };
+  const refresh = () => {
+    // Re-assert the host class: React rewrites className when e.g. the theme
+    // class on the editor wrapper changes, wiping foreign classes.
+    host.classList.add("proxy-scrollbar-host");
+    const gutter = scroller.querySelector<HTMLElement>(".cm-gutters")?.offsetWidth ?? 0;
+    // No real horizontal overflow (word wrap, short lines): no bar at all.
+    // Decided from the scroller itself so strip-width rounding can't leave a
+    // phantom 1px scroll range.
+    const hShown = scroller.scrollWidth - scroller.clientWidth > 1;
+    if (hShown !== last.hShown) {
+      last.hShown = hShown;
+      h.strip.style.display = hShown ? "" : "none";
+    }
+    const scrollerRect = scroller.getBoundingClientRect();
+    const hostRect = host.getBoundingClientRect();
+    // Leave the corner square to the vertical bar, like native scrollbars do.
+    const vOverflow = v !== null && scroller.scrollHeight > scroller.clientHeight + 1;
+    const left = scrollerRect.left - hostRect.left + gutter;
+    const width = Math.max(
+      0,
+      scrollerRect.width - gutter - (vOverflow ? scrollbarThickness() : 0),
+    );
+    // Pin to the pane's bottom edge, but when the document ends inside the
+    // pane (a short diff) sit right under the content instead — where the
+    // native bar would be. Always 0 for self-scrolling editors.
+    const bottom = Math.max(0, hostRect.bottom - scrollerRect.bottom);
+    // Subtract the same insets as the strip width so both scroll ranges stay
+    // equal — otherwise the corner reservation leaves a phantom range that
+    // shows a scrollbar even when nothing overflows (e.g. word wrap on).
+    const hSpacer = Math.max(
+      0,
+      scroller.scrollWidth - gutter - (vOverflow ? scrollbarThickness() : 0),
+    );
+    if (left !== last.left) {
+      last.left = left;
+      h.strip.style.left = `${left}px`;
+    }
+    if (width !== last.width) {
+      last.width = width;
+      h.strip.style.width = `${width}px`;
+    }
+    if (bottom !== last.bottom) {
+      last.bottom = bottom;
+      h.strip.style.bottom = `${bottom}px`;
+    }
+    if (hSpacer !== last.hSpacer) {
+      last.hSpacer = hSpacer;
+      h.spacer.style.width = `${hSpacer}px`;
+    }
+    if (v) {
+      const vSpacer = scroller.scrollHeight;
+      if (vSpacer !== last.vSpacer) {
+        last.vSpacer = vSpacer;
+        v.spacer.style.height = `${vSpacer}px`;
+      }
+    }
+    syncFromScroller();
+  };
+
+  // Mutual sync can't loop: assigning an unchanged scroll position fires no
+  // scroll event.
+  const syncFromScroller = () => {
+    if (h.strip.scrollLeft !== scroller.scrollLeft) {
+      h.strip.scrollLeft = scroller.scrollLeft;
+    }
+    if (v && v.strip.scrollTop !== scroller.scrollTop) {
+      v.strip.scrollTop = scroller.scrollTop;
+    }
+  };
+  const syncFromH = () => {
+    if (scroller.scrollLeft !== h.strip.scrollLeft) {
+      scroller.scrollLeft = h.strip.scrollLeft;
+    }
+  };
+  const syncFromV = () => {
+    if (v && scroller.scrollTop !== v.strip.scrollTop) {
+      scroller.scrollTop = v.strip.scrollTop;
+    }
+  };
+  scroller.addEventListener("scroll", syncFromScroller, { passive: true });
+  h.strip.addEventListener("scroll", syncFromH, { passive: true });
+  v?.strip.addEventListener("scroll", syncFromV, { passive: true });
+
+  // In the diff view, vertical scrolling (on the outer .cm-mergeView) moves
+  // the document's end through the pane, which shifts where the horizontal
+  // strip should sit.
+  const verticalScroller = scroller.closest(".cm-mergeView");
+  verticalScroller?.addEventListener("scroll", refresh, { passive: true });
+
+  // The scroll ranges move whenever the pane resizes, the rendered content's
+  // widest line changes, or the gutter grows another digit.
+  const observer = new ResizeObserver(refresh);
+  observer.observe(host);
+  observer.observe(scroller);
+  for (const selector of [".cm-content", ".cm-gutters"]) {
+    const el = scroller.querySelector(selector);
+    if (el) {
+      observer.observe(el);
+    }
+  }
+  refresh();
+
+  return {
+    refresh,
+    destroy() {
+      observer.disconnect();
+      scroller.removeEventListener("scroll", syncFromScroller);
+      verticalScroller?.removeEventListener("scroll", refresh);
+      h.strip.remove();
+      v?.strip.remove();
+    },
+  };
+}
+
+/**
+ * CodeMirror wiring for self-scrolling editors (the editor tab): proxy bars
+ * for both axes, refreshed whenever the editor's geometry changes.
+ */
+export function proxyScrollbars(): Extension {
+  return ViewPlugin.define((view) => {
+    // The host must be the wrapper around the editor, not view.dom itself:
+    // CodeMirror rewrites view.dom's className on update, which would strip
+    // the proxy-scrollbar-host class (and with it the CSS hiding the native
+    // bars). The wrapper only exists once the view is appended, so attach
+    // lazily.
+    let handle: ProxyScrollbarsHandle | null = null;
+    const ensure = () => {
+      if (!handle && view.dom.parentElement) {
+        handle = attachProxyScrollbars({
+          scroller: view.scrollDOM,
+          host: view.dom.parentElement,
+          axes: "xy",
+        });
+      }
+    };
+    queueMicrotask(ensure);
+    return {
+      update(update) {
+        ensure();
+        if (update.geometryChanged) {
+          handle?.refresh();
+        }
+      },
+      destroy() {
+        handle?.destroy();
+      },
+    };
+  });
+}

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -11,6 +11,7 @@ import { gitFileAtRev, gitResolveRepo } from "@/modules/source-control/lib/gitBr
 import { fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import { loadLanguageExtension } from "@/modules/editor/lib/language";
 import { attachProxyScrollbars, type ProxyScrollbarsHandle } from "@/lib/proxyScrollbar";
+import { linkHorizontalScroll } from "./lib/linkScroll";
 import { dirname, relativePath } from "@/modules/explorer/lib/paths";
 import { editorSyntaxTheme } from "@/themes/editorTheme";
 import { selectTerminalFontFamily, useFontStore } from "@/stores/fontStore";
@@ -171,6 +172,7 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
     }
     let view: MergeView | null = null;
     let scrollbars: ProxyScrollbarsHandle[] = [];
+    let unlinkScroll: (() => void) | null = null;
     let cancelled = false;
     // A failed grammar load falls back to plain text instead of leaving the
     // tab stuck without a MergeView.
@@ -214,6 +216,7 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
         attachProxyScrollbars({ scroller: view.a.scrollDOM, host: parent, axes: "x" }),
         attachProxyScrollbars({ scroller: view.b.scrollDOM, host: parent, axes: "x" }),
       ];
+      unlinkScroll = linkHorizontalScroll(view.a.scrollDOM, view.b.scrollDOM);
       // Re-anchor comments whose line shifted while the docs were reloading,
       // then let the dispatch effect below render them into the new editors.
       const store = useDiffCommentStore.getState();
@@ -236,6 +239,7 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
     return () => {
       cancelled = true;
       mergeViewRef.current = null;
+      unlinkScroll?.();
       for (const bar of scrollbars) {
         bar.destroy();
       }

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -10,6 +10,7 @@ import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import { gitFileAtRev, gitResolveRepo } from "@/modules/source-control/lib/gitBridge";
 import { fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import { loadLanguageExtension } from "@/modules/editor/lib/language";
+import { attachProxyScrollbars, type ProxyScrollbarsHandle } from "@/lib/proxyScrollbar";
 import { dirname, relativePath } from "@/modules/explorer/lib/paths";
 import { editorSyntaxTheme } from "@/themes/editorTheme";
 import { selectTerminalFontFamily, useFontStore } from "@/stores/fontStore";
@@ -169,6 +170,7 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
       return;
     }
     let view: MergeView | null = null;
+    let scrollbars: ProxyScrollbarsHandle[] = [];
     let cancelled = false;
     // A failed grammar load falls back to plain text instead of leaving the
     // tab stuck without a MergeView.
@@ -205,6 +207,13 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
         collapseUnchanged: { margin: 3, minSize: 5 },
       });
       mergeViewRef.current = view;
+      // Pin a bottom horizontal scrollbar per side (the native one lives at
+      // the bottom of the full-height document, out of sight). Vertical
+      // scrolling stays on the outer .cm-mergeView, so "x" only.
+      scrollbars = [
+        attachProxyScrollbars({ scroller: view.a.scrollDOM, host: parent, axes: "x" }),
+        attachProxyScrollbars({ scroller: view.b.scrollDOM, host: parent, axes: "x" }),
+      ];
       // Re-anchor comments whose line shifted while the docs were reloading,
       // then let the dispatch effect below render them into the new editors.
       const store = useDiffCommentStore.getState();
@@ -227,6 +236,9 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
     return () => {
       cancelled = true;
       mergeViewRef.current = null;
+      for (const bar of scrollbars) {
+        bar.destroy();
+      }
       view?.destroy();
     };
   }, [docs, path, themeId, fontFamily, wordWrap]);
@@ -404,7 +416,7 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
       {error ? (
         <p className="px-3 py-2 text-xs text-danger">{t("diffLoadError")}</p>
       ) : (
-        <div ref={containerRef} className="diff-merge-view min-h-0 flex-1 overflow-hidden" />
+        <div ref={containerRef} className="diff-merge-view relative min-h-0 flex-1 overflow-hidden" />
       )}
       {!hintSeen && !error && (
         // One-time pointer at the review-comment loop, anchored under the

--- a/src/modules/diff/lib/linkScroll.ts
+++ b/src/modules/diff/lib/linkScroll.ts
@@ -1,0 +1,35 @@
+/**
+ * Keeps the two diff sides' horizontal scroll positions in lockstep, like
+ * VS Code's side-by-side diff. 1:1, not proportional: the side with shorter
+ * lines simply stops at its own end while the other keeps going.
+ */
+export function linkHorizontalScroll(a: HTMLElement, b: HTMLElement): () => void {
+  // Swallows exactly the echo event caused by our own assignment, so the
+  // clamped side doesn't drag the driving side back to its own maximum.
+  let syncing = false;
+  const follow = (from: HTMLElement, to: HTMLElement) => () => {
+    if (syncing) {
+      syncing = false;
+      return;
+    }
+    if (to.scrollLeft !== from.scrollLeft) {
+      const before = to.scrollLeft;
+      syncing = true;
+      to.scrollLeft = from.scrollLeft;
+      if (to.scrollLeft === before) {
+        // Clamped to the value it already had (target is at its own end):
+        // no echo event will fire, so disarm or the flag would eat the
+        // next genuine scroll on that side.
+        syncing = false;
+      }
+    }
+  };
+  const aToB = follow(a, b);
+  const bToA = follow(b, a);
+  a.addEventListener("scroll", aToB, { passive: true });
+  b.addEventListener("scroll", bToA, { passive: true });
+  return () => {
+    a.removeEventListener("scroll", aToB);
+    b.removeEventListener("scroll", bToA);
+  };
+}

--- a/src/modules/editor/EditorTabContent.tsx
+++ b/src/modules/editor/EditorTabContent.tsx
@@ -6,6 +6,7 @@ import { Compartment } from "@codemirror/state";
 import { editorSyntaxTheme } from "@/themes/editorTheme";
 import { isMarkdownPath, languageLabel, loadLanguageExtension } from "./lib/language";
 import { inlineCompletion, type CompletionRequest } from "./lib/inlineCompletion";
+import { proxyScrollbars } from "@/lib/proxyScrollbar";
 import { useEditorStore } from "./store/editorStore";
 import { aiChat } from "@/modules/ai/lib/aiBridge";
 import { providerById, resolveBaseUrl } from "@/modules/ai/lib/providers";
@@ -125,6 +126,7 @@ export function EditorTabContent({
         "&": { height: "100%", fontSize: `${fontSize}px` },
         ".cm-content, .cm-gutters, .cm-scroller": { fontFamily },
       }),
+      proxyScrollbars(),
       ...(wordWrap ? [CMView.lineWrapping] : []),
       languageCompartment.current.of([]),
     ];

--- a/src/themes/editorTheme.ts
+++ b/src/themes/editorTheme.ts
@@ -28,11 +28,15 @@ import { DEFAULT_THEME_ID } from "./themes";
  * @codemirror/theme-one-dark；one-light 無現成套件，依 akamud One Light 官方
  * 配色手刻。
  *
- * 所有主題都把編輯器自身背景與 gutter 設為透明，沿用底下 app 的背景（bg-bg），
+ * 所有主題都把編輯器自身背景設為透明，沿用底下 app 的背景（bg-bg），
  * 不自己畫一塊底色，這樣切到任何主題都不會出現色塊斷層。「當前行高亮」統一用
  * 各主題的 bg-elevated，讓游標所在行融入 app 的明暗階層。
+ *
+ * 行號 gutter 例外：它在橫向捲動時是 sticky 固定在左側的，若透明，程式碼與
+ * diff 變更行的底色會從行號底下滑過去，所以改用 app 背景 token 畫一層不透明
+ * 底——顏色與透明時完全相同，只是擋住底下捲動的內容。
  */
-const TRANSPARENT = { background: "transparent", gutterBackground: "transparent" } as const;
+const SURFACE = { background: "transparent", gutterBackground: "var(--color-bg)" } as const;
 
 /** 各主題的當前行高亮色（= themes.ts 的 bgElevated）。 */
 const LINE_HIGHLIGHT: Record<string, string> = {
@@ -57,61 +61,63 @@ function activeLine(color: string): Extension {
 
 const vitesseDarkEditor: Extension = [
   createVitesseDarkTheme({
-    settings: { ...defaultSettingsVitesseDark, ...TRANSPARENT, lineHighlight: LINE_HIGHLIGHT["vitesse-dark"] },
+    settings: { ...defaultSettingsVitesseDark, ...SURFACE, lineHighlight: LINE_HIGHLIGHT["vitesse-dark"] },
   }),
   activeLine(LINE_HIGHLIGHT["vitesse-dark"]),
 ];
 
 const vitesseLightEditor: Extension = [
   createVitesseLightTheme({
-    settings: { ...defaultSettingsVitesseLight, ...TRANSPARENT, lineHighlight: LINE_HIGHLIGHT["vitesse-light"] },
+    settings: { ...defaultSettingsVitesseLight, ...SURFACE, lineHighlight: LINE_HIGHLIGHT["vitesse-light"] },
   }),
   activeLine(LINE_HIGHLIGHT["vitesse-light"]),
 ];
 
 const githubDarkEditor: Extension = [
   githubDarkInit({
-    settings: { ...defaultSettingsGithubDark, ...TRANSPARENT, lineHighlight: LINE_HIGHLIGHT["github-dark"] },
+    settings: { ...defaultSettingsGithubDark, ...SURFACE, lineHighlight: LINE_HIGHLIGHT["github-dark"] },
   }),
   activeLine(LINE_HIGHLIGHT["github-dark"]),
 ];
 
 const githubLightEditor: Extension = [
   githubLightInit({
-    settings: { ...defaultSettingsGithubLight, ...TRANSPARENT, lineHighlight: LINE_HIGHLIGHT["github-light"] },
+    settings: { ...defaultSettingsGithubLight, ...SURFACE, lineHighlight: LINE_HIGHLIGHT["github-light"] },
   }),
   activeLine(LINE_HIGHLIGHT["github-light"]),
 ];
 
 const draculaEditor: Extension = [
   draculaInit({
-    settings: { ...defaultSettingsDracula, ...TRANSPARENT, lineHighlight: LINE_HIGHLIGHT["dracula"] },
+    settings: { ...defaultSettingsDracula, ...SURFACE, lineHighlight: LINE_HIGHLIGHT["dracula"] },
   }),
   activeLine(LINE_HIGHLIGHT["dracula"]),
 ];
 
 const gruvboxDarkEditor: Extension = [
   gruvboxDarkInit({
-    settings: { ...defaultSettingsGruvboxDark, ...TRANSPARENT, lineHighlight: LINE_HIGHLIGHT["gruvbox-dark"] },
+    settings: { ...defaultSettingsGruvboxDark, ...SURFACE, lineHighlight: LINE_HIGHLIGHT["gruvbox-dark"] },
   }),
   activeLine(LINE_HIGHLIGHT["gruvbox-dark"]),
 ];
 
 const solarizedLightEditor: Extension = [
   solarizedLightInit({
-    settings: { ...defaultSettingsSolarizedLight, ...TRANSPARENT, lineHighlight: LINE_HIGHLIGHT["solarized-light"] },
+    settings: { ...defaultSettingsSolarizedLight, ...SURFACE, lineHighlight: LINE_HIGHLIGHT["solarized-light"] },
   }),
   activeLine(LINE_HIGHLIGHT["solarized-light"]),
 ];
 
-// 官方 oneDark 自帶 #282c34 背景，疊一層透明覆蓋讓它沿用 app 背景。
+// 官方 oneDark 自帶 #282c34 背景，疊一層覆蓋讓它沿用 app 背景。CodeMirror
+// mount 主題樣式時「排前面的 extension 優先」（facet 反轉後掛載），覆蓋層
+// 必須放在 oneDark 前面才蓋得過去。
 const oneDarkEditor: Extension = [
-  oneDark,
   EditorView.theme({
     "&": { backgroundColor: "transparent" },
-    ".cm-gutters": { backgroundColor: "transparent" },
+    ".cm-gutters": { backgroundColor: SURFACE.gutterBackground },
   }),
   activeLine(LINE_HIGHLIGHT["one-dark"]),
+  oneDark,
 ];
 
 // One Light 沒有維護中的 CM6 套件，依 akamud One Light 官方 token 配色手刻。
@@ -119,7 +125,7 @@ const oneLightEditor: Extension = [
   createTheme({
     theme: "light",
     settings: {
-      ...TRANSPARENT,
+      ...SURFACE,
       foreground: "#383a42",
       caret: "#526fff",
       selection: "#e5e5e6",


### PR DESCRIPTION
## Problem

On Windows, WebView2 only has always-on classic scrollbars, which made scrolling in the code surfaces awkward in three ways:

1. The horizontal scrollbar spans the whole scroller, running beneath the sticky line-number gutter — and since the gutter background was transparent, long lines and diff line tints also slid visibly under the numbers while scrolling.
2. In the diff tab the merge editors are auto-height (the outer `.cm-mergeView` owns vertical scrolling), so each side's horizontal scrollbar sat at the bottom of the whole document — visible only after scrolling all the way down.
3. The two diff sides scrolled horizontally independently.

## Root cause

- The syntax themes deliberately keep the editor background transparent so the app background shows through, but the gutter is `position: sticky` inside the horizontal scroller, so a transparent gutter lets content slide through beneath it.
- While fixing that we found CodeMirror mounts theme style modules with *earlier-extension* precedence (the `styleModule` facet is reversed before mounting), so the existing one-dark transparent-background overlay and unified active-line color, placed *after* `oneDark`, never actually took effect.

## Changes

- **themes**: paint the gutter with the app background token (`var(--color-bg)`) — visually identical to transparent, but opaque, so nothing shows through beneath the line numbers. Move the one-dark overrides before `oneDark` so they win the cascade.
- **`src/lib/proxyScrollbar.ts`** (new, Windows-only via `IS_WINDOWS`; macOS/Linux keep the stock native overlay scrollbars): hide the scroller's own bars and replace them with thin overflow strips the browser renders real native scrollbars for, placed like VS Code — horizontal pinned to the pane bottom starting after the gutter (or right under the content when a short diff ends inside the pane), vertical at the editor's right edge. Strips and scroller get equal scroll ranges so positions map 1:1 with no math on scroll events, and the horizontal strip hides entirely when nothing overflows (e.g. word wrap on). The host class lives on the editor's wrapper rather than `view.dom`, which CodeMirror rewrites on update.
- **diff**: sync horizontal scrolling between the two sides, 1:1 like VS Code — the side with shorter lines stops at its own end while the other keeps going (applies on all platforms).

## Test plan

- [x] `npx pnpm exec tsc --noEmit`
- [x] `npx pnpm exec vitest run` — 1988 passed
- [x] Manual on Windows 11: editor tab and diff tab horizontal/vertical scrolling; thumb drag and track click; word wrap toggle hides the horizontal bar; a short diff keeps its bar under the content instead of the pane bottom; both diff sides scroll in lockstep; line numbers stay pinned with an opaque backdrop while scrolling horizontally (verified via CDP that the strip's left edge equals the gutter's right edge and the native bars are gone)
- [x] macOS: no visual change expected — the proxy bars are Windows-gated; the gutter backdrop and diff scroll sync apply everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)