### PR TITLE
feat(git-graph): fix the branch filter and make it a searchable multi-select

### DIFF
--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -68,6 +68,10 @@ pub struct BranchInfo {
     pub is_current: bool,
     #[serde(rename = "isRemote")]
     pub is_remote: bool,
+    /// 分支 tip commit 的 committer 時間（Unix 秒），拿不到時為 0。
+    /// 前端用它把「最近動過」的分支排前面。
+    #[serde(rename = "lastCommitAt")]
+    pub last_commit_at: i64,
 }
 
 /// 一個 commit 變更的單一檔案。
@@ -1358,6 +1362,7 @@ pub fn branches(repo_path: &str) -> Result<Vec<BranchInfo>, String> {
         .map_err(|e| e.message().to_string())?;
     for entry in local {
         let (branch, _) = entry.map_err(|e| e.message().to_string())?;
+        let last_commit_at = branch_tip_time(&branch);
         if let Some(name) = branch.name().map_err(|e| e.message().to_string())? {
             let name = name.to_string();
             let is_current = Some(&name) == head_name.as_ref();
@@ -1365,6 +1370,7 @@ pub fn branches(repo_path: &str) -> Result<Vec<BranchInfo>, String> {
                 name,
                 is_current,
                 is_remote: false,
+                last_commit_at,
             });
         }
     }
@@ -1374,6 +1380,7 @@ pub fn branches(repo_path: &str) -> Result<Vec<BranchInfo>, String> {
         .map_err(|e| e.message().to_string())?;
     for entry in remote {
         let (branch, _) = entry.map_err(|e| e.message().to_string())?;
+        let last_commit_at = branch_tip_time(&branch);
         if let Some(name) = branch.name().map_err(|e| e.message().to_string())? {
             // 跳過 origin/HEAD 這種 symbolic ref，它只是指向預設分支。
             if name.ends_with("/HEAD") {
@@ -1383,11 +1390,22 @@ pub fn branches(repo_path: &str) -> Result<Vec<BranchInfo>, String> {
                 name: name.to_string(),
                 is_current: false,
                 is_remote: true,
+                last_commit_at,
             });
         }
     }
 
     Ok(out)
+}
+
+/// 分支 tip commit 的 committer 時間（Unix 秒）；解析失敗以 0 墊底，
+/// 讓排序時自然沉到最後而不是整個清單失敗。
+fn branch_tip_time(branch: &git2::Branch<'_>) -> i64 {
+    branch
+        .get()
+        .peel_to_commit()
+        .map(|c| c.time().seconds())
+        .unwrap_or(0)
 }
 
 /// Check out an existing branch.
@@ -2499,10 +2517,12 @@ mod tests {
         assert!(page.has_more);
 
         let branches = branches(&path).unwrap();
-        assert_eq!(
-            branches,
-            vec![BranchInfo { name: "main".into(), is_current: true, is_remote: false }]
-        );
+        assert_eq!(branches.len(), 1);
+        assert_eq!(branches[0].name, "main");
+        assert!(branches[0].is_current);
+        assert!(!branches[0].is_remote);
+        // tip 是剛剛才提交的，時間必須被填上（0 是解析失敗的墊底值）。
+        assert!(branches[0].last_commit_at > 0);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -98,7 +98,8 @@ pub enum CommitOrder {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct GraphOptions {
-    pub branch: Option<String>,
+    /// 篩選用的分支清單；空清單代表「全部分支」。
+    pub branches: Vec<String>,
     pub include_remotes: bool,
     pub include_tags: bool,
     pub include_stashes: bool,
@@ -114,17 +115,20 @@ fn order_flag(order: CommitOrder) -> &'static str {
 }
 
 /// 把顯示選項翻成 git log 的 ref 範圍參數。純函式方便測試。
-/// 指定分支時只給該分支——remote/tag/stash 開關不再疊加，否則 `--remotes`
-/// 會把所有遠端分支的歷史聯集進來，預設開關全開時篩選形同失效；
-/// 沒指定分支才用 --branches 含全部本地分支，並依開關疊加其他 ref 範圍。
+/// 指定分支時只給那些分支（多選為聯集）——remote/tag/stash 開關不再疊加，
+/// 否則 `--remotes` 會把所有遠端分支的歷史聯集進來，預設開關全開時篩選
+/// 形同失效；沒指定分支才用 --branches 含全部本地分支，並依開關疊加其他
+/// ref 範圍。
 fn build_log_refs(options: &GraphOptions) -> Vec<String> {
-    let branch = options
-        .branch
-        .as_deref()
-        .map(str::trim)
-        .filter(|b| !b.is_empty());
-    if let Some(name) = branch {
-        return vec![name.to_string()];
+    let picked: Vec<String> = options
+        .branches
+        .iter()
+        .map(|b| b.trim())
+        .filter(|b| !b.is_empty())
+        .map(str::to_string)
+        .collect();
+    if !picked.is_empty() {
+        return picked;
     }
     let mut refs: Vec<String> = vec!["--branches".to_string()];
     if options.include_remotes {
@@ -1309,13 +1313,11 @@ pub fn graph_log(
     let skip_arg = format!("--skip={skip}");
 
     // 指定分支會當成位置參數傳給 git，先擋掉開頭是 - 的值。
-    if let Some(branch) = options
-        .branch
-        .as_deref()
-        .map(str::trim)
-        .filter(|b| !b.is_empty())
-    {
-        ensure_not_flag(branch)?;
+    for branch in &options.branches {
+        let branch = branch.trim();
+        if !branch.is_empty() {
+            ensure_not_flag(branch)?;
+        }
     }
 
     let ref_args = build_log_refs(options);
@@ -2855,7 +2857,7 @@ mod tests {
     #[test]
     fn build_log_refs_specific_branch() {
         let options = GraphOptions {
-            branch: Some("main".to_string()),
+            branches: vec!["main".to_string()],
             ..GraphOptions::default()
         };
         assert_eq!(build_log_refs(&options), vec!["main".to_string()]);
@@ -2866,7 +2868,7 @@ mod tests {
         // 顯示開關預設全開；若還疊加 --remotes/--tags，選了分支的圖
         // 仍會畫出所有遠端分支的歷史，篩選形同失效。
         let options = GraphOptions {
-            branch: Some("main".to_string()),
+            branches: vec!["main".to_string()],
             include_remotes: true,
             include_tags: true,
             include_stashes: true,
@@ -2876,9 +2878,31 @@ mod tests {
     }
 
     #[test]
+    fn build_log_refs_multiple_branches_union() {
+        let options = GraphOptions {
+            branches: vec!["main".to_string(), "origin/feature".to_string()],
+            include_remotes: true,
+            ..GraphOptions::default()
+        };
+        assert_eq!(
+            build_log_refs(&options),
+            vec!["main".to_string(), "origin/feature".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_log_refs_blank_entries_fall_back_to_show_all() {
+        let options = GraphOptions {
+            branches: vec!["   ".to_string(), "".to_string()],
+            ..GraphOptions::default()
+        };
+        assert_eq!(build_log_refs(&options), vec!["--branches".to_string()]);
+    }
+
+    #[test]
     fn build_log_refs_toggles_stack() {
         let options = GraphOptions {
-            branch: None,
+            branches: Vec::new(),
             include_remotes: true,
             include_tags: true,
             include_stashes: true,
@@ -2895,14 +2919,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn build_log_refs_blank_branch_is_show_all() {
-        let options = GraphOptions {
-            branch: Some("   ".to_string()),
-            ..GraphOptions::default()
-        };
-        assert_eq!(build_log_refs(&options), vec!["--branches".to_string()]);
-    }
 
     #[test]
     fn order_flag_maps_each_commit_order() {

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -114,19 +114,19 @@ fn order_flag(order: CommitOrder) -> &'static str {
 }
 
 /// 把顯示選項翻成 git log 的 ref 範圍參數。純函式方便測試。
-/// 指定分支時只給該分支，沒指定用 --branches 含全部本地分支；
-/// remote/tag/stash 開關各自疊加。
+/// 指定分支時只給該分支——remote/tag/stash 開關不再疊加，否則 `--remotes`
+/// 會把所有遠端分支的歷史聯集進來，預設開關全開時篩選形同失效；
+/// 沒指定分支才用 --branches 含全部本地分支，並依開關疊加其他 ref 範圍。
 fn build_log_refs(options: &GraphOptions) -> Vec<String> {
-    let mut refs: Vec<String> = Vec::new();
     let branch = options
         .branch
         .as_deref()
         .map(str::trim)
         .filter(|b| !b.is_empty());
-    match branch {
-        Some(name) => refs.push(name.to_string()),
-        None => refs.push("--branches".to_string()),
+    if let Some(name) = branch {
+        return vec![name.to_string()];
     }
+    let mut refs: Vec<String> = vec!["--branches".to_string()];
     if options.include_remotes {
         refs.push("--remotes".to_string());
     }
@@ -2857,6 +2857,20 @@ mod tests {
         let options = GraphOptions {
             branch: Some("main".to_string()),
             ..GraphOptions::default()
+        };
+        assert_eq!(build_log_refs(&options), vec!["main".to_string()]);
+    }
+
+    #[test]
+    fn build_log_refs_specific_branch_ignores_ref_toggles() {
+        // 顯示開關預設全開；若還疊加 --remotes/--tags，選了分支的圖
+        // 仍會畫出所有遠端分支的歷史，篩選形同失效。
+        let options = GraphOptions {
+            branch: Some("main".to_string()),
+            include_remotes: true,
+            include_tags: true,
+            include_stashes: true,
+            order: CommitOrder::Date,
         };
         assert_eq!(build_log_refs(&options), vec!["main".to_string()]);
     }

--- a/src/i18n/locales/en/gitGraph.json
+++ b/src/i18n/locales/en/gitGraph.json
@@ -10,6 +10,7 @@
   "toolbar": {
     "branches": "Branches",
     "showAll": "Show All",
+    "filterPlaceholder": "Search branches…",
     "showRemoteBranches": "Show Remote Branches",
     "search": "Search commits",
     "searchPlaceholder": "Search message, author, hash…",

--- a/src/i18n/locales/en/gitGraph.json
+++ b/src/i18n/locales/en/gitGraph.json
@@ -11,6 +11,7 @@
     "branches": "Branches",
     "showAll": "Show All",
     "filterPlaceholder": "Search branches…",
+    "currentBadge": "current",
     "showRemoteBranches": "Show Remote Branches",
     "search": "Search commits",
     "searchPlaceholder": "Search message, author, hash…",

--- a/src/i18n/locales/zh-Hant/gitGraph.json
+++ b/src/i18n/locales/zh-Hant/gitGraph.json
@@ -10,6 +10,7 @@
   "toolbar": {
     "branches": "分支",
     "showAll": "全部分支",
+    "filterPlaceholder": "搜尋分支…",
     "showRemoteBranches": "顯示遠端分支",
     "search": "搜尋提交",
     "searchPlaceholder": "搜尋訊息、作者、hash…",

--- a/src/i18n/locales/zh-Hant/gitGraph.json
+++ b/src/i18n/locales/zh-Hant/gitGraph.json
@@ -11,6 +11,7 @@
     "branches": "分支",
     "showAll": "全部分支",
     "filterPlaceholder": "搜尋分支…",
+    "currentBadge": "目前",
     "showRemoteBranches": "顯示遠端分支",
     "search": "搜尋提交",
     "searchPlaceholder": "搜尋訊息、作者、hash…",

--- a/src/modules/git-graph/BranchFilter.tsx
+++ b/src/modules/git-graph/BranchFilter.tsx
@@ -7,6 +7,8 @@ export interface BranchFilterLabels {
   /** The exclusive "no filter" entry (e.g. "Show All"). */
   showAll: string;
   searchPlaceholder: string;
+  /** Badge text marking the checked-out branch (e.g. "HEAD"). */
+  head: string;
 }
 
 interface BranchFilterProps {
@@ -16,6 +18,8 @@ interface BranchFilterProps {
   remotes: string[];
   /** Selected branch names; empty means "show all". */
   selected: string[];
+  /** The checked-out branch, marked with a HEAD badge in the list. */
+  headName?: string;
   onChange: (selected: string[]) => void;
   labels: BranchFilterLabels;
 }
@@ -27,7 +31,14 @@ interface BranchFilterProps {
  * together. The trigger keeps its width no matter how long the picked branch
  * names are — long values truncate instead of reflowing the toolbar.
  */
-export function BranchFilter({ locals, remotes, selected, onChange, labels }: BranchFilterProps) {
+export function BranchFilter({
+  locals,
+  remotes,
+  selected,
+  headName,
+  onChange,
+  labels,
+}: BranchFilterProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -130,6 +141,7 @@ export function BranchFilter({ locals, remotes, selected, onChange, labels }: Br
               <FilterRow
                 key={name}
                 name={name}
+                badge={name === headName ? labels.head : undefined}
                 checked={selected.includes(name)}
                 onSelect={() => toggleBranch(name)}
               />
@@ -152,10 +164,13 @@ export function BranchFilter({ locals, remotes, selected, onChange, labels }: Br
 
 function FilterRow({
   name,
+  badge,
   checked,
   onSelect,
 }: {
   name: string;
+  /** Small marker after the name (the HEAD badge); ✓ is taken by "picked". */
+  badge?: string;
   checked: boolean;
   onSelect: () => void;
 }) {
@@ -166,11 +181,16 @@ function FilterRow({
         role="option"
         aria-selected={checked}
         onClick={onSelect}
-        className={`flex w-full items-center justify-between gap-2 rounded-md px-2 py-1 text-left text-xs ${
+        className={`flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-xs ${
           checked ? "bg-bg text-fg" : "text-fg-muted hover:bg-bg hover:text-fg"
         }`}
       >
-        <span className="truncate">{name}</span>
+        <span className="min-w-0 flex-1 truncate">{name}</span>
+        {badge && (
+          <span className="shrink-0 rounded border border-success/40 bg-success/15 px-1 font-mono text-[10px] text-success">
+            {badge}
+          </span>
+        )}
         {checked && <Check size={13} className="shrink-0 text-accent" />}
       </button>
     </li>

--- a/src/modules/git-graph/BranchFilter.tsx
+++ b/src/modules/git-graph/BranchFilter.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, Search } from "lucide-react";
+
+export interface BranchFilterLabels {
+  /** Field label, doubles as the trigger's aria-label (e.g. "Filter"). */
+  ariaLabel: string;
+  /** The exclusive "no filter" entry (e.g. "Show All"). */
+  showAll: string;
+  searchPlaceholder: string;
+}
+
+interface BranchFilterProps {
+  /** Local branch names, in display order. */
+  locals: string[];
+  /** Remote branch names; pass an empty list when remotes are hidden. */
+  remotes: string[];
+  /** Selected branch names; empty means "show all". */
+  selected: string[];
+  onChange: (selected: string[]) => void;
+  labels: BranchFilterLabels;
+}
+
+/**
+ * The graph's branch filter: a fixed-width trigger opening a searchable,
+ * multi-select branch list. "Show All" is exclusive (it clears the picks);
+ * every other entry toggles independently so several branches can be graphed
+ * together. The trigger keeps its width no matter how long the picked branch
+ * names are — long values truncate instead of reflowing the toolbar.
+ */
+export function BranchFilter({ locals, remotes, selected, onChange, labels }: BranchFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    inputRef.current?.focus();
+    function onPointerDown(e: MouseEvent) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    window.addEventListener("mousedown", onPointerDown);
+    return () => window.removeEventListener("mousedown", onPointerDown);
+  }, [open]);
+
+  // Reopening starts from a clean search so the full list is visible again.
+  function toggleOpen() {
+    setOpen((o) => {
+      if (!o) {
+        setQuery("");
+      }
+      return !o;
+    });
+  }
+
+  function toggleBranch(name: string) {
+    onChange(
+      selected.includes(name)
+        ? selected.filter((s) => s !== name)
+        : [...selected, name],
+    );
+  }
+
+  const filtered = (names: string[]) =>
+    query.trim() === ""
+      ? names
+      : names.filter((n) => n.toLowerCase().includes(query.trim().toLowerCase()));
+
+  const visibleLocals = filtered(locals);
+  const visibleRemotes = filtered(remotes);
+
+  const isFiltering = selected.length > 0;
+  const triggerText = !isFiltering
+    ? labels.showAll
+    : selected.length === 1
+      ? selected[0]
+      : `${selected[0]} +${selected.length - 1}`;
+
+  return (
+    <div ref={wrapRef} className="relative w-64 shrink-0">
+      <button
+        type="button"
+        aria-label={labels.ariaLabel}
+        aria-expanded={open}
+        onClick={toggleOpen}
+        className={`flex w-full items-center gap-1 rounded-lg border bg-bg px-2 py-1 text-left text-[13px] ${
+          isFiltering ? "border-accent/60 text-accent" : "border-border text-fg-muted"
+        }`}
+      >
+        <span className="min-w-0 flex-1 truncate">{triggerText}</span>
+        <ChevronDown
+          size={13}
+          className={`shrink-0 text-fg-subtle transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full z-50 mt-1.5 w-full rounded-lg border border-border-strong bg-bg-elevated shadow-xl">
+          <div className="flex items-center gap-1.5 border-b border-border px-2 py-1.5">
+            <Search size={13} className="shrink-0 text-fg-subtle" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  setOpen(false);
+                }
+              }}
+              placeholder={labels.searchPlaceholder}
+              spellCheck={false}
+              className="min-w-0 flex-1 bg-transparent text-xs text-fg outline-none placeholder:text-fg-subtle"
+            />
+          </div>
+          <ul className="max-h-64 space-y-0.5 overflow-y-auto p-1" role="listbox" aria-multiselectable>
+            <FilterRow
+              name={labels.showAll}
+              checked={!isFiltering}
+              onSelect={() => {
+                onChange([]);
+                setOpen(false);
+              }}
+            />
+            {visibleLocals.length > 0 && <li className="my-1 border-t border-border" aria-hidden="true" />}
+            {visibleLocals.map((name) => (
+              <FilterRow
+                key={name}
+                name={name}
+                checked={selected.includes(name)}
+                onSelect={() => toggleBranch(name)}
+              />
+            ))}
+            {visibleRemotes.length > 0 && <li className="my-1 border-t border-border" aria-hidden="true" />}
+            {visibleRemotes.map((name) => (
+              <FilterRow
+                key={name}
+                name={name}
+                checked={selected.includes(name)}
+                onSelect={() => toggleBranch(name)}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilterRow({
+  name,
+  checked,
+  onSelect,
+}: {
+  name: string;
+  checked: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        role="option"
+        aria-selected={checked}
+        onClick={onSelect}
+        className={`flex w-full items-center justify-between gap-2 rounded-md px-2 py-1 text-left text-xs ${
+          checked ? "bg-bg text-fg" : "text-fg-muted hover:bg-bg hover:text-fg"
+        }`}
+      >
+        <span className="truncate">{name}</span>
+        {checked && <Check size={13} className="shrink-0 text-accent" />}
+      </button>
+    </li>
+  );
+}

--- a/src/modules/git-graph/BranchFilter.tsx
+++ b/src/modules/git-graph/BranchFilter.tsx
@@ -8,7 +8,7 @@ export interface BranchFilterLabels {
   showAll: string;
   searchPlaceholder: string;
   /** Badge text marking the checked-out branch (e.g. "current"). */
-  head: string;
+  currentBadge: string;
 }
 
 interface BranchFilterProps {
@@ -19,7 +19,7 @@ interface BranchFilterProps {
   /** Selected branch names; empty means "show all". */
   selected: string[];
   /** The checked-out branch, marked with the current-branch badge in the list. */
-  headName?: string;
+  currentBranch?: string;
   onChange: (selected: string[]) => void;
   labels: BranchFilterLabels;
 }
@@ -35,7 +35,7 @@ export function BranchFilter({
   locals,
   remotes,
   selected,
-  headName,
+  currentBranch,
   onChange,
   labels,
 }: BranchFilterProps) {
@@ -141,7 +141,7 @@ export function BranchFilter({
               <FilterRow
                 key={name}
                 name={name}
-                badge={name === headName ? labels.head : undefined}
+                badge={name === currentBranch ? labels.currentBadge : undefined}
                 checked={selected.includes(name)}
                 onSelect={() => toggleBranch(name)}
               />

--- a/src/modules/git-graph/BranchFilter.tsx
+++ b/src/modules/git-graph/BranchFilter.tsx
@@ -7,7 +7,7 @@ export interface BranchFilterLabels {
   /** The exclusive "no filter" entry (e.g. "Show All"). */
   showAll: string;
   searchPlaceholder: string;
-  /** Badge text marking the checked-out branch (e.g. "HEAD"). */
+  /** Badge text marking the checked-out branch (e.g. "current"). */
   head: string;
 }
 
@@ -18,7 +18,7 @@ interface BranchFilterProps {
   remotes: string[];
   /** Selected branch names; empty means "show all". */
   selected: string[];
-  /** The checked-out branch, marked with a HEAD badge in the list. */
+  /** The checked-out branch, marked with the current-branch badge in the list. */
   headName?: string;
   onChange: (selected: string[]) => void;
   labels: BranchFilterLabels;
@@ -169,7 +169,7 @@ function FilterRow({
   onSelect,
 }: {
   name: string;
-  /** Small marker after the name (the HEAD badge); ✓ is taken by "picked". */
+  /** Small marker after the name (the current-branch badge); ✓ is taken by "picked". */
   badge?: string;
   checked: boolean;
   onSelect: () => void;

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -89,7 +89,8 @@ export function GitGraphTabContent() {
   const [modal, setModal] = useState<ModalState | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
+  // Branch names the graph is filtered to; empty means Show All.
+  const [selectedBranches, setSelectedBranches] = useState<string[]>([]);
   const [includeRemotes, setIncludeRemotes] = useState(true);
   const [includeTags, setIncludeTags] = useState(true);
   const [includeStashes, setIncludeStashes] = useState(false);
@@ -103,7 +104,7 @@ export function GitGraphTabContent() {
   const [busy, setBusy] = useState(false);
 
   const options: GraphOptions = {
-    branch: selectedBranch,
+    branches: selectedBranches,
     includeRemotes,
     includeTags,
     includeStashes,
@@ -204,13 +205,13 @@ export function GitGraphTabContent() {
     }
     setLimit(PAGE_SIZE);
     void reload(repo, PAGE_SIZE, {
-      branch: selectedBranch,
+      branches: selectedBranches,
       includeRemotes,
       includeTags,
       includeStashes,
       order: commitOrder,
     });
-  }, [repo, selectedBranch, includeRemotes, includeTags, includeStashes, commitOrder, reload]);
+  }, [repo, selectedBranches, includeRemotes, includeTags, includeStashes, commitOrder, reload]);
 
   // Run an action then refresh the graph; surface any failure inline.
   const runAction = useCallback(
@@ -234,7 +235,7 @@ export function GitGraphTabContent() {
         setBusy(false);
       }
     },
-    [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes, options.order],
+    [repo, limit, reload, options.branches, options.includeRemotes, options.includeTags, options.includeStashes, options.order],
   );
 
   const loadMore = useCallback(() => {
@@ -244,7 +245,7 @@ export function GitGraphTabContent() {
     const next = limit + PAGE_SIZE;
     setLimit(next);
     void reload(repo, next, options);
-  }, [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes, options.order]);
+  }, [repo, limit, reload, options.branches, options.includeRemotes, options.includeTags, options.includeStashes, options.order]);
 
   // Plain click/arrow-nav selects one commit. Shift+click while a commit is
   // already selected (single or as the "to" side of an existing compare)
@@ -355,19 +356,22 @@ export function GitGraphTabContent() {
     }
   }, [pendingHash, commits, visibleCommits, loadMore]);
 
-  // Turning remotes off hides remote branches; if one was selected, fall back
-  // to Show All so the dropdown value and selectedBranch stay in sync.
+  // Turning remotes off hides remote branches; drop any of them from the
+  // filter so the dropdown's picks and the graphed refs stay in sync.
   const handleToggleRemotes = useCallback(
     (value: boolean) => {
       setIncludeRemotes(value);
       if (!value) {
-        const current = branches.find((b) => b.name === selectedBranch);
-        if (current?.isRemote) {
-          setSelectedBranch(null);
-        }
+        const remoteNames = new Set(
+          branches.filter((b) => b.isRemote).map((b) => b.name),
+        );
+        setSelectedBranches((prev) => {
+          const next = prev.filter((name) => !remoteNames.has(name));
+          return next.length === prev.length ? prev : next;
+        });
       }
     },
-    [branches, selectedBranch],
+    [branches],
   );
 
   // Remember the chosen order so it survives reopening the graph tab.
@@ -390,7 +394,7 @@ export function GitGraphTabContent() {
     } finally {
       setFetching(false);
     }
-  }, [repo, limit, reload, options.branch, options.includeRemotes, options.includeTags, options.includeStashes, options.order]);
+  }, [repo, limit, reload, options.branches, options.includeRemotes, options.includeTags, options.includeStashes, options.order]);
 
   // Shared by the ref context menu and the toolbar's branch menu: prompt for a
   // local name, then create the tracking branch.
@@ -419,6 +423,7 @@ export function GitGraphTabContent() {
   const toolbarLabels: GitGraphToolbarLabels = {
     branches: t("toolbar.branches"),
     showAll: t("toolbar.showAll"),
+    filterPlaceholder: t("toolbar.filterPlaceholder"),
     showRemoteBranches: t("toolbar.showRemoteBranches"),
     search: t("toolbar.search"),
     searchPlaceholder: t("toolbar.searchPlaceholder"),
@@ -620,8 +625,8 @@ export function GitGraphTabContent() {
       <div className="mb-2">
         <GitGraphToolbar
           branches={branches}
-          selectedBranch={selectedBranch}
-          onSelectBranch={setSelectedBranch}
+          selectedBranches={selectedBranches}
+          onSelectBranches={setSelectedBranches}
           includeRemotes={includeRemotes}
           onToggleRemotes={handleToggleRemotes}
           includeTags={includeTags}

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -424,6 +424,7 @@ export function GitGraphTabContent() {
     branches: t("toolbar.branches"),
     showAll: t("toolbar.showAll"),
     filterPlaceholder: t("toolbar.filterPlaceholder"),
+    currentBadge: t("toolbar.currentBadge"),
     showRemoteBranches: t("toolbar.showRemoteBranches"),
     search: t("toolbar.search"),
     searchPlaceholder: t("toolbar.searchPlaceholder"),

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -366,6 +366,23 @@ describe("GitGraphToolbar branch filter", () => {
     expect(screen.queryByRole("option", { name: "origin/master" })).not.toBeInTheDocument();
   });
 
+  it("orders the branch list by most recent commit first", () => {
+    renderToolbar({
+      branches: [
+        { name: "old-branch", isRemote: false, lastCommitAt: 100 } as Branch,
+        { name: "fresh-branch", isRemote: false, lastCommitAt: 900 } as Branch,
+        { name: "mid-branch", isRemote: false, lastCommitAt: 500 } as Branch,
+      ],
+    });
+    openFilter();
+
+    const names = screen
+      .getAllByRole("option")
+      .map((o) => o.textContent?.trim())
+      .filter((n) => n !== labels.showAll);
+    expect(names).toEqual(["fresh-branch", "mid-branch", "old-branch"]);
+  });
+
   it("marks picked branches and Show All with their selected state", () => {
     renderToolbar({ selectedBranches: ["dev"] });
     openFilter();

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -42,6 +42,7 @@ const labels: GitGraphToolbarLabels = {
   branches: "Branches",
   showAll: "Show All",
   filterPlaceholder: "Search branches",
+  currentBadge: "current",
   showRemoteBranches: "Show Remote Branches",
   search: "Search commits",
   searchPlaceholder: "Search message, author, hash",
@@ -362,17 +363,19 @@ describe("GitGraphToolbar branch filter", () => {
     renderToolbar({ includeRemotes: false });
     openFilter();
 
-    // The default currentBranch is "master", so its row carries the HEAD badge.
-    expect(screen.getByRole("option", { name: `master ${labels.head}` })).toBeInTheDocument();
+    // The default currentBranch is "master", so its row carries the current badge.
+    expect(
+      screen.getByRole("option", { name: `master ${labels.currentBadge}` }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "origin/master" })).not.toBeInTheDocument();
   });
 
-  it("marks the checked-out branch with a HEAD badge", () => {
+  it("marks the checked-out branch with a current badge", () => {
     renderToolbar({ currentBranch: "dev" });
     openFilter();
 
-    const row = screen.getByRole("option", { name: `dev ${labels.head}` });
-    expect(within(row).getByText(labels.head)).toBeInTheDocument();
+    const row = screen.getByRole("option", { name: `dev ${labels.currentBadge}` });
+    expect(within(row).getByText(labels.currentBadge)).toBeInTheDocument();
     // The others carry no badge.
     expect(screen.getByRole("option", { name: "master" })).toBeInTheDocument();
   });

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -362,8 +362,19 @@ describe("GitGraphToolbar branch filter", () => {
     renderToolbar({ includeRemotes: false });
     openFilter();
 
-    expect(screen.getByRole("option", { name: "master" })).toBeInTheDocument();
+    // The default currentBranch is "master", so its row carries the HEAD badge.
+    expect(screen.getByRole("option", { name: `master ${labels.head}` })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "origin/master" })).not.toBeInTheDocument();
+  });
+
+  it("marks the checked-out branch with a HEAD badge", () => {
+    renderToolbar({ currentBranch: "dev" });
+    openFilter();
+
+    const row = screen.getByRole("option", { name: `dev ${labels.head}` });
+    expect(within(row).getByText(labels.head)).toBeInTheDocument();
+    // The others carry no badge.
+    expect(screen.getByRole("option", { name: "master" })).toBeInTheDocument();
   });
 
   it("orders the branch list by most recent commit first", () => {

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -41,6 +41,7 @@ afterEach(() => {
 const labels: GitGraphToolbarLabels = {
   branches: "Branches",
   showAll: "Show All",
+  filterPlaceholder: "Search branches",
   showRemoteBranches: "Show Remote Branches",
   search: "Search commits",
   searchPlaceholder: "Search message, author, hash",
@@ -69,8 +70,8 @@ const branches: Branch[] = [
 function renderToolbar(overrides: Partial<Parameters<typeof GitGraphToolbar>[0]> = {}) {
   const props = {
     branches,
-    selectedBranch: null,
-    onSelectBranch: vi.fn(),
+    selectedBranches: [] as string[],
+    onSelectBranches: vi.fn(),
     includeRemotes: false,
     onToggleRemotes: vi.fn(),
     includeTags: false,
@@ -299,6 +300,81 @@ describe("GitGraphToolbar worktree selector", () => {
     });
 
     expect(screen.getAllByLabelText(labels.worktree)[0]).toHaveTextContent("/a/repo");
+  });
+});
+
+describe("GitGraphToolbar branch filter", () => {
+  function openFilter() {
+    fireEvent.click(screen.getAllByLabelText(labels.branches)[0]);
+  }
+
+  it("shows Show All on the trigger when nothing is picked", () => {
+    renderToolbar();
+    expect(screen.getAllByLabelText(labels.branches)[0]).toHaveTextContent(labels.showAll);
+  });
+
+  it("summarizes multiple picks as the first name plus a count", () => {
+    renderToolbar({ selectedBranches: ["master", "dev"] });
+    expect(screen.getAllByLabelText(labels.branches)[0]).toHaveTextContent("master +1");
+  });
+
+  it("toggles a branch into the selection without closing the list", () => {
+    const props = renderToolbar({ selectedBranches: ["master"] });
+    openFilter();
+
+    fireEvent.click(screen.getByRole("option", { name: "dev" }));
+    expect(props.onSelectBranches).toHaveBeenCalledWith(["master", "dev"]);
+    // Multi-select keeps the list open for further picks.
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
+  it("toggles an already-picked branch back out", () => {
+    const props = renderToolbar({ selectedBranches: ["master", "dev"] });
+    openFilter();
+
+    fireEvent.click(screen.getByRole("option", { name: "dev" }));
+    expect(props.onSelectBranches).toHaveBeenCalledWith(["master"]);
+  });
+
+  it("Show All is exclusive: it clears the picks and closes the list", () => {
+    const props = renderToolbar({ selectedBranches: ["master", "dev"] });
+    openFilter();
+
+    fireEvent.click(screen.getByRole("option", { name: labels.showAll }));
+    expect(props.onSelectBranches).toHaveBeenCalledWith([]);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("filters the branch list as the search box is typed into", () => {
+    renderToolbar({ includeRemotes: true });
+    openFilter();
+
+    fireEvent.change(screen.getByPlaceholderText(labels.filterPlaceholder), {
+      target: { value: "dev" },
+    });
+
+    expect(screen.getByRole("option", { name: "dev" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "master" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "origin/master" })).not.toBeInTheDocument();
+  });
+
+  it("lists remote branches only while Show Remote Branches is on", () => {
+    renderToolbar({ includeRemotes: false });
+    openFilter();
+
+    expect(screen.getByRole("option", { name: "master" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "origin/master" })).not.toBeInTheDocument();
+  });
+
+  it("marks picked branches and Show All with their selected state", () => {
+    renderToolbar({ selectedBranches: ["dev"] });
+    openFilter();
+
+    expect(screen.getByRole("option", { name: "dev" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("option", { name: labels.showAll })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
   });
 });
 

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -11,6 +11,7 @@ import {
 import { Combobox } from "@/components/Combobox";
 import { Tooltip } from "@/components/Tooltip";
 import { basename } from "@/modules/explorer/lib/paths";
+import { BranchFilter } from "./BranchFilter";
 import type { WorktreeItem } from "./lib/gitGraphBridge";
 import type { Branch, CommitOrder } from "./types";
 
@@ -53,6 +54,7 @@ function samePath(a: string, b: string): boolean {
 export interface GitGraphToolbarLabels {
   branches: string;
   showAll: string;
+  filterPlaceholder: string;
   showRemoteBranches: string;
   search: string;
   searchPlaceholder: string;
@@ -74,8 +76,9 @@ export interface GitGraphToolbarLabels {
 
 interface GitGraphToolbarProps {
   branches: Branch[];
-  selectedBranch: string | null;
-  onSelectBranch: (branch: string | null) => void;
+  /** Branch names the graph is filtered to; empty means Show All. */
+  selectedBranches: string[];
+  onSelectBranches: (branches: string[]) => void;
   includeRemotes: boolean;
   onToggleRemotes: (value: boolean) => void;
   includeTags: boolean;
@@ -102,8 +105,8 @@ interface GitGraphToolbarProps {
 
 export function GitGraphToolbar({
   branches,
-  selectedBranch,
-  onSelectBranch,
+  selectedBranches,
+  onSelectBranches,
   includeRemotes,
   onToggleRemotes,
   includeTags,
@@ -154,15 +157,6 @@ export function GitGraphToolbar({
 
   const locals = branches.filter((b) => !b.isRemote);
   const remotes = branches.filter((b) => b.isRemote);
-
-  // Combobox takes a flat string list. "Show All" doubles as the sentinel that
-  // maps back to null; remote names already carry their "origin/" prefix so the
-  // two groups stay distinguishable without optgroup headers.
-  const branchOptions = [
-    labels.showAll,
-    ...locals.map((b) => b.name),
-    ...(includeRemotes ? remotes.map((b) => b.name) : []),
-  ];
 
   // Toggles render either as the gear popover (roomy) or rows in the overflow
   // menu (compact). Remote-branches lives here too once the toolbar is compact.
@@ -241,13 +235,16 @@ export function GitGraphToolbar({
         {showBranchControls && (
           <div className="flex min-w-0 items-center gap-1.5 text-xs text-fg-subtle">
             <span className="shrink-0">{labels.branches}:</span>
-            <Combobox
-              value={selectedBranch ?? labels.showAll}
-              options={branchOptions}
-              onChange={(v) => onSelectBranch(v === labels.showAll ? null : v)}
-              ariaLabel={labels.branches}
-              textClassName="text-[13px]"
-              noTruncate
+            <BranchFilter
+              locals={locals.map((b) => b.name)}
+              remotes={includeRemotes ? remotes.map((b) => b.name) : []}
+              selected={selectedBranches}
+              onChange={onSelectBranches}
+              labels={{
+                ariaLabel: labels.branches,
+                showAll: labels.showAll,
+                searchPlaceholder: labels.filterPlaceholder,
+              }}
             />
           </div>
         )}

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -55,6 +55,10 @@ export interface GitGraphToolbarLabels {
   branches: string;
   showAll: string;
   filterPlaceholder: string;
+  /** Badge marking the checked-out branch in the filter list. Deliberately NOT
+   * "HEAD": the graph rows already show an `origin/HEAD` ref chip, and two
+   * HEAD-ish labels with different meanings read as the same thing. */
+  currentBadge: string;
   showRemoteBranches: string;
   search: string;
   searchPlaceholder: string;
@@ -255,7 +259,7 @@ export function GitGraphToolbar({
                 ariaLabel: labels.branches,
                 showAll: labels.showAll,
                 searchPlaceholder: labels.filterPlaceholder,
-                head: labels.head,
+                head: labels.currentBadge,
               }}
             />
           </div>

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -249,11 +249,13 @@ export function GitGraphToolbar({
               locals={filterLocals}
               remotes={filterRemotes}
               selected={selectedBranches}
+              headName={currentBranch}
               onChange={onSelectBranches}
               labels={{
                 ariaLabel: labels.branches,
                 showAll: labels.showAll,
                 searchPlaceholder: labels.filterPlaceholder,
+                head: labels.head,
               }}
             />
           </div>

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -158,6 +158,16 @@ export function GitGraphToolbar({
   const locals = branches.filter((b) => !b.isRemote);
   const remotes = branches.filter((b) => b.isRemote);
 
+  // The filter list puts recently-active branches first — with hundreds of
+  // branches the one being looked for is almost always fresh. Name breaks
+  // timestamp ties so the order stays stable.
+  const byRecency = (a: Branch, b: Branch) =>
+    (b.lastCommitAt ?? 0) - (a.lastCommitAt ?? 0) || a.name.localeCompare(b.name);
+  const filterLocals = [...locals].sort(byRecency).map((b) => b.name);
+  const filterRemotes = includeRemotes
+    ? [...remotes].sort(byRecency).map((b) => b.name)
+    : [];
+
   // Toggles render either as the gear popover (roomy) or rows in the overflow
   // menu (compact). Remote-branches lives here too once the toolbar is compact.
   const toggles: ToggleRowProps[] = [
@@ -236,8 +246,8 @@ export function GitGraphToolbar({
           <div className="flex min-w-0 items-center gap-1.5 text-xs text-fg-subtle">
             <span className="shrink-0">{labels.branches}:</span>
             <BranchFilter
-              locals={locals.map((b) => b.name)}
-              remotes={includeRemotes ? remotes.map((b) => b.name) : []}
+              locals={filterLocals}
+              remotes={filterRemotes}
               selected={selectedBranches}
               onChange={onSelectBranches}
               labels={{

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -253,13 +253,13 @@ export function GitGraphToolbar({
               locals={filterLocals}
               remotes={filterRemotes}
               selected={selectedBranches}
-              headName={currentBranch}
+              currentBranch={currentBranch}
               onChange={onSelectBranches}
               labels={{
                 ariaLabel: labels.branches,
                 showAll: labels.showAll,
                 searchPlaceholder: labels.filterPlaceholder,
-                head: labels.currentBadge,
+                currentBadge: labels.currentBadge,
               }}
             />
           </div>

--- a/src/modules/git-graph/types.ts
+++ b/src/modules/git-graph/types.ts
@@ -44,9 +44,9 @@ export interface Branch {
  */
 export type CommitOrder = "date" | "topo";
 
-/** Display options sent to the backend graph log. `branch` null means Show All. */
+/** Display options sent to the backend graph log. Empty `branches` means Show All. */
 export interface GraphOptions {
-  branch: string | null;
+  branches: string[];
   includeRemotes: boolean;
   includeTags: boolean;
   includeStashes: boolean;

--- a/src/modules/git-graph/types.ts
+++ b/src/modules/git-graph/types.ts
@@ -35,6 +35,8 @@ export interface Branch {
   name: string;
   isCurrent: boolean;
   isRemote: boolean;
+  /** Unix seconds of the branch tip's committer time; 0 when unresolvable. */
+  lastCommitAt: number;
 }
 
 /**


### PR DESCRIPTION
## Problem

The Git Graph branch dropdown had two problems:

1. **The filter barely filtered.** With "Show Remote Branches" / "Show Tags" on (the defaults), selecting a branch still passed `--remotes` and `--tags` alongside it, so `git log` returned the union of every remote branch and tag history. Except for unpushed local-only commits, the graph looked identical to Show All.
2. **It didn't scale.** A flat single-select list with no search is unusable on repos with hundreds of branches, and the `noTruncate` trigger let long branch names blow up the toolbar layout.

## Changes

- **Fix**: a selected branch becomes the only ref range — the remote/tag/stash toggles no longer stack on top of an explicit branch filter (`build_log_refs`).
- **Multi-select + search**: the dropdown is now a fixed-width, searchable multi-select (`BranchFilter`). "Show All" stays exclusive; any mix of local and remote branches can be graphed together (`git log` unions the picked refs). The trigger truncates long names (`first-name +N` for multiple picks) and highlights in accent while a filter is active. Turning remotes off drops remote picks from the filter.
- **Recency order**: branches now carry their tip's committer timestamp (`lastCommitAt`), and the filter list sorts by it descending — with hundreds of branches the one being looked for is almost always recently active. Ties fall back to name order.
- **HEAD badge**: the checked-out branch is marked with a small HEAD badge in the list (the check glyph stays reserved for "picked into the filter").

`GraphOptions.branch: Option<String>` becomes `branches: Vec<String>` across the Rust command and frontend types (empty = Show All).

## Screenshots

- Before 
<img width="1550" height="726" alt="image" src="https://github.com/user-attachments/assets/4b6a194d-1b09-4305-a2e7-dac659ab6963" />

- After
<img width="1568" height="733" alt="image" src="https://github.com/user-attachments/assets/64cb7256-ad74-4c75-b546-83dbaf96ae0c" />
<img width="1546" height="1199" alt="image" src="https://github.com/user-attachments/assets/6491f7f8-bf8f-44d8-93be-c5f42f45f708" />

Multi-select + search


## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run` — 2023 passed (includes 10 new BranchFilter cases: exclusivity, toggle in/out, search filtering, remote visibility, recency order, HEAD badge)
- [x] `cargo test` — git-graph tests pass (6 `build_log_refs` cases incl. "toggles don't stack on a specific branch"; `branches()` timestamp assertion). 5 pre-existing environment-dependent failures on this Windows machine (a `restore_file` CRLF assertion under global `core.autocrlf=true`, 4 ConPTY session tests) fail identically on `master`.
- [x] Manual (dev build, repo with 834 branches): search narrows instantly; picking one branch shows only its history with remote toggle on (the bug fix); adding a second branch unions both and the trigger reads `name +1`; Show All resets and closes; current branch carries the HEAD badge; recently-active branches sort first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
