### PR TITLE
fix(git-graph): tighten GraphOptions input and stop peeling discarded refs

### DIFF
--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -99,8 +99,11 @@ pub enum CommitOrder {
     Topo,
 }
 
+/// `deny_unknown_fields` 是刻意的：搭配 `default`，一個拼錯或過時的欄位名
+/// （例如改名前的 `branch`）會安靜地取預設值，篩選就變成「全部分支」而且不
+/// 報錯。寧可讓它在反序列化階段就失敗、把錯誤送回前端。
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct GraphOptions {
     /// 篩選用的分支清單；空清單代表「全部分支」。
     pub branches: Vec<String>,
@@ -1316,10 +1319,29 @@ pub fn graph_log(
     let max_count = format!("--max-count={}", limit + 1);
     let skip_arg = format!("--skip={skip}");
 
+    // 分支清單是從前端的選單挑出來的，正常不會有幾百筆。設上限的理由是超長的
+    // argv 會讓 spawn 直接失敗，而 graph_log 的錯誤被呼叫端 unwrap_or_default
+    // 吞成一張空圖，使用者只看到「沒有 commit」卻不知道原因；擋在這裡至少會回
+    // 一個說得出原因的錯誤。
+    const MAX_BRANCH_FILTERS: usize = 256;
+    const MAX_BRANCH_NAME_LEN: usize = 255;
+    if options.branches.len() > MAX_BRANCH_FILTERS {
+        return Err(format!(
+            "too many branch filters: {} (max {MAX_BRANCH_FILTERS})",
+            options.branches.len()
+        ));
+    }
+
     // 指定分支會當成位置參數傳給 git，先擋掉開頭是 - 的值。
     for branch in &options.branches {
         let branch = branch.trim();
         if !branch.is_empty() {
+            if branch.len() > MAX_BRANCH_NAME_LEN {
+                return Err(format!(
+                    "branch name too long: {} bytes (max {MAX_BRANCH_NAME_LEN})",
+                    branch.len()
+                ));
+            }
             ensure_not_flag(branch)?;
         }
     }
@@ -1362,10 +1384,12 @@ pub fn branches(repo_path: &str) -> Result<Vec<BranchInfo>, String> {
         .map_err(|e| e.message().to_string())?;
     for entry in local {
         let (branch, _) = entry.map_err(|e| e.message().to_string())?;
-        let last_commit_at = branch_tip_time(&branch);
         if let Some(name) = branch.name().map_err(|e| e.message().to_string())? {
             let name = name.to_string();
             let is_current = Some(&name) == head_name.as_ref();
+            // 取 tip 時間要讀一次 object，所以放在名字的 guard 之後，別為了會被
+            // 丟掉的 entry 白跑一趟。
+            let last_commit_at = branch_tip_time(&branch);
             out.push(BranchInfo {
                 name,
                 is_current,
@@ -1380,12 +1404,13 @@ pub fn branches(repo_path: &str) -> Result<Vec<BranchInfo>, String> {
         .map_err(|e| e.message().to_string())?;
     for entry in remote {
         let (branch, _) = entry.map_err(|e| e.message().to_string())?;
-        let last_commit_at = branch_tip_time(&branch);
         if let Some(name) = branch.name().map_err(|e| e.message().to_string())? {
-            // 跳過 origin/HEAD 這種 symbolic ref，它只是指向預設分支。
+            // 跳過 origin/HEAD 這種 symbolic ref，它只是指向預設分支。每個設好的
+            // remote 都有一個，所以這個 continue 擺在讀 tip 時間之前才划算。
             if name.ends_with("/HEAD") {
                 continue;
             }
+            let last_commit_at = branch_tip_time(&branch);
             out.push(BranchInfo {
                 name: name.to_string(),
                 is_current: false,
@@ -2908,6 +2933,37 @@ mod tests {
             build_log_refs(&options),
             vec!["main".to_string(), "origin/feature".to_string()]
         );
+    }
+
+    #[test]
+    fn graph_log_rejects_an_oversized_branch_filter() {
+        // 上限擋在 git 執行之前，所以這裡用不存在的路徑也測得到。超長 argv 會讓
+        // spawn 失敗，而那個錯誤會被呼叫端吞成一張空圖，使用者看不出原因。
+        let options = GraphOptions {
+            branches: vec!["main".to_string(); 257],
+            ..GraphOptions::default()
+        };
+        let err = graph_log("/nonexistent-repo", 100, 0, &options).unwrap_err();
+        assert!(err.contains("too many branch filters"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn graph_log_rejects_an_overlong_branch_name() {
+        let options = GraphOptions {
+            branches: vec!["b".repeat(256)],
+            ..GraphOptions::default()
+        };
+        let err = graph_log("/nonexistent-repo", 100, 0, &options).unwrap_err();
+        assert!(err.contains("branch name too long"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn graph_options_rejects_the_pre_rename_branch_field() {
+        // `branches` 改名前叫 `branch`。沒有 deny_unknown_fields 的話，送舊欄位
+        // 會安靜取到預設值，篩選變成「全部分支」而且不報錯。
+        let err = serde_json::from_str::<GraphOptions>(r#"{"branch":"main"}"#)
+            .expect_err("the old field name must not deserialize");
+        assert!(err.to_string().contains("branch"), "unexpected: {err}");
     }
 
     #[test]

--- a/src/themes/editorTheme.ts
+++ b/src/themes/editorTheme.ts
@@ -58,13 +58,18 @@ const LINE_HIGHLIGHT: Record<string, string> = {
 };
 
 /**
- * 統一的當前行高亮 wrapper，不論底層套件是否自己處理 .cm-activeLine 都生效。
+ * 當前行高亮，外加「有選取時讓位」的行為。
+ *
+ * 這裡的 .cm-activeLine 規則並不會蓋過各主題套件自己的設定：CodeMirror 掛載
+ * 樣式前會把 styleModule 反轉，排在前面的 extension 才勝出，而 activeLine 一律
+ * 接在主題後面。兩邊的顏色都取自 LINE_HIGHLIGHT[id]，結果才會一致，所以這條
+ * 規則實際的作用是替沒有自帶 activeLine 的主題墊底。
  *
  * 選取反白畫在內容層後面，不透明的行高亮會把它整行蓋住，所以有選取時隱藏
- * 行高亮（行號的高亮保留），選取取消才恢復。用
- * editorAttributes 掛 class（CM 自己管理的屬性，不會像手動加在 view.dom 上
- * 那樣被洗掉）；透明規則的 selector 特異度高於各主題套件自己的 activeLine
- * 規則，不受主題掛載順序影響。
+ * 行高亮（行號的高亮保留），選取取消才恢復。用 editorAttributes 掛 class（CM
+ * 自己管理的屬性，不會像手動加在 view.dom 上那樣被洗掉）。透明那條規則帶 &
+ * 前綴，產生的 selector 是 .生成class.cm-has-selection .cm-activeLine，特異度
+ * 0,3,0 高於各套件的 0,2,0，所以它不靠掛載順序也贏。
  */
 function activeLine(color: string): Extension {
   return [


### PR DESCRIPTION
The small items from reviewing #333, plus one docstring correction owed from #328. No user-visible behaviour change.

## 1. `GraphOptions` gains `deny_unknown_fields`

With `default` alone, a stale or misspelled field name is silently ignored and `branches` takes its default, so the filter quietly degrades to Show All with no error anywhere.

This is not hypothetical. While verifying #333 the app ended up with a frontend and a backend one rename apart (the webview had the pre-#333 code sending `branch`, the Rust side expected `branches`). The graph showed every branch, the filter did nothing, and not one thing reported a problem — it looked like a UI bug for several minutes. It now fails at deserialization, where `GitGraphTabContent`'s error path can show it.

Checked before flipping this on: the frontend builds `options` as a type-annotated object literal with exactly the five declared fields (`GitGraphTabContent.tsx:106`), so TypeScript's excess-property check guards the other direction too.

## 2. Cap the `branches` array

256 entries, 255 bytes per name. The adjacent `limit` was already `clamp(1, 2000)`; this was not. An oversized argv makes the spawn fail with `E2BIG`, and `graph_log`'s caller turns any error into an empty graph via `unwrap_or_default()` — so the failure mode is "no commits" with no explanation. The cap lives in the loop that already validates each name, keeping the validated set identical to the used set.

## 3. `branch_tip_time()` moves below the guards

Peeling a ref to its tip commit is an object read. Both loops in `branches()` paid it before the name check and, for remotes, before the `origin/HEAD` skip. Every configured remote has an `origin/HEAD`, so that was one wasted read per remote per reload, and `branches()` runs on every graph reload.

## 4. Correct the `activeLine()` docstring

It claimed the wrapper takes effect regardless of whether the underlying theme package handles `.cm-activeLine`. #327 established that CodeMirror reverses the `styleModule` facet before mounting, so earlier extensions win — and `activeLine()` sits *after* every base theme, meaning its plain `.cm-activeLine` rule loses the tie. It only looks correct because both sides read the same `LINE_HIGHLIGHT[id]`.

The transparent rule #328 added is a different case and genuinely does win, on specificity: the `&` prefix makes it `.<generated>.cm-has-selection .cm-activeLine` at 0,3,0 against the packages' 0,2,0. The docstring now says both things accurately. Code unchanged.

## Test plan

- [x] `cargo test --lib modules::git` — 76 passing, including three new cases: the two rejections, and `{"branch":"main"}` failing to deserialize
- [x] `tsc --noEmit` — clean
- [x] `vitest run src/themes src/modules/git-graph` — 148 passing
- [x] Confirmed the frontend's `graph_log` payload carries exactly the five declared fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)