### PR TITLE
fix(sessions): re-index cached Codex titles and fall back to replayed turns

### DIFF
--- a/src-tauri/src/modules/codex_progress/mod.rs
+++ b/src-tauri/src/modules/codex_progress/mod.rs
@@ -84,10 +84,31 @@ pub(crate) fn item_completed_user_item(payload: &Value) -> Option<&Value> {
 /// What the user actually typed in a UserMessage item: its text pieces joined,
 /// injected pieces skipped. None for e.g. an image-only turn.
 pub(crate) fn user_item_typed_text(item: &Value) -> Option<String> {
-    let pieces = item.get("content").and_then(Value::as_array)?;
+    typed_text_from_content(item.get("content"))
+}
+
+/// The typed text of a replayed user turn (`response_item`/`message` with
+/// role "user") — a compacted continuation's only record of what the user
+/// asked. Same injected-piece filter; None for any other payload.
+pub(crate) fn replayed_user_text(payload: &Value) -> Option<String> {
+    if payload.get("type").and_then(Value::as_str) != Some("message")
+        || payload.get("role").and_then(Value::as_str) != Some("user")
+    {
+        return None;
+    }
+    typed_text_from_content(payload.get("content"))
+}
+
+/// Join a content array's user-typed text pieces ("text" in UserMessage
+/// items, "input_text" in replayed response_items), skipping injected ones.
+fn typed_text_from_content(content: Option<&Value>) -> Option<String> {
+    let pieces = content.and_then(Value::as_array)?;
     let mut out = String::new();
     for piece in pieces {
-        if piece.get("type").and_then(Value::as_str) != Some("text") {
+        if !matches!(
+            piece.get("type").and_then(Value::as_str),
+            Some("text") | Some("input_text")
+        ) {
             continue;
         }
         let Some(text) = piece.get("text").and_then(Value::as_str) else { continue };
@@ -111,6 +132,9 @@ pub(crate) fn user_item_typed_text(item: &Value) -> Option<String> {
 /// Reads lazily and stops at the first match, so a long rollout is not fully
 /// loaded. Returns None when the rollout has no typed user text yet.
 pub fn extract_codex_title<R: BufRead>(reader: R) -> Option<String> {
+    // A compacted continuation may only carry the user's turns as replayed
+    // response_items; an event-based title always wins over this fallback.
+    let mut fallback: Option<String> = None;
     for line in reader.lines() {
         let line = match line {
             Ok(line) => line,
@@ -124,13 +148,20 @@ pub fn extract_codex_title<R: BufRead>(reader: R) -> Option<String> {
             Ok(value) => value,
             Err(_) => continue,
         };
-        if value.get("type").and_then(Value::as_str) != Some("event_msg") {
+        let line_type = value.get("type").and_then(Value::as_str).unwrap_or("");
+        if line_type != "event_msg" && line_type != "response_item" {
             continue;
         }
         let payload = match value.get("payload") {
             Some(payload) => payload,
             None => continue,
         };
+        if line_type == "response_item" {
+            if fallback.is_none() {
+                fallback = replayed_user_text(payload);
+            }
+            continue;
+        }
         if let Some(item) = item_completed_user_item(payload) {
             if let Some(text) = user_item_typed_text(item) {
                 return Some(text.chars().take(MAX_TITLE_CHARS).collect());
@@ -147,7 +178,7 @@ pub fn extract_codex_title<R: BufRead>(reader: R) -> Option<String> {
             }
         }
     }
-    None
+    fallback.map(|t| t.chars().take(MAX_TITLE_CHARS).collect())
 }
 
 /// `~/.codex/sessions` (or under the CODEX_HOME override).
@@ -410,6 +441,18 @@ pub async fn codex_session_title(
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
+
+    #[test]
+    fn extract_title_falls_back_to_replayed_user_turn() {
+        let rollout = concat!(
+            r#"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>x</environment_context>"},{"type":"input_text","text":"replayed question"}]}}"#, "\n",
+            r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}}"#, "\n",
+        );
+        assert_eq!(
+            extract_codex_title(Cursor::new(rollout)),
+            Some("replayed question".to_string())
+        );
+    }
 
     #[test]
     fn extract_title_from_new_format_item_completed() {

--- a/src-tauri/src/modules/sessions_index/codex.rs
+++ b/src-tauri/src/modules/sessions_index/codex.rs
@@ -93,6 +93,7 @@ pub fn parse_codex_meta(path: &Path) -> Option<ParsedSession> {
     let mut id: Option<String> = None;
     let mut project_cwd: Option<String> = None;
     let mut title: Option<String> = None;
+    let mut replay_title: Option<String> = None;
     let mut message_count: i64 = 0;
     let mut user_message_count: i64 = 0;
     let mut output_tokens: Option<i64> = None;
@@ -207,6 +208,12 @@ pub fn parse_codex_meta(path: &Path) -> Option<ParsedSession> {
             "response_item" => {
                 let rtype = payload.get("type").and_then(Value::as_str).unwrap_or("");
                 if rtype == "message" {
+                    // A compacted continuation's only record of the user's
+                    // asks is the replayed turn: title fallback, never a count.
+                    if replay_title.is_none() {
+                        replay_title =
+                            crate::modules::codex_progress::replayed_user_text(payload);
+                    }
                     // Only the assistant's own turns count. The rollout also
                     // replays the user's turn as a response_item with
                     // role:"user" (already counted via event_msg above), and
@@ -242,7 +249,9 @@ pub fn parse_codex_meta(path: &Path) -> Option<ParsedSession> {
 
     let id = id.unwrap_or_else(|| path.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default());
     let project_cwd = project_cwd.unwrap_or_default();
-    let title = title.unwrap_or_default();
+    let title = title
+        .or_else(|| replay_title.map(|t| t.chars().take(MAX_TITLE_CHARS).collect()))
+        .unwrap_or_default();
 
     let mut activity: Vec<ActivityBucket> = buckets.into_values().collect();
     activity.sort_by(|a, b| (a.date.as_str(), a.hour).cmp(&(b.date.as_str(), b.hour)));
@@ -418,6 +427,22 @@ mod tests {
         let meta = parse_codex_meta(&write_fixture("legacyinj", contents)).unwrap();
         assert_eq!(meta.title, "real question");
         assert_eq!(meta.user_message_count, 2);
+    }
+
+    // A compacted continuation replays prior history as response_item
+    // user turns and may hold no typed UserMessage item at all; the title
+    // falls back to the replayed turn (which never counts as a message).
+    #[test]
+    fn compacted_continuation_titles_from_replayed_user_turn() {
+        let contents = concat!(
+            r#"{"timestamp":"2026-08-31T02:00:00.000Z","type":"session_meta","payload":{"id":"codex-3","cwd":"/p/delta"}}"#, "\n",
+            r#"{"timestamp":"2026-08-31T02:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>x</environment_context>"},{"type":"input_text","text":"why is the root cause untouched"}]}}"#, "\n",
+            r#"{"timestamp":"2026-08-31T02:00:02.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"looking"}]}}"#, "\n",
+        );
+        let meta = parse_codex_meta(&write_fixture("compacted", contents)).unwrap();
+        assert_eq!(meta.title, "why is the root cause untouched");
+        assert_eq!(meta.user_message_count, 0);
+        assert_eq!(meta.message_count, 1);
     }
 
     #[test]

--- a/src-tauri/src/modules/sessions_index/index.rs
+++ b/src-tauri/src/modules/sessions_index/index.rs
@@ -10,7 +10,10 @@ use rusqlite::{params, Connection};
 
 use super::types::{ParsedSession, SessionSummary};
 
-pub const SCHEMA_VERSION: &str = "1";
+// "2": Codex titles/counts re-derived for the item_completed rollout format
+// (#372) plus the replayed-turn title fallback — a bump drops and rebuilds the
+// tables so files the old parser already fingerprinted get re-parsed.
+pub const SCHEMA_VERSION: &str = "2";
 
 pub struct Index {
     pub(crate) conn: Connection,


### PR DESCRIPTION
## Problem

After #372, some Codex sessions still listed untitled. Two causes:

1. **Stale cache.** The index re-parses a rollout only when its mtime/size fingerprint changes, so files the old parser had already indexed kept their cached empty titles indefinitely.
2. **Compacted continuations.** A resumed/compacted rollout may contain no typed `UserMessage` item at all — its only record of the user's asks is the history replayed as `response_item` user turns, which #372 deliberately did not read.

A scan of all 1,428 local rollouts found 71 still untitled under #372's rules.

## Change

- Bump `SCHEMA_VERSION` to 2: the data tables drop and rebuild on next launch, re-parsing everything the fingerprint cache was hiding.
- Title fallback from the first typed, non-injected replayed user turn — in `parse_codex_meta` and in the live tracker's `extract_codex_title`. Replays never count as messages (they duplicate turns already counted, or belong to the pre-compaction file). An event-based title always wins over the fallback.
- Sub-agent rollouts where nothing was ever typed stay untitled on purpose.

## Verification

- Written red-first: a compacted-continuation fixture (index) and a replayed-turn fallback case (live tracker)
- `cargo test --lib` 505 green, `RUSTFLAGS="-D warnings" cargo check` clean
- Fixture shapes taken from the real local rollouts that were still untitled

🤖 Generated with [Claude Code](https://claude.com/claude-code)