### PR TITLE
fix(ports): report a failed kill in the app's own dialog

### DIFF
--- a/src/modules/ports/PortsPanelView.test.tsx
+++ b/src/modules/ports/PortsPanelView.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/i18n";
+
+const { usePorts } = vi.hoisted(() => ({ usePorts: vi.fn() }));
+vi.mock("./lib/usePorts", () => ({ usePorts }));
+const { killPortProcess } = vi.hoisted(() => ({ killPortProcess: vi.fn() }));
+vi.mock("./lib/portsBridge", () => ({ killPortProcess }));
+
+import { PortsPanelView } from "./PortsPanelView";
+
+const sample = [
+  {
+    port: 3000,
+    protocol: "tcp",
+    bindAddr: "127.0.0.1",
+    pid: 10,
+    processName: "node",
+    command: "node server.js",
+    cwd: "/work",
+    cpuUsage: 0,
+    memoryBytes: 2048,
+    uptimeSecs: 90,
+    isCurrentUser: true,
+  },
+];
+
+beforeEach(() => {
+  usePorts.mockReset();
+  usePorts.mockReturnValue(sample);
+  killPortProcess.mockReset();
+});
+
+describe("PortsPanelView kill failure", () => {
+  it("reports a failed kill in the app's own dialog, not a native one", async () => {
+    killPortProcess.mockRejectedValue(new Error("EPERM"));
+    render(<PortsPanelView />);
+
+    fireEvent.click(screen.getByRole("button", { name: /kill/i }));
+    // The in-app ConfirmDialog asks first; confirm the kill.
+    fireEvent.click(screen.getByRole("button", { name: "Kill process" }));
+
+    // The failure lands in the app-styled InfoDialog (repo convention: no
+    // native alert surfaces), with the process name and the error detail.
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain("Failed to kill node");
+    expect(dialog.textContent).toContain("EPERM");
+
+    // Acknowledging it closes the dialog.
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/src/modules/ports/PortsPanelView.tsx
+++ b/src/modules/ports/PortsPanelView.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { message } from "@tauri-apps/plugin-dialog";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { InfoDialog } from "@/components/InfoDialog";
 import { usePorts } from "./lib/usePorts";
 import { killPortProcess, type PortInfo } from "./lib/portsBridge";
 import { PortRow } from "./PortRow";
@@ -20,6 +20,7 @@ export function PortsPanelView() {
   const setShowAll = useSettingsStore((s) => s.setShowAllPorts);
   const ports = usePorts(showAll, 5000);
   const [killTarget, setKillTarget] = useState<PortInfo | null>(null);
+  const [killError, setKillError] = useState<string | null>(null);
   const [expandedPid, setExpandedPid] = useState<number | null>(null);
 
   const list = ports ?? [];
@@ -36,10 +37,9 @@ export function PortsPanelView() {
     }
     void killPortProcess(target.port, target.pid).catch((err: unknown) => {
       const detail = err instanceof Error ? err.message : String(err);
-      void message(t("ports.killFailed", { process: target.processName, error: detail }), {
-        title: t("ports.kill"),
-        kind: "error",
-      });
+      // Repo convention: failures surface in the app-styled dialog, never a
+      // native alert (the one former exception in this file included).
+      setKillError(t("ports.killFailed", { process: target.processName, error: detail }));
     });
   };
 
@@ -81,6 +81,14 @@ export function PortsPanelView() {
           ))
         )}
       </div>
+      {killError && (
+        <InfoDialog
+          title={t("ports.kill")}
+          message={killError}
+          confirmLabel={t("actions.confirm")}
+          onConfirm={() => setKillError(null)}
+        />
+      )}
       {killTarget && (
         <ConfirmDialog
           title={t("ports.kill")}


### PR DESCRIPTION
## Problem

An audit of native-dialog usage (requested by the maintainer) found exactly one surface that still bypasses the app's own dialog components: the Ports panel called plugin-dialog's native `message()` when killing a port's process failed. Repo convention is ConfirmDialog / InfoDialog for every choice/acknowledgement.

Everything else in the audit stays native on purpose:
- `lib/dialog.ts`, background-image picker, notes-folder picker — OS file/folder pickers
- `exit_guard.rs`'s close/quit confirmation — deliberately native so it works while the webview is unresponsive (#356)

## Change

Route the kill-failure text into an `InfoDialog` (`ports.killFailed`, acknowledged with the standard confirm label) and drop the `@tauri-apps/plugin-dialog` import from `PortsPanelView.tsx`. Pickers keep the `dialog:default` capability, unchanged.

## Tests

New `PortsPanelView.test.tsx`: a rejected `killPortProcess` surfaces the process name and error detail in an in-app dialog, and acknowledging closes it. Written red-first against the native-message code, green after the change. `pnpm typecheck` passes; ports module tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)