### PR TITLE
fix(sessions): title and count Codex user turns in the new rollout format

### DIFF
--- a/src-tauri/src/modules/codex_progress/mod.rs
+++ b/src-tauri/src/modules/codex_progress/mod.rs
@@ -58,12 +58,58 @@ fn parse_session_meta(first_line: &str) -> Option<SessionMeta> {
 /// Longest session title we keep; longer text is truncated for display.
 const MAX_TITLE_CHARS: usize = 80;
 
-/// Derive a title for a Codex session from a reader over its rollout JSONL: the
-/// first `user_message` event's text, trimmed and truncated. The session opens
-/// with injected `response_item` context (environment, instructions); the user's
-/// own first turn arrives as an `event_msg`/`user_message`, so that is what we
-/// use. Reads lazily and stops at the first match, so a long rollout is not fully
-/// loaded. Returns None when the rollout has no user message yet.
+/// Injected context Codex prepends to a user turn (file/image mentions,
+/// AGENTS.md instructions, XML-wrapped environment blocks). Never a title.
+pub(crate) fn is_injected_user_text(text: &str) -> bool {
+    let t = text.trim_start();
+    t.starts_with('<')
+        || t.starts_with("# Files mentioned by the user")
+        || t.starts_with("# AGENTS.md instructions")
+}
+
+/// The `item` of an `event_msg`/`item_completed` payload when it is a user
+/// turn. 2026-08+ rollouts stopped emitting `event_msg`/`user_message`; this
+/// is where the user's turns live in the new format.
+pub(crate) fn item_completed_user_item(payload: &Value) -> Option<&Value> {
+    if payload.get("type").and_then(Value::as_str) != Some("item_completed") {
+        return None;
+    }
+    let item = payload.get("item")?;
+    if item.get("type").and_then(Value::as_str) != Some("UserMessage") {
+        return None;
+    }
+    Some(item)
+}
+
+/// What the user actually typed in a UserMessage item: its text pieces joined,
+/// injected pieces skipped. None for e.g. an image-only turn.
+pub(crate) fn user_item_typed_text(item: &Value) -> Option<String> {
+    let pieces = item.get("content").and_then(Value::as_array)?;
+    let mut out = String::new();
+    for piece in pieces {
+        if piece.get("type").and_then(Value::as_str) != Some("text") {
+            continue;
+        }
+        let Some(text) = piece.get("text").and_then(Value::as_str) else { continue };
+        let text = text.trim();
+        if text.is_empty() || is_injected_user_text(text) {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(text);
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+/// Derive a title for a Codex session from a reader over its rollout JSONL:
+/// the first text the user actually typed, trimmed and truncated. Legacy
+/// rollouts carry user turns as `event_msg`/`user_message`; 2026-08+ rollouts
+/// carry them as `event_msg`/`item_completed` UserMessage items. Injected
+/// context (file mentions, AGENTS.md, XML wrappers) never titles a session.
+/// Reads lazily and stops at the first match, so a long rollout is not fully
+/// loaded. Returns None when the rollout has no typed user text yet.
 pub fn extract_codex_title<R: BufRead>(reader: R) -> Option<String> {
     for line in reader.lines() {
         let line = match line {
@@ -85,12 +131,18 @@ pub fn extract_codex_title<R: BufRead>(reader: R) -> Option<String> {
             Some(payload) => payload,
             None => continue,
         };
+        if let Some(item) = item_completed_user_item(payload) {
+            if let Some(text) = user_item_typed_text(item) {
+                return Some(text.chars().take(MAX_TITLE_CHARS).collect());
+            }
+            continue;
+        }
         if payload.get("type").and_then(Value::as_str) != Some("user_message") {
             continue;
         }
         if let Some(text) = payload.get("message").and_then(Value::as_str) {
             let trimmed = text.trim();
-            if !trimmed.is_empty() {
+            if !trimmed.is_empty() && !is_injected_user_text(trimmed) {
                 return Some(trimmed.chars().take(MAX_TITLE_CHARS).collect());
             }
         }
@@ -357,6 +409,20 @@ pub async fn codex_session_title(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
+    #[test]
+    fn extract_title_from_new_format_item_completed() {
+        let rollout = concat!(
+            r##"{"type":"event_msg","payload":{"type":"item_completed","item":{"type":"UserMessage","content":[{"type":"text","text":"# Files mentioned by the user:\n\n## a.png"}]}}}"##, "\n",
+            r#"{"type":"event_msg","payload":{"type":"item_completed","item":{"type":"UserMessage","content":[{"type":"text","text":"rename this session"}]}}}"#, "\n",
+        );
+        assert_eq!(
+            extract_codex_title(Cursor::new(rollout)),
+            Some("rename this session".to_string())
+        );
+    }
+
     use super::*;
     use std::path::{Path, PathBuf};
     use std::time::{Duration, SystemTime};

--- a/src-tauri/src/modules/sessions_index/codex.rs
+++ b/src-tauri/src/modules/sessions_index/codex.rs
@@ -141,6 +141,7 @@ pub fn parse_codex_meta(path: &Path) -> Option<ParsedSession> {
             "event_msg" => {
                 let etype = payload.get("type").and_then(Value::as_str).unwrap_or("");
                 match etype {
+                    // Legacy rollouts (pre 2026-08) carry the user's turns here.
                     "user_message" => {
                         let text = payload.get("message").and_then(Value::as_str).map(str::trim).unwrap_or("");
                         if text.is_empty() {
@@ -148,8 +149,33 @@ pub fn parse_codex_meta(path: &Path) -> Option<ParsedSession> {
                         }
                         message_count += 1;
                         user_message_count += 1;
-                        if title.is_none() {
+                        // Injected context (file mentions etc.) counts as a turn
+                        // but never titles the session.
+                        if title.is_none()
+                            && !crate::modules::codex_progress::is_injected_user_text(text)
+                        {
                             title = Some(text.chars().take(MAX_TITLE_CHARS).collect());
+                        }
+                        if let Some(ts) = ts {
+                            bump_message_bucket(&mut buckets, ts, true);
+                        }
+                    }
+                    // 2026-08+ rollouts dropped `user_message`; the user's turns
+                    // arrive as completed UserMessage items instead.
+                    "item_completed" => {
+                        let Some(item) =
+                            crate::modules::codex_progress::item_completed_user_item(payload)
+                        else {
+                            continue;
+                        };
+                        message_count += 1;
+                        user_message_count += 1;
+                        if title.is_none() {
+                            if let Some(text) =
+                                crate::modules::codex_progress::user_item_typed_text(item)
+                            {
+                                title = Some(text.chars().take(MAX_TITLE_CHARS).collect());
+                            }
                         }
                         if let Some(ts) = ts {
                             bump_message_bucket(&mut buckets, ts, true);
@@ -253,12 +279,26 @@ pub fn parse_codex_transcript(path: &Path) -> Vec<TranscriptMessage> {
 
         match type_ {
             "event_msg" => {
+                // Legacy user turns; new-format ones arrive as item_completed
+                // UserMessage items below. An image-only turn has nothing
+                // typed to render, so it gets no row (it still counts in meta).
                 if payload.get("type").and_then(Value::as_str) == Some("user_message") {
                     let text = payload.get("message").and_then(Value::as_str).map(str::trim).unwrap_or("");
                     if !text.is_empty() {
                         out.push(TranscriptMessage {
                             role: "user".to_string(),
                             text: text.to_string(),
+                            timestamp: ts,
+                            tool_name: None,
+                        });
+                    }
+                } else if let Some(item) =
+                    crate::modules::codex_progress::item_completed_user_item(payload)
+                {
+                    if let Some(text) = crate::modules::codex_progress::user_item_typed_text(item) {
+                        out.push(TranscriptMessage {
+                            role: "user".to_string(),
+                            text,
                             timestamp: ts,
                             tool_name: None,
                         });
@@ -335,6 +375,49 @@ mod tests {
         let path = dir.join("rollout-x.jsonl");
         std::fs::write(&path, contents).unwrap();
         path
+    }
+
+    // 2026-08+ Codex rollouts stopped emitting event_msg/user_message; the
+    // user's turns arrive as event_msg/item_completed with item.type
+    // "UserMessage", whose content mixes typed text with injected pieces
+    // (file mentions, AGENTS.md, XML wrappers).
+    const NEW_ROLLOUT: &str = concat!(
+        r#"{"timestamp":"2026-09-01T02:00:00.000Z","type":"session_meta","payload":{"id":"codex-2","cwd":"/p/gamma"}}"#, "\n",
+        r##"{"timestamp":"2026-09-01T02:00:01.000Z","type":"event_msg","payload":{"type":"item_completed","item":{"type":"UserMessage","id":"u1","content":[{"type":"text","text":"# Files mentioned by the user:\n\n## shot.png: /tmp/shot.png"},{"type":"local_image","text":""}]}}}"##, "\n",
+        r#"{"timestamp":"2026-09-01T02:00:02.000Z","type":"event_msg","payload":{"type":"item_completed","item":{"type":"UserMessage","id":"u2","content":[{"type":"text","text":"fix the codex title"}]}}}"#, "\n",
+        r#"{"timestamp":"2026-09-01T02:00:03.000Z","type":"turn_context","payload":{"model":"gpt-5.2-codex"}}"#, "\n",
+        r#"{"timestamp":"2026-09-01T02:00:04.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}"#, "\n",
+        r#"{"timestamp":"2026-09-01T02:00:05.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"output_tokens":7}}}}"#, "\n",
+    );
+
+    #[test]
+    fn new_format_user_turns_title_counts_and_transcript() {
+        let path = write_fixture("newfmt", NEW_ROLLOUT);
+        let meta = parse_codex_meta(&path).unwrap();
+        // The title skips the injected file-mention turn and lands on the
+        // first text the user actually typed.
+        assert_eq!(meta.title, "fix the codex title");
+        // Both user turns count (an image-only turn is still a message).
+        assert_eq!(meta.user_message_count, 2);
+        assert_eq!(meta.message_count, 3);
+        assert_eq!(meta.model.as_deref(), Some("gpt-5.2-codex"));
+
+        let t = parse_codex_transcript(&path);
+        let roles: Vec<&str> = t.iter().map(|m| m.role.as_str()).collect();
+        // The injected-only turn has nothing typed to render.
+        assert_eq!(roles, vec!["user", "assistant"]);
+        assert_eq!(t[0].text, "fix the codex title");
+    }
+
+    #[test]
+    fn legacy_title_skips_injected_file_mentions() {
+        let contents = concat!(
+            r#"{"timestamp":"2026-07-06T02:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"\n# Files mentioned by the user:\n\n## shot.png"}}"#, "\n",
+            r#"{"timestamp":"2026-07-06T02:00:02.000Z","type":"event_msg","payload":{"type":"user_message","message":"real question"}}"#, "\n",
+        );
+        let meta = parse_codex_meta(&write_fixture("legacyinj", contents)).unwrap();
+        assert_eq!(meta.title, "real question");
+        assert_eq!(meta.user_message_count, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Codex sessions started listing with no title in the AI sessions sidebar (and their user-message counts dropped to zero, with no user bubbles in the transcript viewer). Root cause: 2026-08+ Codex rollouts no longer emit `event_msg`/`user_message` — the only event the parser read user turns from. In new rollouts the user's turns arrive as `event_msg`/`item_completed` with `item.type: "UserMessage"`, whose `content` mixes the typed text with injected pieces (file mentions, AGENTS.md instructions, XML-wrapped context).

## Change

Parse the new shape everywhere the legacy event was read, keeping the legacy arm for old files (a rollout resumed across a Codex upgrade can contain both; each turn appears in exactly one format, so no double counting):

- `sessions_index/codex.rs` `parse_codex_meta` — title, user/message counts, activity buckets
- `parse_codex_transcript` — user rows from the typed text; an image-only turn still counts in meta but renders no bubble
- `codex_progress::extract_codex_title` — the live tracker's title

Shared helpers (`is_injected_user_text`, `item_completed_user_item`, `user_item_typed_text`) live in `codex_progress`, mirroring how `sessions_index/claude.rs` reuses `claude_progress`. Injected pieces never title a session — now applied to the legacy path too, which used to take `# Files mentioned by the user` as a title when an image opened the conversation.

## Verification

- Shapes taken from real local rollouts: 2026-05 (legacy `user_message`), 2026-09 (`item_completed` UserMessage, clean and file-mention-polluted turns)
- New tests written red-first: new-format title/counts/transcript, legacy injected-title skip, live-tracker new-format title
- `cargo test --lib` all green, `RUSTFLAGS="-D warnings" cargo check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)