### PR TITLE
fix(themes): hide the active-line highlight while a selection exists

### DIFF
--- a/src/themes/editorTheme.ts
+++ b/src/themes/editorTheme.ts
@@ -47,12 +47,26 @@ const LINE_HIGHLIGHT: Record<string, string> = {
   "solarized-light": "#eee8d5",
 };
 
-/** 統一的當前行高亮 wrapper，不論底層套件是否自己處理 .cm-activeLine 都生效。 */
+/**
+ * 統一的當前行高亮 wrapper，不論底層套件是否自己處理 .cm-activeLine 都生效。
+ *
+ * 選取反白畫在內容層後面，不透明的行高亮會把它整行蓋住，所以有選取時隱藏
+ * 行高亮（行號的高亮保留），選取取消才恢復。用
+ * editorAttributes 掛 class（CM 自己管理的屬性，不會像手動加在 view.dom 上
+ * 那樣被洗掉）；透明規則的 selector 特異度高於各主題套件自己的 activeLine
+ * 規則，不受主題掛載順序影響。
+ */
 function activeLine(color: string): Extension {
-  return EditorView.theme({
-    ".cm-activeLine": { backgroundColor: color },
-    ".cm-activeLineGutter": { backgroundColor: color },
-  });
+  return [
+    EditorView.editorAttributes.compute(["selection"], (state) => ({
+      class: state.selection.ranges.some((range) => !range.empty) ? "cm-has-selection" : "",
+    })),
+    EditorView.theme({
+      ".cm-activeLine": { backgroundColor: color },
+      ".cm-activeLineGutter": { backgroundColor: color },
+      "&.cm-has-selection .cm-activeLine": { backgroundColor: "transparent" },
+    }),
+  ];
 }
 
 const vitesseDarkEditor: Extension = [


### PR DESCRIPTION
## Problem

Selecting text that spans the cursor's line makes the selection highlight invisible on that line: the active-line background covers it, so the selected range appears to have a hole.

## Root cause

CodeMirror paints the selection layer *behind* the content, while the active-line highlight is the line element's own (opaque) background. There is no z-index that can slot a selection between one element's background and its text, so an opaque `.cm-activeLine` always wins over the selection beneath it.

## Changes

Do what VS Code does: suppress the current-line highlight while any selection range is non-empty (the gutter's line-number highlight stays), and restore it when the selection collapses.

- The state-dependent class is applied through `EditorView.editorAttributes.compute` — CodeMirror manages that attribute itself; classes added to `view.dom` by hand get wiped on update.
- The transparent override selector (`&.cm-has-selection .cm-activeLine`) outranks the theme packages' own activeLine rules by specificity, so it works regardless of theme mount order.

Applies to all nine themes via the shared `activeLine` wrapper.

## Test plan

- [x] `npx pnpm exec tsc --noEmit`
- [x] `npx pnpm exec vitest run` — 2013 passed
- [x] Manual on Windows 11 (verified via CDP against the running app): with a non-empty selection the editor gains `cm-has-selection` and the active line's computed background is transparent; collapsing the selection removes the class and restores the highlight color

🤖 Generated with [Claude Code](https://claude.com/claude-code)