### PR TITLE
fix(source-control): toggle a folder from its whole label, not just the chevron

### DIFF
--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -380,6 +380,31 @@ describe("SourceControlView nested folder tree", () => {
     expect(screen.queryByText("aaa")).not.toBeInTheDocument();
   });
 
+  it("toggles a folder from anywhere on its label, not just the chevron", async () => {
+    render(<SourceControlView />);
+    fireEvent.click(screen.getByRole("button", { name: "Group by folder" }));
+    await screen.findByText("x.ts");
+
+    // The folder name is the obvious click target; aiming for the 13px
+    // chevron was the only thing that worked before.
+    fireEvent.click(screen.getByText("dist"));
+    expect(screen.queryByText("x.ts")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("dist"));
+    expect(await screen.findByText("x.ts")).toBeInTheDocument();
+  });
+
+  it("does not toggle the folder when its subtree action is clicked", async () => {
+    render(<SourceControlView />);
+    fireEvent.click(screen.getByRole("button", { name: "Group by folder" }));
+    await screen.findByText("x.ts");
+
+    fireEvent.click(screen.getByRole("button", { name: /stage folder.*: dist$/i }));
+
+    await waitFor(() => expect(gitBridge.gitStage).toHaveBeenCalled());
+    expect(screen.getByText("x.ts")).toBeInTheDocument();
+  });
+
   it("gives same-named folders at different paths distinct collapse-button labels", async () => {
     vi.mocked(gitBridge.gitStatus).mockResolvedValue({
       branch: "main",

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -433,6 +433,14 @@ function FileTreeRows({
               style={{ paddingLeft: `${depth * 14 + 12}px` }}
               className="group flex items-center gap-1 py-1 pr-3 text-sm hover:bg-bg-elevated/60 focus-within:bg-bg-elevated/60"
             >
+              {/* The whole label — chevron, icon and name — is the toggle, the
+                  way the section headers and the Git Graph details tree work.
+                  Aiming for the 13px chevron alone was the only way to open a
+                  folder here. The subtree action stays a sibling button, so it
+                  never toggles the folder it acts on. Hover is the row
+                  background only, never a text colour: in this list a bright
+                  label means "this is the file you are viewing" (StatusRow's
+                  active row), and nothing else. */}
               <button
                 type="button"
                 onClick={() => onToggleCollapse(node.path)}
@@ -441,14 +449,18 @@ function FileTreeRows({
                     ? t("expandFolder", { name: node.path })
                     : t("collapseFolder", { name: node.path })
                 }
-                className="flex shrink-0 items-center text-fg-subtle hover:text-fg"
+                className="flex min-w-0 flex-1 items-center gap-1 text-left text-fg-subtle"
               >
-                {isCollapsed ? <ChevronRight size={13} /> : <ChevronDown size={13} />}
+                {isCollapsed ? (
+                  <ChevronRight size={13} className="shrink-0" />
+                ) : (
+                  <ChevronDown size={13} className="shrink-0" />
+                )}
+                <Folder size={13} className="shrink-0" />
+                <Tooltip label={node.path} className="min-w-0 flex-1">
+                  <span className="min-w-0 flex-1 truncate text-fg-muted">{node.name}</span>
+                </Tooltip>
               </button>
-              <Folder size={13} className="shrink-0 text-fg-subtle" />
-              <Tooltip label={node.path} className="min-w-0 flex-1">
-                <span className="min-w-0 flex-1 truncate text-fg-muted">{node.name}</span>
-              </Tooltip>
               {/* Permanently revealed, like the section headers: folder rows
                   have no context menu to fall back on for pointers with no
                   hover, and one icon costs little of the width the file rows'


### PR DESCRIPTION
## Problem

In the Source Control panel's folder view, only the 13px chevron toggled a folder. Clicking the folder icon or its name — the obvious targets, and most of the row's width — did nothing, which reads as a dead row rather than a collapsed one.

The Git Graph commit details tree already makes the whole folder row the toggle, so the same gesture behaved differently in the two panels showing the same kind of list.

## Changes

- The chevron, folder icon and name are one button spanning the row, the same shape `SectionHeader` already uses. The subtree action button stays a sibling, so staging or unstaging a folder still never toggles it.
- No text colour on hover. In this list a bright label means "this is the file you are viewing" (`StatusRow`'s active row), and hovering must not imitate that — the row background alone signals hover. Documented at the row, since the button previously carried a `hover:text-fg` that brightened the icons but not the name, splitting one button into two-tone halves.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 228 files, 2099 tests passing
- [x] New tests: toggling a folder by clicking its name (both directions), and the subtree action not toggling the folder it acts on
- [x] Manual: in folder view, click a folder name, its icon, and its chevron; then its stage button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
