### PR TITLE
feat(git-graph): merge a branch with its remotes into one ref chip

### DIFF
--- a/src/i18n/locales/en/gitGraph.json
+++ b/src/i18n/locales/en/gitGraph.json
@@ -3,6 +3,7 @@
   "loadMore": "Load more",
   "dismiss": "Dismiss",
   "refHint": "{{name}} — right-click for options",
+  "moreRefs": "{{count}} more refs — click to list them",
   "empty": {
     "title": "No commits yet",
     "hint": "Make a commit to start building history, and it will appear here."
@@ -70,6 +71,8 @@
     "checkoutRemote": "Checkout branch… (git checkout --track)",
     "pull": "Pull into current branch (git pull)",
     "deleteRemote": "Delete remote branch… (git push --delete)",
+    "pullFrom": "Pull from {{remote}} (git pull)",
+    "deleteRemoteOn": "Delete branch on {{remote}}… (git push --delete)",
     "copyBranchName": "Copy branch name",
     "openWorktree": "Open worktree for this branch"
   },

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -6,8 +6,20 @@
     "fonts": "Fonts",
     "ai": "AI",
     "workspace": "Groups",
+    "gitGraph": "Git Graph",
     "shortcuts": "Shortcuts",
     "about": "About"
+  },
+  "gitGraph": {
+    "refsTitle": "Branch labels",
+    "refsDescription": "How the Git Graph condenses the branch and tag chips on a commit row.",
+    "mergeLocalRemoteLabel": "Merge a branch with its remotes",
+    "mergeLocalRemoteHint": "The branch and each remote carrying it become blocks of a single chip, with one right-click menu for both. A remote that is ahead or behind keeps its own origin/… chip.",
+    "hideOriginHeadLabel": "Hide origin/HEAD",
+    "hideOriginHeadHint": "A symbolic link to the remote's default branch — the same commit its own branch chip already marks.",
+    "collapseLabel": "Collapse extra labels into +N",
+    "refLimitLabel": "Labels shown",
+    "collapseHint": "Anything past the limit hides behind a +N chip that lists the rest, so the commit message keeps its room."
   },
   "workspace": {
     "blocksTitle": "Card details",

--- a/src/i18n/locales/zh-Hant/gitGraph.json
+++ b/src/i18n/locales/zh-Hant/gitGraph.json
@@ -3,6 +3,7 @@
   "loadMore": "載入更多",
   "dismiss": "關閉",
   "refHint": "{{name}}，按右鍵開啟選單",
+  "moreRefs": "另有 {{count}} 個 ref，點擊展開",
   "empty": {
     "title": "還沒有任何提交",
     "hint": "做一次提交開始建立歷史紀錄，之後就會顯示在這裡。"
@@ -70,6 +71,8 @@
     "checkoutRemote": "建立本地分支並切換… (git checkout --track)",
     "pull": "拉取到目前分支 (git pull)",
     "deleteRemote": "刪除遠端分支… (git push --delete)",
+    "pullFrom": "從 {{remote}} 拉取 (git pull)",
+    "deleteRemoteOn": "刪除 {{remote}} 上的分支… (git push --delete)",
     "copyBranchName": "複製分支名稱",
     "openWorktree": "為這個分支開 worktree"
   },

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -6,8 +6,20 @@
     "fonts": "字體",
     "ai": "AI",
     "workspace": "群組",
+    "gitGraph": "Git Graph",
     "shortcuts": "快捷鍵",
     "about": "關於"
+  },
+  "gitGraph": {
+    "refsTitle": "分支標籤",
+    "refsDescription": "Git Graph 在 commit 列上如何精簡分支與標籤 chip。",
+    "mergeLocalRemoteLabel": "同名的本地與遠端分支合併成一顆",
+    "mergeLocalRemoteHint": "本地分支與帶著它的每個遠端，在同一顆 chip 上各佔一塊，右鍵選單一次涵蓋本地與遠端操作。超前／落後的遠端分支仍保有自己的 origin/… chip。",
+    "hideOriginHeadLabel": "隱藏 origin/HEAD",
+    "hideOriginHeadHint": "它只是遠端預設分支的符號連結，指向的 commit 已經有自己的分支 chip 標著了。",
+    "collapseLabel": "超量的標籤收合成 +N",
+    "refLimitLabel": "列上顯示幾顆",
+    "collapseHint": "超過上限的收進 +N chip，點開即可列出其餘標籤，commit 訊息因此保有可視空間。"
   },
   "workspace": {
     "blocksTitle": "卡片資訊",

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Check, Clock, GitBranch, Tag, User } from "lucide-react";
+import { Clock, GitBranch, User } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
 import type { CommitNode, CommitRef, GraphSelection } from "./types";
+import { RefChipStrip } from "./RefChipStrip";
+import { DEFAULT_REF_CHIP_OPTIONS, type RefChipOptions } from "./lib/refChips";
 import {
   computeGraphLayout,
   DEFAULT_GEOMETRY,
@@ -18,6 +20,7 @@ export interface GitGraphLabels {
   emptyHint: string;
   loadMore: string;
   refHint: string;
+  moreRefs: string;
 }
 
 interface GitGraphProps {
@@ -25,21 +28,19 @@ interface GitGraphProps {
   selection: GraphSelection | null;
   onSelectCommit: (commit: CommitNode, options: { shiftKey: boolean }) => void;
   onCommitContextMenu?: (commit: CommitNode, x: number, y: number) => void;
-  onRefContextMenu?: (ref: CommitRef, x: number, y: number) => void;
+  onRefContextMenu?: (
+    ref: CommitRef,
+    /** Remote refs folded into the clicked chip; empty for an unmerged one. */
+    remotes: CommitRef[],
+    x: number,
+    y: number,
+  ) => void;
+  /** How ref chips are condensed; defaults to the shipped defaults. */
+  refChipOptions?: RefChipOptions;
   hasMore?: boolean;
   onLoadMore?: () => void;
   labels: GitGraphLabels;
 }
-
-// Decoration chip styles per ref kind, built from semantic tokens.
-const REF_CHIP_STYLES: Record<string, string> = {
-  head: "border-success/40 bg-success/15 text-success",
-  branch: "border-accent/40 bg-accent/15 text-accent",
-  tag: "border-warning/40 bg-warning/15 text-warning",
-  remote: "border-border-strong bg-bg-inset text-fg-subtle",
-  stash: "border-purple-500/40 bg-purple-500/15 text-purple-500",
-  unknown: "border-border bg-bg-inset text-fg-subtle",
-};
 
 const NODE_RADIUS = 6;
 const ROW_HEIGHT = DEFAULT_GEOMETRY.rowHeight;
@@ -51,6 +52,7 @@ export function GitGraph({
   onSelectCommit,
   onCommitContextMenu,
   onRefContextMenu,
+  refChipOptions = DEFAULT_REF_CHIP_OPTIONS,
   hasMore = false,
   onLoadMore,
   labels,
@@ -346,43 +348,12 @@ export function GitGraph({
                       {commit.hash}
                     </span>
 
-                    {commit.refs.map((ref) => {
-                      // head / branch / tag / remote are actionable; unknown
-                      // refs stay read-only with no context menu.
-                      const interactive =
-                        ref.kind === "tag" ||
-                        ref.kind === "branch" ||
-                        ref.kind === "head" ||
-                        ref.kind === "remote";
-                      const chip = REF_CHIP_STYLES[ref.kind] ?? REF_CHIP_STYLES.branch;
-                      return (
-                        <Tooltip
-                          key={`${ref.kind}:${ref.name}`}
-                          label={interactive ? labels.refHint.replace("{{name}}", ref.name) : ref.name}
-                          className="shrink-0"
-                        >
-                          <span
-                            onClick={(e) => e.stopPropagation()}
-                            onContextMenu={
-                              interactive
-                                ? (e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    onRefContextMenu?.(ref, e.clientX, e.clientY);
-                                  }
-                                : undefined
-                            }
-                            className={`flex select-none items-center space-x-0.5 rounded border px-1.5 py-0.5 text-[12px] font-medium ${chip} ${
-                              interactive ? "cursor-context-menu" : ""
-                            }`}
-                          >
-                            {ref.kind === "tag" && <Tag className="h-2.5 w-2.5" />}
-                            {ref.kind === "head" && <Check className="h-2.5 w-2.5" />}
-                            <span>{ref.name}</span>
-                          </span>
-                        </Tooltip>
-                      );
-                    })}
+                    <RefChipStrip
+                      refs={commit.refs}
+                      options={refChipOptions}
+                      labels={labels}
+                      onRefContextMenu={onRefContextMenu}
+                    />
 
                     <span className="truncate font-sans text-[13px] font-medium text-fg">
                       {commit.message}

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -36,6 +36,8 @@ import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore"
 import { filterCommits } from "./lib/filterCommits";
 import { buildCommitMenu, buildRefMenu } from "./lib/contextMenuItems";
 import { splitRemoteRef } from "./lib/remoteRef";
+import type { RefChipOptions } from "./lib/refChips";
+import { useSettingsStore } from "@/stores/settingsStore";
 import { withMinDuration } from "@/lib/withMinDuration";
 import type { Branch, CommitNode, CommitRef, CommitOrder, GraphOptions, GraphSelection } from "./types";
 
@@ -46,7 +48,7 @@ const MIN_BUSY_MS = 400;
 
 type MenuTarget =
   | { type: "commit"; commit: CommitNode; x: number; y: number }
-  | { type: "ref"; ref: CommitRef; x: number; y: number };
+  | { type: "ref"; ref: CommitRef; remotes: CommitRef[]; x: number; y: number };
 
 interface ModalState {
   title: string;
@@ -70,6 +72,7 @@ function getErrorMessage(error: unknown): string {
 export function GitGraphTabContent() {
   const { t } = useTranslation("gitGraph");
   const rootPath = useWorkspaceStore((s) => s.rootPath);
+  const gitGraphRefs = useSettingsStore((s) => s.gitGraphRefs);
 
   const [repo, setRepo] = useState<string | null>(null);
   const [resolved, setResolved] = useState(false);
@@ -451,11 +454,19 @@ export function GitGraphTabContent() {
     );
   }, []);
 
+  // The user's Git Graph display settings, in the shape buildRefChips wants.
+  const refChipOptions: RefChipOptions = {
+    mergeLocalRemote: gitGraphRefs.mergeLocalRemote,
+    hideOriginHead: gitGraphRefs.hideOriginHead,
+    collapseAfter: gitGraphRefs.collapseExtraRefs ? gitGraphRefs.refLimit : null,
+  };
+
   const labels: GitGraphLabels = {
     emptyTitle: t("empty.title"),
     emptyHint: t("empty.hint"),
     loadMore: t("loadMore"),
     refHint: t("refHint"),
+    moreRefs: t("moreRefs"),
   };
 
   const detailsLabels: CommitDetailsLabels = {
@@ -550,7 +561,9 @@ export function GitGraphTabContent() {
     );
 
   // Build the right-click menu for a branch / tag / remote / HEAD decoration.
-  const refMenuItems = (ref: CommitRef): ContextMenuItem[] =>
+  // `remotes` are the remote refs merged into the chip, so one menu covers both
+  // the local branch and every remote that has it at this commit.
+  const refMenuItems = (ref: CommitRef, remotes: CommitRef[]): ContextMenuItem[] =>
     buildRefMenu(
       ref,
       {
@@ -564,6 +577,8 @@ export function GitGraphTabContent() {
         deleteRemote: t("menu.deleteRemote"),
         copyBranchName: t("menu.copyBranchName"),
         openWorktree: t("menu.openWorktree"),
+        pullFrom: (remote: string) => t("menu.pullFrom", { remote }),
+        deleteRemoteOn: (remote: string) => t("menu.deleteRemoteOn", { remote }),
       },
       {
         onCheckout: () => void runAction(() => gitBranchCheckout(repo!, ref.name)),
@@ -572,15 +587,15 @@ export function GitGraphTabContent() {
         onDeleteTag: () => void runAction(() => gitTagDelete(repo!, ref.name)),
         onCheckoutRemote: () => openCheckoutRemoteModal(ref.name),
         onMergeRemote: () => void runAction(() => gitMerge(repo!, ref.name)),
-        onPull: () => {
-          const { remote, branch } = splitRemoteRef(ref.name);
+        onPull: (remoteRef) => {
+          const { remote, branch } = splitRemoteRef(remoteRef);
           void runAction(() => gitPull(repo!, remote, branch));
         },
-        onDeleteRemote: () => {
-          const { remote, branch } = splitRemoteRef(ref.name);
+        onDeleteRemote: (remoteRef) => {
+          const { remote, branch } = splitRemoteRef(remoteRef);
           setModal({
             title: t("modal.deleteRemote.title"),
-            message: t("modal.deleteRemote.message", { name: ref.name }),
+            message: t("modal.deleteRemote.message", { name: remoteRef }),
             confirmLabel: t("modal.deleteRemote.confirm"),
             confirmDanger: true,
             fields: [],
@@ -597,6 +612,7 @@ export function GitGraphTabContent() {
           }
         },
       },
+      remotes,
     );
 
   if (resolved && !repo) {
@@ -662,7 +678,10 @@ export function GitGraphTabContent() {
             onCommitContextMenu={(commit, x, y) =>
               setMenu({ type: "commit", commit, x, y })
             }
-            onRefContextMenu={(ref, x, y) => setMenu({ type: "ref", ref, x, y })}
+            onRefContextMenu={(ref, remotes, x, y) =>
+              setMenu({ type: "ref", ref, remotes, x, y })
+            }
+            refChipOptions={refChipOptions}
             hasMore={hasMore}
             onLoadMore={loadMore}
             labels={labels}
@@ -694,9 +713,10 @@ export function GitGraphTabContent() {
           const items =
             menu.type === "commit"
               ? commitMenuItems(menu.commit)
-              : refMenuItems(menu.ref);
-          // The current branch (kind "head") has no applicable actions; skip the
-          // menu rather than flashing an empty one.
+              : refMenuItems(menu.ref, menu.remotes);
+          // The current branch (kind "head") with no remote folded into its chip
+          // has no applicable actions; skip the menu rather than flashing an
+          // empty one.
           if (items.length === 0) {
             return null;
           }

--- a/src/modules/git-graph/RefChipStrip.test.tsx
+++ b/src/modules/git-graph/RefChipStrip.test.tsx
@@ -1,0 +1,165 @@
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RefChipStrip } from "./RefChipStrip";
+import type { RefChipOptions } from "./lib/refChips";
+import type { CommitRef } from "./types";
+
+const LABELS = { refHint: "{{name}}", moreRefs: "{{count}} more" };
+const OPTIONS: RefChipOptions = {
+  mergeLocalRemote: true,
+  hideOriginHead: true,
+  collapseAfter: 3,
+};
+
+function ref(kind: string, name: string): CommitRef {
+  return { kind, name };
+}
+
+describe("RefChipStrip", () => {
+  function chipOf(text: string): HTMLElement {
+    return screen.getByText(text).closest("span.rounded.border") as HTMLElement;
+  }
+
+  it("paints one chip for a branch and its remotes, and drops origin/HEAD", () => {
+    render(
+      <RefChipStrip
+        refs={[ref("head", "master"), ref("remote", "origin/master"), ref("remote", "origin/HEAD")]}
+        options={OPTIONS}
+        labels={LABELS}
+      />,
+    );
+
+    // One chip, two blocks: the branch and the remote that carries it.
+    const chip = chipOf("master");
+    expect(chip.textContent).toBe("masterorigin");
+    expect(chipOf("origin")).toBe(chip);
+    expect(screen.queryByText("origin/HEAD")).toBeNull();
+  });
+
+  it("hands the merged remotes to the context-menu handler, not just the local ref", () => {
+    const onRefContextMenu = vi.fn();
+    render(
+      <RefChipStrip
+        refs={[ref("head", "master"), ref("remote", "origin/master")]}
+        options={OPTIONS}
+        labels={LABELS}
+        onRefContextMenu={onRefContextMenu}
+      />,
+    );
+
+    fireEvent.contextMenu(chipOf("origin"), { clientX: 5, clientY: 7 });
+    expect(onRefContextMenu).toHaveBeenCalledWith(
+      { kind: "head", name: "master" },
+      [{ kind: "remote", name: "origin/master" }],
+      5,
+      7,
+    );
+  });
+
+  it("keeps the row short with a +N chip that lists the rest on click", () => {
+    render(
+      <RefChipStrip
+        refs={[
+          ref("head", "master"),
+          ref("branch", "a"),
+          ref("branch", "b"),
+          ref("branch", "c"),
+          ref("tag", "v1"),
+        ]}
+        options={OPTIONS}
+        labels={LABELS}
+      />,
+    );
+
+    expect(screen.queryByText("c")).toBeNull();
+    const more = screen.getByRole("button", { name: "+2" });
+    fireEvent.click(more);
+
+    expect(screen.getByText("c")).toBeTruthy();
+    expect(screen.getByText("v1")).toBeTruthy();
+  });
+
+  it("right-clicking an overflow chip opens its menu and leaves the list up", () => {
+    const onRefContextMenu = vi.fn();
+    render(
+      <RefChipStrip
+        refs={[ref("branch", "a"), ref("branch", "b"), ref("branch", "c"), ref("branch", "d")]}
+        options={OPTIONS}
+        labels={LABELS}
+        onRefContextMenu={onRefContextMenu}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "+1" }));
+    fireEvent.contextMenu(screen.getByText("d"), { clientX: 1, clientY: 2 });
+
+    expect(onRefContextMenu).toHaveBeenCalledWith({ kind: "branch", name: "d" }, [], 1, 2);
+    // The other refs stay a right-click away instead of vanishing under the menu.
+    expect(screen.getByText("d")).toBeTruthy();
+  });
+
+  it("opens the list on a right-click too, rather than dead-ending there", () => {
+    const onRefContextMenu = vi.fn();
+    render(
+      <RefChipStrip
+        refs={[ref("branch", "a"), ref("branch", "b"), ref("branch", "c"), ref("branch", "d")]}
+        options={OPTIONS}
+        labels={LABELS}
+        onRefContextMenu={onRefContextMenu}
+      />,
+    );
+
+    const more = screen.getByRole("button", { name: "+1" });
+    const event = createEvent.contextMenu(more);
+    fireEvent(more, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(screen.getByText("d")).toBeTruthy();
+    // It is not a ref, so it never opens a ref menu of its own.
+    expect(onRefContextMenu).not.toHaveBeenCalled();
+  });
+
+  it("keeps the list under the tooltip layer so its chips' tooltips stay visible", () => {
+    render(
+      <RefChipStrip
+        refs={[ref("branch", "a"), ref("branch", "b"), ref("branch", "c"), ref("branch", "d")]}
+        options={OPTIONS}
+        labels={LABELS}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "+1" }));
+    const list = screen.getByText("d").closest("div[class*='z-']") as HTMLElement;
+    // Tooltip renders at z-100, the ref context menu at z-200.
+    expect(list.className).toContain("z-[95]");
+  });
+
+  it("gives the chips with a menu a hover state, and read-only ones none", () => {
+    render(
+      <RefChipStrip
+        refs={[ref("branch", "a"), ref("unknown", "refs/notes/commits")]}
+        options={OPTIONS}
+        labels={LABELS}
+      />,
+    );
+
+    expect(chipOf("a").className).toContain("hover:");
+    // Lighting up would promise a right-click menu this ref does not have.
+    expect(chipOf("refs/notes/commits").className).not.toContain("hover:");
+  });
+
+  it("leaves every ref on the row when the user turns the options off", () => {
+    render(
+      <RefChipStrip
+        refs={[ref("head", "master"), ref("remote", "origin/master"), ref("remote", "origin/HEAD")]}
+        options={{ mergeLocalRemote: false, hideOriginHead: false, collapseAfter: null }}
+        labels={LABELS}
+      />,
+    );
+
+    expect(screen.getByText("master")).toBeTruthy();
+    expect(screen.getByText("origin/master")).toBeTruthy();
+    expect(screen.getByText("origin/HEAD")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/src/modules/git-graph/RefChipStrip.test.tsx
+++ b/src/modules/git-graph/RefChipStrip.test.tsx
@@ -148,6 +148,61 @@ describe("RefChipStrip", () => {
     expect(chipOf("refs/notes/commits").className).not.toContain("hover:");
   });
 
+  it("stays open while its own list scrolls, and closes when anything else does", () => {
+    render(
+      <RefChipStrip
+        refs={[
+          ref("branch", "one"),
+          ref("branch", "two"),
+          ref("branch", "three"),
+          ref("branch", "four"),
+          ref("branch", "five"),
+        ]}
+        options={OPTIONS}
+        labels={LABELS}
+      />,
+    );
+    fireEvent.click(screen.getByText("+2"));
+    const list = screen.getByText("five").closest("div") as HTMLElement;
+
+    // The list itself is max-h + overflow-y-auto: reading past its fold is a
+    // scroll event whose target is the list. Capture-phase listeners on window
+    // see it too, and closing on it would make the tail unreachable.
+    fireEvent.scroll(list);
+    expect(screen.queryByText("five")).not.toBeNull();
+
+    // The graph scrolling underneath is what the dismissal is for.
+    fireEvent.scroll(document);
+    expect(screen.queryByText("five")).toBeNull();
+  });
+
+  it("closes on Escape and on a click outside, but not on a click inside", () => {
+    render(
+      <RefChipStrip
+        refs={[
+          ref("branch", "one"),
+          ref("branch", "two"),
+          ref("branch", "three"),
+          ref("branch", "four"),
+        ]}
+        options={OPTIONS}
+        labels={LABELS}
+      />,
+    );
+    const opener = screen.getByText("+1");
+
+    fireEvent.click(opener);
+    fireEvent.mouseDown(screen.getByText("four"));
+    expect(screen.queryByText("four")).not.toBeNull();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByText("four")).toBeNull();
+
+    fireEvent.click(opener);
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText("four")).toBeNull();
+  });
+
   it("leaves every ref on the row when the user turns the options off", () => {
     render(
       <RefChipStrip

--- a/src/modules/git-graph/RefChipStrip.tsx
+++ b/src/modules/git-graph/RefChipStrip.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Check, Tag } from "lucide-react";
+import { Tooltip } from "@/components/Tooltip";
+import type { CommitRef } from "./types";
+import { buildRefChips, type RefChip, type RefChipOptions } from "./lib/refChips";
+
+// Decoration chip styles per ref kind, built from semantic tokens.
+export const REF_CHIP_STYLES: Record<string, string> = {
+  head: "border-success/40 bg-success/15 text-success",
+  branch: "border-accent/40 bg-accent/15 text-accent",
+  tag: "border-warning/40 bg-warning/15 text-warning",
+  remote: "border-border-strong bg-bg-inset text-fg-subtle",
+  stash: "border-purple-500/40 bg-purple-500/15 text-purple-500",
+  unknown: "border-border bg-bg-inset text-fg-subtle",
+};
+
+// Hover state, only ever applied to the kinds that actually have a menu — a
+// read-only decoration lighting up would promise an action that isn't there.
+// Deliberately faint: one step of the same colour, no colour change, so that
+// dragging the pointer across a row of chips doesn't set off a light show.
+const REF_CHIP_HOVER_STYLES: Record<string, string> = {
+  head: "hover:border-success/55 hover:bg-success/20",
+  branch: "hover:border-accent/55 hover:bg-accent/20",
+  tag: "hover:border-warning/55 hover:bg-warning/20",
+  // A grey chip has no hue to deepen, so its step is the fill lifting from
+  // inset to elevated — a comparable amount of change, just in lightness.
+  remote: "hover:border-fg-subtle/40 hover:bg-bg-elevated",
+};
+
+export interface RefChipLabels {
+  /** "{{name}} — right-click for options" */
+  refHint: string;
+  /** "{{count}} more refs — click to show" */
+  moreRefs: string;
+}
+
+type RefMenuHandler = (ref: CommitRef, remotes: CommitRef[], x: number, y: number) => void;
+
+/** head / branch / tag / remote are actionable; the rest are read-only. */
+function isInteractive(kind: string): boolean {
+  return kind === "tag" || kind === "branch" || kind === "head" || kind === "remote";
+}
+
+function Chip({
+  chip,
+  labels,
+  onRefContextMenu,
+}: {
+  chip: RefChip;
+  labels: RefChipLabels;
+  onRefContextMenu?: RefMenuHandler;
+}) {
+  const interactive = isInteractive(chip.ref.kind);
+  const style = REF_CHIP_STYLES[chip.ref.kind] ?? REF_CHIP_STYLES.branch;
+  return (
+    <Tooltip
+      label={interactive ? labels.refHint.replace("{{name}}", chip.label) : chip.label}
+      className="shrink-0"
+    >
+      <span
+        onClick={(e) => e.stopPropagation()}
+        onContextMenu={
+          interactive
+            ? (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onRefContextMenu?.(chip.ref, chip.remotes, e.clientX, e.clientY);
+              }
+            : undefined
+        }
+        // leading-4 pins the line box: without it the chip inherits the row's
+        // line-height, so the italic remote block's font metrics make a merged
+        // chip a hair taller than a plain one sitting next to it.
+        className={`flex select-none items-center rounded border text-[12px] font-medium leading-4 transition-colors ${style} ${
+          interactive ? `cursor-context-menu ${REF_CHIP_HOVER_STYLES[chip.ref.kind] ?? ""}` : ""
+        }`}
+      >
+        <span className="flex items-center space-x-0.5 px-1.5 py-0.5">
+          {chip.ref.kind === "tag" && <Tag className="h-2.5 w-2.5" />}
+          {chip.ref.kind === "head" && <Check className="h-2.5 w-2.5" />}
+          <span>{chip.ref.name}</span>
+        </span>
+        {/* Each merged remote gets its own block inside the same chip, so the
+            branch and the remotes that carry it read as one thing without a
+            separator character having to stand in for the divider. */}
+        {chip.remoteNames.map((remote) => (
+          <span
+            key={remote}
+            className="border-l border-current/30 px-1.5 py-0.5 italic"
+          >
+            {remote}
+          </span>
+        ))}
+      </span>
+    </Tooltip>
+  );
+}
+
+/**
+ * The `+N` chip and the list it opens. The list is a portal, like ContextMenu,
+ * because the commit row clips its own overflow — and its entries are the same
+ * chips as the row's, right-click menus included, so nothing is demoted to a
+ * plain text list by being pushed off the row.
+ */
+function OverflowChips({
+  overflow,
+  labels,
+  onRefContextMenu,
+}: {
+  overflow: RefChip[];
+  labels: RefChipLabels;
+  onRefContextMenu?: RefMenuHandler;
+}) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ left: 0, top: 0 });
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
+    const anchor = buttonRef.current?.getBoundingClientRect();
+    const list = listRef.current?.getBoundingClientRect();
+    if (!anchor || !list) {
+      return;
+    }
+    const pad = 8;
+    const left = Math.max(pad, Math.min(anchor.left, window.innerWidth - list.width - pad));
+    const top =
+      anchor.bottom + 4 + list.height > window.innerHeight - pad
+        ? Math.max(pad, anchor.top - 4 - list.height)
+        : anchor.bottom + 4;
+    setPos({ left, top });
+  }, [open, overflow.length]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const close = () => setOpen(false);
+    function onPointerDown(event: MouseEvent) {
+      const target = event.target as Node;
+      if (listRef.current?.contains(target) || buttonRef.current?.contains(target)) {
+        return;
+      }
+      close();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        close();
+      }
+    }
+    document.addEventListener("mousedown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    // The list is anchored to a row that scrolls away underneath it.
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close, true);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close, true);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <Tooltip
+        label={labels.moreRefs.replace("{{count}}", String(overflow.length))}
+        className="shrink-0"
+      >
+        <button
+          ref={buttonRef}
+          type="button"
+          aria-haspopup="true"
+          aria-expanded={open}
+          onClick={(e) => {
+            e.stopPropagation();
+            setOpen((prev) => !prev);
+          }}
+          onContextMenu={(e) => {
+            // The +N chip is not a ref, so it has no menu of its own — but a
+            // right-click on it must not fall through to the row's menu, and
+            // ending there as a dead end (having just dismissed whatever menu
+            // was open) is worse than simply showing the list.
+            e.preventDefault();
+            e.stopPropagation();
+            setOpen(true);
+          }}
+          className={`flex select-none items-center rounded border border-border-strong bg-bg-inset px-1.5 py-0.5 text-[12px] font-medium leading-4 text-fg-muted transition-colors hover:border-fg-subtle/40 hover:bg-bg-elevated hover:text-fg ${
+            open ? "border-accent text-fg" : ""
+          }`}
+        >
+          +{overflow.length}
+        </button>
+      </Tooltip>
+      {open &&
+        createPortal(
+          <div
+            ref={listRef}
+            style={{ position: "fixed", left: pos.left, top: pos.top }}
+            onClick={(e) => e.stopPropagation()}
+            // Below the tooltip layer (z-100): the chips in here have tooltips
+            // of their own, and a list painted over them would hide every one.
+            className="z-[95] flex max-h-[50vh] flex-col items-start gap-1 overflow-y-auto rounded-md border border-border-strong bg-bg-elevated p-1.5 shadow-lg"
+          >
+            {/* The list stays open behind the ref menu it just opened, so the
+                other refs are still there to right-click next; the menu paints
+                above it (z-200) and the outside-click that picks an item is
+                what closes the list. */}
+            {overflow.map((chip) => (
+              <Chip
+                key={chip.key}
+                chip={chip}
+                labels={labels}
+                onRefContextMenu={onRefContextMenu}
+              />
+            ))}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+/**
+ * The ref decorations of one commit row, condensed per the user's Git Graph
+ * settings: same-named local/remote branches share a chip, `origin/HEAD` is
+ * dropped, and anything past the limit hides behind `+N` so the commit message
+ * keeps its room.
+ */
+export function RefChipStrip({
+  refs,
+  options,
+  labels,
+  onRefContextMenu,
+}: {
+  refs: CommitRef[];
+  options: RefChipOptions;
+  labels: RefChipLabels;
+  onRefContextMenu?: RefMenuHandler;
+}) {
+  const { chips, overflow } = buildRefChips(refs, options);
+  return (
+    <>
+      {chips.map((chip) => (
+        <Chip key={chip.key} chip={chip} labels={labels} onRefContextMenu={onRefContextMenu} />
+      ))}
+      {overflow.length > 0 && (
+        <OverflowChips
+          overflow={overflow}
+          labels={labels}
+          onRefContextMenu={onRefContextMenu}
+        />
+      )}
+    </>
+  );
+}

--- a/src/modules/git-graph/RefChipStrip.tsx
+++ b/src/modules/git-graph/RefChipStrip.tsx
@@ -152,15 +152,24 @@ function OverflowChips({
         close();
       }
     }
+    function onScroll(event: Event) {
+      // Capture-phase scroll on window sees every descendant's scrolling,
+      // including the list's own overflow-y-auto box — and closing on that
+      // would put the tail of a long list permanently out of reach.
+      if (listRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      close();
+    }
     document.addEventListener("mousedown", onPointerDown, true);
     document.addEventListener("keydown", onKeyDown, true);
     // The list is anchored to a row that scrolls away underneath it.
-    window.addEventListener("scroll", close, true);
+    window.addEventListener("scroll", onScroll, true);
     window.addEventListener("resize", close, true);
     return () => {
       document.removeEventListener("mousedown", onPointerDown, true);
       document.removeEventListener("keydown", onKeyDown, true);
-      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("scroll", onScroll, true);
       window.removeEventListener("resize", close, true);
     };
   }, [open]);

--- a/src/modules/git-graph/lib/contextMenuItems.test.ts
+++ b/src/modules/git-graph/lib/contextMenuItems.test.ts
@@ -20,6 +20,8 @@ const refLabels: RefMenuLabels = {
   deleteRemote: "Delete remote branch",
   copyBranchName: "Copy branch name",
   openWorktree: "Open worktree for this branch",
+  pullFrom: (remote: string) => `Pull from ${remote}`,
+  deleteRemoteOn: (remote: string) => `Delete branch on ${remote}`,
 };
 
 function refActions(): RefMenuActions {
@@ -98,9 +100,61 @@ describe("buildRefMenu", () => {
     expect(items.find((i) => i.id === "deleteBranch")?.danger).toBe(true);
   });
 
-  it("offers nothing for the current branch (head)", () => {
+  it("offers nothing for the current branch (head) with no remote folded in", () => {
     const ref: CommitRef = { name: "main", kind: "head" };
     expect(buildRefMenu(ref, refLabels, refActions())).toEqual([]);
+  });
+
+  it("covers local and remote actions in one menu for a merged chip", () => {
+    const ref: CommitRef = { name: "master", kind: "branch" };
+    const remotes: CommitRef[] = [{ name: "origin/master", kind: "remote" }];
+    const items = buildRefMenu(ref, refLabels, refActions(), remotes);
+    expect(ids(items)).toEqual([
+      "checkout",
+      "merge",
+      "openWorktree",
+      "pull:origin/master",
+      "deleteBranch",
+      "deleteRemote:origin/master",
+      "copyBranchName",
+    ]);
+    // Both deletions sit in the same group so one divider fences them off.
+    expect(items.find((i) => i.id === "deleteBranch")?.group).toBe(2);
+    expect(items.find((i) => i.id === "deleteRemote:origin/master")?.group).toBe(2);
+    expect(items.find((i) => i.id === "deleteRemote:origin/master")?.danger).toBe(true);
+  });
+
+  it("gives the current branch its remotes' actions once they are merged in", () => {
+    const ref: CommitRef = { name: "master", kind: "head" };
+    const remotes: CommitRef[] = [
+      { name: "origin/master", kind: "remote" },
+      { name: "upstream/master", kind: "remote" },
+    ];
+    const items = buildRefMenu(ref, refLabels, refActions(), remotes);
+    expect(ids(items)).toEqual([
+      "pull:origin/master",
+      "pull:upstream/master",
+      "deleteRemote:origin/master",
+      "deleteRemote:upstream/master",
+      "copyBranchName",
+    ]);
+    // With several remotes the label has to say which one it acts on.
+    expect(items[0].label).toBe("Pull from origin");
+    expect(items[1].label).toBe("Pull from upstream");
+  });
+
+  it("passes each merged remote's own ref name to pull and delete", () => {
+    const actions = refActions();
+    const ref: CommitRef = { name: "master", kind: "head" };
+    const remotes: CommitRef[] = [
+      { name: "origin/master", kind: "remote" },
+      { name: "upstream/master", kind: "remote" },
+    ];
+    const items = buildRefMenu(ref, refLabels, actions, remotes);
+    items.find((i) => i.id === "pull:upstream/master")?.onSelect();
+    items.find((i) => i.id === "deleteRemote:origin/master")?.onSelect();
+    expect(actions.onPull).toHaveBeenCalledWith("upstream/master");
+    expect(actions.onDeleteRemote).toHaveBeenCalledWith("origin/master");
   });
 
   it("wires the remote actions to their callbacks", () => {
@@ -113,8 +167,8 @@ describe("buildRefMenu", () => {
     items.find((i) => i.id === "deleteRemote")?.onSelect();
     expect(actions.onCopyBranchName).toHaveBeenCalledTimes(1);
     expect(actions.onCheckoutRemote).toHaveBeenCalledTimes(1);
-    expect(actions.onPull).toHaveBeenCalledTimes(1);
-    expect(actions.onDeleteRemote).toHaveBeenCalledTimes(1);
+    expect(actions.onPull).toHaveBeenCalledWith("origin/feat/x");
+    expect(actions.onDeleteRemote).toHaveBeenCalledWith("origin/feat/x");
   });
 });
 

--- a/src/modules/git-graph/lib/contextMenuItems.ts
+++ b/src/modules/git-graph/lib/contextMenuItems.ts
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import type { ContextMenuItem } from "@/components/ContextMenu";
 import type { CommitRef } from "../types";
+import { splitRemoteRef } from "./remoteRef";
 
 /**
  * Pure assembly of the git graph's right-click menus. Labels are passed in
@@ -129,6 +130,9 @@ export interface RefMenuLabels {
   deleteRemote: string;
   copyBranchName: string;
   openWorktree: string;
+  /** Names the remote, for a merged chip where the label alone is ambiguous. */
+  pullFrom: (remote: string) => string;
+  deleteRemoteOn: (remote: string) => string;
 }
 
 export interface RefMenuActions {
@@ -138,16 +142,23 @@ export interface RefMenuActions {
   onDeleteTag: () => void;
   onCheckoutRemote: () => void;
   onMergeRemote: () => void;
-  onPull: () => void;
-  onDeleteRemote: () => void;
+  /** Take the full remote ref name ("origin/master") — a merged chip has several. */
+  onPull: (remoteRef: string) => void;
+  onDeleteRemote: (remoteRef: string) => void;
   onCopyBranchName: () => void;
   onOpenWorktree: () => void;
 }
 
+/**
+ * `remotes` are the remote refs folded into this chip by `buildRefChips`. They
+ * turn the local chip's menu into the one place both halves of a branch are
+ * operated on, so the user no longer has to know which chip owns pull.
+ */
 export function buildRefMenu(
   ref: CommitRef,
   labels: RefMenuLabels,
   actions: RefMenuActions,
+  remotes: CommitRef[] = [],
 ): ContextMenuItem[] {
   if (ref.kind === "tag") {
     return [
@@ -162,34 +173,75 @@ export function buildRefMenu(
     ];
   }
 
-  if (ref.kind === "branch") {
-    return [
-      {
-        id: "checkout",
-        label: labels.checkout,
-        icon: GitBranch,
-        group: 0,
-        onSelect: actions.onCheckout,
-      },
-      { id: "merge", label: labels.merge, icon: GitMerge, group: 0, onSelect: actions.onMerge },
-      {
-        // Branch off without leaving what you are doing: unlike checkout, this
-        // touches neither the current working tree nor whatever is running in it.
-        id: "openWorktree",
-        label: labels.openWorktree,
-        icon: FolderGit2,
-        group: 0,
-        onSelect: actions.onOpenWorktree,
-      },
-      {
+  if (ref.kind === "branch" || ref.kind === "head") {
+    // A merged chip owns both halves of the branch, so its menu runs
+    // checkout/merge, then pull, then the deletions, then copy.
+    const isBranch = ref.kind === "branch";
+    const items: ContextMenuItem[] = [];
+    if (isBranch) {
+      items.push(
+        {
+          id: "checkout",
+          label: labels.checkout,
+          icon: GitBranch,
+          group: 0,
+          onSelect: actions.onCheckout,
+        },
+        { id: "merge", label: labels.merge, icon: GitMerge, group: 0, onSelect: actions.onMerge },
+        {
+          // Branch off without leaving what you are doing: unlike checkout, this
+          // touches neither the current working tree nor whatever is running in it.
+          id: "openWorktree",
+          label: labels.openWorktree,
+          icon: FolderGit2,
+          group: 0,
+          onSelect: actions.onOpenWorktree,
+        },
+      );
+    }
+    // The current branch with nothing folded in has no applicable actions.
+    if (remotes.length === 0 && !isBranch) {
+      return items;
+    }
+    for (const remote of remotes) {
+      items.push({
+        id: `pull:${remote.name}`,
+        label: labels.pullFrom(splitRemoteRef(remote.name).remote),
+        icon: DownloadCloud,
+        group: 1,
+        onSelect: () => actions.onPull(remote.name),
+      });
+    }
+    if (isBranch) {
+      items.push({
         id: "deleteBranch",
         label: labels.deleteBranch,
         icon: Trash2,
-        group: 1,
+        group: 2,
         danger: true,
         onSelect: actions.onDeleteBranch,
-      },
-    ];
+      });
+    }
+    for (const remote of remotes) {
+      items.push({
+        id: `deleteRemote:${remote.name}`,
+        label: labels.deleteRemoteOn(splitRemoteRef(remote.name).remote),
+        icon: Trash2,
+        group: 2,
+        danger: true,
+        onSelect: () => actions.onDeleteRemote(remote.name),
+      });
+    }
+    if (remotes.length > 0) {
+      items.push({
+        id: "copyBranchName",
+        label: labels.copyBranchName,
+        icon: Copy,
+        group: 3,
+        onSelect: actions.onCopyBranchName,
+      });
+    }
+    return items;
   }
 
   if (ref.kind === "remote") {
@@ -213,7 +265,7 @@ export function buildRefMenu(
         label: labels.pull,
         icon: DownloadCloud,
         group: 0,
-        onSelect: actions.onPull,
+        onSelect: () => actions.onPull(ref.name),
       },
       {
         id: "deleteRemote",
@@ -221,7 +273,7 @@ export function buildRefMenu(
         icon: Trash2,
         group: 1,
         danger: true,
-        onSelect: actions.onDeleteRemote,
+        onSelect: () => actions.onDeleteRemote(ref.name),
       },
       {
         id: "copyBranchName",
@@ -233,6 +285,6 @@ export function buildRefMenu(
     ];
   }
 
-  // head (current branch) and unknown refs have no applicable actions.
+  // Stash and unknown refs have no applicable actions.
   return [];
 }

--- a/src/modules/git-graph/lib/refChips.test.ts
+++ b/src/modules/git-graph/lib/refChips.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { buildRefChips, DEFAULT_REF_CHIP_OPTIONS, type RefChipOptions } from "./refChips";
+import type { CommitRef } from "../types";
+
+const ALL: RefChipOptions = { mergeLocalRemote: true, hideOriginHead: true, collapseAfter: null };
+const NONE: RefChipOptions = {
+  mergeLocalRemote: false,
+  hideOriginHead: false,
+  collapseAfter: null,
+};
+
+function ref(kind: string, name: string): CommitRef {
+  return { kind, name };
+}
+
+describe("buildRefChips", () => {
+  it("folds the same-named remote into the local chip and labels the remote after it", () => {
+    const { chips } = buildRefChips(
+      [ref("head", "master"), ref("remote", "origin/master")],
+      ALL,
+    );
+
+    expect(chips).toHaveLength(1);
+    expect(chips[0].label).toBe("master (origin)");
+    expect(chips[0].remoteNames).toEqual(["origin"]);
+    expect(chips[0].ref.kind).toBe("head");
+    expect(chips[0].remotes.map((r) => r.name)).toEqual(["origin/master"]);
+  });
+
+  it("chains every remote that has the branch at this commit", () => {
+    const { chips } = buildRefChips(
+      [ref("branch", "master"), ref("remote", "origin/master"), ref("remote", "upstream/master")],
+      ALL,
+    );
+
+    expect(chips).toHaveLength(1);
+    expect(chips[0].label).toBe("master (origin, upstream)");
+    expect(chips[0].remoteNames).toEqual(["origin", "upstream"]);
+  });
+
+  it("merges a remote listed before its local twin, keeping the local ref's slot", () => {
+    const { chips } = buildRefChips(
+      [ref("remote", "origin/feat/x"), ref("tag", "v1"), ref("branch", "feat/x")],
+      ALL,
+    );
+
+    expect(chips.map((c) => c.label)).toEqual(["v1", "feat/x (origin)"]);
+    expect(chips[1].remotes.map((r) => r.name)).toEqual(["origin/feat/x"]);
+  });
+
+  it("leaves a remote with no local twin here as its own origin/ chip", () => {
+    const { chips } = buildRefChips([ref("remote", "origin/master")], ALL);
+
+    expect(chips.map((c) => c.label)).toEqual(["origin/master"]);
+    expect(chips[0].ref.kind).toBe("remote");
+  });
+
+  it("never folds a detached HEAD into origin/HEAD", () => {
+    const { chips } = buildRefChips([ref("head", "HEAD"), ref("remote", "origin/HEAD")], {
+      ...ALL,
+      hideOriginHead: false,
+    });
+
+    expect(chips.map((c) => c.label)).toEqual(["HEAD", "origin/HEAD"]);
+  });
+
+  it("hides origin/HEAD, and keeps it when the option is off", () => {
+    const refs = [ref("head", "master"), ref("remote", "origin/HEAD")];
+
+    expect(buildRefChips(refs, ALL).chips.map((c) => c.label)).toEqual(["master"]);
+    expect(buildRefChips(refs, { ...ALL, hideOriginHead: false }).chips.map((c) => c.label)).toEqual(
+      ["master", "origin/HEAD"],
+    );
+  });
+
+  it("leaves every ref alone when both options are off", () => {
+    const { chips, overflow } = buildRefChips(
+      [ref("head", "master"), ref("remote", "origin/master"), ref("remote", "origin/HEAD")],
+      NONE,
+    );
+
+    expect(chips.map((c) => c.label)).toEqual(["master", "origin/master", "origin/HEAD"]);
+    expect(overflow).toEqual([]);
+  });
+
+  it("collapses everything past the threshold into the overflow list", () => {
+    const refs = [
+      ref("head", "master"),
+      ref("branch", "a"),
+      ref("branch", "b"),
+      ref("branch", "c"),
+      ref("tag", "v1"),
+    ];
+
+    const { chips, overflow } = buildRefChips(refs, { ...ALL, collapseAfter: 3 });
+
+    expect(chips.map((c) => c.label)).toEqual(["master", "a", "b"]);
+    expect(overflow.map((c) => c.label)).toEqual(["c", "v1"]);
+  });
+
+  it("counts merged chips, not raw refs, against the threshold", () => {
+    const { chips, overflow } = buildRefChips(
+      [
+        ref("head", "master"),
+        ref("remote", "origin/master"),
+        ref("remote", "origin/HEAD"),
+        ref("branch", "a"),
+      ],
+      { ...ALL, collapseAfter: 3 },
+    );
+
+    expect(chips.map((c) => c.label)).toEqual(["master (origin)", "a"]);
+    expect(overflow).toEqual([]);
+  });
+
+  it("defaults to merging, hiding origin/HEAD and collapsing past three", () => {
+    expect(DEFAULT_REF_CHIP_OPTIONS).toEqual({
+      mergeLocalRemote: true,
+      hideOriginHead: true,
+      collapseAfter: 3,
+    });
+  });
+});

--- a/src/modules/git-graph/lib/refChips.ts
+++ b/src/modules/git-graph/lib/refChips.ts
@@ -1,0 +1,129 @@
+import type { CommitRef } from "../types";
+import { splitRemoteRef } from "./remoteRef";
+
+/** How a commit row turns its raw refs into the chips it actually paints. */
+export interface RefChipOptions {
+  /** Fold `origin/x` into the local `x` chip when both point here. */
+  mergeLocalRemote: boolean;
+  /** Drop `origin/HEAD` — a symbolic link to the remote's default branch. */
+  hideOriginHead: boolean;
+  /** Keep at most this many chips on the row; null keeps them all. */
+  collapseAfter: number | null;
+}
+
+export const DEFAULT_REF_CHIP_OPTIONS: RefChipOptions = {
+  mergeLocalRemote: true,
+  hideOriginHead: true,
+  collapseAfter: 3,
+};
+
+/** One painted chip: a ref plus any same-named remote refs folded into it. */
+export interface RefChip {
+  /** Stable React key. */
+  key: string;
+  /** Drives the chip style and its local actions (the local ref when merged). */
+  ref: CommitRef;
+  /** Remote refs folded into this chip, in the order git listed them. */
+  remotes: CommitRef[];
+  /** The remotes' short names ("origin", "upstream"), one painted block each. */
+  remoteNames: string[];
+  /** Plain-text name for tooltips: "master", or "master (origin, upstream)". */
+  label: string;
+}
+
+/** A row's chips, split into what fits and what the `+N` chip hides. */
+export interface RefChipRow {
+  chips: RefChip[];
+  overflow: RefChip[];
+}
+
+/** Local branch refs a remote ref can be folded into. Detached HEAD is not one. */
+function localBranchName(ref: CommitRef): string | null {
+  if (ref.kind === "branch") {
+    return ref.name;
+  }
+  // "HEAD" as a head ref is a detached HEAD, not a branch anything tracks.
+  if (ref.kind === "head" && ref.name !== "HEAD") {
+    return ref.name;
+  }
+  return null;
+}
+
+function isOriginHead(ref: CommitRef): boolean {
+  return ref.kind === "remote" && splitRemoteRef(ref.name).branch === "HEAD";
+}
+
+function soloChip(ref: CommitRef): RefChip {
+  return { key: `${ref.kind}:${ref.name}`, ref, remotes: [], remoteNames: [], label: ref.name };
+}
+
+/** Re-derive the merged fields after a remote is folded into `chip`. */
+function refreshMerged(chip: RefChip): void {
+  chip.remoteNames = chip.remotes.map((remote) => splitRemoteRef(remote.name).remote);
+  chip.label =
+    chip.remoteNames.length === 0
+      ? chip.ref.name
+      : `${chip.ref.name} (${chip.remoteNames.join(", ")})`;
+}
+
+/**
+ * Turn a commit's refs into the chips its row paints.
+ *
+ * `master`, `origin/master` and `origin/HEAD` on one commit is three chips of
+ * near-identical information that pushes the commit message out of view, and it
+ * splits the right-click menu in two (local actions on one chip, remote ones on
+ * another). Merging folds the same-named remotes into the local chip so one
+ * menu covers both; a remote with no local twin here — the ahead/behind case —
+ * keeps its own `origin/…` chip on the commit it really points at, so nothing
+ * about the divergence is lost. Pure so the rules stay testable without a repo.
+ */
+export function buildRefChips(refs: CommitRef[], options: RefChipOptions): RefChipRow {
+  const kept = options.hideOriginHead ? refs.filter((ref) => !isOriginHead(ref)) : refs;
+
+  const chips: RefChip[] = [];
+  if (!options.mergeLocalRemote) {
+    for (const ref of kept) {
+      chips.push(soloChip(ref));
+    }
+  } else {
+    // Git does not promise the local ref comes before its remote twin in the
+    // decoration, so collect the local names first and hold back any remote
+    // that arrives early — the merged chip then sits where the local ref is.
+    const locals = new Set(
+      kept.map(localBranchName).filter((name): name is string => name !== null),
+    );
+    const pending = new Map<string, CommitRef[]>();
+    const merged = new Map<string, RefChip>();
+    for (const ref of kept) {
+      const local = localBranchName(ref);
+      if (local !== null && !merged.has(local)) {
+        const chip = soloChip(ref);
+        chip.remotes = pending.get(local) ?? [];
+        refreshMerged(chip);
+        merged.set(local, chip);
+        chips.push(chip);
+        continue;
+      }
+      if (ref.kind === "remote") {
+        const branch = splitRemoteRef(ref.name).branch;
+        const target = merged.get(branch);
+        if (target) {
+          target.remotes.push(ref);
+          refreshMerged(target);
+          continue;
+        }
+        if (locals.has(branch)) {
+          pending.set(branch, [...(pending.get(branch) ?? []), ref]);
+          continue;
+        }
+      }
+      chips.push(soloChip(ref));
+    }
+  }
+
+  const limit = options.collapseAfter;
+  if (limit !== null && limit > 0 && chips.length > limit) {
+    return { chips: chips.slice(0, limit), overflow: chips.slice(limit) };
+  }
+  return { chips, overflow: [] };
+}

--- a/src/modules/settings/GitGraphSettingsSection.test.tsx
+++ b/src/modules/settings/GitGraphSettingsSection.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import "@/i18n";
+import { GitGraphSettingsSection } from "./GitGraphSettingsSection";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+beforeEach(() => {
+  useSettingsStore.setState({
+    gitGraphRefs: {
+      mergeLocalRemote: true,
+      hideOriginHead: true,
+      collapseExtraRefs: true,
+      refLimit: 3,
+    },
+  });
+});
+
+function checkbox(name: RegExp): HTMLInputElement {
+  return screen.getByLabelText(name) as HTMLInputElement;
+}
+
+describe("GitGraphSettingsSection", () => {
+  it("ships every condensing option on", () => {
+    render(<GitGraphSettingsSection />);
+    expect(checkbox(/Merge a branch/).checked).toBe(true);
+    expect(checkbox(/Hide origin\/HEAD/).checked).toBe(true);
+    expect(checkbox(/Collapse extra labels/).checked).toBe(true);
+  });
+
+  it("turns an option off in the store, so the row goes back to how it was", () => {
+    render(<GitGraphSettingsSection />);
+    fireEvent.click(checkbox(/Merge a branch/));
+    expect(useSettingsStore.getState().gitGraphRefs.mergeLocalRemote).toBe(false);
+  });
+
+  it("keeps the +N threshold within range and disables it when collapsing is off", () => {
+    render(<GitGraphSettingsSection />);
+    const limit = screen.getByLabelText(/Labels shown/) as HTMLInputElement;
+
+    fireEvent.change(limit, { target: { value: "99" } });
+    expect(useSettingsStore.getState().gitGraphRefs.refLimit).toBe(10);
+
+    fireEvent.click(checkbox(/Collapse extra labels/));
+    expect((screen.getByLabelText(/Labels shown/) as HTMLInputElement).disabled).toBe(true);
+  });
+});

--- a/src/modules/settings/GitGraphSettingsSection.tsx
+++ b/src/modules/settings/GitGraphSettingsSection.tsx
@@ -1,0 +1,77 @@
+import { useTranslation } from "react-i18next";
+import {
+  MAX_GIT_GRAPH_REF_LIMIT,
+  MIN_GIT_GRAPH_REF_LIMIT,
+  useSettingsStore,
+} from "@/stores/settingsStore";
+
+/**
+ * Git Graph display preferences. Every toggle here condenses the ref chips on a
+ * commit row and ships on by default; turning them all off restores exactly the
+ * row as it was before, so nobody's habits break on upgrade.
+ */
+export function GitGraphSettingsSection() {
+  const { t } = useTranslation("settings");
+  const refs = useSettingsStore((s) => s.gitGraphRefs);
+  const setRefs = useSettingsStore((s) => s.setGitGraphRefs);
+
+  return (
+    <section>
+      <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-fg-subtle">
+        {t("sections.gitGraph")}
+      </h2>
+
+      <label className="mb-1 block text-sm font-medium text-fg">{t("gitGraph.refsTitle")}</label>
+      <p className="mb-2 text-xs text-fg-muted">{t("gitGraph.refsDescription")}</p>
+
+      <label className="mb-1 flex items-center gap-2 text-sm text-fg">
+        <input
+          type="checkbox"
+          checked={refs.mergeLocalRemote}
+          onChange={(e) => setRefs({ mergeLocalRemote: e.target.checked })}
+          className="h-4 w-4 accent-accent"
+        />
+        {t("gitGraph.mergeLocalRemoteLabel")}
+      </label>
+      <p className="mb-3 ml-6 text-xs text-fg-muted">{t("gitGraph.mergeLocalRemoteHint")}</p>
+
+      <label className="mb-1 flex items-center gap-2 text-sm text-fg">
+        <input
+          type="checkbox"
+          checked={refs.hideOriginHead}
+          onChange={(e) => setRefs({ hideOriginHead: e.target.checked })}
+          className="h-4 w-4 accent-accent"
+        />
+        {t("gitGraph.hideOriginHeadLabel")}
+      </label>
+      <p className="mb-3 ml-6 text-xs text-fg-muted">{t("gitGraph.hideOriginHeadHint")}</p>
+
+      <label className="mb-1 flex items-center gap-2 text-sm text-fg">
+        <input
+          type="checkbox"
+          checked={refs.collapseExtraRefs}
+          onChange={(e) => setRefs({ collapseExtraRefs: e.target.checked })}
+          className="h-4 w-4 accent-accent"
+        />
+        {t("gitGraph.collapseLabel")}
+      </label>
+      <label
+        className={`mb-1 ml-6 flex items-center gap-2 text-sm ${
+          refs.collapseExtraRefs ? "text-fg" : "text-fg-subtle"
+        }`}
+      >
+        {t("gitGraph.refLimitLabel")}
+        <input
+          type="number"
+          min={MIN_GIT_GRAPH_REF_LIMIT}
+          max={MAX_GIT_GRAPH_REF_LIMIT}
+          value={refs.refLimit}
+          disabled={!refs.collapseExtraRefs}
+          onChange={(e) => setRefs({ refLimit: Number(e.target.value) })}
+          className="w-16 rounded-md border border-border bg-bg px-2 py-1 text-sm text-fg outline-none focus:border-accent disabled:opacity-50"
+        />
+      </label>
+      <p className="ml-6 text-xs text-fg-muted">{t("gitGraph.collapseHint")}</p>
+    </section>
+  );
+}

--- a/src/modules/settings/SettingsView.tsx
+++ b/src/modules/settings/SettingsView.tsx
@@ -12,11 +12,20 @@ import { FontsSettingsSection } from "./FontsSettingsSection";
 import { TerminalSettingsSection } from "./TerminalSettingsSection";
 import { AiSettingsSection } from "./AiSettingsSection";
 import { WorkspaceSettingsSection } from "./WorkspaceSettingsSection";
+import { GitGraphSettingsSection } from "./GitGraphSettingsSection";
 import { ShortcutsSettingsSection } from "./ShortcutsSettingsSection";
 import { AboutSettingsSection } from "./AboutSettingsSection";
 import { BackgroundImageSettingsSection } from "./BackgroundImageSettingsSection";
 
-const SECTIONS = ["appearance", "terminal", "ai", "workspace", "shortcuts", "about"] as const;
+const SECTIONS = [
+  "appearance",
+  "terminal",
+  "ai",
+  "workspace",
+  "gitGraph",
+  "shortcuts",
+  "about",
+] as const;
 type SectionId = typeof SECTIONS[number];
 
 function isSectionId(value: string): value is SectionId {
@@ -246,6 +255,7 @@ export function SettingsView() {
           {section === "terminal" && <TerminalSettingsSection />}
           {section === "ai" && <AiSettingsSection />}
           {section === "workspace" && <WorkspaceSettingsSection />}
+          {section === "gitGraph" && <GitGraphSettingsSection />}
           {section === "shortcuts" && <ShortcutsSettingsSection />}
           {section === "about" && <AboutSettingsSection />}
         </div>

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_BACKGROUND_IMAGE_OPACITY,
   DEFAULT_TERMINAL_BACKGROUND_IMAGE_OPACITY,
+  DEFAULT_GIT_GRAPH_REF_LIMIT,
   DEFAULT_TERMINAL_PADDING,
   MAX_BACKGROUND_IMAGE_OPACITY,
+  MAX_GIT_GRAPH_REF_LIMIT,
   MAX_TERMINAL_PADDING,
   MIN_BACKGROUND_IMAGE_OPACITY,
   MIN_TERMINAL_PADDING,
@@ -32,6 +34,7 @@ describe("settingsStore", () => {
       codexFlags: initialState.codexFlags,
       autoResumeAiSessions: initialState.autoResumeAiSessions,
       customShellPath: initialState.customShellPath,
+      gitGraphRefs: initialState.gitGraphRefs,
     });
   });
 
@@ -126,6 +129,47 @@ describe("settingsStore", () => {
       terminalBackgroundImageOpacity: DEFAULT_TERMINAL_BACKGROUND_IMAGE_OPACITY,
       backgroundImageScope: "workspace",
       backgroundImageTextColor: null,
+    });
+  });
+
+  it("defaults every Git Graph ref option on, collapsing past three chips", () => {
+    expect(useSettingsStore.getState().gitGraphRefs).toEqual({
+      mergeLocalRemote: true,
+      hideOriginHead: true,
+      collapseExtraRefs: true,
+      refLimit: DEFAULT_GIT_GRAPH_REF_LIMIT,
+    });
+  });
+
+  it("patches one Git Graph ref option without touching the others", () => {
+    useSettingsStore.getState().setGitGraphRefs({ hideOriginHead: false });
+    expect(useSettingsStore.getState().gitGraphRefs).toMatchObject({
+      hideOriginHead: false,
+      mergeLocalRemote: true,
+      collapseExtraRefs: true,
+    });
+  });
+
+  it("clamps the ref limit so a stray value cannot hide every chip behind +N", () => {
+    useSettingsStore.getState().setGitGraphRefs({ refLimit: 99 });
+    expect(useSettingsStore.getState().gitGraphRefs.refLimit).toBe(MAX_GIT_GRAPH_REF_LIMIT);
+    useSettingsStore.getState().setGitGraphRefs({ refLimit: 0 });
+    expect(useSettingsStore.getState().gitGraphRefs.refLimit).toBe(1);
+  });
+
+  it("fills in the Git Graph ref block a store written by an older build lacks", async () => {
+    localStorage.setItem(
+      "tempoterm-settings",
+      JSON.stringify({ state: { language: "en" }, version: 0 }),
+    );
+
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().gitGraphRefs).toEqual({
+      mergeLocalRemote: true,
+      hideOriginHead: true,
+      collapseExtraRefs: true,
+      refLimit: DEFAULT_GIT_GRAPH_REF_LIMIT,
     });
   });
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -30,6 +30,29 @@ export interface WorkspaceCardBlocks {
 /** Where PR data comes from; "auto" detects gh, else falls back to a token. */
 export type WorkspacePrSource = "auto" | "gh" | "token" | "off";
 
+export const MIN_GIT_GRAPH_REF_LIMIT = 1;
+export const MAX_GIT_GRAPH_REF_LIMIT = 10;
+export const DEFAULT_GIT_GRAPH_REF_LIMIT = 3;
+
+/** How the Git Graph condenses the ref chips on a commit row. */
+export interface GitGraphRefSettings {
+  /** Fold `origin/x` into the local `x` chip when both point at the commit. */
+  mergeLocalRemote: boolean;
+  /** Drop `origin/HEAD`, a symbolic link with no information of its own. */
+  hideOriginHead: boolean;
+  /** Collapse the chips past `refLimit` into a single `+N`. */
+  collapseExtraRefs: boolean;
+  /** How many chips stay on the row before `+N` takes over. */
+  refLimit: number;
+}
+
+const DEFAULT_GIT_GRAPH_REFS: GitGraphRefSettings = {
+  mergeLocalRemote: true,
+  hideOriginHead: true,
+  collapseExtraRefs: true,
+  refLimit: DEFAULT_GIT_GRAPH_REF_LIMIT,
+};
+
 const DEFAULT_WORKSPACE_CARD: WorkspaceCardBlocks = {
   status: true,
   branch: true,
@@ -59,6 +82,8 @@ interface SettingsState {
   notesFolderPath: string | null;
   /** Which info blocks the workspace cards show. */
   workspaceCard: WorkspaceCardBlocks;
+  /** How the Git Graph condenses a commit row's ref chips. */
+  gitGraphRefs: GitGraphRefSettings;
   /** Where workspace cards source PR data. */
   prSource: WorkspacePrSource;
   /** Default flags appended to the `claude` command when launched from the launcher. */
@@ -125,6 +150,7 @@ interface SettingsState {
   setRestoreTerminalHistory: (value: boolean) => void;
   setNotesFolderPath: (path: string | null) => void;
   setWorkspaceCardBlock: (key: keyof WorkspaceCardBlocks, value: boolean) => void;
+  setGitGraphRefs: (patch: Partial<GitGraphRefSettings>) => void;
   setPrSource: (source: WorkspacePrSource) => void;
   setClaudeFlags: (flags: string) => void;
   setCodexFlags: (flags: string) => void;
@@ -149,6 +175,24 @@ function clampPadding(value: number): number {
     return DEFAULT_TERMINAL_PADDING;
   }
   return Math.min(MAX_TERMINAL_PADDING, Math.max(MIN_TERMINAL_PADDING, Math.round(value)));
+}
+
+/**
+ * Coerce a persisted (or patched) Git Graph ref block back into shape: a store
+ * written by an older build has no block at all, and a hand-edited one can
+ * carry a nonsense limit that would hide every chip behind `+N`.
+ */
+function normalizeGitGraphRefs(value: Partial<GitGraphRefSettings> | undefined): GitGraphRefSettings {
+  const stored = value ?? {};
+  const limit = Number(stored.refLimit);
+  return {
+    mergeLocalRemote: stored.mergeLocalRemote ?? DEFAULT_GIT_GRAPH_REFS.mergeLocalRemote,
+    hideOriginHead: stored.hideOriginHead ?? DEFAULT_GIT_GRAPH_REFS.hideOriginHead,
+    collapseExtraRefs: stored.collapseExtraRefs ?? DEFAULT_GIT_GRAPH_REFS.collapseExtraRefs,
+    refLimit: Number.isFinite(limit)
+      ? Math.min(MAX_GIT_GRAPH_REF_LIMIT, Math.max(MIN_GIT_GRAPH_REF_LIMIT, Math.round(limit)))
+      : DEFAULT_GIT_GRAPH_REF_LIMIT,
+  };
 }
 
 function clampZoom(value: number): number {
@@ -196,6 +240,7 @@ export const useSettingsStore = create<SettingsState>()(
       restoreTerminalHistory: true,
       notesFolderPath: null,
       workspaceCard: DEFAULT_WORKSPACE_CARD,
+      gitGraphRefs: DEFAULT_GIT_GRAPH_REFS,
       prSource: "auto",
       claudeFlags: "",
       codexFlags: "",
@@ -243,6 +288,10 @@ export const useSettingsStore = create<SettingsState>()(
       setNotesFolderPath: (path) => set({ notesFolderPath: path }),
       setWorkspaceCardBlock: (key, value) =>
         set((state) => ({ workspaceCard: { ...state.workspaceCard, [key]: value } })),
+      setGitGraphRefs: (patch) =>
+        set((state) => ({
+          gitGraphRefs: normalizeGitGraphRefs({ ...state.gitGraphRefs, ...patch }),
+        })),
       setPrSource: (prSource) => set({ prSource }),
       setClaudeFlags: (claudeFlags) => set({ claudeFlags }),
       setCodexFlags: (codexFlags) => set({ codexFlags }),
@@ -284,6 +333,7 @@ export const useSettingsStore = create<SettingsState>()(
           backgroundImageTextColor: normalizeBackgroundImageTextColor(
             stored.backgroundImageTextColor,
           ),
+          gitGraphRefs: normalizeGitGraphRefs(stored.gitGraphRefs),
         };
       },
     },


### PR DESCRIPTION
## Problem

A commit that has `master`, `origin/master` and `origin/HEAD` on it draws three
chips of near-identical information. Add a couple of other branches and a row
easily carries four or five, and the chip strip runs longer than the commit
message — which gets pushed out of view entirely.

`origin/HEAD` is the worst offender: it is a symbolic link to the remote's
default branch, so it marks a commit that already has its own branch chip, and
it costs a permanent chip slot to say nothing.

The right-click menu is split along the same lines. Local operations (checkout,
merge, delete) live on the `master` chip, while remote ones (pull, delete the
remote branch) live on `origin/master`. The user has to know which chip owns
which half before they can right-click.

## Changes

- `lib/refChips.ts` — a pure `buildRefChips(refs, options)` that folds a local
  branch and the same-named remotes at that commit into one chip, drops
  `origin/HEAD`, and splits off whatever exceeds the row's limit. Git does not
  promise the local ref precedes its remote twin in the decoration, so remotes
  seen first are held back and the merged chip keeps the local ref's slot. A
  detached `HEAD` is never folded into `origin/HEAD`.
- `RefChipStrip.tsx` — a merged chip is drawn as blocks inside one border: the
  branch, then each remote in italic behind a divider. Everything past the limit
  collapses into a `+N` chip that opens a portal list of the same chips, each
  still right-clickable; the list sits below the tooltip layer so the chips'
  tooltips stay visible over it, and it stays open behind the menu it opens.
  Only the ref kinds that actually have a menu get a hover state.
- `lib/contextMenuItems.ts` — `buildRefMenu` takes the merged remotes, so one
  menu runs checkout / merge / worktree, then pull per remote, then both
  deletions, then copy. The current branch (`head`), which had no menu at all,
  gets its remotes' actions once they are folded in. `onPull` / `onDeleteRemote`
  now take a remote ref name, since a merged chip can carry several.
- A remote with no local twin at that commit — the ahead/behind case — is
  untouched: it keeps its own `origin/…` chip on the commit it really points at,
  so nothing about the divergence is lost.
- Settings > Git Graph (new section): merging, hiding `origin/HEAD` and the `+N`
  threshold are each switchable, all on by default with a limit of 3. Turning
  all three off restores exactly the previous row, so the change breaks nobody's
  habits. The persisted block is normalized on hydration, so a store written by
  an older build gets the defaults and a stray limit is clamped to 1–10.

Closes #330.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run` — 227 files, 2076 tests passing (new: `refChips`
      10, `RefChipStrip` 8, `GitGraphSettingsSection` 3, plus cases added to
      `contextMenuItems` and `settingsStore`)
- [x] Ran `tauri dev` on Windows against two real repos: a fork with `origin`
      and `upstream` renders master, origin and upstream as one three-block chip,
      `origin/HEAD` is gone, a row with six refs shows three chips and `+3`, and
      the `+N` list right-clicks through to the same menus. Toggling each
      setting off restores the old rendering live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
