### PR TITLE
test(git-graph): wait for the pending selection to clear instead of asserting it bare

### DIFF
--- a/src/modules/git-graph/GitGraphTabContent.test.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.test.tsx
@@ -55,7 +55,7 @@ describe("GitGraphTabContent pending commit selection", () => {
     await waitFor(() => expect(screen.getByText("msg bbb2222")).toBeInTheDocument());
     // Selecting opens the details panel, which fetches this commit's details.
     await waitFor(() => expect(screen.getAllByText("bbb2222").length).toBeGreaterThan(0));
-    expect(usePendingGraphSelectionStore.getState().hash).toBeNull();
+    await waitFor(() => expect(usePendingGraphSelectionStore.getState().hash).toBeNull());
   });
 
   it("loads more pages to find a pending commit not on the first page, up to a cap", async () => {
@@ -67,7 +67,7 @@ describe("GitGraphTabContent pending commit selection", () => {
     render(<GitGraphTabContent />);
 
     await waitFor(() => expect(screen.getByText("msg ccc3333")).toBeInTheDocument());
-    expect(usePendingGraphSelectionStore.getState().hash).toBeNull();
+    await waitFor(() => expect(usePendingGraphSelectionStore.getState().hash).toBeNull());
   });
 
   it("gives up silently once retries are exhausted and the hash is never found", async () => {
@@ -153,7 +153,7 @@ describe("GitGraphTabContent pending commit selection", () => {
     usePendingGraphSelectionStore.getState().request("eee5555");
 
     await waitFor(() => expect(screen.getAllByText("eee5555").length).toBeGreaterThan(0));
-    expect(usePendingGraphSelectionStore.getState().hash).toBeNull();
+    await waitFor(() => expect(usePendingGraphSelectionStore.getState().hash).toBeNull());
   });
 
   it("does not burn retries or stack loads on re-renders while a page load is in flight", async () => {


### PR DESCRIPTION
## Problem

`GitGraphTabContent.test.tsx` has flaked twice recently on CI, always in the "pending commit selection" block:

- master run [32794824044](https://github.com/mukiwu/tempo-term/actions/runs/32794824044): `loads more pages to find a pending commit not on the first page` — `expected 'ccc3333' to be null` (line 70)
- PR #347 run [32804637352](https://github.com/mukiwu/tempo-term/actions/runs/32804637352): `gives a fresh retry budget to a new request` — `expected 'eee5555' to be null` (line 156)

## Root cause

Both tests `waitFor` the commit row to render and then assert **synchronously** that `usePendingGraphSelectionStore.getState().hash` is null. The row is painted as soon as the page loads; clearing the hash happens in a later effect, so a slow runner asserts in the gap. `ec31dea` (#290) fixed this exact race at line 80 but left lines 58, 70 and 156 as bare assertions (58 has not flaked, since it waits on the details panel that only appears after selection, but it is the same shape).

Diagnosis credit: @oberonlai spelled this out in https://github.com/mukiwu/tempo-term/pull/347#issuecomment-5462829118.

## Change

Wrap the three remaining bare assertions in `await waitFor(...)`, matching the other seven in the file. Test-only change; no production code touched.

## Verification

- `pnpm exec vitest run src/modules/git-graph/GitGraphTabContent.test.tsx` × 10 consecutive runs: 0 failures
- `pnpm typecheck`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)