### PR TITLE
chore(release): prepare 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tempo-term",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-term"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-term"
-version = "0.3.4"
+version = "0.3.5"
 description = "TempoTerm - AI-powered terminal, editor and file explorer"
 authors = ["TempoTerm"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TempoTerm",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "identifier": "com.tempoterm.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump for 0.3.5. `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` (the last via `cargo update -p tempo-term --offline`).

`CHANGELOG-NEXT.md` is already in place from #340 and #343, so nothing to write here.

## What 0.3.5 carries

**feat**
- Git Graph branch filter as a searchable multi-select (#333)
- VS Code-style editor and diff scrollbars on Windows, plus diff horizontal scroll sync on every platform (#327)

**fix**
- Git Graph branch filter having almost no effect (#333)
- Selection highlight hidden by the active-line background (#328)
- Gutter tint compounding over a custom background image (#342)
- Sessions row action strip reserving width when idle (#338, #339)

Contributors: @yw-chan for #327, #328, #333, #338.

Not in the notes: #344, which is internal only (input validation, one fewer object read per remote per reload, a docstring correction) with nothing a user can observe.

## Preflight, run locally before this PR

- [x] `node scripts/checkChangelog.mjs CHANGELOG-NEXT.md` — passes, no empty sections
- [x] Updater key present at `~/.tauri/tempo-term.key`
- [x] `v0.3.5` not taken on GitHub
- [x] Finder responsive, `/Volumes` clean, no stray `rw.*.dmg` (the dmg bundling traps)

`scripts/release.sh` runs after this lands, so the tag points at a commit that still carries the filled-in changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)