### PR TITLE
fix(sessions): keep the row action strip's focus ring unclipped

### DIFF
--- a/src/modules/sessions/SessionsPanel.tsx
+++ b/src/modules/sessions/SessionsPanel.tsx
@@ -129,9 +129,13 @@ function SessionRow({ session, selected, onRequestDelete }: SessionRowProps) {
     // inside it: the button only spans the row's left part, so highlighting
     // there left the action strip that hover reveals sitting on bare
     // background, reading as a detached block instead of part of the row.
+    // `focus-within` gets the same fill: tabbing to an action button reveals
+    // the strip exactly like hover does, so it needs the row behind it too.
     <div
       role="listitem"
-      className={`group ${selected ? "bg-bg-elevated" : "hover:bg-bg-elevated"}`}
+      className={`group ${
+        selected ? "bg-bg-elevated" : "hover:bg-bg-elevated focus-within:bg-bg-elevated"
+      }`}
     >
       <div className="flex items-center">
         <button
@@ -202,8 +206,13 @@ function SessionRow({ session, selected, onRequestDelete }: SessionRowProps) {
             its width on every row, so titles truncated against a permanent
             blank gutter. Width (not `hidden`) keeps the buttons focusable, and
             `group-focus-within` expands the strip when one is tabbed to — with
-            `display: none` they'd drop out of the tab order entirely. */}
-        <div className="flex w-0 shrink-0 items-center overflow-hidden group-hover:w-auto group-hover:pr-2 group-focus-within:w-auto group-focus-within:pr-2">
+            `display: none` they'd drop out of the tab order entirely.
+            Clipping is only needed while collapsed, so it lifts on expand: the
+            buttons sit flush with the strip's box, and the global
+            `:focus-visible` outline (2px, 1px offset, index.css) is painted
+            outside that box — left clipped it, cutting the ring off a
+            tabbed-to button. */}
+        <div className="flex w-0 shrink-0 items-center overflow-hidden group-hover:w-auto group-hover:overflow-visible group-hover:pr-2 group-focus-within:w-auto group-focus-within:overflow-visible group-focus-within:pr-2">
           {canResume && (
             <Tooltip label={resumeLabel}>
               <button


### PR DESCRIPTION
## Problem

Follow-up to #338, which collapsed the Sessions row action strip to `w-0 overflow-hidden` so an idle row spends its full width on the title. Two gaps came out of reviewing it, both on the keyboard path that change set out to improve:

1. **The focus ring gets clipped.** The strip stays `overflow-hidden` once expanded. Its buttons sit flush with the strip's own box, and the app's global `:focus-visible` outline (`2px solid var(--color-accent)`, `outline-offset: 1px`, `src/index.css:196`) paints *outside* that box. Tabbing to a button therefore drew a ring with its top and bottom cut away — and the first button (resume) lost its left edge too, since only `pr-2` is added on expand.
2. **The keyboard-revealed strip sits on bare background.** #338 moved the hover fill to the row wrapper precisely so a revealed strip would not read as a block detached from its row, but the fill was `hover:`-only. `group-focus-within` reveals the strip exactly the same way and got no fill, so the original problem persisted on the keyboard path.

## Changes

- The strip lifts its clipping on expand (`group-hover:overflow-visible`, `group-focus-within:overflow-visible`). `overflow-hidden` is still needed while collapsed, otherwise the buttons spill out of the zero-width box; expanded, the box already fits its contents, so nothing else changes visually.
- The row wrapper's fill gains `focus-within:bg-bg-elevated` alongside `hover:bg-bg-elevated`. A selected row keeps its unconditional fill as before.

No behavior change to the buttons themselves, and none of this is reachable with the strip collapsed.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run src/modules/sessions` — 154 tests in 14 files passing
- [x] Manual (`tauri dev`, macOS): hovering a row reveals the strip over a full-row highlight as before; tabbing into the strip now highlights the row and paints a complete focus ring on all four sides, including the first button's left edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)