### PR TITLE
fix(sessions): stop the row action strip from reserving width when idle

### DIFF
--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -125,7 +125,14 @@ function SessionRow({ session, selected, onRequestDelete }: SessionRowProps) {
   const canResume = resumeCommand(session.agent, session.id) !== null;
 
   return (
-    <div role="listitem" className="group">
+    // The highlight sits on the whole row, not on the select-session button
+    // inside it: the button only spans the row's left part, so highlighting
+    // there left the action strip that hover reveals sitting on bare
+    // background, reading as a detached block instead of part of the row.
+    <div
+      role="listitem"
+      className={`group ${selected ? "bg-bg-elevated" : "hover:bg-bg-elevated"}`}
+    >
       <div className="flex items-center">
         <button
           type="button"
@@ -134,9 +141,7 @@ function SessionRow({ session, selected, onRequestDelete }: SessionRowProps) {
             select(session.id);
             openSessionsTab();
           }}
-          className={`flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left ${
-            selected ? "bg-bg-elevated" : "hover:bg-bg-elevated"
-          }`}
+          className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left"
         >
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-1.5">
@@ -192,7 +197,13 @@ function SessionRow({ session, selected, onRequestDelete }: SessionRowProps) {
             </div>
           </div>
         </button>
-        <div className="flex shrink-0 items-center opacity-0 pr-2 group-hover:opacity-100">
+        {/* Collapsed to zero width instead of `opacity-0`: the panel is
+            narrow, and an invisible-but-present action strip still reserved
+            its width on every row, so titles truncated against a permanent
+            blank gutter. Width (not `hidden`) keeps the buttons focusable, and
+            `group-focus-within` expands the strip when one is tabbed to — with
+            `display: none` they'd drop out of the tab order entirely. */}
+        <div className="flex w-0 shrink-0 items-center overflow-hidden group-hover:w-auto group-hover:pr-2 group-focus-within:w-auto group-focus-within:pr-2">
           {canResume && (
             <Tooltip label={resumeLabel}>
               <button


### PR DESCRIPTION
## Problem

In the Sessions sidebar, each history row's resume/pin/delete buttons were hidden with `opacity-0`. Invisible, but still laid out — so every row reserved ~70px for them and the title truncated early against a permanent blank gutter running down the right edge of the list. The sidebar is narrow enough that this is a noticeable chunk of the row.

A second, smaller issue: the hover/selected fill lived on the select-session button, which only spans the row's left part. The action strip that hover reveals therefore sat on bare background and read as a block detached from the row it belongs to.

## Changes

- The action strip collapses to `w-0 overflow-hidden` and expands to `w-auto` on `group-hover` / `group-focus-within`, so an idle row spends its full width on the title.
  - Width rather than `display: none` on purpose: `hidden` would drop the buttons out of the tab order entirely. `group-focus-within` expands the strip when one is tabbed to, which is also an improvement on the old `opacity-0` (focusable, but with no visible focus ring).
- The hover/selected fill moves from the select-session button to the row wrapper, so the highlight covers the action strip too.

No behavior change to the buttons themselves.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run` — 2013 tests in 223 files passing
- [x] Manual: ran `pnpm tauri dev`, opened the Sessions sidebar — idle rows use the full width for the title, hovering a row reveals the buttons over a highlight that spans the whole row, and resume/pin/delete still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)