### PR TITLE
fix(exit-guard): only prompt for busy sessions, not idle prompts

### DIFF
--- a/src-tauri/src/modules/exit_guard.rs
+++ b/src-tauri/src/modules/exit_guard.rs
@@ -59,11 +59,15 @@ enum WindowCloseDecision {
 fn decide_window_close(
     enabled: bool,
     session_count: usize,
+    busy_count: usize,
     prompting: bool,
 ) -> WindowCloseDecision {
     if session_count == 0 {
         WindowCloseDecision::Allow
-    } else if !enabled {
+    } else if !enabled || busy_count == 0 {
+        // Idle shells still need their backend sessions cleaned up, but they
+        // hold no work a prompt could save — close without asking, the way
+        // Terminal.app and iTerm2 treat a bare prompt.
         WindowCloseDecision::CloseAndDestroy
     } else if prompting {
         WindowCloseDecision::Ignore
@@ -72,10 +76,20 @@ fn decide_window_close(
     }
 }
 
-fn all_session_count(app: &AppHandle) -> usize {
+/// Sessions whose terminal is actually running a job (#366). SSH sessions all
+/// count: a live remote shell's foreground state cannot be probed from here,
+/// and over-asking beats silently dropping a remote connection.
+fn all_busy_count(app: &AppHandle) -> usize {
     let pty = app.state::<PtyState>();
     let ssh = app.state::<SshState>();
-    crate::modules::pty::session_count(&pty) + crate::modules::ssh::session_count(&ssh)
+    crate::modules::pty::busy_session_count(&pty) + crate::modules::ssh::session_count(&ssh)
+}
+
+fn window_busy_count(app: &AppHandle, owner: &str) -> usize {
+    let pty = app.state::<PtyState>();
+    let ssh = app.state::<SshState>();
+    crate::modules::pty::busy_owned_session_count(&pty, owner)
+        + crate::modules::ssh::owned_session_count(&ssh, owner)
 }
 
 fn window_session_count(app: &AppHandle, owner: &str) -> usize {
@@ -97,7 +111,7 @@ fn close_window_sessions(app: &AppHandle, owner: &str) {
 #[cfg(target_os = "macos")]
 pub fn request_quit(app: &AppHandle) {
     let guard = app.state::<ExitGuardState>();
-    let count = all_session_count(app);
+    let count = all_busy_count(app);
     if !guard.enabled.load(Ordering::Acquire) || count == 0 {
         guard.bypass_once.store(true, Ordering::Release);
         app.exit(0);
@@ -142,9 +156,11 @@ pub fn handle_run_event(app: &AppHandle, event: &RunEvent) {
     {
         let guard = app.state::<ExitGuardState>();
         let session_count = window_session_count(app, label);
+        let busy_count = window_busy_count(app, label);
         let decision = decide_window_close(
             guard.enabled.load(Ordering::Acquire),
             session_count,
+            busy_count,
             guard.prompting.load(Ordering::Acquire),
         );
 
@@ -188,7 +204,7 @@ pub fn handle_run_event(app: &AppHandle, event: &RunEvent) {
         let label = label.clone();
         let language = guard.language.lock().unwrap().clone();
         std::thread::spawn(move || {
-            let confirmed = show_confirmation(&app, &language, session_count, false, Some(&label));
+            let confirmed = show_confirmation(&app, &language, busy_count, false, Some(&label));
             let guard = app.state::<ExitGuardState>();
             guard.finish_prompt();
             if confirmed {
@@ -207,7 +223,7 @@ pub fn handle_run_event(app: &AppHandle, event: &RunEvent) {
     let guard = app.state::<ExitGuardState>();
     if guard.bypass_once.swap(false, Ordering::AcqRel)
         || !guard.enabled.load(Ordering::Acquire)
-        || all_session_count(app) == 0
+        || all_busy_count(app) == 0
     {
         return;
     }
@@ -219,7 +235,7 @@ pub fn handle_run_event(app: &AppHandle, event: &RunEvent) {
 
     let app = app.clone();
     let language = guard.language.lock().unwrap().clone();
-    let count = all_session_count(&app);
+    let count = all_busy_count(&app);
     std::thread::spawn(move || {
         let confirmed = show_confirmation(&app, &language, count, true, None);
 
@@ -309,7 +325,7 @@ mod tests {
     #[test]
     fn disabled_confirmation_still_closes_and_destroys_owned_sessions() {
         assert_eq!(
-            decide_window_close(false, 1, false),
+            decide_window_close(false, 1, 1, false),
             WindowCloseDecision::CloseAndDestroy
         );
     }
@@ -317,19 +333,30 @@ mod tests {
     #[test]
     fn close_without_owned_sessions_is_allowed() {
         assert_eq!(
-            decide_window_close(true, 0, false),
+            decide_window_close(true, 0, 0, false),
             WindowCloseDecision::Allow
+        );
+    }
+
+    // #366: an idle prompt holds no work a prompt could save — clean up and
+    // close without asking, exactly like a disabled guard, never like Allow
+    // (the backend sessions still need closing).
+    #[test]
+    fn idle_sessions_close_without_a_prompt_but_with_cleanup() {
+        assert_eq!(
+            decide_window_close(true, 2, 0, false),
+            WindowCloseDecision::CloseAndDestroy
         );
     }
 
     #[test]
     fn repeated_close_while_prompting_is_ignored() {
         assert_eq!(
-            decide_window_close(true, 1, false),
+            decide_window_close(true, 1, 1, false),
             WindowCloseDecision::Prompt
         );
         assert_eq!(
-            decide_window_close(true, 1, true),
+            decide_window_close(true, 1, 1, true),
             WindowCloseDecision::Ignore
         );
     }
@@ -341,7 +368,7 @@ mod tests {
         state.finish_prompt();
 
         assert_eq!(
-            decide_window_close(true, 1, state.prompting.load(Ordering::Acquire)),
+            decide_window_close(true, 1, 1, state.prompting.load(Ordering::Acquire)),
             WindowCloseDecision::Prompt
         );
     }

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -5,7 +5,8 @@ pub mod shell;
 
 pub use session::PtyState;
 pub(crate) use session::{
-    close_owned as close_owned_sessions, owned_count as owned_session_count, session_count,
+    busy_owned_count as busy_owned_session_count, busy_total_count as busy_session_count,
+    close_owned as close_owned_sessions, owned_count as owned_session_count,
 };
 
 use tauri::ipc::{Channel, Response};

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -18,6 +18,10 @@ use super::shell::{
 /// A single live terminal session.
 pub struct Session {
     owner_label: Mutex<Option<String>>,
+    /// The spawned shell's own pid, kept to tell "sitting at the prompt"
+    /// apart from "running a job" (see `session_is_busy`). None when the
+    /// backend could not report it — treated as busy, never as idle.
+    shell_pid: Option<u32>,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     master: Mutex<Box<dyn MasterPty + Send>>,
     killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
@@ -170,6 +174,7 @@ pub fn spawn_with_sinks(
         .map_err(|e| e.to_string())?;
 
     let mut child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    let shell_pid = child.process_id();
     // Drop the slave so EOF propagates to the reader once the child exits
     // (unix; on Windows EOF needs the pseudo console closed — see the waiter
     // thread below).
@@ -181,6 +186,7 @@ pub fn spawn_with_sinks(
 
     let session = Arc::new(Session {
         owner_label: Mutex::new(owner_label),
+        shell_pid,
         writer: Arc::new(Mutex::new(writer)),
         master: Mutex::new(pair.master),
         killer: Mutex::new(killer),
@@ -491,8 +497,67 @@ pub fn close_all(state: &PtyState) {
     }
 }
 
-pub fn session_count(state: &PtyState) -> usize {
-    state.sessions.read().unwrap().len()
+/// Busy = the terminal is doing something a close would kill: its foreground
+/// process group is not the shell itself. Pure and cfg-free so both platform
+/// rules stay unit-tested on every host. Unknown states count as busy —
+/// over-asking is recoverable, silently killing a job is not.
+#[cfg_attr(windows, allow(dead_code))]
+fn busy_from_foreground(foreground: Option<i32>, shell_pid: Option<u32>) -> bool {
+    match (foreground, shell_pid) {
+        (Some(fg), Some(shell)) => fg < 0 || fg as u32 != shell,
+        _ => true,
+    }
+}
+
+/// Windows has no foreground process group (see foreground_pid); a shell that
+/// spawned children it still owns is the closest observable notion of busy.
+/// `processes` is (pid, parent pid) for every live process.
+#[cfg_attr(unix, allow(dead_code))]
+fn busy_from_children(shell_pid: u32, processes: &[(u32, Option<u32>)]) -> bool {
+    processes.iter().any(|(_, parent)| *parent == Some(shell_pid))
+}
+
+#[cfg(unix)]
+fn session_is_busy(session: &Session) -> bool {
+    busy_from_foreground(foreground_pid(session), session.shell_pid)
+}
+
+#[cfg(not(unix))]
+fn session_is_busy(session: &Session) -> bool {
+    let Some(shell) = session.shell_pid else { return true };
+    let mut system = sysinfo::System::new();
+    system.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+    let processes: Vec<(u32, Option<u32>)> = system
+        .processes()
+        .iter()
+        .map(|(pid, proc_)| (pid.as_u32(), proc_.parent().map(|p| p.as_u32())))
+        .collect();
+    busy_from_children(shell, &processes)
+}
+
+/// Sessions in this window whose terminal is running a foreground job. Only
+/// the exit guard's "should we ask" reads this; cleanup still uses the full
+/// counts, because closing kills idle shells too.
+pub fn busy_owned_count(state: &PtyState, owner_label: &str) -> usize {
+    state
+        .sessions
+        .read()
+        .unwrap()
+        .values()
+        .filter(|session| session.owner_label.lock().unwrap().as_deref() == Some(owner_label))
+        .filter(|session| session_is_busy(session))
+        .count()
+}
+
+/// Busy sessions across every window (the app-quit prompt's gate).
+pub fn busy_total_count(state: &PtyState) -> usize {
+    state
+        .sessions
+        .read()
+        .unwrap()
+        .values()
+        .filter(|session| session_is_busy(session))
+        .count()
 }
 
 pub fn owned_count(state: &PtyState, owner_label: &str) -> usize {
@@ -635,6 +700,71 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[test]
+    fn unknown_foreground_or_shell_counts_as_busy() {
+        assert!(busy_from_foreground(None, Some(10)));
+        assert!(busy_from_foreground(Some(10), None));
+        assert!(busy_from_foreground(None, None));
+    }
+
+    #[test]
+    fn foreground_group_decides_busy_on_unix_semantics() {
+        assert!(!busy_from_foreground(Some(42), Some(42))); // at the prompt
+        assert!(busy_from_foreground(Some(43), Some(42))); // a job owns the tty
+        assert!(busy_from_foreground(Some(-1), Some(42))); // tcgetpgrp error
+    }
+
+    #[test]
+    fn shell_children_decide_busy_on_windows_semantics() {
+        let table = [(1u32, None), (42, Some(1)), (99, Some(42))];
+        assert!(busy_from_children(42, &table)); // 99 is the shell's child
+        assert!(!busy_from_children(99, &table)); // leaf process: idle
+    }
+
+    /// Real end-to-end check of the unix rule against a live interactive
+    /// shell: idle at the prompt, busy while `sleep` owns the terminal.
+    /// Ignored by default: it needs an interactive zsh with job control and
+    /// real timing; run with `cargo test --lib busy -- --ignored`.
+    #[test]
+    #[ignore]
+    fn live_shell_reports_busy_only_while_a_job_runs() {
+        let state = PtyState::default();
+        let mut cmd = CommandBuilder::new("/bin/zsh");
+        cmd.args(["-f", "-i"]);
+        let id = spawn_with_sinks(
+            &state,
+            state.alloc_id(),
+            80,
+            24,
+            cmd,
+            "zsh".to_string(),
+            Some("main".to_string()),
+            |_| true,
+            |_| {},
+        )
+        .expect("spawn interactive zsh");
+
+        let wait_for = |want_busy: bool| -> bool {
+            for _ in 0..50 {
+                let busy = {
+                    let sessions = state.sessions.read().unwrap();
+                    session_is_busy(sessions.get(&id).expect("session alive"))
+                };
+                if busy == want_busy {
+                    return true;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            false
+        };
+
+        assert!(wait_for(false), "idle prompt must not be busy");
+        write_input(&state, id, "sleep 3\r".as_bytes()).unwrap();
+        assert!(wait_for(true), "a running sleep must be busy");
+        assert!(wait_for(false), "back at the prompt must be idle again");
+        close(&state, id);
+    }
+
     #[test]
     fn registers_owner_with_the_session_atomically() {
         let state = PtyState::new();


### PR DESCRIPTION
Closes #366.

## Problem

The #356 confirmation counted every live PTY session — and every open terminal tab is one — so the dialog fired on effectively every window close and quit, even with nothing but idle prompts open. A dialog that always fires protects nothing.

## Change

Count only **busy** sessions (Terminal.app / iTerm2 semantics):

- **Unix**: the PTY's `process_group_leader` (already used for cwd tracking) vs the shell's own pid, captured at spawn. Foreground group ≠ shell ⇒ a job owns the terminal.
- **Windows**: no foreground-group concept — a shell with live child processes counts as busy, read via the `sysinfo` dependency the ports/sysmon modules already carry (one scan at close time, never polled).
- Both platform rules are pure functions with unit tests that run on every host (per the `windows-tauri` skill's parameterize-don't-cfg guidance); unknown states count as busy.
- **SSH sessions always count** — a remote shell's foreground state cannot be probed; over-asking beats dropping a remote connection silently.
- **Cleanup is unchanged**: an idle-only window closes without a prompt but still through `CloseAndDestroy`, so its backend sessions are cleaned up; the dialog's number now reports busy sessions.
- `pty::session_count` and the guard's total counter lost their last consumers and are removed.

## Verification

- New unit tests: unknown-state-is-busy, Unix foreground rule, Windows children rule, and the idle-only ⇒ CloseAndDestroy decision case
- An `#[ignore]`d integration test drives a real interactive zsh (prompt → `sleep` → prompt) and asserts the busy transitions — passes locally on macOS
- `cargo test --lib` 509 green; `RUSTFLAGS="-D warnings" cargo check` clean

Follow-up unlocked (tracked in #366's notes): per-tab close confirmation can now reuse `session_is_busy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)