### PR TITLE
feat(git-graph): copy a ref name from every branch and tag chip

### DIFF
--- a/src/i18n/locales/en/gitGraph.json
+++ b/src/i18n/locales/en/gitGraph.json
@@ -74,6 +74,7 @@
     "pullFrom": "Pull from {{remote}} (git pull)",
     "deleteRemoteOn": "Delete branch on {{remote}}… (git push --delete)",
     "copyBranchName": "Copy branch name",
+    "copyTagName": "Copy tag name",
     "openWorktree": "Open worktree for this branch"
   },
   "modal": {

--- a/src/i18n/locales/zh-Hant/gitGraph.json
+++ b/src/i18n/locales/zh-Hant/gitGraph.json
@@ -74,6 +74,7 @@
     "pullFrom": "從 {{remote}} 拉取 (git pull)",
     "deleteRemoteOn": "刪除 {{remote}} 上的分支… (git push --delete)",
     "copyBranchName": "複製分支名稱",
+    "copyTagName": "複製標籤名稱",
     "openWorktree": "為這個分支開 worktree"
   },
   "modal": {

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -576,6 +576,7 @@ export function GitGraphTabContent() {
         pull: t("menu.pull"),
         deleteRemote: t("menu.deleteRemote"),
         copyBranchName: t("menu.copyBranchName"),
+        copyTagName: t("menu.copyTagName"),
         openWorktree: t("menu.openWorktree"),
         pullFrom: (remote: string) => t("menu.pullFrom", { remote }),
         deleteRemoteOn: (remote: string) => t("menu.deleteRemoteOn", { remote }),
@@ -602,7 +603,7 @@ export function GitGraphTabContent() {
             onConfirm: () => void runAction(() => gitPushDelete(repo!, remote, branch)),
           });
         },
-        onCopyBranchName: () => void navigator.clipboard.writeText(ref.name),
+        onCopyRefName: () => void navigator.clipboard.writeText(ref.name),
         // The branch already exists, so this checks it out into a worktree of
         // its own rather than cutting a new one — unlike checkout, it leaves
         // the current working tree and whatever is running in it alone.
@@ -714,9 +715,8 @@ export function GitGraphTabContent() {
             menu.type === "commit"
               ? commitMenuItems(menu.commit)
               : refMenuItems(menu.ref, menu.remotes);
-          // The current branch (kind "head") with no remote folded into its chip
-          // has no applicable actions; skip the menu rather than flashing an
-          // empty one.
+          // A detached HEAD, a stash and an unknown ref have no applicable
+          // actions; skip the menu rather than flashing an empty one.
           if (items.length === 0) {
             return null;
           }

--- a/src/modules/git-graph/lib/contextMenuItems.test.ts
+++ b/src/modules/git-graph/lib/contextMenuItems.test.ts
@@ -19,6 +19,7 @@ const refLabels: RefMenuLabels = {
   pull: "Pull into current branch",
   deleteRemote: "Delete remote branch",
   copyBranchName: "Copy branch name",
+  copyTagName: "Copy tag name",
   openWorktree: "Open worktree for this branch",
   pullFrom: (remote: string) => `Pull from ${remote}`,
   deleteRemoteOn: (remote: string) => `Delete branch on ${remote}`,
@@ -34,7 +35,7 @@ function refActions(): RefMenuActions {
     onMergeRemote: vi.fn(),
     onPull: vi.fn(),
     onDeleteRemote: vi.fn(),
-    onCopyBranchName: vi.fn(),
+    onCopyRefName: vi.fn(),
     onOpenWorktree: vi.fn(),
   };
 }
@@ -86,22 +87,46 @@ describe("buildRefMenu", () => {
     expect(items.find((i) => i.id === "copyBranchName")?.danger).toBeFalsy();
   });
 
-  it("offers only delete for a tag, in the danger colour", () => {
+  it("offers delete in the danger colour, then copy, for a tag", () => {
+    const actions = refActions();
     const ref: CommitRef = { name: "v1.0.0", kind: "tag" };
-    const items = buildRefMenu(ref, refLabels, refActions());
-    expect(ids(items)).toEqual(["deleteTag"]);
+    const items = buildRefMenu(ref, refLabels, actions);
+    expect(ids(items)).toEqual(["deleteTag", "copyTagName"]);
     expect(items[0].danger).toBe(true);
+    const copy = items[1];
+    expect(copy.danger).toBeFalsy();
+    // The delete sits in its own group so a divider fences it off from copy.
+    expect(copy.group).not.toBe(items[0].group);
+    copy.onSelect();
+    expect(actions.onCopyRefName).toHaveBeenCalledTimes(1);
   });
 
-  it("offers checkout, merge and delete for a local branch", () => {
+  it("offers copy on a local branch that has no remote yet", () => {
     const ref: CommitRef = { name: "feature", kind: "branch" };
     const items = buildRefMenu(ref, refLabels, refActions());
-    expect(ids(items)).toEqual(["checkout", "merge", "openWorktree", "deleteBranch"]);
+    expect(ids(items)).toEqual([
+      "checkout",
+      "merge",
+      "openWorktree",
+      "deleteBranch",
+      "copyBranchName",
+    ]);
     expect(items.find((i) => i.id === "deleteBranch")?.danger).toBe(true);
   });
 
-  it("offers nothing for the current branch (head) with no remote folded in", () => {
+  it("offers copy on the current branch (head) with no remote folded in", () => {
+    const actions = refActions();
     const ref: CommitRef = { name: "main", kind: "head" };
+    const items = buildRefMenu(ref, refLabels, actions);
+    // Checkout, merge and delete do not apply to the branch already checked
+    // out, but its name is the one most often wanted.
+    expect(ids(items)).toEqual(["copyBranchName"]);
+    items[0].onSelect();
+    expect(actions.onCopyRefName).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers nothing for a detached HEAD", () => {
+    const ref: CommitRef = { name: "HEAD", kind: "head" };
     expect(buildRefMenu(ref, refLabels, refActions())).toEqual([]);
   });
 
@@ -165,7 +190,7 @@ describe("buildRefMenu", () => {
     items.find((i) => i.id === "checkoutRemote")?.onSelect();
     items.find((i) => i.id === "pull")?.onSelect();
     items.find((i) => i.id === "deleteRemote")?.onSelect();
-    expect(actions.onCopyBranchName).toHaveBeenCalledTimes(1);
+    expect(actions.onCopyRefName).toHaveBeenCalledTimes(1);
     expect(actions.onCheckoutRemote).toHaveBeenCalledTimes(1);
     expect(actions.onPull).toHaveBeenCalledWith("origin/feat/x");
     expect(actions.onDeleteRemote).toHaveBeenCalledWith("origin/feat/x");

--- a/src/modules/git-graph/lib/contextMenuItems.ts
+++ b/src/modules/git-graph/lib/contextMenuItems.ts
@@ -129,6 +129,7 @@ export interface RefMenuLabels {
   pull: string;
   deleteRemote: string;
   copyBranchName: string;
+  copyTagName: string;
   openWorktree: string;
   /** Names the remote, for a merged chip where the label alone is ambiguous. */
   pullFrom: (remote: string) => string;
@@ -145,7 +146,8 @@ export interface RefMenuActions {
   /** Take the full remote ref name ("origin/master") — a merged chip has several. */
   onPull: (remoteRef: string) => void;
   onDeleteRemote: (remoteRef: string) => void;
-  onCopyBranchName: () => void;
+  /** Copies the ref's own name — the branch, the remote ref, or the tag. */
+  onCopyRefName: () => void;
   onOpenWorktree: () => void;
 }
 
@@ -170,6 +172,13 @@ export function buildRefMenu(
         danger: true,
         onSelect: actions.onDeleteTag,
       },
+      {
+        id: "copyTagName",
+        label: labels.copyTagName,
+        icon: Copy,
+        group: 1,
+        onSelect: actions.onCopyRefName,
+      },
     ];
   }
 
@@ -177,6 +186,11 @@ export function buildRefMenu(
     // A merged chip owns both halves of the branch, so its menu runs
     // checkout/merge, then pull, then the deletions, then copy.
     const isBranch = ref.kind === "branch";
+    // A detached HEAD is not a branch: none of these act on it, and its name is
+    // the literal "HEAD", which is not worth copying.
+    if (!isBranch && ref.name === "HEAD") {
+      return [];
+    }
     const items: ContextMenuItem[] = [];
     if (isBranch) {
       items.push(
@@ -198,10 +212,6 @@ export function buildRefMenu(
           onSelect: actions.onOpenWorktree,
         },
       );
-    }
-    // The current branch with nothing folded in has no applicable actions.
-    if (remotes.length === 0 && !isBranch) {
-      return items;
     }
     for (const remote of remotes) {
       items.push({
@@ -232,15 +242,15 @@ export function buildRefMenu(
         onSelect: () => actions.onDeleteRemote(remote.name),
       });
     }
-    if (remotes.length > 0) {
-      items.push({
-        id: "copyBranchName",
-        label: labels.copyBranchName,
-        icon: Copy,
-        group: 3,
-        onSelect: actions.onCopyBranchName,
-      });
-    }
+    // Every branch chip can be copied, remote twin or not — the branch you are
+    // standing on is the name most often wanted, and it never has one.
+    items.push({
+      id: "copyBranchName",
+      label: labels.copyBranchName,
+      icon: Copy,
+      group: 3,
+      onSelect: actions.onCopyRefName,
+    });
     return items;
   }
 
@@ -280,7 +290,7 @@ export function buildRefMenu(
         label: labels.copyBranchName,
         icon: Copy,
         group: 2,
-        onSelect: actions.onCopyBranchName,
+        onSelect: actions.onCopyRefName,
       },
     ];
   }


### PR DESCRIPTION
## Problem

`Copy branch name` was only reachable from a remote chip, or from a local chip
that had a remote folded into it. A branch that has not been pushed yet — the
one whose name you most often want on the clipboard, to paste into a checkout
or a PR — had no way to copy it.

The chip for the branch you are standing on was worse: with no remote merged in
it produced an empty item list, and the graph skips an empty menu, so
right-clicking the current branch did nothing at all.

A tag chip has the same gap in a smaller way: its only entry is the red
`Delete tag`, so a right-click on `v1.0.0` offers a destructive action and
nothing else.

## Root cause

`buildRefMenu` gated the copy entry on `remotes.length > 0`, which happens to be
true for every chip the author was looking at while building the merged chip in
#357 — a local branch with a remote twin. The `head` path returned early with an
empty list whenever nothing was folded in, on the reasoning that checkout, merge
and delete do not apply to the branch already checked out. Copy does.

## Changes

- `lib/contextMenuItems.ts` — copy is now unconditional on a branch chip, so a
  local-only branch and the current branch both have it. The early return is
  replaced by a narrower guard: a detached `HEAD` still has no menu, because
  nothing here acts on it and its name is the literal `HEAD`.
- A tag chip gains `Copy tag name`, in its own group so a divider fences it off
  from the delete above it.
- `onCopyBranchName` is renamed `onCopyRefName`: one handler now serves the
  branch, the remote ref and the tag, and it has always just copied `ref.name`.
- New `menu.copyTagName` string in `en` and `zh-Hant`.

Closes #332.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run` — 227 files, 2080 tests passing (`contextMenuItems`
      covers the local-only branch, the current branch, the detached `HEAD` and
      the tag chip)
- [x] `tauri dev` on Windows: right-click an unpushed branch chip, the green
      current-branch chip and a tag chip, and confirm each copies its own name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
