### PR TITLE
docs: add the Sessions row action strip entries to CHANGELOG-NEXT

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -4,7 +4,11 @@
 
 ### fix
 
+- AI 對話側邊欄的操作按鈕改為閒置時收合，不再佔用行寬，標題可用滿整列；滑鼠移入或鍵盤聚焦時展開，並套用整列高亮 (#338, #339)
+
 ### 貢獻者
+
+- @yw-chan (#338)
 
 ## English
 
@@ -12,4 +16,8 @@
 
 ### fix
 
+- Sessions sidebar action buttons collapse when idle instead of reserving row width, giving titles the full row; they expand on hover or keyboard focus, with the highlight spanning the whole row (#338, #339)
+
 ### Contributors
+
+- @yw-chan (#338)


### PR DESCRIPTION
Changelog for #338 (community, @yw-chan) and #339 (the review follow-up), both merged.

They are a single change as far as a user is concerned — the Sessions row action strip stops reserving width when idle, and reveals correctly on hover *and* on keyboard focus — so they share one entry carrying both PR numbers rather than reading as two separate fixes.

@yw-chan is credited in the contributors section for #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)