### PR TITLE
feat(explorer): 右鍵選單新增「在瀏覽器開啟」

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -2,6 +2,8 @@
 
 ### feat
 
+- 檔案總管的右鍵選單新增「在瀏覽器開啟」，用內建的網頁預覽開啟檔案，不必先把它開進編輯器再按工具列那顆預覽鈕。開啟位置沿用既有的規則：分頁裡已經有預覽面板就換掉它的內容，單面板分頁就在旁邊分割，已經分割的分頁則使用專屬的預覽分頁。只有內建瀏覽器渲染得出來的檔案才會出現這個選項（HTML、SVG、PDF、圖片與影音），遠端 (SSH) 檔案則不適用 (#347)
+
 ### fix
 
 ### 貢獻者
@@ -9,6 +11,8 @@
 ## English
 
 ### feat
+
+- The explorer's context menu gains "Open in Browser", which opens a file in the built-in web preview instead of making you open it in the editor first and reach for the toolbar's preview button. Where it lands follows the existing rule: replace a preview pane the tab already has, split beside a single-pane tab, or use the dedicated preview tab when the tab is already split. The item only appears for files the built-in browser can actually render (HTML, SVG, PDF, images and media), and never for remote (SSH) files (#347)
 
 ### fix
 

--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -12,6 +12,7 @@
 ### 貢獻者
 
 - @yw-chan (#348, #350)
+- @oberonlai (#347)
 
 ## English
 
@@ -27,3 +28,4 @@
 ### Contributors
 
 - @yw-chan (#348, #350)
+- @oberonlai (#347)

--- a/src/i18n/locales/en/explorer.json
+++ b/src/i18n/locales/en/explorer.json
@@ -17,6 +17,7 @@
   "menu": {
     "open": "Open in Split Pane",
     "openInNewTab": "Open in New Tab",
+    "openInBrowser": "Open in Browser",
     "reveal": "Reveal in Finder",
     "openInTerminal": "Open in Terminal",
     "newFile": "New File",

--- a/src/i18n/locales/zh-Hant/explorer.json
+++ b/src/i18n/locales/zh-Hant/explorer.json
@@ -17,6 +17,7 @@
   "menu": {
     "open": "在分割面板開啟",
     "openInNewTab": "在新分頁開啟",
+    "openInBrowser": "在瀏覽器開啟",
     "reveal": "在 Finder 中顯示",
     "openInTerminal": "從終端機開啟",
     "newFile": "新增檔案",

--- a/src/modules/explorer/FileTree.test.tsx
+++ b/src/modules/explorer/FileTree.test.tsx
@@ -342,6 +342,53 @@ describe("FileTree context menu: open in new tab", () => {
   });
 });
 
+describe("FileTree context menu: open in browser", () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+  });
+
+  it("opens a previewable file in the built-in browser, not an editor pane", () => {
+    const entries = [{ name: "index.html", path: "/p/index.html", is_dir: false, size: 0 }];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.contextMenu(screen.getByText("index.html"));
+    fireEvent.click(screen.getByText("menu.openInBrowser"));
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    const pane = tabs[0].paneTree;
+    expect(pane.kind === "leaf" && pane.pane).toEqual({
+      kind: "preview",
+      url: "file:///p/index.html",
+    });
+  });
+
+  it("hides the item for files the built-in browser cannot render", () => {
+    const entries = [{ name: "main.ts", path: "/p/main.ts", is_dir: false, size: 0 }];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.contextMenu(screen.getByText("main.ts"));
+
+    expect(screen.queryByText("menu.openInBrowser")).not.toBeInTheDocument();
+  });
+
+  it("hides the item for a remote (SFTP) file, which the asset protocol cannot reach", () => {
+    const entries = [
+      {
+        name: "index.html",
+        path: "ssh://conn-1/srv/index.html",
+        is_dir: false,
+        size: 0,
+      },
+    ];
+    render(<FileTree entries={entries} onReloadRoot={() => {}} />);
+
+    fireEvent.contextMenu(screen.getByText("index.html"));
+
+    expect(screen.queryByText("menu.openInBrowser")).not.toBeInTheDocument();
+  });
+});
+
 describe("FileTree rename", () => {
   // fsRename is a shared mock across both tests below; vitest does not clear
   // call history between tests in the same file (no clearMocks/restoreMocks

--- a/src/modules/explorer/FileTree.tsx
+++ b/src/modules/explorer/FileTree.tsx
@@ -9,6 +9,7 @@ import {
   FilePlus,
   FolderOpen,
   FolderPlus,
+  Globe,
   MessageSquarePlus,
   Pencil,
   SquarePlus,
@@ -29,6 +30,7 @@ import {
 import { dirname, joinPath, relativePath } from "./lib/paths";
 import { beginEntryDrag, consumeDragClick } from "./lib/dragEntry";
 import { isRemoteUri } from "@/modules/ssh/lib/remotePath";
+import { isBrowserPreviewable } from "@/modules/preview/lib/previewableFile";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { InfoDialog } from "@/components/InfoDialog";
@@ -135,6 +137,7 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
 
   const openFromSidebar = useTabsStore((s) => s.openFromSidebar);
   const openInNewTab = useTabsStore((s) => s.openInNewTab);
+  const openPreviewFromSidebar = useTabsStore((s) => s.openPreviewFromSidebar);
   const rootPath = useWorkspaceStore((s) => s.rootPath);
   const activatePanel = useUiStore((s) => s.activatePanel);
   const attachPath = useChatStore((s) => s.attachPath);
@@ -287,6 +290,24 @@ function TreeNode({ entry, depth, onReloadParent, collapseSignal, expandSignal }
             icon: SquarePlus,
             group: 0,
             onSelect: () => openInNewTab({ kind: "editor", path: entry.path }),
+          } satisfies ContextMenuItem,
+        ]
+      : []),
+    // Only for files the built-in browser can actually render, and only for
+    // local ones: the preview loads through Tauri's asset protocol, which has
+    // no way to reach a file that lives on an SFTP host.
+    ...(!entry.is_dir && !isRemoteUri(entry.path) && isBrowserPreviewable(entry.path)
+      ? [
+          {
+            id: "openInBrowser",
+            label: t("menu.openInBrowser"),
+            icon: Globe,
+            group: 0,
+            onSelect: () => {
+              if (openPreviewFromSidebar(entry.path).status === "at-capacity") {
+                setAtCapacity(true);
+              }
+            },
           } satisfies ContextMenuItem,
         ]
       : []),

--- a/src/modules/preview/lib/previewableFile.test.ts
+++ b/src/modules/preview/lib/previewableFile.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { isBrowserPreviewable } from "./previewableFile";
+
+describe("isBrowserPreviewable", () => {
+  it("accepts pages, images and media the WebView renders itself", () => {
+    expect(isBrowserPreviewable("/p/index.html")).toBe(true);
+    expect(isBrowserPreviewable("/p/page.htm")).toBe(true);
+    expect(isBrowserPreviewable("/p/logo.svg")).toBe(true);
+    expect(isBrowserPreviewable("/p/spec.pdf")).toBe(true);
+    expect(isBrowserPreviewable("/p/avatar.jpg")).toBe(true);
+    expect(isBrowserPreviewable("/p/clip.mp4")).toBe(true);
+  });
+
+  it("rejects source files and other things the WebView cannot render", () => {
+    expect(isBrowserPreviewable("/p/main.ts")).toBe(false);
+    expect(isBrowserPreviewable("/p/lib.rs")).toBe(false);
+    expect(isBrowserPreviewable("/p/notes.md")).toBe(false);
+    expect(isBrowserPreviewable("/p/archive.zip")).toBe(false);
+  });
+
+  it("is case-insensitive on the extension", () => {
+    expect(isBrowserPreviewable("/p/INDEX.HTML")).toBe(true);
+    expect(isBrowserPreviewable("/p/Photo.JPEG")).toBe(true);
+  });
+
+  it("treats a dotfile's leading dot as a name, not an extension", () => {
+    // `.html` as a whole filename is a config-ish dotfile, not an HTML page.
+    expect(isBrowserPreviewable("/p/.html")).toBe(false);
+    expect(isBrowserPreviewable("/p/.env")).toBe(false);
+    expect(isBrowserPreviewable("/p/Makefile")).toBe(false);
+  });
+
+  it("only looks at the last segment, so a directory named *.html does not leak in", () => {
+    expect(isBrowserPreviewable("/p/site.html/main.ts")).toBe(false);
+    expect(isBrowserPreviewable("C:\\p\\index.html")).toBe(true);
+  });
+});

--- a/src/modules/preview/lib/previewableFile.ts
+++ b/src/modules/preview/lib/previewableFile.ts
@@ -1,0 +1,44 @@
+/**
+ * File types the built-in browser (a real WebView) renders on its own. Source
+ * files, archives and binaries are deliberately absent: the WebView would show
+ * them as raw text or refuse them outright, so the explorer hides "Open in
+ * Browser" for those and the editor stays the way to look at them.
+ */
+const PREVIEWABLE_EXTENSIONS = new Set([
+  // Documents the WebView renders as pages.
+  "html",
+  "htm",
+  "xhtml",
+  "svg",
+  "pdf",
+  // Images.
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "avif",
+  "bmp",
+  "ico",
+  // Media the WebView has a built-in player for.
+  "mp4",
+  "webm",
+  "mp3",
+  "wav",
+  "ogg",
+]);
+
+/**
+ * Whether the built-in browser can render this file. Extension-based (the
+ * explorer has no file contents to sniff), case-insensitive, and false for
+ * extension-less files and dotfiles like `.env` — a leading dot is the name,
+ * not a suffix.
+ */
+export function isBrowserPreviewable(path: string): boolean {
+  const name = path.split(/[\\/]/).pop() ?? "";
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) {
+    return false;
+  }
+  return PREVIEWABLE_EXTENSIONS.has(name.slice(dot + 1).toLowerCase());
+}

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -941,6 +941,58 @@ describe("openHtmlPreview", () => {
   });
 });
 
+describe("openPreviewFromSidebar", () => {
+  beforeEach(reset);
+
+  it("opens a preview tab when nothing is open yet", () => {
+    const result = useTabsStore.getState().openPreviewFromSidebar("/proj/index.html");
+    expect(result).toEqual({ status: "opened" });
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].title).toBe("index.html");
+    expect(firstLeafContent(tabs[0])).toEqual({
+      kind: "preview",
+      url: "file:///proj/index.html",
+    });
+  });
+
+  it("splits beside the active tab instead of stealing the whole window", () => {
+    const tabId = useTabsStore.getState().openEditorTab("/proj/main.ts");
+    useTabsStore.getState().openPreviewFromSidebar("/proj/index.html");
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    const tab = tabs.find((t) => t.id === tabId)!;
+    expect(tab.paneTree.kind).toBe("split");
+    const kinds = leafIds(tab.paneTree).map((id) => findPaneContent(tab.paneTree, id)?.kind);
+    expect(kinds).toEqual(expect.arrayContaining(["editor", "preview"]));
+  });
+
+  it("reuses the tab's existing preview pane rather than opening a second one", () => {
+    const tabId = useTabsStore.getState().openEditorTab("/proj/main.ts");
+    useTabsStore.getState().openPreviewFromSidebar("/proj/a.html");
+    useTabsStore.getState().openPreviewFromSidebar("/proj/b.html");
+    const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)!;
+    const previews = leafIds(tab.paneTree)
+      .map((id) => findPaneContent(tab.paneTree, id))
+      .filter((c) => c?.kind === "preview");
+    expect(previews).toEqual([{ kind: "preview", url: "file:///proj/b.html" }]);
+  });
+
+  it("replaces a launcher tab instead of splitting into its ignored paneTree", () => {
+    // TabsArea renders LauncherPanel for a launcher tab and never looks at its
+    // paneTree, so a preview split into it would be invisible.
+    const launcherId = useTabsStore.getState().openLauncherTab();
+    useTabsStore.getState().openPreviewFromSidebar("/proj/index.html");
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].id).not.toBe(launcherId);
+    expect(firstLeafContent(tabs[0])).toEqual({
+      kind: "preview",
+      url: "file:///proj/index.html",
+    });
+  });
+});
+
 describe("splitPaneWith", () => {
   beforeEach(reset);
 

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -129,6 +129,14 @@ interface TabsState {
    * else open/reuse a per-space preview tab.
    */
   openHtmlPreview: (tabId: string, fromLeafId: string, filePath: string) => void;
+  /**
+   * Open a local file in the built-in browser from the sidebar, where there is
+   * no owning tab/pane to anchor on. Delegates to openHtmlPreview's smart
+   * target when there is a real active tab, and falls back to openFromSidebar
+   * when there is none or it is a Launcher tab (whose paneTree TabsArea
+   * ignores, so splitting into it would render nothing).
+   */
+  openPreviewFromSidebar: (filePath: string) => OpenFromSidebarResult;
   setTabTitle: (id: string, title: string) => void;
   /** Update a terminal tab's title to follow its cwd, unless the user renamed it. */
   syncTabTitleToCwd: (id: string, cwd: string) => void;
@@ -877,6 +885,18 @@ export const useTabsStore = create<TabsState>()(
       paneOrder: [paneId],
     };
     set((state) => ({ tabs: [...state.tabs, newTab], activeId: id }));
+  },
+
+  openPreviewFromSidebar: (filePath) => {
+    const activeTab = get().tabs.find((t) => t.id === get().activeId);
+    if (!activeTab || activeTab.kind === "launcher") {
+      return get().openFromSidebar(
+        { kind: "preview", url: fileUrl(filePath) },
+        basename(filePath) || "preview",
+      );
+    }
+    get().openHtmlPreview(activeTab.id, activeTab.activeLeafId, filePath);
+    return { status: "opened" };
   },
 
   setTabTitle: (id, title) =>


### PR DESCRIPTION
檔案總管的右鍵選單多一個「在瀏覽器開啟」，用內建的預覽面板開啟檔案，而不是叫外部瀏覽器。編輯器工具列本來就有這顆網頁預覽鈕，但要先把檔案開進編輯器才按得到；直接在檔案樹上右鍵是更短的路徑，尤其是圖片、PDF 這種本來就不會想用編輯器打開的檔案。

## 做法

**`isBrowserPreviewable`（`src/modules/preview/lib/previewableFile.ts`）**
只對內建 WebView 真的渲染得出來的副檔名顯示這個選項：html/htm/xhtml/svg/pdf、常見圖片格式、以及 WebView 自帶播放器的 mp4/webm/mp3/wav/ogg。`.ts`、`.rs`、`.zip` 這些不顯示——在 WebView 裡只會變成一片原始文字或直接觸發下載，選單多一列沒有用的項目反而是噪音。判斷只看最後一個路徑片段，所以名為 `site.html/` 的目錄底下的 `main.ts` 不會誤判；開頭的點視為檔名而非副檔名，`.env` 不算。

**`openPreviewFromSidebar`（`tabsStore`）**
既有的 `openHtmlPreview` 需要 `tabId` + `fromLeafId` 來決定預覽開在哪，但側邊欄沒有「所屬分頁／面板」可以依附，所以多包一層決定目標：有作用中分頁就沿用 `openHtmlPreview` 的智慧規則（已有預覽面板就換內容、單面板就在旁邊分割、已分割就用專屬預覽分頁），沒有分頁或作用中是 Launcher 分頁時改走 `openFromSidebar`——Launcher 分頁的 `paneTree` 會被 `TabsArea` 忽略（它直接渲染 `LauncherPanel`），分割進去的預覽面板根本不會被畫出來。

**遠端檔案不顯示**
預覽是走 Tauri 的 asset protocol 載入本機檔案，構不到 SFTP 主機上的檔案，所以 `isRemoteUri` 的路徑一律隱藏這個選項，而不是讓使用者點了之後看到空白面板。

## 測試

新增 12 項測試：

- `previewableFile.test.ts` — 可預覽／不可預覽的副檔名、大小寫、dotfile、目錄名含 `.html` 的邊界
- `FileTree.test.tsx` — HTML 檔開出 preview 面板（不是 editor 面板）、非可預覽檔案隱藏選項、遠端 SFTP 檔案隱藏選項
- `tabsStore.test.ts` — 四種開啟目標：沒有分頁時開新預覽分頁、有作用中分頁時在旁邊分割、重複開啟時沿用既有預覽面板而非疊第二個、Launcher 分頁被取代而非被分割

`pnpm typecheck`、`pnpm test`（224 檔 / 2035 項）、`cargo test`（493 項）皆通過。

## 備註

沒有動到 `tauri.conf.json` 或任何 Rust 程式碼，純前端。`openHtmlPreview` 的行為完全沒改，只是多一個進入點。

🤖 Generated with [Claude Code](https://claude.com/claude-code)