### PR TITLE
fix(tabs): make an overflowing tab strip usable

### DIFF
--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -11,6 +11,16 @@ import { useSshDragStore } from "@/modules/ssh/lib/sshDrag";
 import { useUiStore } from "@/stores/uiStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
+// IS_MAC is a module-load const; expose it through a getter so a test can flip
+// the platform without re-importing the module.
+const platformMock = vi.hoisted(() => ({ isMac: false }));
+vi.mock("@/lib/platform", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/platform")>()),
+  get IS_MAC() {
+    return platformMock.isMac;
+  },
+}));
+
 beforeEach(() => {
   useTabsStore.setState({
     spaces: [{ id: "s1", name: "One" }],
@@ -182,34 +192,183 @@ describe("TabBar insertion line", () => {
   it("renders the insertion line immediately before the tab named by insertBeforeId", () => {
     useEntryDragStore.setState({ tabBarHover: { insertBeforeId: "t2" } });
     render(<TabBar />);
-    const tabBar = document.querySelector("[data-tab-bar]");
-    expect(tabBar).not.toBeNull();
-    const children = Array.from(tabBar!.children);
+    const strip = document.querySelector("[data-tab-strip]");
+    expect(strip).not.toBeNull();
+    const children = Array.from(strip!.children);
     const lineIndex = children.findIndex((el) => el.getAttribute("data-testid") === "tab-insertion-line");
     const t2Index = children.findIndex((el) => el.getAttribute("data-tab-id") === "t2");
     expect(lineIndex).toBeGreaterThanOrEqual(0);
     expect(lineIndex).toBe(t2Index - 1);
   });
 
-  it("renders the insertion line after the last tab and before the add-tab button when insertBeforeId is null", () => {
+  it("renders the insertion line after the last tab when insertBeforeId is null", () => {
     useNoteDragStore.setState({ tabBarHover: { insertBeforeId: null } });
     render(<TabBar />);
-    const tabBar = document.querySelector("[data-tab-bar]");
-    expect(tabBar).not.toBeNull();
-    const children = Array.from(tabBar!.children);
+    const strip = document.querySelector("[data-tab-strip]");
+    expect(strip).not.toBeNull();
+    const children = Array.from(strip!.children);
     const lineIndex = children.findIndex((el) => el.getAttribute("data-testid") === "tab-insertion-line");
-    // The add-tab button sits inside its Tooltip wrapper, so match the child
-    // that contains it rather than the button element itself.
-    const addButtonIndex = children.findIndex(
-      (el) => el.querySelector('[aria-label="Add tab"]') !== null,
-    );
+    // Last thing in the strip: the add-tab button lives outside it now, so
+    // there is nothing left for the line to sit in front of.
     expect(lineIndex).toBeGreaterThanOrEqual(0);
-    expect(lineIndex).toBe(addButtonIndex - 1);
+    expect(lineIndex).toBe(children.length - 1);
+    expect(children[lineIndex - 1].getAttribute("data-tab-id")).toBe("t2");
   });
 
   it("falls back through the entry, note, and ssh drag stores in that order", () => {
     useSshDragStore.setState({ tabBarHover: { insertBeforeId: "t1" } });
     render(<TabBar />);
     expect(screen.getByTestId("tab-insertion-line")).toBeInTheDocument();
+  });
+});
+
+describe("TabBar overflow scrolling", () => {
+  function addTab(id: string, title: string) {
+    useTabsStore.setState((state) => ({
+      tabs: [
+        ...state.tabs,
+        {
+          id,
+          spaceId: "s1",
+          title,
+          kind: "terminal" as const,
+          paneTree: leaf(`p-${id}`, { kind: "terminal" as const }),
+          activeLeafId: `p-${id}`,
+          paneOrder: [`p-${id}`],
+        },
+      ],
+    }));
+  }
+
+  it("asks for the hairline scrollbar on the platforms that draw a classic one", () => {
+    render(<TabBar />);
+    const strip = document.querySelector("[data-tab-strip]");
+    expect(strip?.className).toContain("overflow-x-auto");
+    // index.css keys its ::-webkit-scrollbar rule off this value.
+    expect(strip?.getAttribute("data-tab-strip")).toBe("hairline");
+  });
+
+  it("keeps the window drag region off the scrolling strip", () => {
+    render(<TabBar />);
+    const strip = document.querySelector<HTMLElement>("[data-tab-strip]")!;
+
+    // Tauri swallows mousedown on a drag region to move the window, and the
+    // scrollbar belongs to this element, so a drag region here means the thumb
+    // can never be dragged. The slack beside the strip carries it instead.
+    expect(strip.hasAttribute("data-tauri-drag-region")).toBe(false);
+    const slack = strip.parentElement?.querySelector("[data-tauri-drag-region]");
+    expect(slack).not.toBeNull();
+  });
+
+  it("leaves macOS its native overlay scrollbar", () => {
+    platformMock.isMac = true;
+    try {
+      render(<TabBar />);
+      // A ::-webkit-scrollbar rule would swap WKWebView's thin, transient,
+      // zero-height overlay bar for an always-present one that takes height.
+      expect(document.querySelector("[data-tab-strip]")?.getAttribute("data-tab-strip")).toBe("");
+    } finally {
+      platformMock.isMac = false;
+    }
+  });
+
+  it("blocks the autoscroll that would eat middle-click-to-close", () => {
+    render(<TabBar />);
+    const strip = document.querySelector<HTMLElement>("[data-tab-strip]")!;
+    const tab = document.querySelector<HTMLElement>('[data-tab-id="t1"]')!;
+
+    // A scrolling strip is a scroll container, and Chromium opens autoscroll on
+    // a middle-click there instead of delivering the auxclick the close gesture
+    // listens for. Cancelled on the strip, so tabs and empty space both count.
+    for (const target of [strip, tab]) {
+      const middle = fireEvent.mouseDown(target, { button: 1, bubbles: true, cancelable: true });
+      expect(middle).toBe(false);
+    }
+    // Left-clicks are untouched — dragging a tab still has to work.
+    expect(fireEvent.mouseDown(tab, { button: 0, bubbles: true, cancelable: true })).toBe(true);
+  });
+
+  it("scrolls the strip sideways on a plain wheel", () => {
+    render(<TabBar />);
+    const strip = document.querySelector<HTMLElement>("[data-tab-strip]")!;
+
+    fireEvent.wheel(strip, { deltaY: 120 });
+
+    expect(strip.scrollLeft).toBe(120);
+  });
+
+  it("steps through the tabs on shift+wheel, stopping at the ends", () => {
+    addTab("t2", "Terminal 2");
+    render(<TabBar />);
+    const strip = document.querySelector<HTMLElement>("[data-tab-strip]")!;
+
+    fireEvent.wheel(strip, { deltaY: 100, shiftKey: true });
+    expect(useTabsStore.getState().activeId).toBe("t2");
+    // Last tab: nothing to step onto, and the strip must not scroll instead.
+    fireEvent.wheel(strip, { deltaY: 100, shiftKey: true });
+    expect(useTabsStore.getState().activeId).toBe("t2");
+    expect(strip.scrollLeft).toBe(0);
+
+    fireEvent.wheel(strip, { deltaY: -100, shiftKey: true });
+    expect(useTabsStore.getState().activeId).toBe("t1");
+  });
+
+  it("ignores a shift+wheel too small to count as a step", () => {
+    addTab("t2", "Terminal 2");
+    render(<TabBar />);
+    const strip = document.querySelector<HTMLElement>("[data-tab-strip]")!;
+
+    // A trackpad's fine deltas accumulate rather than stepping on every event.
+    for (let i = 0; i < 4; i++) {
+      fireEvent.wheel(strip, { deltaY: 20, shiftKey: true });
+    }
+    expect(useTabsStore.getState().activeId).toBe("t1");
+    fireEvent.wheel(strip, { deltaY: 20, shiftKey: true });
+    expect(useTabsStore.getState().activeId).toBe("t2");
+  });
+
+  it("keeps the add-tab button out of the scrolling strip", () => {
+    render(<TabBar />);
+    const add = screen.getByLabelText("Add tab");
+
+    // Outside the strip, so overflowing tabs scroll past it rather than over
+    // it — and it needs no backdrop of its own, which over a background image
+    // would only compound the row's tint into a visible patch.
+    expect(add.closest("[data-tab-strip]")).toBeNull();
+    // Still inside the drop target the drag stores resolve against.
+    expect(add.closest("[data-tab-bar]")).not.toBeNull();
+  });
+
+  it("brings a newly activated tab into view", () => {
+    addTab("t2", "Terminal 2");
+    render(<TabBar />);
+    const strip = document.querySelector<HTMLElement>("[data-tab-strip]")!;
+    const tab = document.querySelector<HTMLElement>('[data-tab-id="t2"]')!;
+    // jsdom does no layout: the strip shows 0-200 and t2 sits at 260-360.
+    strip.getBoundingClientRect = () => ({ left: 0, right: 200 }) as DOMRect;
+    tab.getBoundingClientRect = () => ({ left: 260, right: 360 }) as DOMRect;
+
+    act(() => {
+      useTabsStore.setState({ activeId: "t2" });
+    });
+
+    // Scrolled by exactly what it took to make t2's right edge flush, no more.
+    expect(strip.scrollLeft).toBe(160);
+  });
+
+  it("leaves the strip alone when the activated tab is already visible", () => {
+    addTab("t2", "Terminal 2");
+    render(<TabBar />);
+    const strip = document.querySelector<HTMLElement>("[data-tab-strip]")!;
+    const tab = document.querySelector<HTMLElement>('[data-tab-id="t2"]')!;
+    strip.scrollLeft = 40;
+    strip.getBoundingClientRect = () => ({ left: 0, right: 200 }) as DOMRect;
+    tab.getBoundingClientRect = () => ({ left: 90, right: 190 }) as DOMRect;
+
+    act(() => {
+      useTabsStore.setState({ activeId: "t2" });
+    });
+
+    expect(strip.scrollLeft).toBe(40);
   });
 });

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   FileCode,
@@ -81,8 +81,14 @@ function TabItem({ id }: { id: string }) {
   const activeId = useTabsStore((s) => s.activeId);
   const setActive = useTabsStore((s) => s.setActive);
   const setTabTitle = useTabsStore((s) => s.setTabTitle);
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
-    useSortable({ id });
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
   const { dirty, requestClose, confirmCloseDialog } = useTabCloseRequest(tab);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
@@ -115,7 +121,9 @@ function TabItem({ id }: { id: string }) {
     <div
       ref={setNodeRef}
       style={{
-        transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+        transform: transform
+          ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
+          : undefined,
         transition,
       }}
       {...attributes}
@@ -147,11 +155,16 @@ function TabItem({ id }: { id: string }) {
       // font, so a bold/regular swap would jostle tab widths on every
       // activation.
       className={`group relative flex cursor-pointer items-center gap-2 px-3 text-xs transition-colors ${
-        active ? "bg-accent/10 text-fg" : "text-fg-muted hover:bg-bg-elevated/60"
+        active
+          ? "bg-accent/10 text-fg"
+          : "text-fg-muted hover:bg-bg-elevated/60"
       } ${isDragging ? "opacity-40" : ""}`}
     >
       {active && (
-        <span aria-hidden="true" className="absolute inset-x-0 bottom-0 h-[2px] bg-accent" />
+        <span
+          aria-hidden="true"
+          className="absolute inset-x-0 bottom-0 h-[2px] bg-accent"
+        />
       )}
       <Icon size={13} className="shrink-0" />
       {editing ? (
@@ -181,7 +194,10 @@ function TabItem({ id }: { id: string }) {
         all, with no undo — hovered to plain grey. The weight now matches the
         cost, and the tooltip names which is which.
       */}
-      <Tooltip label={dirty ? t("editor:unsaved") : t("actions.closeTab")} side="bottom">
+      <Tooltip
+        label={dirty ? t("editor:unsaved") : t("actions.closeTab")}
+        side="bottom"
+      >
         <button
           type="button"
           aria-label={dirty ? t("editor:unsaved") : t("actions.closeTab")}
@@ -244,9 +260,30 @@ function TabOverlay({ tab }: { tab: Tab }) {
   );
 }
 
+/**
+ * Wheel distance, in pixels, that steps one tab across with Shift held. One
+ * mouse notch is 100 on both platforms, so a notch is a tab; a trackpad's finer
+ * deltas accumulate up to it, walking the tabs one at a time instead of flying
+ * past them.
+ */
+const TAB_STEP_DELTA = 100;
+
+/** A wheel event's delta in pixels, whatever unit the device reports it in. */
+function wheelPixels(event: WheelEvent, viewport: number): number {
+  const delta = event.deltaY !== 0 ? event.deltaY : event.deltaX;
+  if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+    return delta * 16;
+  }
+  if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+    return delta * viewport;
+  }
+  return delta;
+}
+
 export function TabBar() {
   const { t } = useTranslation();
   const tabs = useTabsStore((s) => s.tabs);
+  const activeId = useTabsStore((s) => s.activeId);
   const activeSpaceId = useTabsStore((s) => s.activeSpaceId);
   const visibleTabs = tabs.filter((tab) => tab.spaceId === activeSpaceId);
   const openLauncherTab = useTabsStore((s) => s.openLauncherTab);
@@ -260,10 +297,100 @@ export function TabBar() {
   const entryTabBarHover = useEntryDragStore((s) => s.tabBarHover);
   const noteTabBarHover = useNoteDragStore((s) => s.tabBarHover);
   const sshTabBarHover = useSshDragStore((s) => s.tabBarHover);
-  const tabBarHover = entryTabBarHover ?? noteTabBarHover ?? sshTabBarHover ?? null;
+  const tabBarHover =
+    entryTabBarHover ?? noteTabBarHover ?? sshTabBarHover ?? null;
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const sensors = useSensors(useSensor(PointerSensor, POINTER_SENSOR_OPTIONS));
   const draggingTab = visibleTabs.find((tab) => tab.id === draggingId);
+  const stripRef = useRef<HTMLDivElement>(null);
+
+  // The strip's own scrollbar is hidden, so a tab past either edge would be
+  // reachable by the wheel alone. Activating one — Ctrl+Tab, a new tab, a file
+  // opened from the explorer — brings it in, by the shortest distance that
+  // makes it whole, leaving an already-visible tab exactly where it is.
+  //
+  // Positioned by hand rather than with scrollIntoView: WKWebView's is
+  // unreliable inside nested scroll containers (see NoteToc), and it would also
+  // be free to scroll ancestors, which here means yanking the whole shell
+  // sideways. Rects, not offsetLeft — the strip is not a positioned ancestor.
+  useEffect(() => {
+    const strip = stripRef.current;
+    if (!strip || !activeId) {
+      return;
+    }
+    const tab = strip.querySelector<HTMLElement>(
+      `[data-tab-id="${CSS.escape(activeId)}"]`,
+    );
+    if (!tab) {
+      return;
+    }
+    const stripBox = strip.getBoundingClientRect();
+    const tabBox = tab.getBoundingClientRect();
+    if (tabBox.left < stripBox.left) {
+      strip.scrollLeft -= stripBox.left - tabBox.left;
+    } else if (tabBox.right > stripBox.right) {
+      strip.scrollLeft += tabBox.right - stripBox.right;
+    }
+  }, [activeId]);
+
+  // A plain wheel scrolls the strip sideways — the browser only does that by
+  // itself once the strip can scroll nothing else, and here it can (the tabs
+  // stretch it to the row's full height), so it is done explicitly. Shift+wheel
+  // steps through the tabs instead, which is worth more on a bar than the
+  // sideways scroll Shift normally means.
+  //
+  // Registered by hand because React marks wheel listeners passive, and both
+  // branches have to cancel the default. Tab state is read at event time, so
+  // this attaches once instead of on every tab change.
+  useEffect(() => {
+    const strip = stripRef.current;
+    if (!strip) {
+      return;
+    }
+    let pending = 0;
+    const step = (direction: 1 | -1) => {
+      const state = useTabsStore.getState();
+      const spaceTabs = state.tabs.filter(
+        (tab) => tab.spaceId === state.activeSpaceId,
+      );
+      const index = spaceTabs.findIndex((tab) => tab.id === state.activeId);
+      const next = index === -1 ? undefined : spaceTabs[index + direction];
+      // Stops at either end rather than wrapping: a wheel has no detent to
+      // tell you that you just crossed from the last tab back to the first.
+      if (next) {
+        state.setActive(next.id);
+      }
+    };
+    const onWheel = (event: WheelEvent) => {
+      const delta = wheelPixels(event, strip.clientWidth);
+      if (delta === 0) {
+        return;
+      }
+      if (event.shiftKey) {
+        event.preventDefault();
+        // Reset on a reversal so a direction change takes effect immediately
+        // instead of first paying off the distance built up the other way.
+        pending =
+          Math.sign(pending) === -Math.sign(delta) ? delta : pending + delta;
+        // Direction comes from the accumulated distance, not from what is left
+        // after a step is paid out — a leftover of 0 would read as forwards.
+        const direction = pending > 0 ? 1 : -1;
+        while (Math.abs(pending) >= TAB_STEP_DELTA) {
+          pending -= direction * TAB_STEP_DELTA;
+          step(direction);
+        }
+        return;
+      }
+      // A trackpad's own sideways swipe already arrives as deltaX; leave it be.
+      if (event.deltaX !== 0) {
+        return;
+      }
+      event.preventDefault();
+      strip.scrollLeft += delta;
+    };
+    strip.addEventListener("wheel", onWheel, { passive: false });
+    return () => strip.removeEventListener("wheel", onWheel);
+  }, []);
 
   function handleDragStart(event: DragStartEvent) {
     setDraggingId(String(event.active.id));
@@ -288,7 +415,11 @@ export function TabBar() {
         IS_MAC ? "pl-20" : "pl-3"
       }`}
     >
-      <Tooltip label={t("workspace.toggleSidebar")} side="bottom" className="shrink-0">
+      <Tooltip
+        label={t("workspace.toggleSidebar")}
+        side="bottom"
+        className="shrink-0"
+      >
         <button
           type="button"
           aria-label={t("workspace.toggleSidebar")}
@@ -310,27 +441,79 @@ export function TabBar() {
         onDragEnd={handleDragEnd}
         onDragCancel={handleDragCancel}
       >
+        {/* data-tab-bar is the drop target the drag stores resolve against, so
+            it spans the strip and the slack beside it, exactly as it did when
+            the strip filled the row. The strip itself only takes the width its
+            tabs need, which leaves the add button sitting right after the last
+            one until they overflow — then the strip shrinks and scrolls
+            underneath, and the button stays put without needing a backdrop of
+            its own to hide them behind. */}
         <div
           data-tab-bar
-          data-tauri-drag-region
-          // self-stretch + items-stretch let tabs fill the bar's content
-          // height, so the active fill and underline sit flush against the
-          // bar's bottom border.
-          className="flex min-w-0 flex-1 items-stretch gap-1 self-stretch overflow-x-auto"
+          className="flex min-w-0 flex-1 items-stretch gap-1 self-stretch"
         >
-          <SortableContext
-            items={visibleTabs.map((tab) => tab.id)}
-            strategy={horizontalListSortingStrategy}
+          <div
+            ref={stripRef}
+            // The hairline scrollbar in index.css keys off this value, and only
+            // the platforms that draw classic scrollbars get it: Windows, where
+            // a bar with real height squashing a 36px row was the bug, and
+            // Linux, which draws them the same way. macOS is left alone — its
+            // overlay scrollbar is already thin, transient and free of layout
+            // cost, and a ::-webkit-scrollbar rule would trade that for an
+            // always-present bar that takes height, making things worse there
+            // to fix something it never had.
+            data-tab-strip={IS_MAC ? "" : "hairline"}
+            // No data-tauri-drag-region here, unlike before: Tauri swallows
+            // mousedown on a drag region to start moving the window, and the
+            // strip's own scrollbar is part of this element, so its thumb could
+            // never be dragged. The slack beside the strip carries the drag
+            // region instead, which is the part of the row that was ever worth
+            // grabbing — the tabs themselves were never draggable-by-window.
+            onMouseDown={(e) => {
+              // Once the strip overflows it is a scroll container, and Chromium
+              // answers a middle-click on one with autoscroll — swallowing the
+              // auxclick a tab's close-on-middle-click needs. Cancelling the
+              // default here covers the tabs and the empty space alike; auxclick
+              // fires on mouseup, so it still arrives.
+              if (e.button === 1) {
+                e.preventDefault();
+              }
+            }}
+            // items-stretch, inside a parent that stretches too, lets tabs fill
+            // the bar's content height, so the active fill and underline sit
+            // flush against the bar's bottom border.
+            //
+            // Windows renders a classic scrollbar here, which takes real height
+            // out of a 36px row and squashes every tab to make room — the same
+            // reason the editor and diff views proxy their scrollbars (#327).
+            // index.css restyles this one strip down to a 3px hairline (the
+            // data-tab-strip attribute is the hook). The wheel scrolls it too: a
+            // vertical wheel over a horizontally-only scrollable box scrolls it
+            // sideways.
+            className="flex min-w-0 shrink items-stretch gap-1 overflow-x-auto"
           >
-            {visibleTabs.map((tab) => (
-              <Fragment key={tab.id}>
-                {tabBarHover?.insertBeforeId === tab.id && <TabInsertionLine />}
-                <TabItem id={tab.id} />
-              </Fragment>
-            ))}
-          </SortableContext>
-          {tabBarHover !== null && tabBarHover.insertBeforeId === null && <TabInsertionLine />}
-          <Tooltip label={t("workspace.addTab")} side="bottom" className="shrink-0 self-center">
+            <SortableContext
+              items={visibleTabs.map((tab) => tab.id)}
+              strategy={horizontalListSortingStrategy}
+            >
+              {visibleTabs.map((tab) => (
+                <Fragment key={tab.id}>
+                  {tabBarHover?.insertBeforeId === tab.id && (
+                    <TabInsertionLine />
+                  )}
+                  <TabItem id={tab.id} />
+                </Fragment>
+              ))}
+            </SortableContext>
+            {tabBarHover !== null && tabBarHover.insertBeforeId === null && (
+              <TabInsertionLine />
+            )}
+          </div>
+          <Tooltip
+            label={t("workspace.addTab")}
+            side="bottom"
+            className="shrink-0 self-center"
+          >
             <button
               type="button"
               aria-label={t("workspace.addTab")}
@@ -340,10 +523,19 @@ export function TabBar() {
               <Plus size={16} />
             </button>
           </Tooltip>
+          {/* The slack the strip used to hold: still part of the drop target,
+            still a place to grab the window by. */}
+          <div data-tauri-drag-region className="min-w-0 flex-1 self-stretch" />
         </div>
-        <DragOverlay>{draggingTab ? <TabOverlay tab={draggingTab} /> : null}</DragOverlay>
+        <DragOverlay>
+          {draggingTab ? <TabOverlay tab={draggingTab} /> : null}
+        </DragOverlay>
       </DndContext>
-      <Tooltip label={t("explorer:findFiles")} side="bottom" className="shrink-0">
+      <Tooltip
+        label={t("explorer:findFiles")}
+        side="bottom"
+        className="shrink-0"
+      >
         <button
           type="button"
           aria-label={t("explorer:findFiles")}
@@ -354,7 +546,11 @@ export function TabBar() {
           <Search size={15} />
         </button>
       </Tooltip>
-      <Tooltip label={t("workspace.toggleRightSidebar")} side="bottom" className="shrink-0">
+      <Tooltip
+        label={t("workspace.toggleRightSidebar")}
+        side="bottom"
+        className="shrink-0"
+      >
         <button
           type="button"
           aria-label={t("workspace.toggleRightSidebar")}

--- a/src/index.css
+++ b/src/index.css
@@ -165,6 +165,35 @@ body {
  */
 
 /*
+ * The one exception, and a deliberate one: the tab strip. Windows (and Linux)
+ * would draw a classic bar into a 36px row and squash every tab to fit it; the
+ * alternative, hiding the bar outright, leaves no sign that tabs continue past
+ * the edge. A 3px hairline costs almost nothing and reads the way VS Code's
+ * does.
+ *
+ * Keyed off the attribute's value, which TabBar only sets to "hairline" off
+ * macOS. WKWebView's overlay scrollbars are already thin, transient and free of
+ * layout cost; a ::-webkit-scrollbar rule is exactly what would trade them for
+ * an always-present bar that takes height.
+ */
+[data-tab-strip="hairline"]::-webkit-scrollbar {
+  height: 3px;
+}
+
+[data-tab-strip="hairline"]::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[data-tab-strip="hairline"]::-webkit-scrollbar-thumb {
+  background: var(--color-border-strong);
+  border-radius: 999px;
+}
+
+[data-tab-strip="hairline"]:hover::-webkit-scrollbar-thumb {
+  background: var(--color-fg-subtle);
+}
+
+/*
  * Editor/diff proxy scrollbars (Windows only, where classic scrollbars are
  * always-on): the scroller's own bars are hidden and replaced with thin
  * overflow strips that the browser renders real native scrollbars for,


### PR DESCRIPTION
## Problem

Open enough tabs and the strip overflows. On Windows the browser answers that with a classic horizontal scrollbar, which takes real height out of a 36px row: every tab is squashed to make room and the bar itself sits somewhere it clearly does not belong.

Behind that, everything else about an overflowing strip was untested ground, and most of it was broken:

- The wheel did not scroll it.
- The add-tab button scrolled away with the tabs, out of reach.
- Middle-click-to-close stopped working.
- Activating a tab past the edge left it off-screen.

## Root cause

Each has its own cause, and they only appear once the strip actually scrolls:

- **The wheel.** A browser only turns a vertical wheel sideways once the box can scroll nothing else. This one can: the tabs stretch it to the row's full height.
- **Middle-click.** A scrolling strip is a scroll container, and Chromium answers a middle-click on one with autoscroll instead of delivering the `auxclick` the close gesture listens for.
- **The add-tab button.** It lived inside the scrolling strip, after the last tab.
- **The scrollbar itself was undraggable** even once styled: `data-tauri-drag-region` was on the strip, and Tauri swallows mousedown on a drag region to start moving the window, so the thumb never got the press.

## Changes

- **A 3px hairline scrollbar** (`index.css`): transparent track, `--color-border-strong` thumb, brighter on hover. Only visible when the tabs actually overflow. This is the file's one `::-webkit-scrollbar` rule, against the note at the top of that section — and it is keyed off `data-tab-strip="hairline"`, which `TabBar` sets only off macOS. WKWebView's overlay scrollbars are already thin, transient and free of layout cost; a pseudo-element rule is exactly what would trade them for an always-present bar that takes height, i.e. inflict this bug on the one platform that never had it. Windows and Linux, which draw classic bars, get the hairline.
- **A plain wheel scrolls the strip sideways; Shift+wheel steps through the tabs**, one per mouse notch, stopping at either end rather than wrapping — a wheel has no detent to tell you that you just crossed from the last tab back to the first. A trackpad's finer deltas accumulate to the same step, and its own sideways swipe (`deltaX`) is left to the browser, inertia and all. Registered by hand because React marks wheel listeners passive and both branches cancel the default.
- **The strip now takes only the width its tabs need**, with the add-tab button after it and the leftover slack after that. The button keeps its place right behind the last tab, and overflowing tabs scroll *past* it rather than over it. Pinning it inside the strip works too, but only with a backdrop for the tabs to slide under — and over a background image that second layer of the row's own tint reads as a lighter patch, the compounding #342 fixed for the editor gutter. `data-tab-bar` moves out to a wrapper around all three, so the drop target the drag stores resolve against covers the same ground as before; the strip carries `data-tab-strip`.
- **`data-tauri-drag-region` comes off the strip**, so its scrollbar can be dragged. The slack beside it carries the drag region instead — the part of the row that was ever worth grabbing.
- **Activating a tab past either edge brings it in**, by the shortest distance that makes it whole. Positioned by hand from rects rather than with `scrollIntoView`: WKWebView's is unreliable inside nested scroll containers (the same reason `NoteToc` positions its container itself), and it would be free to scroll ancestors, which here means yanking the whole shell sideways.
- **Middle-click's autoscroll is cancelled** on the strip, covering its tabs and its empty space alike. `auxclick` fires on mouseup, so the close still lands.

macOS gets the wheel behaviour and the layout; it keeps its native overlay scrollbar, never had middle-click autoscroll (that `preventDefault` is a no-op there), and is specifically why the scroll positioning avoids `scrollIntoView`.

## Test plan

- [x] `npx pnpm exec tsc --noEmit`
- [x] `npx pnpm exec vitest run` — 2033 passed
- [x] New tests: hairline requested off macOS and withheld on it; drag region off the strip; wheel scrolls; shift+wheel steps and stops at the ends; a sub-step delta accumulates instead of stepping; add button outside the strip but inside the drop target; activating an off-screen tab scrolls it in by the exact distance, and an on-screen one not at all
- [x] Manual (Windows): open enough tabs to overflow, then check the tabs keep their full height, the hairline appears and drags, the wheel scrolls, Shift+wheel walks the tabs and stops at both ends, middle-click still closes, the add button stays reachable, and Ctrl+Tab pulls an off-screen tab into view
- [ ] Manual (macOS): same, minus the hairline — the overlay scrollbar should be untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)