### PR TITLE
feat(source-control): pin Recent commits to the bottom and remember the panel layout

### DIFF
--- a/src/modules/git-graph/CommitDetailsPanel.test.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/i18n";
 import { CommitDetailsPanel } from "./CommitDetailsPanel";
 import {
@@ -49,6 +49,10 @@ const COMMIT: CommitNode = {
 };
 
 describe("CommitDetailsPanel changed-files tree", () => {
+  // The flat/folder toggle is remembered, so one test's choice must not
+  // leak into the next.
+  beforeEach(() => localStorage.clear());
+
   it("nests dist/aaa and dist/bbb under one dist folder in tree mode", async () => {
     vi.mocked(gitCommitDetails).mockResolvedValue({
       message: "feat: x",
@@ -72,6 +76,31 @@ describe("CommitDetailsPanel changed-files tree", () => {
     await waitFor(() => expect(screen.getAllByText("dist")).toHaveLength(1));
     expect(screen.getByText("aaa")).toBeInTheDocument();
     expect(screen.getByText("x.ts")).toBeInTheDocument();
+  });
+
+  it("remembers the flat/folder view mode across remounts", async () => {
+    vi.mocked(gitCommitDetails).mockResolvedValue({
+      message: "feat: x",
+      files: [{ status: "M", path: "dist/aaa/x.ts" }],
+    });
+    const panel = () => (
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "single", commit: COMMIT }}
+        onClose={() => {}}
+        labels={LABELS}
+      />
+    );
+    const first = render(panel());
+    await screen.findByText("dist/aaa/x.ts");
+    fireEvent.click(screen.getByRole("button", { name: "Group by folder" }));
+    await screen.findByText("x.ts");
+    first.unmount();
+
+    render(panel());
+
+    expect(await screen.findByText("x.ts")).toBeInTheDocument();
+    expect(screen.queryByText("dist/aaa/x.ts")).not.toBeInTheDocument();
   });
 
   it("collapsing a folder in tree mode hides its files", async () => {
@@ -122,6 +151,10 @@ describe("CommitDetailsPanel changed-files tree", () => {
 });
 
 describe("CommitDetailsPanel compare mode", () => {
+  // The flat/folder toggle is remembered, so one test's choice must not
+  // leak into the next.
+  beforeEach(() => localStorage.clear());
+
   const OTHER: CommitNode = {
     hash: "def5678",
     parents: [],

--- a/src/modules/git-graph/CommitDetailsPanel.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.tsx
@@ -66,6 +66,10 @@ const FILE_OVERSCAN = 20;
 
 type FilesViewMode = "flat" | "folder";
 
+// Remembered per panel, not shared with the Source Control sidebar: the two
+// lists live at very different widths, so one preference would fit neither.
+const FILES_VIEW_MODE_KEY = "tempoterm-gitgraph-files-view-mode";
+
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
@@ -176,7 +180,12 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
   // run yet). Fall back to "diff" here so the content below never tries to
   // render the AI tab (and dereference `singleCommit`) while isCompare.
   const activeTab = isCompare ? "diff" : tab;
-  const [filesViewMode, setFilesViewMode] = useState<FilesViewMode>("flat");
+  const [filesViewMode, setFilesViewMode] = useState<FilesViewMode>(() =>
+    localStorage.getItem(FILES_VIEW_MODE_KEY) === "folder" ? "folder" : "flat",
+  );
+  useEffect(() => {
+    localStorage.setItem(FILES_VIEW_MODE_KEY, filesViewMode);
+  }, [filesViewMode]);
   const {
     collapsed: collapsedFolders,
     toggle: toggleDetailsFolder,

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -35,6 +35,7 @@ const STATUS_ONE_MODIFIED: GitStatus = {
 describe("SourceControlView row interactions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.mocked(gitBridge.gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitBridge.gitLog).mockResolvedValue([]);
     vi.mocked(gitBridge.gitStatus).mockResolvedValue(STATUS_ONE_MODIFIED);
@@ -149,6 +150,7 @@ describe("SourceControlView row interactions", () => {
 describe("SourceControlView collapsible sections", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.mocked(gitBridge.gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitBridge.gitLog).mockResolvedValue([]);
     vi.mocked(gitBridge.gitStatus).mockResolvedValue(STATUS_ONE_MODIFIED);
@@ -226,6 +228,51 @@ describe("SourceControlView collapsible sections", () => {
     expect(after[1].closest("li")).not.toHaveAttribute("aria-current");
   });
 
+  it("keeps Recent commits pinned outside the scrolling area in both states", async () => {
+    vi.mocked(gitBridge.gitLog).mockResolvedValue([
+      { id: "abc1234", summary: "feat: x", author: "a", timestamp: 1, parents: [] },
+    ]);
+    render(<SourceControlView />);
+    await screen.findByText("feat: x");
+
+    // The header must never live inside the Changes scroller, or expanding it
+    // would drop it into that scroll flow and carry it out of view.
+    const scroller = screen.getByRole("button", { name: "Changes" }).closest("section")
+      ?.parentElement;
+    const history = () => screen.getByRole("button", { name: "Recent commits" });
+    expect(scroller).not.toBeNull();
+    expect(scroller!.contains(history())).toBe(false);
+
+    fireEvent.click(history());
+    expect(screen.queryByText("feat: x")).not.toBeInTheDocument();
+    expect(scroller!.contains(history())).toBe(false);
+  });
+
+  it("remembers which sections are collapsed across remounts", async () => {
+    const first = render(<SourceControlView />);
+    await screen.findByText("src/a.ts");
+    fireEvent.click(screen.getByRole("button", { name: "Changes" }));
+    expect(screen.queryByText("src/a.ts")).not.toBeInTheDocument();
+    first.unmount();
+
+    render(<SourceControlView />);
+    const header = await screen.findByRole("button", { name: "Changes" });
+    expect(header).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("remembers the flat/folder view mode across remounts", async () => {
+    const first = render(<SourceControlView />);
+    await screen.findByText("src/a.ts");
+    // The button offers the mode you'd switch *to*, so "Group by folder" means
+    // the panel is flat right now.
+    fireEvent.click(screen.getByRole("button", { name: "Group by folder" }));
+    expect(screen.getByRole("button", { name: "Flat view" })).toBeInTheDocument();
+    first.unmount();
+
+    render(<SourceControlView />);
+    expect(await screen.findByRole("button", { name: "Flat view" })).toBeInTheDocument();
+  });
+
   it("unstages every staged file from the staged section header", async () => {
     vi.mocked(gitBridge.gitStatus).mockResolvedValue({
       branch: "main",
@@ -249,6 +296,7 @@ describe("SourceControlView collapsible sections", () => {
 describe("SourceControlView folder view", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.mocked(gitBridge.gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitBridge.gitLog).mockResolvedValue([]);
     vi.mocked(gitBridge.gitStage).mockResolvedValue(undefined);
@@ -329,6 +377,7 @@ describe("SourceControlView folder view", () => {
 describe("SourceControlView nested folder tree", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.mocked(gitBridge.gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitBridge.gitLog).mockResolvedValue([]);
     vi.mocked(gitBridge.gitStatus).mockResolvedValue({
@@ -400,6 +449,7 @@ describe("SourceControlView nested folder tree", () => {
 describe("SourceControlView refresh feedback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.mocked(gitBridge.gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitBridge.gitLog).mockResolvedValue([]);
     useWorkspaceStore.setState({ rootPath: "/root" });
@@ -438,6 +488,7 @@ describe("SourceControlView refresh feedback", () => {
 describe("SourceControlView commit jump", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.mocked(gitBridge.gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitBridge.gitStatus).mockResolvedValue({ branch: "main", staged: [], unstaged: [] });
     vi.mocked(gitBridge.gitLog).mockResolvedValue([
@@ -470,6 +521,7 @@ describe("SourceControlView commit jump", () => {
 describe("SourceControlView commit graph", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.mocked(gitBridge.gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitBridge.gitStatus).mockResolvedValue({ branch: "main", staged: [], unstaged: [] });
     useWorkspaceStore.getState().setRoot("/repo");

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ChevronDown,
@@ -24,6 +24,7 @@ import {
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { InfoDialog } from "@/components/InfoDialog";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
+import { Resizer } from "@/components/Resizer";
 import { fsReveal } from "@/modules/explorer/lib/fsBridge";
 import {
   gitCommit,
@@ -57,6 +58,15 @@ type ViewMode = "flat" | "folder";
 // Local git reads finish almost instantly; keep the refresh spinner up at least
 // this long so the feedback is perceptible.
 const MIN_REFRESH_MS = 400;
+
+// The history pane is drag-resizable and its height outlives the session, the
+// same deal as the Git Graph details pane.
+const COLLAPSED_SECTIONS_KEY = "tempoterm-sourcecontrol-collapsed-sections";
+const VIEW_MODE_KEY = "tempoterm-sourcecontrol-view-mode";
+const HISTORY_HEIGHT_KEY = "tempoterm-sourcecontrol-history-height";
+const HISTORY_HEIGHT_DEFAULT = 200;
+const HISTORY_HEIGHT_MIN = 60;
+const HISTORY_HEIGHT_MAX = 600;
 
 const STATUS_COLOR: Record<string, string> = {
   M: "text-warning",
@@ -571,6 +581,22 @@ function FileList({
 /** Keys of the collapsible sections, a closed set so typos fail typecheck. */
 type SectionKey = "staged" | "changes" | "history";
 
+const SECTION_KEYS: SectionKey[] = ["staged", "changes", "history"];
+
+/** Collapsed sections as last left by the user; an unreadable value just means
+ *  "nothing collapsed", never a crash. */
+function readCollapsedSections(): Set<SectionKey> {
+  try {
+    const raw = JSON.parse(localStorage.getItem(COLLAPSED_SECTIONS_KEY) ?? "[]");
+    const keys = Array.isArray(raw)
+      ? raw.filter((k): k is SectionKey => SECTION_KEYS.includes(k as SectionKey))
+      : [];
+    return new Set(keys);
+  } catch {
+    return new Set();
+  }
+}
+
 /**
  * Collapsible section heading. The toggle is a real button stretched across
  * the row (like WorkspacePanel's group headers) so it works from the keyboard
@@ -624,11 +650,27 @@ export function SourceControlView() {
   const [message, setMessage] = useState("");
   const [generating, setGenerating] = useState(false);
   const [pushing, setPushing] = useState(false);
-  const [viewMode, setViewMode] = useState<ViewMode>("flat");
+  const [viewMode, setViewMode] = useState<ViewMode>(() =>
+    localStorage.getItem(VIEW_MODE_KEY) === "folder" ? "folder" : "flat",
+  );
+  useEffect(() => {
+    localStorage.setItem(VIEW_MODE_KEY, viewMode);
+  }, [viewMode]);
   const [refreshing, setRefreshing] = useState(false);
-  // Section headers the user has collapsed. Component-local, like viewMode —
-  // resets when the view remounts.
-  const [collapsedSections, setCollapsedSections] = useState<Set<SectionKey>>(new Set());
+  const [historyHeight, setHistoryHeight] = useState<number>(() => {
+    const v = Number(localStorage.getItem(HISTORY_HEIGHT_KEY));
+    return Number.isFinite(v) && v > 0 ? v : HISTORY_HEIGHT_DEFAULT;
+  });
+  const historyHeightRef = useRef(historyHeight);
+  historyHeightRef.current = historyHeight;
+  const persistHistoryHeight = useCallback(() => {
+    localStorage.setItem(HISTORY_HEIGHT_KEY, String(historyHeightRef.current));
+  }, []);
+  // Section headers the user has collapsed. Remembered across sessions, like
+  // the history pane's height — reopening the panel should not undo the layout.
+  const [collapsedSections, setCollapsedSections] = useState<Set<SectionKey>>(
+    readCollapsedSections,
+  );
   const toggleSection = useCallback((key: SectionKey) => {
     setCollapsedSections((prev) => {
       const next = new Set(prev);
@@ -640,6 +682,9 @@ export function SourceControlView() {
       return next;
     });
   }, []);
+  useEffect(() => {
+    localStorage.setItem(COLLAPSED_SECTIONS_KEY, JSON.stringify([...collapsedSections]));
+  }, [collapsedSections]);
   const providerId = useChatStore((s) => s.providerId);
   const model = useChatStore((s) => s.model);
   const customBaseUrl = useChatStore((s) => s.customBaseUrl);
@@ -949,36 +994,50 @@ export function SourceControlView() {
                 />
               ))}
           </section>
-
-          {/* Expanded: history lives in the normal scroll flow below Changes, so
-              it never eats into or covers the Changes area — you just scroll. */}
-          {history.length > 0 && !collapsedSections.has("history") && (
-            <section className="mt-2 border-t border-border pt-1">
-              <SectionHeader
-                label={t("history")}
-                collapsed={false}
-                onToggle={() => toggleSection("history")}
-              />
-              <div className="flex gap-1 px-3 pb-2">
-                <HistoryGraphColumn commits={history} />
-                <ul className="min-w-0 flex-1">
-                  {history.map((commit) => (
-                    <HistoryRow key={commit.id} commit={commit} />
-                  ))}
-                </ul>
-              </div>
-            </section>
-          )}
         </div>
 
-        {/* Collapsed: just the header, pinned to the very bottom of the panel. */}
-        {history.length > 0 && collapsedSections.has("history") && (
-          <section className="shrink-0 border-t border-border">
+        {/* History is its own pane pinned to the bottom of the panel in both
+            states, so its header never rides the Changes scroll out of view:
+            expanding opens the list upward instead of moving the header. Its
+            height is dragged from the top edge and remembered; the max-height
+            keeps a squeezed panel from pushing Changes off the top. */}
+        {history.length > 0 && !collapsedSections.has("history") && (
+          <Resizer
+            orientation="horizontal"
+            onResize={(delta) =>
+              setHistoryHeight((h) =>
+                Math.min(HISTORY_HEIGHT_MAX, Math.max(HISTORY_HEIGHT_MIN, h - delta)),
+              )
+            }
+            onResizeEnd={persistHistoryHeight}
+          />
+        )}
+        {history.length > 0 && (
+          <section
+            style={
+              collapsedSections.has("history") ? undefined : { height: `${historyHeight}px` }
+            }
+            className={`flex min-h-0 shrink-0 flex-col border-t border-border ${
+              collapsedSections.has("history") ? "" : "max-h-[70%]"
+            }`}
+          >
             <SectionHeader
               label={t("history")}
-              collapsed
+              collapsed={collapsedSections.has("history")}
               onToggle={() => toggleSection("history")}
             />
+            {!collapsedSections.has("history") && (
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <div className="flex gap-1 px-3 pb-2">
+                  <HistoryGraphColumn commits={history} />
+                  <ul className="min-w-0 flex-1">
+                    {history.map((commit) => (
+                      <HistoryRow key={commit.id} commit={commit} />
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            )}
           </section>
         )}
       </div>


### PR DESCRIPTION
## Problem

Two annoyances in the Source Control panel, both about layout the user cannot keep.

**Recent commits jumped when you expanded it.** Collapsed, its header sat pinned at the very bottom of the panel. Expanding moved it back into the normal scroll flow under Changes — so with a long Changes list the header you just clicked scrolled out of view entirely, and there was no way to make the history taller or shorter.

**Nothing about the layout survived a remount.** Which sections you collapsed, and whether you view changes flat or grouped by folder, were component-local state: switch panels and come back, and the panel was back to its defaults. The Git Graph commit details panel had the same problem with its own flat/folder toggle.

## Changes

- Recent commits is its own pane pinned to the bottom of the panel in both states. Expanding opens the list upward with its own scrollbar instead of moving the header, so the header never rides the Changes scroll out of view.
- That pane is drag-resizable from its top edge (the existing `Resizer`, same as the Git Graph details pane), 60–600px, and additionally capped at 70% of the panel so a squeezed panel can never push Changes off the top.
- The pane height, the set of collapsed sections, and the flat/folder view mode are remembered in `localStorage`, following the `tempoterm-gitgraph-details-height` pattern already in the codebase.
- `CommitDetailsPanel` remembers its own flat/folder toggle under a separate key. The two lists live at very different widths — a 22px-row, monospace, virtualized list in a 280px column vs. the sidebar — so a single shared preference would fit neither.
- Tests that toggle a now-persisted preference clear `localStorage` in `beforeEach`, so one test's choice cannot leak into the next.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 228 files, 2091 tests passing
- [x] New regression tests: the Recent commits header stays outside the Changes scroll container in both states; collapsed sections and both view modes survive a remount
- [x] Manual: drag the history pane, collapse a section, switch view mode, reopen the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
