### PR TITLE
perf: pause background window polling

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -8,6 +8,10 @@
 - Git Graph 的 ref 標籤整併：同名的本地分支與其遠端摺成同一顆標籤、不再各佔一格，origin/HEAD 不再顯示，超出行寬上限的標籤收進 +N 清單，點開後每顆仍可右鍵操作；合併後的標籤右鍵選單同時帶本地與各遠端的操作，不必再記哪顆標籤管哪半邊 (#357)
 - 檔案總管的右鍵選單新增「在瀏覽器開啟」，用內建的網頁預覽開啟檔案，不必先把它開進編輯器再按工具列那顆預覽鈕。開啟位置沿用既有的規則：分頁裡已經有預覽面板就換掉它的內容，單面板分頁就在旁邊分割，已經分割的分頁則使用專屬的預覽分頁。只有內建瀏覽器渲染得出來的檔案才會出現這個選項（HTML、SVG、PDF、圖片與影音），遠端 (SSH) 檔案則不適用 (#347)
 
+### perf
+
+- 視窗不可見時暫停 ports、system stats、preview 與 cwd 更新，回到前景時立即重新整理終端畫面與尺寸；仍可見但沒有焦點的多視窗會維持即時更新 (#369)
+
 ### fix
 
 - Ports 面板結束程序失敗時，錯誤訊息改用 app 自己的對話框顯示，不再跳原生警告框；這是全庫盤點後最後一處原生警告，檔案挑選器與關閉確認的原生對話框則屬刻意保留 (#367)
@@ -20,7 +24,7 @@
 
 ### 貢獻者
 
-- @mark22013333 (#355, #356)
+- @mark22013333 (#355, #356, #369)
 - @yw-chan (#348, #349, #350, #357, #360, #361, #364)
 - @oberonlai (#347, #362)
 
@@ -34,6 +38,10 @@
 - Git Graph ref chips are consolidated: a local branch and its same-named remotes fold into one chip instead of taking a slot each, origin/HEAD is no longer drawn, and chips past the row's limit collapse into a +N chip whose list keeps every chip right-clickable; a merged chip's context menu carries the local and each remote's operations, so there is no need to remember which chip owns which half (#357)
 - The explorer's context menu gains "Open in Browser", which opens a file in the built-in web preview instead of making you open it in the editor first and reach for the toolbar's preview button. Where it lands follows the existing rule: replace a preview pane the tab already has, split beside a single-pane tab, or use the dedicated preview tab when the tab is already split. The item only appears for files the built-in browser can actually render (HTML, SVG, PDF, images and media), and never for remote (SSH) files (#347)
 
+### perf
+
+- Pause ports, system stats, preview and cwd updates while a window is not visible, then immediately refresh the terminal frame and size on foreground return; visible but unfocused windows continue updating in multi-window use (#369)
+
 ### fix
 
 - When killing a port's process fails, the Ports panel now reports the error in the app's own dialog instead of a native alert — the last such surface found in an audit; file pickers and the close-confirmation prompt stay native by design (#367)
@@ -46,6 +54,6 @@
 
 ### Contributors
 
-- @mark22013333 (#355, #356)
+- @mark22013333 (#355, #356, #369)
 - @yw-chan (#348, #349, #350, #357, #360, #361, #364)
 - @oberonlai (#347, #362)

--- a/src/lib/windowActivity.test.ts
+++ b/src/lib/windowActivity.test.ts
@@ -1,0 +1,40 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isWindowVisible, useWindowVisible } from "./windowActivity";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("windowActivity", () => {
+  it("stays visible when another window takes focus", () => {
+    const { result } = renderHook(() => useWindowVisible());
+
+    act(() => window.dispatchEvent(new Event("blur")));
+
+    expect(result.current).toBe(true);
+  });
+
+  it("publishes one state transition per visibility change", () => {
+    const visibility = vi.spyOn(document, "visibilityState", "get");
+    visibility.mockReturnValue("visible");
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useWindowVisible();
+    });
+
+    expect(result.current).toBe(true);
+    visibility.mockReturnValue("hidden");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(result.current).toBe(false);
+    expect(isWindowVisible()).toBe(false);
+    const afterHidden = renders;
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(renders).toBe(afterHidden);
+
+    visibility.mockReturnValue("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/lib/windowActivity.ts
+++ b/src/lib/windowActivity.ts
@@ -1,0 +1,33 @@
+import { useSyncExternalStore } from "react";
+
+let visible = typeof document === "undefined" || document.visibilityState === "visible";
+const listeners = new Set<() => void>();
+let initialized = false;
+
+function publish(next: boolean): void {
+  if (next === visible) return;
+  visible = next;
+  for (const listener of listeners) listener();
+}
+
+function initialize(): void {
+  if (initialized || typeof window === "undefined") return;
+  initialized = true;
+  document.addEventListener("visibilitychange", () => {
+    publish(document.visibilityState === "visible");
+  });
+}
+
+export function isWindowVisible(): boolean {
+  initialize();
+  return visible;
+}
+
+export function useWindowVisible(): boolean {
+  initialize();
+  return useSyncExternalStore(
+    (listener) => { listeners.add(listener); return () => listeners.delete(listener); },
+    () => visible,
+    () => true,
+  );
+}

--- a/src/modules/ports/lib/usePorts.test.ts
+++ b/src/modules/ports/lib/usePorts.test.ts
@@ -1,8 +1,10 @@
-import { renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { fetchPorts } = vi.hoisted(() => ({ fetchPorts: vi.fn() }));
+const windowState = vi.hoisted(() => ({ visible: true }));
 vi.mock("./portsBridge", () => ({ fetchPorts }));
+vi.mock("@/lib/windowActivity", () => ({ useWindowVisible: () => windowState.visible }));
 
 import { usePorts } from "./usePorts";
 
@@ -23,9 +25,12 @@ const sample = [
 ];
 
 beforeEach(() => {
+  windowState.visible = true;
   fetchPorts.mockReset();
   fetchPorts.mockResolvedValue(sample);
 });
+
+afterEach(() => vi.useRealTimers());
 
 describe("usePorts", () => {
   it("returns null before the first sample, then the latest ports", async () => {
@@ -37,5 +42,25 @@ describe("usePorts", () => {
   it("passes the showAll flag through to fetchPorts", async () => {
     renderHook(() => usePorts(true));
     await waitFor(() => expect(fetchPorts).toHaveBeenCalledWith(true));
+  });
+
+  it("stops polling while hidden and resumes with one immediate poll", async () => {
+    vi.useFakeTimers();
+    const { rerender } = renderHook(() => usePorts(false, 5_000));
+    await act(async () => Promise.resolve());
+    expect(fetchPorts).toHaveBeenCalledTimes(1);
+
+    windowState.visible = false;
+    rerender();
+    await act(async () => vi.advanceTimersByTimeAsync(15_000));
+    expect(fetchPorts).toHaveBeenCalledTimes(1);
+
+    windowState.visible = true;
+    rerender();
+    await act(async () => Promise.resolve());
+    expect(fetchPorts).toHaveBeenCalledTimes(2);
+
+    await act(async () => vi.advanceTimersByTimeAsync(5_000));
+    expect(fetchPorts).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/modules/ports/lib/usePorts.ts
+++ b/src/modules/ports/lib/usePorts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { fetchPorts, type PortInfo } from "./portsBridge";
+import { useWindowVisible } from "@/lib/windowActivity";
 
 /** Default cadence; callers poll slower while the panel is closed. */
 const DEFAULT_POLL_INTERVAL_MS = 5000;
@@ -12,6 +13,7 @@ const DEFAULT_POLL_INTERVAL_MS = 5000;
  */
 export function usePorts(showAll: boolean, intervalMs: number = DEFAULT_POLL_INTERVAL_MS): PortInfo[] | null {
   const [ports, setPorts] = useState<PortInfo[] | null>(null);
+  const windowVisible = useWindowVisible();
 
   useEffect(() => {
     let active = true;
@@ -30,13 +32,14 @@ export function usePorts(showAll: boolean, intervalMs: number = DEFAULT_POLL_INT
           // A failed poll leaves the previous list on screen.
         });
     };
+    if (!windowVisible) return;
     poll();
     const interval = setInterval(poll, intervalMs);
     return () => {
       active = false;
       clearInterval(interval);
     };
-  }, [showAll, intervalMs]);
+  }, [showAll, intervalMs, windowVisible]);
 
   return ports;
 }

--- a/src/modules/preview/hooks/useNativePreviewWebview.ts
+++ b/src/modules/preview/hooks/useNativePreviewWebview.ts
@@ -7,6 +7,7 @@ import { debounce } from "@/lib/debounce";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { resolvePreviewSrc } from "../lib/resolvePreviewSrc";
 import { previewWebviewLabel } from "../lib/previewWebview";
+import { useWindowVisible } from "@/lib/windowActivity";
 
 interface Rect {
   x: number;
@@ -114,6 +115,7 @@ function sameRect(a: Rect | null, b: Rect | null): boolean {
  * Returns the host ref plus navigate/reload/back/forward controls.
  */
 export function useNativePreviewWebview({ url, leafId, visible, onNavigate, onTitle }: Options) {
+  const windowVisible = useWindowVisible();
   const hostRef = useRef<HTMLDivElement>(null);
   const webviewRef = useRef<Webview | null>(null);
   const visibleRef = useRef(visible);
@@ -132,7 +134,7 @@ export function useNativePreviewWebview({ url, leafId, visible, onNavigate, onTi
   const onNavigateRef = useRef(onNavigate);
   const onTitleRef = useRef(onTitle);
 
-  visibleRef.current = visible;
+  visibleRef.current = visible && windowVisible;
   zoomRef.current = uiZoom;
   onNavigateRef.current = onNavigate;
   onTitleRef.current = onTitle;

--- a/src/modules/sysmon/lib/useSystemStats.test.ts
+++ b/src/modules/sysmon/lib/useSystemStats.test.ts
@@ -1,22 +1,47 @@
-import { renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { fetchSystemStats } = vi.hoisted(() => ({ fetchSystemStats: vi.fn() }));
+const windowState = vi.hoisted(() => ({ visible: true }));
 vi.mock("./sysinfoBridge", () => ({ fetchSystemStats }));
+vi.mock("@/lib/windowActivity", () => ({ useWindowVisible: () => windowState.visible }));
 
 import { useSystemStats } from "./useSystemStats";
 
 const sample = { cpuUsage: 42, ramUsed: 8, ramTotal: 16, netRx: 1024, netTx: 512 };
 
 beforeEach(() => {
+  windowState.visible = true;
   fetchSystemStats.mockReset();
   fetchSystemStats.mockResolvedValue(sample);
 });
+
+afterEach(() => vi.useRealTimers());
 
 describe("useSystemStats", () => {
   it("returns null before the first sample, then the latest stats", async () => {
     const { result } = renderHook(() => useSystemStats());
     expect(result.current).toBeNull();
     await waitFor(() => expect(result.current).toEqual(sample));
+  });
+
+  it("stops polling while hidden and resumes with one immediate poll", async () => {
+    vi.useFakeTimers();
+    const { rerender } = renderHook(() => useSystemStats());
+    await act(async () => Promise.resolve());
+    expect(fetchSystemStats).toHaveBeenCalledTimes(1);
+
+    windowState.visible = false;
+    rerender();
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+    expect(fetchSystemStats).toHaveBeenCalledTimes(1);
+
+    windowState.visible = true;
+    rerender();
+    await act(async () => Promise.resolve());
+    expect(fetchSystemStats).toHaveBeenCalledTimes(2);
+
+    await act(async () => vi.advanceTimersByTimeAsync(2_000));
+    expect(fetchSystemStats).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/modules/sysmon/lib/useSystemStats.ts
+++ b/src/modules/sysmon/lib/useSystemStats.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { fetchSystemStats, type SystemStats } from "./sysinfoBridge";
+import { useWindowVisible } from "@/lib/windowActivity";
 
 /** How often the status bar refreshes the system metrics. */
 const POLL_INTERVAL_MS = 2000;
@@ -11,6 +12,7 @@ const POLL_INTERVAL_MS = 2000;
  */
 export function useSystemStats(): SystemStats | null {
   const [stats, setStats] = useState<SystemStats | null>(null);
+  const windowVisible = useWindowVisible();
 
   useEffect(() => {
     let active = true;
@@ -31,13 +33,14 @@ export function useSystemStats(): SystemStats | null {
           // A failed poll just leaves the previous value on screen.
         });
     };
+    if (!windowVisible) return;
     poll();
     const interval = setInterval(poll, POLL_INTERVAL_MS);
     return () => {
       active = false;
       clearInterval(interval);
     };
-  }, []);
+  }, [windowVisible]);
 
   return stats;
 }

--- a/src/modules/terminal/TerminalView.tsx
+++ b/src/modules/terminal/TerminalView.tsx
@@ -19,6 +19,7 @@ import { openPty, type PtySession } from "./lib/pty-bridge";
 import { openSsh, type SshSession } from "@/modules/ssh/lib/ssh-bridge";
 import { useForwardStatusStore } from "@/modules/ssh/lib/forwardStatusStore";
 import { liveSessionsStore } from "@/modules/ssh/lib/liveSessionsStore";
+import { useWindowVisible } from "@/lib/windowActivity";
 
 /** Narrows a session to PtySession (which has cwd/foregroundCommand). */
 function isPtySession(s: PtySession | SshSession): s is PtySession {
@@ -171,10 +172,14 @@ export function TerminalView({
   onOpenFile,
   onOpenPreview,
 }: TerminalViewProps) {
+  const windowVisible = useWindowVisible();
   const leafIdRef = useRef(leafId);
   leafIdRef.current = leafId;
   const activeRef = useRef(active);
   activeRef.current = active;
+  const isActiveTabRef = useRef(isActiveTab);
+  isActiveTabRef.current = isActiveTab;
+  const wasWindowVisibleRef = useRef(windowVisible);
   const cwdRef = useRef(cwd);
   cwdRef.current = cwd;
   const containerRef = useRef<HTMLDivElement>(null);
@@ -1206,6 +1211,36 @@ export function TerminalView({
     return () => cancelAnimationFrame(frame);
   }, [active, isActiveTab]);
 
+  // Commit a fresh terminal frame on foreground return and send a resize so
+  // full-screen TUIs repaint after WebKit has suspended their backing layer.
+  useEffect(() => {
+    const wasVisible = wasWindowVisibleRef.current;
+    wasWindowVisibleRef.current = windowVisible;
+    if (
+      !windowVisible
+      || wasVisible
+      || !activeRef.current
+      || !isActiveTabRef.current
+    ) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      const handle = handleRef.current;
+      const container = containerRef.current;
+      if (!handle || !container || container.clientWidth <= 0 || container.clientHeight <= 0) {
+        return;
+      }
+      try {
+        handle.fit.fit();
+        handle.term.refresh(0, Math.max(0, handle.term.rows - 1));
+      } catch {
+        // Ignore a transient zero-size container while the window is restoring.
+      }
+      void sessionRef.current?.resize(handle.term.cols, handle.term.rows);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [windowVisible]);
+
   // Apply live font changes from the settings panel to an already-open terminal.
   useEffect(() => {
     const handle = handleRef.current;
@@ -1272,7 +1307,7 @@ export function TerminalView({
   // the file explorer tracks `cd`. SSH panes take a different path below — no
   // cwd() or foregroundCommand() methods, so they ride OSC 7 reports instead.
   useEffect(() => {
-    if (!cwdTracking) {
+    if (!cwdTracking || !windowVisible) {
       return;
     }
     const paneSsh = sshRef.current;
@@ -1428,7 +1463,7 @@ export function TerminalView({
       }
       unsubscribe();
     };
-  }, [cwdTracking]);
+  }, [cwdTracking, windowVisible]);
 
   // Snapshot the cwd when this pane stops being active (e.g. switching tabs), so
   // its last directory is saved between polls. SSH panes skip this — no cwd() method.


### PR DESCRIPTION
## 摘要

這是 #341 拆分後的第 3 個 PR，接續已合併的 #355 與 #356，只處理背景視窗降載；WebView 掉線復原與工作階段重新附掛會留在第 4 個 PR。

## 行為

- 以 `document.visibilityState` 作為共用的 window visibility 狀態；另一個仍可見但未聚焦的視窗會維持正常更新
- 視窗不可見時暫停 listening ports 與 system stats IPC 輪詢，回到前景立即取得最新資料
- 不可見時隱藏原生 preview WebView，停止不必要的 bounds/show 更新，回到前景重新同步位置與顯示狀態
- 不可見時暫停 cwd 輪詢；scrollback 快照維持原本的定期保存，不因背景化遺失長時間輸出
- hidden → visible 時只對目前 active tab 的 active pane 重新 fit、refresh 並推送最新尺寸，讓全螢幕 TUI 收到 SIGWINCH 後重繪

## 範圍

本 PR 不包含 Output Hub、runtime ID、WebView 重新附掛、error boundary、persist v3、editor dirty 快照或 ⌘⇧R；這些維持第 4 塊獨立審查。

## 驗證

- `CI=true pnpm test`：229 test files／2,091 tests passed
- `CI=true pnpm build`
- `CI=true pnpm typecheck`
- window visibility 單元測試：視窗失焦仍維持 visible；visibility hidden／visible 各只發布一次狀態轉換
- ports／system stats hook 測試：hidden 時停止輪詢，visible 恢復時立即輪詢一次，之後維持原 cadence
