### PR TITLE
fix(editor): stop the gutter backdrop from compounding over a wallpaper

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -51,6 +51,13 @@
   --color-bg: #222222;
   --color-bg-elevated: #292929;
   --color-bg-inset: #222222;
+  /*
+   * The editor's line-number gutter is sticky inside the horizontal scroller,
+   * so it needs an opaque backdrop or code slides through beneath the numbers.
+   * It gets its own token because that backdrop has to give way under a
+   * wallpaper: see the .wallpaper-surface override below.
+   */
+  --color-editor-gutter-bg: var(--color-bg);
   --color-border: #333333;
   --color-border-strong: #454545;
   --color-fg: #dbd7ca;
@@ -98,6 +105,17 @@ body {
     var(--color-bg-solid) var(--wallpaper-surface-alpha, 82%),
     transparent
   );
+  /*
+   * The gutter backdrop goes away under a wallpaper. The editor's wrapper
+   * already paints one --color-bg layer; a second one on the gutter composites
+   * to ~97% opacity against the wrapper's ~82%, showing up as a darker stripe
+   * down the line numbers. Same compounding this file guards against for
+   * TabsArea and PaneTabContent below. Transparent here falls back to the
+   * wrapper's own tint, so the gutter matches the code beside it and the
+   * horizontal-scroll bleed returns only in wallpaper mode, where it was the
+   * behaviour before the gutter got a backdrop at all.
+   */
+  --color-editor-gutter-bg: transparent;
   --color-bg-inset: color-mix(
     in srgb,
     var(--color-bg-inset-solid) var(--wallpaper-surface-alpha, 82%),

--- a/src/lib/proxyScrollbar.ts
+++ b/src/lib/proxyScrollbar.ts
@@ -225,8 +225,12 @@ export function proxyScrollbars(): Extension {
     // bars). The wrapper only exists once the view is appended, so attach
     // lazily.
     let handle: ProxyScrollbarsHandle | null = null;
+    // A reconfigure can swap this plugin out before the queued microtask runs.
+    // destroy() has no handle to release at that point, so without this flag
+    // the microtask would go on to attach strips nothing owns any more.
+    let destroyed = false;
     const ensure = () => {
-      if (!handle && view.dom.parentElement) {
+      if (!destroyed && !handle && view.dom.parentElement) {
         handle = attachProxyScrollbars({
           scroller: view.scrollDOM,
           host: view.dom.parentElement,
@@ -243,6 +247,7 @@ export function proxyScrollbars(): Extension {
         }
       },
       destroy() {
+        destroyed = true;
         handle?.destroy();
       },
     };

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -420,7 +420,7 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
       {error ? (
         <p className="px-3 py-2 text-xs text-danger">{t("diffLoadError")}</p>
       ) : (
-        <div ref={containerRef} className="diff-merge-view relative min-h-0 flex-1 overflow-hidden" />
+        <div ref={containerRef} className="diff-merge-view min-h-0 flex-1 overflow-hidden" />
       )}
       {!hintSeen && !error && (
         // One-time pointer at the review-comment loop, anchored under the

--- a/src/themes/editorTheme.ts
+++ b/src/themes/editorTheme.ts
@@ -33,10 +33,16 @@ import { DEFAULT_THEME_ID } from "./themes";
  * 各主題的 bg-elevated，讓游標所在行融入 app 的明暗階層。
  *
  * 行號 gutter 例外：它在橫向捲動時是 sticky 固定在左側的，若透明，程式碼與
- * diff 變更行的底色會從行號底下滑過去，所以改用 app 背景 token 畫一層不透明
- * 底——顏色與透明時完全相同，只是擋住底下捲動的內容。
+ * diff 變更行的底色會從行號底下滑過去，所以畫一層底把捲動的內容擋住。用
+ * --color-editor-gutter-bg 而不是直接用 --color-bg：沒有背景圖時兩者同值，
+ * 有背景圖時 --color-bg 是半透明的，編輯器外層已經塗過一層，gutter 再塗一層
+ * 會疊成一條明顯更深的直帶，所以那個 token 在背景圖模式下會退回透明
+ * （見 index.css 的 .wallpaper-surface）。
  */
-const SURFACE = { background: "transparent", gutterBackground: "var(--color-bg)" } as const;
+const SURFACE = {
+  background: "transparent",
+  gutterBackground: "var(--color-editor-gutter-bg)",
+} as const;
 
 /** 各主題的當前行高亮色（= themes.ts 的 bgElevated）。 */
 const LINE_HIGHLIGHT: Record<string, string> = {


### PR DESCRIPTION
Follow-ups to #327, from reviewing it. Three fixes, one of them user-visible.

## 1. The gutter backdrop compounds over a custom background image

#327 gave the sticky line-number gutter an opaque backdrop so code stops sliding through beneath the numbers, using `var(--color-bg)` and describing it as "visually identical to transparent".

It is, until a custom background image (#305) is in play. `.wallpaper-surface` rebinds `--color-bg` to a `color-mix(... 82%, transparent)` tint (`src/index.css:95`). The editor's own wrapper already paints one such layer via `bg-bg`, so a second layer on the gutter composites to ~96.8% opacity against the wrapper's ~82% — the background image drops to ~3% visibility down the gutter against ~18% in the code area beside it, reading as a darker vertical stripe. The gap widens as the user lowers the image alpha (~25pp at 50%).

`src/index.css:112` already guards this exact compounding for TabsArea and PaneTabContent, with `.wallpaper-passthrough-surface` built for it.

**Fix:** the gutter now reads a dedicated `--color-editor-gutter-bg`, which equals `--color-bg` by default and goes `transparent` under `.wallpaper-surface`.

A token rather than a competing selector, because CodeMirror mounts its theme styles dynamically — matching specificity from `index.css` would be a bet on mount order (the very thing #327 had to correct for the one-dark overrides). Transparent also behaves correctly inside `.wallpaper-solid-surface`, where the wrapper's layer is already solid, so the gutter looks opaque there without a second rule.

In wallpaper mode the horizontal-scroll bleed comes back, which was the behaviour before the gutter had any backdrop. Trading it for a stripe across the whole gutter seems clearly worse.

## 2. Unconditional `relative` on the diff container

`.proxy-scrollbar-host` already carries `position: relative` in CSS and is only applied on Windows, so the JSX copy widened the change past #327's Windows-only scope.

## 3. Destroy-then-microtask race in the proxy-scrollbar plugin

The plugin queues its attach in a microtask. A reconfigure (rapid word-wrap or font toggles) can swap the plugin out first; `destroy()` then has no handle to release, and the microtask goes on to attach strips nothing owns. A `destroyed` flag closes it.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run src/themes src/modules/diff src/modules/editor` — 71 tests in 15 files passing
- [x] Manual (`tauri dev`, macOS): with a background image set, the gutter now matches the code area beside it and the image shows through evenly, at default and reduced alpha; with no image, horizontal scrolling still keeps code from sliding under the line numbers; diff sides still scroll horizontally in lockstep; word-wrap toggles and tab switches leave no stray scrollbars

🤖 Generated with [Claude Code](https://claude.com/claude-code)