### PR TITLE
fix(editor): paint the wallpaper into the gutter instead of leaking code through it

### DIFF
--- a/src/components/BackgroundImageLayer.test.tsx
+++ b/src/components/BackgroundImageLayer.test.tsx
@@ -34,6 +34,38 @@ describe("BackgroundImageLayer", () => {
     expect(screen.queryByTestId("background-image-window")).toBeNull();
   });
 
+  it("publishes where the image landed so the gutter can pin the same copy", () => {
+    useSettingsStore.setState({
+      backgroundImagePath: "/app-data/appearance/background.png",
+      backgroundImageOpacity: 20,
+      backgroundImageScope: "workspace",
+    });
+    const { unmount } = render(<BackgroundImageLayer scope="workspace" />);
+    const image = screen.getByTestId("background-image-workspace");
+    Object.defineProperty(image, "naturalWidth", { value: 200, configurable: true });
+    Object.defineProperty(image, "naturalHeight", { value: 100, configurable: true });
+    image.getBoundingClientRect = () =>
+      ({ left: 40, top: 20, width: 400, height: 400 }) as DOMRect;
+
+    act(() => {
+      image.dispatchEvent(new Event("load"));
+    });
+
+    // cover on a 400x400 box scales the 200x100 source by 4, so it overflows
+    // 200px to each side of a box that itself starts 40px into the viewport.
+    const root = document.documentElement.style;
+    expect(root.getPropertyValue("--wallpaper-fixed-size")).toBe("800px 400px");
+    expect(root.getPropertyValue("--wallpaper-fixed-pos")).toBe("-160px 20px");
+    expect(root.getPropertyValue("--wallpaper-image")).toBe(
+      'url("/app-data/appearance/background.png")',
+    );
+
+    unmount();
+    expect(root.getPropertyValue("--wallpaper-image")).toBe("");
+    expect(root.getPropertyValue("--wallpaper-fixed-size")).toBe("");
+    expect(root.getPropertyValue("--wallpaper-fixed-pos")).toBe("");
+  });
+
   it("does not mount an invisible or unconfigured image", () => {
     const { rerender } = render(<BackgroundImageLayer scope="workspace" />);
     expect(screen.queryByRole("img", { hidden: true })).toBeNull();

--- a/src/components/BackgroundImageLayer.tsx
+++ b/src/components/BackgroundImageLayer.tsx
@@ -1,23 +1,74 @@
+import { useLayoutEffect, useRef } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { useSettingsStore, type BackgroundImageScope } from "@/stores/settingsStore";
 import { useBackgroundImage } from "@/lib/useBackgroundImage";
 import { useBackgroundImageDraftStore } from "@/stores/backgroundImageDraftStore";
 
+/** Where this layer's image lands, in viewport coordinates. */
+const VARS = ["--wallpaper-image", "--wallpaper-fixed-size", "--wallpaper-fixed-pos"] as const;
+
 /**
  * Decorative app-managed image painted behind translucent theme surfaces.
  * Scope owners mount their own layer, so workspace mode never bleeds into the
  * dock columns while window mode naturally covers the full shell.
+ *
+ * The editor's line-number gutter has to repaint this image to cover the code
+ * that scrolls under it (see gutterWallpaper in themes/editorTheme.ts), and it
+ * can only pin a background to the viewport, not to this layer's box. So the
+ * layer publishes where `object-fit: cover` actually put the image, in viewport
+ * coordinates, for `background-attachment: fixed` to reproduce exactly.
  */
 export function BackgroundImageLayer({ scope }: { scope: BackgroundImageScope }) {
   const { path, active, previewingDraft } = useBackgroundImage(scope);
+  const imageRef = useRef<HTMLImageElement>(null);
+  const src = path && active ? convertFileSrc(path) : null;
 
-  if (!path || !active) {
+  useLayoutEffect(() => {
+    const image = imageRef.current;
+    const root = document.documentElement;
+    if (!image || !src) {
+      return;
+    }
+    const publish = () => {
+      const { naturalWidth, naturalHeight } = image;
+      const box = image.getBoundingClientRect();
+      if (!naturalWidth || !naturalHeight || !box.width || !box.height) {
+        return;
+      }
+      // The same geometry `object-fit: cover` + `object-position: center` uses.
+      const scale = Math.max(box.width / naturalWidth, box.height / naturalHeight);
+      const width = naturalWidth * scale;
+      const height = naturalHeight * scale;
+      root.style.setProperty("--wallpaper-image", `url("${src}")`);
+      root.style.setProperty("--wallpaper-fixed-size", `${width}px ${height}px`);
+      root.style.setProperty(
+        "--wallpaper-fixed-pos",
+        `${box.left + (box.width - width) / 2}px ${box.top + (box.height - height) / 2}px`,
+      );
+    };
+    publish();
+    // Only ever fires on layout changes — a pane resize, the dock collapsing,
+    // the window itself. Nothing here rides on scrolling.
+    const observer = new ResizeObserver(publish);
+    observer.observe(image);
+    image.addEventListener("load", publish);
+    return () => {
+      observer.disconnect();
+      image.removeEventListener("load", publish);
+      for (const name of VARS) {
+        root.style.removeProperty(name);
+      }
+    };
+  }, [src]);
+
+  if (!src) {
     return null;
   }
 
   return (
     <img
-      src={convertFileSrc(path)}
+      ref={imageRef}
+      src={src}
       alt=""
       aria-hidden="true"
       draggable={false}

--- a/src/index.css
+++ b/src/index.css
@@ -114,8 +114,17 @@ body {
    * wrapper's own tint, so the gutter matches the code beside it and the
    * horizontal-scroll bleed returns only in wallpaper mode, where it was the
    * behaviour before the gutter got a backdrop at all.
+   *
+   * Transparent alone would let horizontally scrolled code slide through from
+   * beneath the numbers, so the gutter paints its own copy of the wallpaper
+   * plus the same tint instead: opaque enough to hide the code, identical to
+   * what sits beside it, and static, unlike anything that has to chase
+   * scrollLeft from JS. BackgroundImageLayer measures the two values it is
+   * pinned with; see gutterWallpaper in themes/editorTheme.ts.
    */
   --color-editor-gutter-bg: transparent;
+  --cm-gutter-bg-image: linear-gradient(var(--color-bg), var(--color-bg)),
+    var(--wallpaper-image);
   --color-bg-inset: color-mix(
     in srgb,
     var(--color-bg-inset-solid) var(--wallpaper-surface-alpha, 82%),

--- a/src/themes/editorTheme.test.ts
+++ b/src/themes/editorTheme.test.ts
@@ -1,3 +1,4 @@
+import { EditorView } from "@codemirror/view";
 import { describe, expect, it } from "vitest";
 import { editorSyntaxTheme } from "./editorTheme";
 import { DEFAULT_THEME_ID, THEMES } from "./themes";
@@ -14,5 +15,45 @@ describe("editorSyntaxTheme", () => {
 
   it("falls back to the default theme's editor for an unknown id", () => {
     expect(editorSyntaxTheme("does-not-exist")).toBe(editorSyntaxTheme(DEFAULT_THEME_ID));
+  });
+});
+
+describe("gutter wallpaper", () => {
+  function gutterRules() {
+    const view = new EditorView({ doc: "x", extensions: [editorSyntaxTheme(DEFAULT_THEME_ID)] });
+    try {
+      return [...document.querySelectorAll("style")]
+        .flatMap((style) => [...(style.sheet?.cssRules ?? [])])
+        .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+        .filter((rule) => rule.selectorText.endsWith(".cm-gutters"));
+    } finally {
+      view.destroy();
+    }
+  }
+
+  it("pins the gutter's copy of the wallpaper to the viewport", () => {
+    const painted = gutterRules().filter(
+      (rule) => rule.style.getPropertyValue("background-image") !== "",
+    );
+
+    expect(painted).toHaveLength(1);
+    const style = painted[0].style;
+    expect(style.getPropertyValue("background-image")).toBe("var(--cm-gutter-bg-image, none)");
+    // Pinned to the viewport, so scrolling the gutter never moves the image —
+    // that is what keeps it from lagging the way anything JS-driven would.
+    expect(style.getPropertyValue("background-attachment")).toBe("scroll, fixed");
+    expect(style.getPropertyValue("background-size")).toContain("--wallpaper-fixed-size");
+    expect(style.getPropertyValue("background-position")).toContain("--wallpaper-fixed-pos");
+  });
+
+  it("adds no colour of its own, so an unset wallpaper leaves the gutter alone", () => {
+    // The wallpaper layer is an image, never a colour: without a background
+    // image --cm-gutter-bg-image is undefined, the whole declaration drops out,
+    // and the gutter keeps whatever --color-editor-gutter-bg gave it.
+    const painted = gutterRules().filter(
+      (rule) => rule.style.getPropertyValue("background-image") !== "",
+    );
+
+    expect(painted[0].style.getPropertyValue("background-color")).toBe("");
   });
 });

--- a/src/themes/editorTheme.ts
+++ b/src/themes/editorTheme.ts
@@ -37,7 +37,8 @@ import { DEFAULT_THEME_ID } from "./themes";
  * --color-editor-gutter-bg 而不是直接用 --color-bg：沒有背景圖時兩者同值，
  * 有背景圖時 --color-bg 是半透明的，編輯器外層已經塗過一層，gutter 再塗一層
  * 會疊成一條明顯更深的直帶，所以那個 token 在背景圖模式下會退回透明
- * （見 index.css 的 .wallpaper-surface）。
+ * （見 index.css 的 .wallpaper-surface）。那樣 gutter 就擋不住從底下滑過去的
+ * 內容，所以背景圖模式改成讓 gutter 自己畫一份對齊的桌布，見 gutterWallpaper。
  */
 const SURFACE = {
   background: "transparent",
@@ -56,6 +57,34 @@ const LINE_HIGHLIGHT: Record<string, string> = {
   "gruvbox-dark": "#32302f",
   "solarized-light": "#eee8d5",
 };
+
+/**
+ * 背景圖模式下，gutter 自己畫一份和底下完全對齊的桌布。
+ *
+ * gutter 是 sticky 固定在左側的，橫向捲動時程式碼與 diff 變更行的底色會滑到
+ * 行號底下。沒有背景圖時 gutter 有自己的不透明底色，擋得住；有背景圖時 #342
+ * 把那層底色拿掉了（它會疊在編輯器外層的 tint 上，變成一條更深的直帶），內容
+ * 就直接透出來和行號疊在一起。
+ *
+ * 補一層純色會把那條直帶帶回來，改用 JS 追 scrollLeft 去裁掉捲過去的內容則會
+ * 抖——捲動是 compositor 在做的，JS 拿到 scroll 事件時畫面已經動過了。所以這裡
+ * 讓 gutter 畫「桌布 + 同一層 tint」：不透明，擋得住內容，看起來又和旁邊一模
+ * 一樣，而且完全靜態，沒有任何東西需要跟著捲動更新。
+ *
+ * 對齊靠 background-attachment: fixed（定位原點是 viewport，不受 gutter 自己
+ * 被捲到哪影響）配上 BackgroundImageLayer 量好的尺寸與位置。沒有背景圖時
+ * --cm-gutter-bg-image 沒有定義，整條規則就是 none，gutter 維持原本的底色。
+ */
+const gutterWallpaper: Extension = EditorView.theme({
+  ".cm-gutters": {
+    backgroundImage: "var(--cm-gutter-bg-image, none)",
+    backgroundRepeat: "no-repeat",
+    // 第一層是 tint，跟著 gutter 走；第二層是桌布，釘在 viewport 上。
+    backgroundAttachment: "scroll, fixed",
+    backgroundSize: "auto, var(--wallpaper-fixed-size, cover)",
+    backgroundPosition: "0 0, var(--wallpaper-fixed-pos, center)",
+  },
+});
 
 /**
  * 當前行高亮，外加「有選取時讓位」的行為。
@@ -180,7 +209,7 @@ const oneLightEditor: Extension = [
   activeLine(LINE_HIGHLIGHT["one-light"]),
 ];
 
-const EDITOR_THEMES: Record<string, Extension> = {
+const SYNTAX_THEMES: Record<string, Extension> = {
   "vitesse-dark": vitesseDarkEditor,
   "vitesse-light": vitesseLightEditor,
   "github-dark": githubDarkEditor,
@@ -191,6 +220,11 @@ const EDITOR_THEMES: Record<string, Extension> = {
   "gruvbox-dark": gruvboxDarkEditor,
   "solarized-light": solarizedLightEditor,
 };
+
+/** 語法主題配上所有主題共用的編輯器行為（目前是 gutter 的桌布層）。 */
+const EDITOR_THEMES: Record<string, Extension> = Object.fromEntries(
+  Object.entries(SYNTAX_THEMES).map(([id, syntax]) => [id, [gutterWallpaper, syntax]]),
+);
 
 /** 依 app 主題 id 挑選對應的編輯器語法高亮主題；未知 id 回退到預設主題。 */
 export function editorSyntaxTheme(themeId: string): Extension {


### PR DESCRIPTION
## Problem

With a custom background image set, horizontally scrolling the editor or the diff view drags code straight through the line-number gutter — numbers and code render on top of each other. Both CodeMirror surfaces are affected, and in the diff view both sides show it.

## Root cause

#327 gave the sticky gutter an opaque backdrop precisely so scrolled code stops sliding through beneath the numbers. #342 then found that backdrop compounding over a wallpaper — the editor's wrapper already paints one `--color-bg` layer, a second one on the gutter composites to ~97% against the wrapper's ~82% — and made the gutter transparent under `.wallpaper-surface`. That fixed the stripe and, as its message noted, let the pre-#327 bleed back in for wallpaper mode. This is that bleed.

Two things that do **not** work, for the record:

- Painting a flat backdrop back on, even only while scrolled: that is #342's stripe again.
- Clipping the scrolled-past content from JS. Scrolling runs on the compositor, so by the time a scroll event lands the frame is already on screen and the clip edge trails it by one; dragging the proxy scrollbar and syncing the diff's other side add another frame each. It visibly jitters along the gutter edge.

## Changes

The gutter paints the wallpaper itself, plus the same tint the wrapper uses. It is opaque, so the code beneath it stays hidden; it is the same image and the same tint as the surface beside it, so there is no stripe; and it is completely static — nothing tracks the scroll position, so there is nothing to lag.

- `themes/editorTheme.ts`: `.cm-gutters` gains a `--cm-gutter-bg-image` layer pinned with `background-attachment: fixed`, which positions from the viewport rather than from the gutter's own scrolled box.
- `index.css`: `.wallpaper-surface` defines that token as `linear-gradient(tint, tint), var(--wallpaper-image)`. Outside wallpaper mode the token is undefined, the declaration drops out, and the gutter keeps the opaque colour #342 left it with.
- `BackgroundImageLayer.tsx`: `fixed` can only be told about the viewport, and a workspace-scoped wallpaper covers just the workspace column — so the layer publishes where `object-fit: cover` actually put its image, in viewport coordinates, as `--wallpaper-fixed-size` / `--wallpaper-fixed-pos`. Measured on layout changes only (a `ResizeObserver` plus the image's own `load`), never on scroll.

Both surfaces pick this up through `editorSyntaxTheme`, so the editor and the diff view are covered.

## Test plan

- [x] `npx pnpm exec tsc --noEmit`
- [x] `npx pnpm exec vitest run` — 2026 passed
- [x] New tests: the gutter's wallpaper layer is pinned to the viewport and adds no colour of its own; the published geometry matches what `object-fit: cover` does
- [x] Manual (Windows, background image set): scroll the editor and both diff sides horizontally — with the mouse wheel and by dragging the bottom proxy scrollbar — and confirm no code shows through the numbers, no darker stripe appears down the gutter, and nothing jitters. Repeat with no background image to confirm the gutter is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
