### PR TITLE
feat(git-graph): order a commit's ref chips by what the row is read for

### DIFF
--- a/src/modules/git-graph/RefChipStrip.test.tsx
+++ b/src/modules/git-graph/RefChipStrip.test.tsx
@@ -152,38 +152,38 @@ describe("RefChipStrip", () => {
     render(
       <RefChipStrip
         refs={[
-          ref("branch", "one"),
-          ref("branch", "two"),
-          ref("branch", "three"),
-          ref("branch", "four"),
-          ref("branch", "five"),
+          ref("branch", "a"),
+          ref("branch", "b"),
+          ref("branch", "c"),
+          ref("branch", "d"),
+          ref("branch", "e"),
         ]}
         options={OPTIONS}
         labels={LABELS}
       />,
     );
     fireEvent.click(screen.getByText("+2"));
-    const list = screen.getByText("five").closest("div") as HTMLElement;
+    const list = screen.getByText("e").closest("div") as HTMLElement;
 
     // The list itself is max-h + overflow-y-auto: reading past its fold is a
     // scroll event whose target is the list. Capture-phase listeners on window
     // see it too, and closing on it would make the tail unreachable.
     fireEvent.scroll(list);
-    expect(screen.queryByText("five")).not.toBeNull();
+    expect(screen.queryByText("e")).not.toBeNull();
 
     // The graph scrolling underneath is what the dismissal is for.
     fireEvent.scroll(document);
-    expect(screen.queryByText("five")).toBeNull();
+    expect(screen.queryByText("e")).toBeNull();
   });
 
   it("closes on Escape and on a click outside, but not on a click inside", () => {
     render(
       <RefChipStrip
         refs={[
-          ref("branch", "one"),
-          ref("branch", "two"),
-          ref("branch", "three"),
-          ref("branch", "four"),
+          ref("branch", "a"),
+          ref("branch", "b"),
+          ref("branch", "c"),
+          ref("branch", "d"),
         ]}
         options={OPTIONS}
         labels={LABELS}
@@ -192,15 +192,15 @@ describe("RefChipStrip", () => {
     const opener = screen.getByText("+1");
 
     fireEvent.click(opener);
-    fireEvent.mouseDown(screen.getByText("four"));
-    expect(screen.queryByText("four")).not.toBeNull();
+    fireEvent.mouseDown(screen.getByText("d"));
+    expect(screen.queryByText("d")).not.toBeNull();
 
     fireEvent.keyDown(document, { key: "Escape" });
-    expect(screen.queryByText("four")).toBeNull();
+    expect(screen.queryByText("d")).toBeNull();
 
     fireEvent.click(opener);
     fireEvent.mouseDown(document.body);
-    expect(screen.queryByText("four")).toBeNull();
+    expect(screen.queryByText("d")).toBeNull();
   });
 
   it("leaves every ref on the row when the user turns the options off", () => {

--- a/src/modules/git-graph/lib/refChips.test.ts
+++ b/src/modules/git-graph/lib/refChips.test.ts
@@ -38,14 +38,14 @@ describe("buildRefChips", () => {
     expect(chips[0].remoteNames).toEqual(["origin", "upstream"]);
   });
 
-  it("merges a remote listed before its local twin, keeping the local ref's slot", () => {
+  it("merges a remote listed before its local twin rather than giving it a chip", () => {
     const { chips } = buildRefChips(
       [ref("remote", "origin/feat/x"), ref("tag", "v1"), ref("branch", "feat/x")],
       ALL,
     );
 
-    expect(chips.map((c) => c.label)).toEqual(["v1", "feat/x (origin)"]);
-    expect(chips[1].remotes.map((r) => r.name)).toEqual(["origin/feat/x"]);
+    expect(chips.map((c) => c.label)).toEqual(["feat/x (origin)", "v1"]);
+    expect(chips[0].remotes.map((r) => r.name)).toEqual(["origin/feat/x"]);
   });
 
   it("leaves a remote with no local twin here as its own origin/ chip", () => {
@@ -73,14 +73,86 @@ describe("buildRefChips", () => {
     );
   });
 
-  it("leaves every ref alone when both options are off", () => {
+  it("keeps every ref when both options are off, still in the row's order", () => {
     const { chips, overflow } = buildRefChips(
       [ref("head", "master"), ref("remote", "origin/master"), ref("remote", "origin/HEAD")],
       NONE,
     );
 
-    expect(chips.map((c) => c.label)).toEqual(["master", "origin/master", "origin/HEAD"]);
+    // The options govern what a row shows, not what order it shows it in: the
+    // remotes are still here unmerged, they just no longer lead the row.
+    expect(chips.map((c) => c.label)).toEqual(["master", "origin/HEAD", "origin/master"]);
     expect(overflow).toEqual([]);
+  });
+
+  it("ranks the row by what it is read for: HEAD, branches, tags, then remotes", () => {
+    const { chips } = buildRefChips(
+      [
+        ref("stash", "refs/stash"),
+        ref("remote", "origin/solo"),
+        ref("tag", "v1"),
+        ref("branch", "feature"),
+        ref("head", "master"),
+      ],
+      ALL,
+    );
+
+    expect(chips.map((c) => c.label)).toEqual([
+      "master",
+      "feature",
+      "v1",
+      "origin/solo",
+      "refs/stash",
+    ]);
+  });
+
+  it("sorts within a kind by name, with origin ahead of the other remotes", () => {
+    const { chips } = buildRefChips(
+      [
+        ref("branch", "zeta"),
+        ref("remote", "upstream/solo"),
+        ref("branch", "alpha"),
+        ref("remote", "origin/solo"),
+      ],
+      ALL,
+    );
+
+    expect(chips.map((c) => c.label)).toEqual([
+      "alpha",
+      "zeta",
+      "origin/solo",
+      "upstream/solo",
+    ]);
+  });
+
+  it("puts origin's block first inside a merged chip", () => {
+    const { chips } = buildRefChips(
+      [
+        ref("branch", "master"),
+        ref("remote", "upstream/master"),
+        ref("remote", "origin/master"),
+      ],
+      ALL,
+    );
+
+    expect(chips[0].remoteNames).toEqual(["origin", "upstream"]);
+    expect(chips[0].label).toBe("master (origin, upstream)");
+  });
+
+  it("collapses the least important refs, not whichever git listed last", () => {
+    const { chips, overflow } = buildRefChips(
+      [
+        ref("remote", "origin/solo"),
+        ref("tag", "v1"),
+        ref("head", "master"),
+        ref("branch", "feature"),
+      ],
+      { ...ALL, collapseAfter: 2 },
+    );
+
+    // Git lists the remote first; the row keeps HEAD and the branch instead.
+    expect(chips.map((c) => c.label)).toEqual(["master", "feature"]);
+    expect(overflow.map((c) => c.label)).toEqual(["v1", "origin/solo"]);
   });
 
   it("collapses everything past the threshold into the overflow list", () => {

--- a/src/modules/git-graph/lib/refChips.ts
+++ b/src/modules/git-graph/lib/refChips.ts
@@ -88,17 +88,28 @@ function compareChips(a: RefChip, b: RefChip): number {
       return rankA - rankB;
     }
     if (remoteA !== remoteB) {
-      return remoteA.localeCompare(remoteB);
+      return byCodepoint(remoteA, remoteB);
     }
   }
-  return a.ref.name.localeCompare(b.ref.name);
+  return byCodepoint(a.ref.name, b.ref.name);
 }
 
 /** Same rule inside a merged chip: origin's block first, then the rest by name. */
 function compareRemotes(a: CommitRef, b: CommitRef): number {
   const [rankA, remoteA] = remoteRank(a.name);
   const [rankB, remoteB] = remoteRank(b.name);
-  return rankA - rankB || remoteA.localeCompare(remoteB);
+  return rankA - rankB || byCodepoint(remoteA, remoteB);
+}
+
+/**
+ * Deterministic name tiebreak. `localeCompare` follows the runtime's default
+ * collator, which differs between Node (tests) and WKWebView (the app) and
+ * between users' systems — the same repo could paint rows in different orders.
+ * Plain codepoint order is stable everywhere, and ref names are ASCII enough
+ * that nothing linguistic is lost.
+ */
+function byCodepoint(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 function isOriginHead(ref: CommitRef): boolean {

--- a/src/modules/git-graph/lib/refChips.ts
+++ b/src/modules/git-graph/lib/refChips.ts
@@ -49,6 +49,58 @@ function localBranchName(ref: CommitRef): string | null {
   return null;
 }
 
+/** What a reader looks for first on a commit row, by ref kind. */
+const KIND_RANK: Record<string, number> = {
+  head: 0,
+  branch: 1,
+  tag: 2,
+  remote: 3,
+  stash: 4,
+  unknown: 5,
+};
+
+/** "origin" is the remote nearly every repo pushes to; it leads its own kind. */
+function remoteRank(name: string): [number, string] {
+  const remote = splitRemoteRef(name).remote;
+  return [remote === "origin" ? 0 : 1, remote];
+}
+
+/**
+ * Order two chips for the row.
+ *
+ * Git lists decorations in the reverse of the order it walked the refs, so
+ * `refs/remotes/…` lands before `refs/heads/…` — an implementation detail that
+ * means nothing to a reader, and that decides which chips `collapseAfter`
+ * hides. Rank by what the row is actually read for instead: where HEAD is,
+ * then the branches you act on, then the tags, then the remotes with no local
+ * twin here (the ahead/behind case), then the read-only decorations. Ties fall
+ * back to the name, so a row keeps the same shape across refreshes.
+ */
+function compareChips(a: RefChip, b: RefChip): number {
+  const byKind = (KIND_RANK[a.ref.kind] ?? 9) - (KIND_RANK[b.ref.kind] ?? 9);
+  if (byKind !== 0) {
+    return byKind;
+  }
+  if (a.ref.kind === "remote" && b.ref.kind === "remote") {
+    const [rankA, remoteA] = remoteRank(a.ref.name);
+    const [rankB, remoteB] = remoteRank(b.ref.name);
+    if (rankA !== rankB) {
+      return rankA - rankB;
+    }
+    if (remoteA !== remoteB) {
+      return remoteA.localeCompare(remoteB);
+    }
+  }
+  return a.ref.name.localeCompare(b.ref.name);
+}
+
+/** Same rule inside a merged chip: origin's block first, then the rest by name. */
+function compareRemotes(a: CommitRef, b: CommitRef): number {
+  const [rankA, remoteA] = remoteRank(a.name);
+  const [rankB, remoteB] = remoteRank(b.name);
+  return rankA - rankB || remoteA.localeCompare(remoteB);
+}
+
 function isOriginHead(ref: CommitRef): boolean {
   return ref.kind === "remote" && splitRemoteRef(ref.name).branch === "HEAD";
 }
@@ -120,6 +172,16 @@ export function buildRefChips(refs: CommitRef[], options: RefChipOptions): RefCh
       chips.push(soloChip(ref));
     }
   }
+
+  // Sorted after the folding, so a merged chip is ranked as the branch it is
+  // rather than as whichever half of it git happened to list first.
+  for (const chip of chips) {
+    if (chip.remotes.length > 1) {
+      chip.remotes.sort(compareRemotes);
+      refreshMerged(chip);
+    }
+  }
+  chips.sort(compareChips);
 
   const limit = options.collapseAfter;
   if (limit !== null && limit > 0 && chips.length > limit) {


### PR DESCRIPTION
## Problem

The chips on a commit row appear in the order git hands them over, and git
lists decorations in the reverse of the order it walked the refs. In practice
that puts `refs/remotes/…` ahead of `refs/heads/…`:

```
(refs/remotes/origin/fix/tab-bar-overflow-scroll, refs/heads/fix/tab-bar-overflow-scroll)
```

Reverse ref-name order is an implementation detail with nothing to say to a
reader, and it was deciding two things it should not. It picks what the eye
hits first on the row, and — since #357 — it picks which chips survive
`collapseAfter` and which fold into `+N`, because that is a plain
`slice(0, limit)` over git's order. A row can therefore hide a local branch
behind a remote chip that carries no information the branch does not.

## Changes

- `lib/refChips.ts` — `compareChips` ranks by ref kind: `head`, then `branch`,
  then `tag`, then `remote`, then `stash` / `unknown`. That is the order the row
  is read in — where HEAD is, then the branches you act on, then the milestones,
  then the remotes with no local twin at this commit (the ahead/behind case),
  then the read-only decorations. Ties fall back to the ref name, so a row keeps
  the same shape across refreshes.
- `origin` leads its own kind, since it is the remote nearly every repo pushes
  to. The same rule sorts the blocks inside a merged chip, so it reads
  `master │ origin │ upstream` rather than in whatever order git listed them.
- The sort runs after the folding, so a merged chip is ranked as the branch it
  is rather than as whichever half of it git happened to list first.
- No new switch. The three Git Graph options govern what a row shows; the order
  it shows it in is not a preference anyone holds. This does narrow #357's
  "turn all three off and you get exactly the previous row" slightly: with the
  options off you still get every ref, unmerged, `origin/HEAD` included — just
  not in git's reverse-alphabetical order. `refChips.test.ts` states that
  explicitly now.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec vitest run` — 227 files, 2083 tests passing (4 new in
      `refChips`: the kind ranking, name and `origin`-first ordering within a
      kind, `origin`'s block leading a merged chip, and `+N` collapsing the
      least important refs rather than whichever git listed last)
- [x] Two existing tests were about git's order and are rewritten, not deleted:
      the merged-remote case now asserts that a remote listed before its local
      twin gets folded rather than given a chip of its own, and the
      options-off case asserts the refs are all still there. The `RefChipStrip`
      overflow fixtures are renamed `a`–`e` so they stop depending on the order
      by accident.
- [x] `tauri dev` on Windows: a commit carrying HEAD, a branch, a tag and a
      lone remote renders in that order, and a row past the threshold keeps the
      branches on the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
