### PR TITLE
docs: add the #374 fix to CHANGELOG-NEXT

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -11,6 +11,7 @@
 
 ### fix
 
+- 接續 #372：升級索引 schema 版本，強制重掃所有已被舊 parser 快取成空標題的 Codex 對話；compacted 續用檔沒有任何打字紀錄時，標題改從 replay 的使用者發言撈取（僅取標題、不計入訊息數） (#374)
 - 修正新版 Codex 對話在 AI 對話側邊欄沒有標題、使用者訊息數為零、對話內容看不到使用者發言的問題。新版 rollout 改用 item_completed 事件記錄使用者輸入，索引、對話檢視與即時追蹤三處都補上新格式；注入的脈絡（檔案提及、AGENTS.md 等）不再被拿來當標題，舊格式同樣受惠 (#372)
 - Ports 面板結束程序失敗時，錯誤訊息改用 app 自己的對話框顯示，不再跳原生警告框；這是全庫盤點後最後一處原生警告，檔案挑選器與關閉確認的原生對話框則屬刻意保留 (#367)
 - 修正 Windows 上開啟任何對話框時，自訂標題列右上角的最小化、最大化、關閉按鈕被遮罩蓋住而點不到的問題。三顆按鈕改為固定在視窗右上、永遠位於對話框之上；選單列維持被遮罩蓋住，避免隔著遮罩操作選單 (#349)
@@ -39,6 +40,7 @@
 
 ### fix
 
+- Follow-up to #372: bump the index schema version so Codex sessions the old parser had cached with empty titles are re-parsed, and title compacted continuations from their replayed user turns when no typed turn exists (title only, never counted as messages) (#374)
 - Fix new-format Codex sessions listing untitled in the AI sessions sidebar, with zero user messages and no user bubbles in the transcript. Newer rollouts record user turns as item_completed events; the index, the transcript viewer and the live tracker all parse the new shape, and injected context (file mentions, AGENTS.md) no longer titles a session on either format (#372)
 - When killing a port's process fails, the Ports panel now reports the error in the app's own dialog instead of a native alert — the last such surface found in an audit; file pickers and the close-confirmation prompt stay native by design (#367)
 - Fix the custom title bar's minimize, maximize and close controls on Windows being covered and made unclickable by any dialog's backdrop. The controls are now pinned to the window's top-right above every dialog, while the menu bar deliberately stays under the backdrop so a dialog cannot be operated from behind its own overlay (#349)


### PR DESCRIPTION
Adds the bilingual changelog entry for #374 (Codex title cache re-index and replayed-turn fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)