### PR TITLE
fix: confirm before closing live terminal sessions

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -8,13 +8,14 @@
 ### fix
 
 - 修正 Windows 上開啟任何對話框時，自訂標題列右上角的最小化、最大化、關閉按鈕被遮罩蓋住而點不到的問題。三顆按鈕改為固定在視窗右上、永遠位於對話框之上；選單列維持被遮罩蓋住，避免隔著遮罩操作選單 (#349)
+- 關閉仍有本機終端或 SSH 工作階段的視窗／App 前顯示可停用的原生確認提示，支援 macOS 與 Windows (#356)
 - 避免 macOS 在建立 PTY 的 fork 後子行程中掃描檔案描述符。這項非 async-signal-safe 操作依程式碼分析理論上可能造成崩潰，但目前實機測試未重現 (#355)
 - 修正分頁開到超出視窗寬度時分頁列的一連串問題：Windows 上原本會冒出一根傳統捲軸吃掉列高、把每個分頁壓扁，現改為只在溢位時出現的 3px 細線（macOS 維持系統原生的覆蓋式捲軸）；滑鼠滾輪可橫向捲動分頁列，Shift＋滾輪逐格切換分頁並在兩端停住；新增分頁按鈕固定在最後一個分頁之後，不再跟著捲走；中鍵關閉分頁恢復可用；以快捷鍵切到畫面外的分頁時會自動捲入視野 (#350)
 - 修正套用自訂背景圖時，橫向捲動編輯器或 diff 會讓程式碼從行號欄底下透出、與行號重疊的問題。行號欄改為自行繪製同一張桌布與相同色調，既能遮住底下的程式碼，也不會再出現 #342 修掉的深色直帶，而且完全不隨捲動重算 (#348)
 
 ### 貢獻者
 
-- @mark22013333 (#355)
+- @mark22013333 (#355, #356)
 - @yw-chan (#348, #349, #350, #357)
 - @oberonlai (#347)
 
@@ -28,12 +29,13 @@
 ### fix
 
 - Fix the custom title bar's minimize, maximize and close controls on Windows being covered and made unclickable by any dialog's backdrop. The controls are now pinned to the window's top-right above every dialog, while the menu bar deliberately stays under the backdrop so a dialog cannot be operated from behind its own overlay (#349)
+- Add an optional native confirmation before closing a window or quitting the app with live terminal or SSH sessions on macOS and Windows (#356)
 - Avoid scanning file descriptors in the post-fork macOS PTY child. Code analysis shows this non-async-signal-safe operation could theoretically crash, although hardware testing has not reproduced it (#355)
 - Fix a run of problems with a tab strip that overflows the window. On Windows the classic scrollbar that appeared took height from the row and squashed every tab; it is replaced by a 3px hairline shown only while the tabs overflow (macOS keeps its native overlay scrollbar). The mouse wheel scrolls the strip sideways, Shift+wheel steps through the tabs one at a time and stops at either end, the add-tab button stays put after the last tab instead of scrolling away, middle-click-to-close works again, and activating an off-screen tab by shortcut scrolls it into view (#350)
 - Fix code showing through the line-number gutter when the editor or diff view is scrolled horizontally with a custom background image set. The gutter now paints the same wallpaper and tint itself, so it hides the code beneath it without bringing back the darker stripe #342 removed, and nothing tracks the scroll position (#348)
 
 ### Contributors
 
-- @mark22013333 (#355)
+- @mark22013333 (#355, #356)
 - @yw-chan (#348, #349, #350, #357)
 - @oberonlai (#347)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use modules::appearance::{
     appearance_remove_background_image, appearance_save_background_image,
 };
 use modules::fonts::fonts_report;
+use modules::exit_guard::{exit_guard_configure, ExitGuardState};
 use modules::fs::{
     fs_create_dir, fs_create_file, fs_delete, fs_grep, fs_home_dir, fs_is_file, fs_list_files,
     fs_read_dir, fs_read_file, fs_rename, fs_reveal, fs_write_file,
@@ -147,6 +148,7 @@ pub fn run() {
                 .build(),
         )
         .manage(PtyState::new())
+        .manage(ExitGuardState::new())
         .manage(SshState::new())
         .manage(SftpState::new())
         .manage(ClaudeProgressState::new())
@@ -226,6 +228,7 @@ pub fn run() {
             pty_cwd,
             pty_close,
             pty_close_all,
+            exit_guard_configure,
             app_build_info,
             open_new_window,
             appearance_save_background_image,
@@ -354,6 +357,9 @@ pub fn run() {
             detect_tools,
             install_tool
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            modules::exit_guard::handle_run_event(app_handle, &event);
+        });
 }

--- a/src-tauri/src/modules/exit_guard.rs
+++ b/src-tauri/src/modules/exit_guard.rs
@@ -1,0 +1,347 @@
+//! Cross-platform protection against quitting while terminal sessions are live.
+//!
+//! Window close requests are confirmed by the renderer so each window can be
+//! handled independently. App-level exits (macOS Cmd+Q, an OS quit request, or
+//! an explicit `AppHandle::exit`) bypass window events, so this module also
+//! guards `RunEvent::ExitRequested` with a native dialog that remains usable
+//! even when a WebView is unresponsive.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use tauri::{AppHandle, Manager, RunEvent, State, WindowEvent};
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+
+use crate::modules::pty::PtyState;
+use crate::modules::ssh::SshState;
+
+pub struct ExitGuardState {
+    enabled: AtomicBool,
+    prompting: AtomicBool,
+    bypass_once: AtomicBool,
+    language: Mutex<String>,
+}
+
+impl ExitGuardState {
+    pub fn new() -> Self {
+        Self {
+            // Opt-out: old installations that have not persisted this setting
+            // are protected immediately, even before the frontend is loaded.
+            enabled: AtomicBool::new(true),
+            prompting: AtomicBool::new(false),
+            bypass_once: AtomicBool::new(false),
+            language: Mutex::new("en".to_string()),
+        }
+    }
+
+    pub(crate) fn language(&self) -> String {
+        self.language.lock().unwrap().clone()
+    }
+
+    fn finish_prompt(&self) {
+        self.prompting.store(false, Ordering::Release);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WindowCloseDecision {
+    /// No live sessions belong to this window, so Tauri may close it normally.
+    Allow,
+    /// Ask before stopping the window's live sessions.
+    Prompt,
+    /// Stop the sessions and destroy the window without asking.
+    CloseAndDestroy,
+    /// A confirmation is already visible; suppress duplicate close requests.
+    Ignore,
+}
+
+fn decide_window_close(
+    enabled: bool,
+    session_count: usize,
+    prompting: bool,
+) -> WindowCloseDecision {
+    if session_count == 0 {
+        WindowCloseDecision::Allow
+    } else if !enabled {
+        WindowCloseDecision::CloseAndDestroy
+    } else if prompting {
+        WindowCloseDecision::Ignore
+    } else {
+        WindowCloseDecision::Prompt
+    }
+}
+
+fn all_session_count(app: &AppHandle) -> usize {
+    let pty = app.state::<PtyState>();
+    let ssh = app.state::<SshState>();
+    crate::modules::pty::session_count(&pty) + crate::modules::ssh::session_count(&ssh)
+}
+
+fn window_session_count(app: &AppHandle, owner: &str) -> usize {
+    let pty = app.state::<PtyState>();
+    let ssh = app.state::<SshState>();
+    crate::modules::pty::owned_session_count(&pty, owner)
+        + crate::modules::ssh::owned_session_count(&ssh, owner)
+}
+
+fn close_window_sessions(app: &AppHandle, owner: &str) {
+    let pty = app.state::<PtyState>();
+    let ssh = app.state::<SshState>();
+    crate::modules::pty::close_owned_sessions(&pty, owner);
+    crate::modules::ssh::close_owned_sessions(&ssh, owner);
+}
+
+/// macOS's custom Cmd+Q menu item enters here instead of using AppKit's
+/// predefined `terminate:` selector, which cannot be cancelled by Tauri.
+#[cfg(target_os = "macos")]
+pub fn request_quit(app: &AppHandle) {
+    let guard = app.state::<ExitGuardState>();
+    let count = all_session_count(app);
+    if !guard.enabled.load(Ordering::Acquire) || count == 0 {
+        guard.bypass_once.store(true, Ordering::Release);
+        app.exit(0);
+        return;
+    }
+    if guard.prompting.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
+    let app = app.clone();
+    let language = guard.language.lock().unwrap().clone();
+    std::thread::spawn(move || {
+        let confirmed = show_confirmation(&app, &language, count, true, None);
+        let guard = app.state::<ExitGuardState>();
+        guard.finish_prompt();
+        if confirmed {
+            guard.bypass_once.store(true, Ordering::Release);
+            app.exit(0);
+        }
+    });
+}
+
+#[tauri::command]
+pub fn exit_guard_configure(
+    app: AppHandle,
+    state: State<'_, ExitGuardState>,
+    enabled: bool,
+    language: String,
+) -> Result<(), String> {
+    state.enabled.store(enabled, Ordering::Release);
+    *state.language.lock().unwrap() = language.clone();
+    crate::modules::menu::refresh_language(&app, &language)
+}
+
+/// Protect exits that do not pass through a window's CloseRequested event.
+pub fn handle_run_event(app: &AppHandle, event: &RunEvent) {
+    if let RunEvent::WindowEvent {
+        label,
+        event: WindowEvent::CloseRequested { api, .. },
+        ..
+    } = event
+    {
+        let guard = app.state::<ExitGuardState>();
+        let session_count = window_session_count(app, label);
+        let decision = decide_window_close(
+            guard.enabled.load(Ordering::Acquire),
+            session_count,
+            guard.prompting.load(Ordering::Acquire),
+        );
+
+        match decision {
+            WindowCloseDecision::Allow => return,
+            WindowCloseDecision::CloseAndDestroy => {
+                // Confirmation is optional, cleanup is not. Prevent the native
+                // close long enough to remove every owned backend session,
+                // then explicitly destroy the window.
+                api.prevent_close();
+                close_window_sessions(app, label);
+                if let Some(window) = app.get_webview_window(label) {
+                    let _ = window.destroy();
+                }
+                return;
+            }
+            WindowCloseDecision::Ignore => {
+                api.prevent_close();
+                return;
+            }
+            WindowCloseDecision::Prompt => {}
+        }
+
+        // This is intentionally native and synchronous up to prevent_close():
+        // React may be remounting, WebView2/WKWebView may be unresponsive, or
+        // the renderer may already have terminated. The guard must still work
+        // identically on macOS and Windows.
+        api.prevent_close();
+        // The pure decision used a snapshot. Claim the prompt atomically so two
+        // close events racing between that snapshot and here still produce one
+        // dialog at most.
+        if guard
+            .prompting
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let app = app.clone();
+        let label = label.clone();
+        let language = guard.language.lock().unwrap().clone();
+        std::thread::spawn(move || {
+            let confirmed = show_confirmation(&app, &language, session_count, false, Some(&label));
+            let guard = app.state::<ExitGuardState>();
+            guard.finish_prompt();
+            if confirmed {
+                close_window_sessions(&app, &label);
+                if let Some(window) = app.get_webview_window(&label) {
+                    let _ = window.destroy();
+                }
+            }
+        });
+        return;
+    }
+
+    let RunEvent::ExitRequested { api, .. } = event else {
+        return;
+    };
+    let guard = app.state::<ExitGuardState>();
+    if guard.bypass_once.swap(false, Ordering::AcqRel)
+        || !guard.enabled.load(Ordering::Acquire)
+        || all_session_count(app) == 0
+    {
+        return;
+    }
+
+    api.prevent_exit();
+    if guard.prompting.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
+    let app = app.clone();
+    let language = guard.language.lock().unwrap().clone();
+    let count = all_session_count(&app);
+    std::thread::spawn(move || {
+        let confirmed = show_confirmation(&app, &language, count, true, None);
+
+        let guard = app.state::<ExitGuardState>();
+        guard.finish_prompt();
+        if confirmed {
+            guard.bypass_once.store(true, Ordering::Release);
+            app.exit(0);
+        }
+    });
+}
+
+fn show_confirmation(
+    app: &AppHandle,
+    language: &str,
+    count: usize,
+    quitting: bool,
+    parent_label: Option<&str>,
+) -> bool {
+    let zh_hant = language.starts_with("zh");
+    let (title, message, confirm, cancel) = if zh_hant {
+        let action = if quitting {
+            "結束 TempoTerm"
+        } else {
+            "關閉視窗"
+        };
+        (
+            "仍有終端機正在執行",
+            format!(
+                "目前仍有 {count} 個終端或 SSH 工作階段。{action}會中止這些工作階段，確定要繼續嗎？"
+            ),
+            if quitting {
+                "仍要結束"
+            } else {
+                "仍要關閉"
+            },
+            "取消",
+        )
+    } else {
+        let action = if quitting {
+            "Quitting TempoTerm"
+        } else {
+            "Closing this window"
+        };
+        (
+            "Terminal sessions are still running",
+            format!(
+                "{count} terminal or SSH session(s) are still running. {action} will stop them. Do you want to continue?"
+            ),
+            if quitting { "Quit Anyway" } else { "Close Anyway" },
+            "Cancel",
+        )
+    };
+    let mut dialog = app
+        .dialog()
+        .message(message)
+        .title(title)
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            confirm.to_string(),
+            cancel.to_string(),
+        ));
+    let parent = parent_label
+        .and_then(|label| app.get_webview_window(label))
+        .or_else(|| {
+            app.webview_windows()
+                .into_values()
+                .find(|window| window.is_focused().unwrap_or(false))
+        });
+    if let Some(parent) = parent {
+        dialog = dialog.parent(&parent);
+    }
+    dialog.blocking_show()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_confirmation_defaults_to_enabled() {
+        let state = ExitGuardState::new();
+        assert!(state.enabled.load(Ordering::Acquire));
+        assert!(!state.prompting.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn disabled_confirmation_still_closes_and_destroys_owned_sessions() {
+        assert_eq!(
+            decide_window_close(false, 1, false),
+            WindowCloseDecision::CloseAndDestroy
+        );
+    }
+
+    #[test]
+    fn close_without_owned_sessions_is_allowed() {
+        assert_eq!(
+            decide_window_close(true, 0, false),
+            WindowCloseDecision::Allow
+        );
+    }
+
+    #[test]
+    fn repeated_close_while_prompting_is_ignored() {
+        assert_eq!(
+            decide_window_close(true, 1, false),
+            WindowCloseDecision::Prompt
+        );
+        assert_eq!(
+            decide_window_close(true, 1, true),
+            WindowCloseDecision::Ignore
+        );
+    }
+
+    #[test]
+    fn close_can_retry_after_prompt_finishes_even_if_destroy_failed() {
+        let state = ExitGuardState::new();
+        state.prompting.store(true, Ordering::Release);
+        state.finish_prompt();
+
+        assert_eq!(
+            decide_window_close(true, 1, state.prompting.load(Ordering::Acquire)),
+            WindowCloseDecision::Prompt
+        );
+    }
+}

--- a/src-tauri/src/modules/exit_guard.rs
+++ b/src-tauri/src/modules/exit_guard.rs
@@ -34,6 +34,7 @@ impl ExitGuardState {
         }
     }
 
+    #[cfg(target_os = "macos")]
     pub(crate) fn language(&self) -> String {
         self.language.lock().unwrap().clone()
     }

--- a/src-tauri/src/modules/menu.rs
+++ b/src-tauri/src/modules/menu.rs
@@ -90,6 +90,7 @@ fn build_app_submenu(
         .build()
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn quit_menu_title(app_name: &str, language: &str) -> String {
     if language.starts_with("zh") {
         format!("結束 {app_name}")

--- a/src-tauri/src/modules/menu.rs
+++ b/src-tauri/src/modules/menu.rs
@@ -44,19 +44,39 @@ pub enum NativeItemKind {
     Predefined,
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Default)]
+struct NativeMenuState {
+    model: std::sync::Mutex<Option<NativeMenuModel>>,
+}
+
 /// Event emitted to the focused window when a native menu item is clicked.
 /// Predefined items (copy/paste/undo/etc.) are handled by the system and never
 /// reach `on_menu_event`, so only custom item ids are ever seen here.
 #[cfg(target_os = "macos")]
 pub const NATIVE_MENU_EVENT: &str = "native-menu-click";
+#[cfg(target_os = "macos")]
+pub const QUIT_MENU_ID: &str = "quit-tempoterm";
 
 /// Build the App submenu (About/Services/Hide/Quit): the one macOS requires to
 /// exist for services / hide / quit to work at all. `set_menu` replaces the
 /// entire menu bar, so every rebuild (fallback `init()` and `set_native_menu`)
 /// must prepend this or TempoTerm/about/quit disappear from the menu bar.
 #[cfg(target_os = "macos")]
-fn build_app_submenu(handle: &tauri::AppHandle) -> tauri::Result<tauri::menu::Submenu<tauri::Wry>> {
-    use tauri::menu::{AboutMetadata, SubmenuBuilder};
+fn build_app_submenu(
+    handle: &tauri::AppHandle,
+    language: &str,
+) -> tauri::Result<tauri::menu::Submenu<tauri::Wry>> {
+    use tauri::menu::{AboutMetadata, MenuItemBuilder, SubmenuBuilder};
+    // The predefined Quit item calls AppKit `terminate:` directly and bypasses
+    // Tauri's preventable ExitRequested event. Keep the native appearance and
+    // accelerator while routing the action through the Rust exit guard.
+    let quit = MenuItemBuilder::with_id(
+        QUIT_MENU_ID,
+        quit_menu_title(&handle.package_info().name, language),
+    )
+    .accelerator("Cmd+Q")
+    .build(handle)?;
     SubmenuBuilder::new(handle, &handle.package_info().name)
         .about(Some(AboutMetadata::default()))
         .separator()
@@ -66,8 +86,37 @@ fn build_app_submenu(handle: &tauri::AppHandle) -> tauri::Result<tauri::menu::Su
         .hide_others()
         .show_all()
         .separator()
-        .quit()
+        .item(&quit)
         .build()
+}
+
+fn quit_menu_title(app_name: &str, language: &str) -> String {
+    if language.starts_with("zh") {
+        format!("結束 {app_name}")
+    } else {
+        format!("Quit {app_name}")
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn rebuild_fallback_menu(app: &AppHandle, language: &str) -> tauri::Result<()> {
+    use tauri::menu::{MenuBuilder, SubmenuBuilder};
+
+    let app_menu = build_app_submenu(app, language)?;
+    let edit_menu = SubmenuBuilder::new(app, "Edit")
+        .undo()
+        .redo()
+        .separator()
+        .cut()
+        .copy()
+        .paste()
+        .select_all()
+        .build()?;
+    let menu = MenuBuilder::new(app)
+        .items(&[&app_menu, &edit_menu])
+        .build()?;
+    app.set_menu(menu)?;
+    Ok(())
 }
 
 /// Build the native macOS menu, reduced to the system minimum (App + Edit).
@@ -95,31 +144,18 @@ pub fn init(app: &mut App) -> tauri::Result<()> {
     // Windows renders the in-window menu bar; no native menu at all.
     #[cfg(target_os = "macos")]
     {
-        use tauri::menu::{MenuBuilder, SubmenuBuilder};
         let handle = app.handle();
-
-        let app_menu = build_app_submenu(handle)?;
-
-        // Edit menu: keeps Cmd+C/V/X/A routed by the system into the webview.
-        let edit_menu = SubmenuBuilder::new(handle, "Edit")
-            .undo()
-            .redo()
-            .separator()
-            .cut()
-            .copy()
-            .paste()
-            .select_all()
-            .build()?;
-
-        let menu = MenuBuilder::new(handle)
-            .items(&[&app_menu, &edit_menu])
-            .build()?;
-        app.set_menu(menu)?;
+        app.manage(NativeMenuState::default());
+        rebuild_fallback_menu(handle, "en")?;
 
         // Dispatch custom item clicks to the focused window; predefined items
         // (copy/paste/undo/etc.) are handled by the system and never reach here.
         app.on_menu_event(|app, event| {
             use tauri::Emitter;
+            if event.id().0 == QUIT_MENU_ID {
+                crate::modules::exit_guard::request_quit(app);
+                return;
+            }
             if let Some(win) = app.get_focused_window() {
                 let id = event.id().0.clone();
                 let _ = win.emit_to(win.label(), NATIVE_MENU_EVENT, id);
@@ -205,9 +241,13 @@ fn build_items(app: &tauri::AppHandle, defs: &[NativeMenuItem]) -> tauri::Result
 /// frontend model. `set_menu` swaps the bar wholesale, so the App submenu
 /// (About/Services/Hide/Quit) is rebuilt and prepended on every call.
 #[cfg(target_os = "macos")]
-fn rebuild_menu(app: &tauri::AppHandle, model: &NativeMenuModel) -> tauri::Result<()> {
+fn rebuild_menu(
+    app: &tauri::AppHandle,
+    model: &NativeMenuModel,
+    language: &str,
+) -> tauri::Result<()> {
     use tauri::menu::{MenuBuilder, SubmenuBuilder};
-    let mut mb = MenuBuilder::new(app).item(&build_app_submenu(app)?);
+    let mut mb = MenuBuilder::new(app).item(&build_app_submenu(app, language)?);
     for menu in &model.menus {
         let built = build_items(app, &menu.items)?;
         // Carry the frontend's menu id onto the muda Submenu id so the menu
@@ -236,11 +276,39 @@ pub fn set_native_menu(app: AppHandle, model: NativeMenuModel) -> Result<(), Str
         // never refreshes (verified on-device), so call it directly and let a
         // rebuild failure bubble to the frontend caller while the previous menu
         // stays in place.
-        rebuild_menu(&app, &model).map_err(|e| e.to_string())
+        let language = app
+            .state::<crate::modules::exit_guard::ExitGuardState>()
+            .language();
+        let state = app.state::<NativeMenuState>();
+        let mut stored_model = state.model.lock().unwrap();
+        rebuild_menu(&app, &model, &language).map_err(|e| e.to_string())?;
+        *stored_model = Some(model);
+        Ok(())
     }
     #[cfg(not(target_os = "macos"))]
     {
         let _ = (app, model);
+        Ok(())
+    }
+}
+
+/// Rebuild the current macOS menu when the exit guard's language changes.
+/// Keeping the last frontend model avoids replacing its menus with the minimal
+/// startup fallback merely to update the custom Quit item.
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+pub fn refresh_language(app: &AppHandle, language: &str) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let state = app.state::<NativeMenuState>();
+        let stored_model = state.model.lock().unwrap();
+        match stored_model.as_ref() {
+            Some(model) => rebuild_menu(app, model, language),
+            None => rebuild_fallback_menu(app, language),
+        }
+        .map_err(|e| e.to_string())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
         Ok(())
     }
 }
@@ -304,6 +372,13 @@ fn next_window_label(app: &AppHandle) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn quit_title_follows_exit_guard_language() {
+        assert_eq!(quit_menu_title("TempoTerm", "en"), "Quit TempoTerm");
+        assert_eq!(quit_menu_title("TempoTerm", "zh-TW"), "結束 TempoTerm");
+        assert_eq!(quit_menu_title("TempoTerm", "zh-Hant"), "結束 TempoTerm");
+    }
 
     #[test]
     fn deserializes_native_menu_model() {

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -8,6 +8,7 @@ pub mod codex_progress;
 pub mod codex_status_hook;
 pub mod clipboard;
 pub mod editor_watch;
+pub mod exit_guard;
 pub mod fonts;
 pub mod fs;
 pub mod git;

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -4,6 +4,9 @@ mod session;
 pub mod shell;
 
 pub use session::PtyState;
+pub(crate) use session::{
+    close_owned as close_owned_sessions, owned_count as owned_session_count, session_count,
+};
 
 use tauri::ipc::{Channel, Response};
 use tauri::State;
@@ -12,6 +15,7 @@ use tauri::State;
 #[allow(clippy::too_many_arguments)]
 pub fn pty_open(
     app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
     state: State<'_, PtyState>,
     cols: u16,
     rows: u16,
@@ -28,6 +32,7 @@ pub fn pty_open(
         cwd,
         suggestions,
         shell_override,
+        window.label().to_string(),
         &app,
         on_data,
         on_exit,

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -17,6 +17,7 @@ use super::shell::{
 
 /// A single live terminal session.
 pub struct Session {
+    owner_label: Mutex<Option<String>>,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     master: Mutex<Box<dyn MasterPty + Send>>,
     killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
@@ -160,6 +161,7 @@ pub fn spawn_with_sinks(
     rows: u16,
     cmd: CommandBuilder,
     shell_name: String,
+    owner_label: Option<String>,
     on_bytes: impl Fn(Vec<u8>) -> bool + Send + 'static,
     on_exit: impl FnOnce(i32) + Send + 'static,
 ) -> Result<u32, String> {
@@ -178,6 +180,7 @@ pub fn spawn_with_sinks(
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
 
     let session = Arc::new(Session {
+        owner_label: Mutex::new(owner_label),
         writer: Arc::new(Mutex::new(writer)),
         master: Mutex::new(pair.master),
         killer: Mutex::new(killer),
@@ -291,6 +294,7 @@ pub fn spawn(
     cwd: Option<String>,
     suggestions: bool,
     shell_override: Option<String>,
+    owner_label: String,
     app: &tauri::AppHandle,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
@@ -323,6 +327,7 @@ pub fn spawn(
         rows,
         cmd,
         shell_name,
+        Some(owner_label),
         move |bytes| {
             if let Some(tx) = &log_tx {
                 // Drop on a full channel rather than stall the reader thread.
@@ -486,6 +491,35 @@ pub fn close_all(state: &PtyState) {
     }
 }
 
+pub fn session_count(state: &PtyState) -> usize {
+    state.sessions.read().unwrap().len()
+}
+
+pub fn owned_count(state: &PtyState, owner_label: &str) -> usize {
+    state
+        .sessions
+        .read()
+        .unwrap()
+        .values()
+        .filter(|session| session.owner_label.lock().unwrap().as_deref() == Some(owner_label))
+        .count()
+}
+
+pub fn close_owned(state: &PtyState, owner_label: &str) {
+    let ids: Vec<u32> = state
+        .sessions
+        .read()
+        .unwrap()
+        .iter()
+        .filter_map(|(id, session)| {
+            (session.owner_label.lock().unwrap().as_deref() == Some(owner_label)).then_some(*id)
+        })
+        .collect();
+    for id in ids {
+        close(state, id);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -510,6 +544,7 @@ mod tests {
             24,
             cmd,
             "test".to_string(),
+            None,
             move |bytes| {
                 sink.lock().unwrap().extend_from_slice(&bytes);
                 true
@@ -550,8 +585,18 @@ mod tests {
     fn registers_session_in_state() {
         let state = PtyState::new();
         let cmd = CommandBuilder::new("/bin/echo");
-        let id = spawn_with_sinks(&state, state.alloc_id(), 80, 24, cmd, "echo".to_string(), |_| true, |_| {})
-            .expect("spawn should succeed");
+        let id = spawn_with_sinks(
+            &state,
+            state.alloc_id(),
+            80,
+            24,
+            cmd,
+            "echo".to_string(),
+            None,
+            |_| true,
+            |_| {},
+        )
+        .expect("spawn should succeed");
         assert!(state.get(id).is_ok());
     }
 
@@ -572,6 +617,7 @@ mod tests {
             24,
             cmd,
             "echo".to_string(),
+            None,
             |_| true,
             move |code| {
                 let _ = exit_tx.send(code);
@@ -586,6 +632,28 @@ mod tests {
             state.get(id).is_err(),
             "session should be pruned from the registry before the exit event fires"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn registers_owner_with_the_session_atomically() {
+        let state = PtyState::new();
+        let cmd = CommandBuilder::new("/bin/cat");
+        let id = spawn_with_sinks(
+            &state,
+            state.alloc_id(),
+            80,
+            24,
+            cmd,
+            "cat".to_string(),
+            Some("secondary".to_string()),
+            |_| true,
+            |_| {},
+        )
+        .expect("spawn should succeed");
+
+        assert_eq!(owned_count(&state, "secondary"), 1);
+        close(&state, id);
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/modules/ssh/mod.rs
+++ b/src-tauri/src/modules/ssh/mod.rs
@@ -6,6 +6,9 @@ mod session;
 
 pub use prompt::PromptReply;
 pub use session::SshState;
+pub(crate) use session::{
+    close_owned as close_owned_sessions, owned_count as owned_session_count, session_count,
+};
 pub(crate) use client::{connect_authenticated, AuthedConnectArgs, PromptRegistryHandle};
 
 use tauri::ipc::{Channel, Response};

--- a/src-tauri/src/modules/ssh/session.rs
+++ b/src-tauri/src/modules/ssh/session.rs
@@ -40,6 +40,7 @@ pub enum SshControl {
 /// The frontend-facing handle to one running session: just the sender side of
 /// its control channel. The worker thread holds the receiver.
 struct SshHandle {
+    owner_label: String,
     control: mpsc::UnboundedSender<SshControl>,
 }
 
@@ -102,7 +103,13 @@ pub fn open(
         .sessions
         .lock()
         .unwrap()
-        .insert(id, SshHandle { control: control_tx });
+        .insert(
+            id,
+            SshHandle {
+                owner_label: window_label.clone(),
+                control: control_tx,
+            },
+        );
 
     let registry = state.registry.clone();
     let app = app.clone();
@@ -511,6 +518,33 @@ fn close_inner(state: &SshState, id: u32) {
 /// remove the (now stale) entry either way so the id doesn't leak.
 pub fn close(state: &State<'_, SshState>, id: u32) {
     close_inner(state, id)
+}
+
+pub fn session_count(state: &SshState) -> usize {
+    state.sessions.lock().unwrap().len()
+}
+
+pub fn owned_count(state: &SshState, owner: &str) -> usize {
+    state
+        .sessions
+        .lock()
+        .unwrap()
+        .values()
+        .filter(|handle| handle.owner_label == owner)
+        .count()
+}
+
+pub fn close_owned(state: &SshState, owner: &str) {
+    let ids: Vec<u32> = state
+        .sessions
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|(id, handle)| (handle.owner_label == owner).then_some(*id))
+        .collect();
+    for id in ids {
+        close_inner(state, id);
+    }
 }
 
 /// Drop a session's registry entry, looked up from the app's managed `SshState`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ import { installStatusHook, installCodexStatusHook } from "@/modules/claude-prog
 import { installSessionNotifications } from "@/modules/claude-progress/lib/sessionNotifications";
 import { ensureNotificationPermission } from "@/modules/claude-progress/lib/notify";
 import { useWatchNotes } from "@/modules/notes/lib/useWatchNotes";
-import { registerSecondaryWindowCleanup, restoreFocusOnWindowRefocus } from "@/lib/windowLifecycle";
+import { restoreFocusOnWindowRefocus } from "@/lib/windowLifecycle";
 import { SshPromptDialog } from "@/modules/ssh/SshPromptDialog";
 import { SetupWizard } from "@/modules/setup/SetupWizard";
 import { detectTools, isToolReady } from "@/modules/setup/lib/setupTools";
@@ -293,16 +293,26 @@ function App() {
     void enforceLogRetention(30).catch(() => {});
   }, []);
 
-  // In a secondary window, close this window's PTY sessions before it is
-  // destroyed so no background shells leak. No-op in the main window.
+  // Mirror the persisted opt-out and language into Rust. Rust owns native
+  // window/app close handling, including while the WebView is unresponsive.
   useEffect(() => {
-    let unlisten: (() => void) | null = null;
-    void registerSecondaryWindowCleanup()
-      .then((off) => {
-        unlisten = off;
-      })
-      .catch(() => {});
-    return () => unlisten?.();
+    const sync = () => {
+      const settings = useSettingsStore.getState();
+      void invoke("exit_guard_configure", {
+        enabled: settings.confirmCloseWithRunningTerminals,
+        language: settings.language,
+      }).catch(() => {});
+    };
+    sync();
+    return useSettingsStore.subscribe((state, previous) => {
+      if (
+        state.confirmCloseWithRunningTerminals !==
+          previous.confirmCloseWithRunningTerminals ||
+        state.language !== previous.language
+      ) {
+        sync();
+      }
+    });
   }, []);
 
   // On Windows, WebView2 drops DOM focus when the window regains focus, so

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -178,6 +178,8 @@
     "previewText": "$ tempo --version\nTempoTerm terminal padding preview",
     "restoreHistory": "Restore terminal history on relaunch",
     "restoreHistoryHint": "Reopen each terminal with its previous output (read-only), unless its shell was exited or the pane was closed",
+    "confirmClose": "Confirm before closing running terminals",
+    "confirmCloseHint": "Show a confirmation before closing a window or quitting the app while local terminal or SSH sessions are still running (enabled by default)",
     "suggestions": "Suggest previous commands",
     "suggestionsHint": "Show a dim completion from your shell history as you type; press → to accept",
     "actionLinks": "Hover action cards",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -178,6 +178,8 @@
     "previewText": "$ tempo --version\nTempoTerm 終端機間距預覽",
     "restoreHistory": "重新啟動時還原終端機歷史",
     "restoreHistoryHint": "重開時把每個終端機的上次輸出以唯讀方式還原,除非該 shell 已結束或分頁已關閉",
+    "confirmClose": "關閉時確認仍在執行的終端機",
+    "confirmCloseHint": "關閉視窗或結束 App 前，若仍有本機終端或 SSH 工作階段，先顯示確認提示（預設開啟）",
     "suggestions": "提示曾經輸入過的指令",
     "suggestionsHint": "輸入時根據 shell 歷史以灰色顯示補完建議，按 → 接受",
     "actionLinks": "滑鼠懸停動作卡片",

--- a/src/lib/windowLifecycle.test.ts
+++ b/src/lib/windowLifecycle.test.ts
@@ -1,17 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { getCurrentWindow } = vi.hoisted(() => ({ getCurrentWindow: vi.fn() }));
-const { closeLocalSessions } = vi.hoisted(() => ({ closeLocalSessions: vi.fn() }));
 const platform = vi.hoisted(() => ({ IS_WINDOWS: true }));
 vi.mock("@tauri-apps/api/window", () => ({ getCurrentWindow }));
-vi.mock("@/modules/terminal/lib/pty-bridge", () => ({ closeLocalSessions }));
 vi.mock("@/lib/platform", () => ({
   get IS_WINDOWS() {
     return platform.IS_WINDOWS;
   },
 }));
 
-import { registerSecondaryWindowCleanup, restoreFocusOnWindowRefocus } from "./windowLifecycle";
+import { restoreFocusOnWindowRefocus } from "./windowLifecycle";
 
 // restoreFocusOnWindowRefocus attaches a real document-level `focusin` listener;
 // collect each call's unlisten so afterEach removes it and listeners can't leak
@@ -21,7 +19,6 @@ const cleanups: Array<() => void> = [];
 afterEach(() => {
   cleanups.splice(0).forEach((fn) => fn());
   getCurrentWindow.mockReset();
-  closeLocalSessions.mockReset();
   platform.IS_WINDOWS = true;
   document.body.replaceChildren();
   vi.restoreAllMocks();
@@ -52,104 +49,6 @@ function mockFocusWindow() {
     focus: () => cb({ payload: true }),
   };
 }
-
-describe("registerSecondaryWindowCleanup", () => {
-  it("registers nothing in the main window", async () => {
-    const onCloseRequested = vi.fn();
-    getCurrentWindow.mockReturnValue({ label: "main", onCloseRequested });
-    const unlisten = await registerSecondaryWindowCleanup();
-    expect(unlisten).toBeNull();
-    expect(onCloseRequested).not.toHaveBeenCalled();
-  });
-
-  it("closes local sessions then destroys the window on close", async () => {
-    let handler: (e: { preventDefault: () => void }) => Promise<void> = async () => {};
-    const onCloseRequested = vi.fn(async (h) => {
-      handler = h;
-      return () => {};
-    });
-    const destroy = vi.fn().mockResolvedValue(undefined);
-    closeLocalSessions.mockResolvedValue(undefined);
-    getCurrentWindow.mockReturnValue({ label: "win-1", onCloseRequested, destroy });
-
-    await registerSecondaryWindowCleanup();
-    expect(onCloseRequested).toHaveBeenCalledTimes(1);
-
-    const preventDefault = vi.fn();
-    await handler({ preventDefault });
-
-    expect(preventDefault).toHaveBeenCalled();
-    expect(closeLocalSessions).toHaveBeenCalled();
-    expect(destroy).toHaveBeenCalled();
-  });
-
-  it("still destroys the window when closing local sessions fails", async () => {
-    // The close is preventDefault'd, so if a closeLocalSessions rejection skipped
-    // destroy the window would be stranded open. Session cleanup is best-effort.
-    let handler: (e: { preventDefault: () => void }) => Promise<void> = async () => {};
-    const onCloseRequested = vi.fn(async (h) => {
-      handler = h;
-      return () => {};
-    });
-    const destroy = vi.fn().mockResolvedValue(undefined);
-    closeLocalSessions.mockRejectedValue(new Error("pty bridge down"));
-    getCurrentWindow.mockReturnValue({ label: "win-1", onCloseRequested, destroy });
-
-    await registerSecondaryWindowCleanup();
-    await handler({ preventDefault: vi.fn() });
-
-    expect(closeLocalSessions).toHaveBeenCalled();
-    expect(destroy).toHaveBeenCalled();
-  });
-
-  it("prevents but does not re-clean when the close is requested twice", async () => {
-    // The second request (double Cmd+W while the first cleanup is in flight) must
-    // still be prevented so Tauri's default close can't race the cleanup, but it
-    // must not close sessions or destroy a second time.
-    let handler: (e: { preventDefault: () => void }) => Promise<void> = async () => {};
-    const onCloseRequested = vi.fn(async (h) => {
-      handler = h;
-      return () => {};
-    });
-    const destroy = vi.fn().mockResolvedValue(undefined);
-    closeLocalSessions.mockResolvedValue(undefined);
-    getCurrentWindow.mockReturnValue({ label: "win-1", onCloseRequested, destroy });
-
-    await registerSecondaryWindowCleanup();
-    const preventFirst = vi.fn();
-    const preventSecond = vi.fn();
-    await handler({ preventDefault: preventFirst });
-    await handler({ preventDefault: preventSecond });
-
-    expect(preventFirst).toHaveBeenCalled();
-    expect(preventSecond).toHaveBeenCalled();
-    expect(closeLocalSessions).toHaveBeenCalledTimes(1);
-    expect(destroy).toHaveBeenCalledTimes(1);
-  });
-
-  it("can be retried after a destroy failure instead of stranding the window", async () => {
-    // If destroy fails, `cleaning` must reset so a later close request runs the
-    // cleanup again rather than being swallowed by the reentrancy guard forever.
-    let handler: (e: { preventDefault: () => void }) => Promise<void> = async () => {};
-    const onCloseRequested = vi.fn(async (h) => {
-      handler = h;
-      return () => {};
-    });
-    const destroy = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("destroy failed"))
-      .mockResolvedValueOnce(undefined);
-    closeLocalSessions.mockResolvedValue(undefined);
-    getCurrentWindow.mockReturnValue({ label: "win-1", onCloseRequested, destroy });
-
-    await registerSecondaryWindowCleanup();
-    await expect(handler({ preventDefault: vi.fn() })).rejects.toThrow("destroy failed");
-    await handler({ preventDefault: vi.fn() });
-
-    expect(destroy).toHaveBeenCalledTimes(2);
-    expect(closeLocalSessions).toHaveBeenCalledTimes(2);
-  });
-});
 
 describe("restoreFocusOnWindowRefocus", () => {
   // This webview holds OS focus by default; the sibling-webview case overrides it.

--- a/src/lib/windowLifecycle.ts
+++ b/src/lib/windowLifecycle.ts
@@ -1,48 +1,5 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { isMainWindow } from "@/lib/window";
 import { IS_WINDOWS } from "@/lib/platform";
-import { closeLocalSessions } from "@/modules/terminal/lib/pty-bridge";
-
-/**
- * In a secondary window, intercept the close: shut down this window's PTY
- * sessions, then destroy the window. The main window keeps its default close
- * behavior (its sessions die with the process on quit). Returns an unlisten
- * function, or null when nothing was registered.
- */
-export async function registerSecondaryWindowCleanup(): Promise<(() => void) | null> {
-  if (isMainWindow()) {
-    return null;
-  }
-  const win = getCurrentWindow();
-  let cleaning = false;
-  return win.onCloseRequested(async (event) => {
-    if (cleaning) {
-      // A second request (double Cmd+W, rapid clicks) while the first cleanup is
-      // in flight must also be prevented, or Tauri's default close races the
-      // in-progress closeLocalSessions and orphans its PTYs.
-      event.preventDefault();
-      return;
-    }
-    cleaning = true;
-    event.preventDefault();
-    try {
-      // Session cleanup is best-effort: the close is already prevented, so a
-      // closeLocalSessions failure must not skip destroy or the window is
-      // stranded open with no way to close it.
-      try {
-        await closeLocalSessions();
-      } catch {
-        // fall through to destroy
-      }
-      await win.destroy();
-    } catch (error) {
-      // destroy failed: reset so the user can try closing again instead of being
-      // stuck with a permanently un-closeable window.
-      cleaning = false;
-      throw error;
-    }
-  });
-}
 
 /**
  * On Windows, WebView2 does not restore DOM focus to the previously-focused

--- a/src/modules/settings/TerminalSettingsSection.test.tsx
+++ b/src/modules/settings/TerminalSettingsSection.test.tsx
@@ -25,4 +25,14 @@ describe("TerminalSettingsSection custom shell", () => {
     fireEvent.change(input, { target: { value: "/opt/homebrew/bin/pwsh" } });
     expect(useSettingsStore.getState().customShellPath).toBe("/opt/homebrew/bin/pwsh");
   });
+
+  it("shows the close warning enabled by default and persists an opt-out", () => {
+    render(<TerminalSettingsSection />);
+    const checkbox = screen.getByLabelText(
+      "Confirm before closing running terminals",
+    );
+    expect(checkbox).toBeChecked();
+    fireEvent.click(checkbox);
+    expect(useSettingsStore.getState().confirmCloseWithRunningTerminals).toBe(false);
+  });
 });

--- a/src/modules/settings/TerminalSettingsSection.tsx
+++ b/src/modules/settings/TerminalSettingsSection.tsx
@@ -14,6 +14,12 @@ export function TerminalSettingsSection() {
   const setTerminalPadding = useSettingsStore((s) => s.setTerminalPadding);
   const restoreTerminalHistory = useSettingsStore((s) => s.restoreTerminalHistory);
   const setRestoreTerminalHistory = useSettingsStore((s) => s.setRestoreTerminalHistory);
+  const confirmCloseWithRunningTerminals = useSettingsStore(
+    (s) => s.confirmCloseWithRunningTerminals,
+  );
+  const setConfirmCloseWithRunningTerminals = useSettingsStore(
+    (s) => s.setConfirmCloseWithRunningTerminals,
+  );
   const terminalSuggestions = useSettingsStore((s) => s.terminalSuggestions);
   const setTerminalSuggestions = useSettingsStore((s) => s.setTerminalSuggestions);
   const customShellPath = useSettingsStore((s) => s.customShellPath);
@@ -77,6 +83,21 @@ export function TerminalSettingsSection() {
           className="w-full max-w-md rounded-md border border-border bg-bg px-2 py-1 font-mono text-sm text-fg outline-none focus:border-accent"
         />
         <p className="mt-1 text-xs text-fg-muted">{t("terminalSettings.customShellHint")}</p>
+      </div>
+
+      <div className="mb-6">
+        <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg">
+          <input
+            type="checkbox"
+            checked={confirmCloseWithRunningTerminals}
+            onChange={(e) => setConfirmCloseWithRunningTerminals(e.target.checked)}
+            className="accent-accent"
+          />
+          {t("terminalSettings.confirmClose")}
+        </label>
+        <p className="mt-1 text-xs text-fg-muted">
+          {t("terminalSettings.confirmCloseHint")}
+        </p>
       </div>
 
       <div className="mb-6">

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -28,6 +28,7 @@ describe("settingsStore", () => {
       backgroundImageTextColor: null,
       terminalPadding: initialState.terminalPadding,
       wordWrap: initialState.wordWrap,
+      confirmCloseWithRunningTerminals: true,
       workspaceCard: { status: true, branch: true, cwd: true, pr: true },
       prSource: "auto",
       claudeFlags: initialState.claudeFlags,
@@ -292,5 +293,14 @@ describe("settingsStore", () => {
     expect(useSettingsStore.getState().customShellPath).toBe("");
     useSettingsStore.getState().setCustomShellPath("/opt/homebrew/bin/pwsh");
     expect(useSettingsStore.getState().customShellPath).toBe("/opt/homebrew/bin/pwsh");
+  });
+
+  it("defaults terminal close confirmation on and persists an opt-out", () => {
+    expect(useSettingsStore.getState().confirmCloseWithRunningTerminals).toBe(true);
+    useSettingsStore.getState().setConfirmCloseWithRunningTerminals(false);
+    expect(useSettingsStore.getState().confirmCloseWithRunningTerminals).toBe(false);
+    expect(localStorage.getItem("tempoterm-settings")).toContain(
+      '"confirmCloseWithRunningTerminals":false',
+    );
   });
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -78,6 +78,8 @@ interface SettingsState {
   wordWrap: boolean;
   /** Persist each terminal's scrollback and restore it on next launch. */
   restoreTerminalHistory: boolean;
+  /** Ask before closing a window or app that still owns live PTY/SSH sessions. */
+  confirmCloseWithRunningTerminals: boolean;
   /** Folder that backs global notes; null until the user picks one. */
   notesFolderPath: string | null;
   /** Which info blocks the workspace cards show. */
@@ -148,6 +150,7 @@ interface SettingsState {
   setTerminalPadding: (padding: number) => void;
   toggleWordWrap: () => void;
   setRestoreTerminalHistory: (value: boolean) => void;
+  setConfirmCloseWithRunningTerminals: (value: boolean) => void;
   setNotesFolderPath: (path: string | null) => void;
   setWorkspaceCardBlock: (key: keyof WorkspaceCardBlocks, value: boolean) => void;
   setGitGraphRefs: (patch: Partial<GitGraphRefSettings>) => void;
@@ -238,6 +241,7 @@ export const useSettingsStore = create<SettingsState>()(
       terminalPadding: DEFAULT_TERMINAL_PADDING,
       wordWrap: false,
       restoreTerminalHistory: true,
+      confirmCloseWithRunningTerminals: true,
       notesFolderPath: null,
       workspaceCard: DEFAULT_WORKSPACE_CARD,
       gitGraphRefs: DEFAULT_GIT_GRAPH_REFS,
@@ -285,6 +289,8 @@ export const useSettingsStore = create<SettingsState>()(
       setTerminalPadding: (padding) => set({ terminalPadding: clampPadding(padding) }),
       toggleWordWrap: () => set((s) => ({ wordWrap: !s.wordWrap })),
       setRestoreTerminalHistory: (value) => set({ restoreTerminalHistory: value }),
+      setConfirmCloseWithRunningTerminals: (value) =>
+        set({ confirmCloseWithRunningTerminals: value }),
       setNotesFolderPath: (path) => set({ notesFolderPath: path }),
       setWorkspaceCardBlock: (key, value) =>
         set((state) => ({ workspaceCard: { ...state.workspaceCard, [key]: value } })),
@@ -334,6 +340,10 @@ export const useSettingsStore = create<SettingsState>()(
             stored.backgroundImageTextColor,
           ),
           gitGraphRefs: normalizeGitGraphRefs(stored.gitGraphRefs),
+          confirmCloseWithRunningTerminals:
+            typeof stored.confirmCloseWithRunningTerminals === "boolean"
+              ? stored.confirmCloseWithRunningTerminals
+              : current.confirmCloseWithRunningTerminals,
         };
       },
     },


### PR DESCRIPTION
## 摘要

這是 #341 拆分後的第 2 個 PR，接續已合併的 #355，只處理仍有 live terminal／SSH session 時的關閉確認。

## 行為

- 預設開啟、可在終端機設定中停用 `confirmCloseWithRunningTerminals`
- 保護視窗關閉、macOS `⌘Q`、Windows `Alt+F4` 與 App-level exit
- 提示期間忽略重複關閉請求；確認後只繞過一次 guard
- PTY／SSH session 由 Rust 記錄所屬視窗，可分視窗計數與關閉
- macOS 使用外觀與快捷鍵相同的自訂 Quit 選單項目，避免 AppKit `terminate:` 略過可取消事件
- 原生對話框附著於正在關閉或目前聚焦的 WebView 視窗，確保 macOS sheet／Windows owner window 正確
- 移除舊有只清理次要視窗 PTY 的前端 lifecycle cleanup

公開 Tauri command 只新增前端實際使用的 `exit_guard_configure`；session 計數與關閉維持 Rust 內部介面。

## 驗證

- `CI=true pnpm test`：224 test files／2,045 tests passed
- `CI=true pnpm build`
- `RUSTFLAGS='-D warnings' cargo check`
- exit guard module：1 passed
- PTY module：36 passed
- SSH module：28 passed

### macOS 實機

使用獨立 bundle ID 的本機測試 App 建立 live PTY，確認：

- 關閉視窗會顯示附著於該視窗的原生提示
- 取消後視窗與 shell 持續執行
- `⌘Q` 顯示 App 結束提示
- 提示期間再次按 `⌘Q` 不會建立第二個對話框
- 選擇「仍要關閉」後視窗與 session 確實結束

Windows 編譯路徑由 CI 檢查；`Alt+F4`／關閉按鈕仍需在 Windows 實機確認。
