### PR TITLE
fix(worktrees): prune a stale worktree instead of removing it

### DIFF
--- a/src/modules/worktrees/RemoveWorktreeDialog.test.tsx
+++ b/src/modules/worktrees/RemoveWorktreeDialog.test.tsx
@@ -164,7 +164,9 @@ describe("RemoveWorktreeDialog — what it refuses outright", () => {
 
     expect(confirmButton()).toBeEnabled();
     fireEvent.click(confirmButton());
-    await waitFor(() => expect(gitWorktreeRemove).toHaveBeenCalled());
+    // Dropped by pruning the stale record — never by git worktree remove,
+    // which validates the (gone) directory on some git versions.
+    await waitFor(() => expect(gitWorktreePrune).toHaveBeenCalled());
   });
 });
 

--- a/src/modules/worktrees/RemoveWorktreeDialog.test.tsx
+++ b/src/modules/worktrees/RemoveWorktreeDialog.test.tsx
@@ -52,6 +52,27 @@ const confirmButton = () => screen.getByRole("button", { name: /remove/i });
 const discardBox = () => screen.getByRole("checkbox", { name: /discard/i });
 const branchBox = () => screen.getByRole("checkbox", { name: /branch/i });
 
+describe("RemoveWorktreeDialog — a stale worktree (directory gone)", () => {
+  // `git worktree remove` validates the directory and hard-fails on some git
+  // versions (Apple git 2.50: "validation failed, cannot remove working tree:
+  // '<path>/.git' does not exist"). Pruning is the porcelain built for gone
+  // directories, and it is what the dialog's own copy promises ("這只是把
+  // git 的紀錄清掉").
+  it("prunes the record instead of asking git to remove a directory that is gone", async () => {
+    gitWorktreePrune.mockResolvedValue([WT]);
+    const onDone = vi.fn();
+    render(
+      <RemoveWorktreeDialog repoPath={REPO} detail={detail({ prunable: true })} dirty={0} onDone={onDone} />,
+    );
+
+    fireEvent.click(confirmButton());
+
+    await waitFor(() => expect(onDone).toHaveBeenCalled());
+    expect(gitWorktreePrune).toHaveBeenCalledWith(REPO);
+    expect(gitWorktreeRemove).not.toHaveBeenCalled();
+  });
+});
+
 describe("RemoveWorktreeDialog — a clean worktree", () => {
   it("removes it, keeping the branch, forcing nothing", async () => {
     render(<RemoveWorktreeDialog repoPath={REPO} detail={detail()} dirty={0} onDone={vi.fn()} />);

--- a/src/modules/worktrees/RemoveWorktreeDialog.tsx
+++ b/src/modules/worktrees/RemoveWorktreeDialog.tsx
@@ -32,6 +32,7 @@ export function RemoveWorktreeDialog({
   const [busy, setBusy] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
   const remove = useWorktreesStore((s) => s.remove);
+  const prune = useWorktreesStore((s) => s.prune);
 
   const blocker = removalBlocker({
     dirty,
@@ -52,12 +53,21 @@ export function RemoveWorktreeDialog({
     setBusy(true);
     setFailure(null);
     try {
-      await remove(repoPath, detail.path, {
-        deleteBranch: deleteBranch && detail.branch ? detail.branch : undefined,
-        forceDeleteBranch: deleteBranch && forceDeleteBranch,
-        // Only ever from the checkbox. Never a default, never inferred.
-        force: needsAcknowledgement && acknowledged,
-      });
+      if (detail.prunable) {
+        // The directory is already gone, and `git worktree remove` validates
+        // it — Apple git 2.50 hard-fails with "validation failed, cannot
+        // remove working tree". Pruning is the porcelain for stale records,
+        // works on every git version, and is exactly what this dialog's copy
+        // promises. It refreshes the list the same way remove does.
+        await prune(repoPath);
+      } else {
+        await remove(repoPath, detail.path, {
+          deleteBranch: deleteBranch && detail.branch ? detail.branch : undefined,
+          forceDeleteBranch: deleteBranch && forceDeleteBranch,
+          // Only ever from the checkbox. Never a default, never inferred.
+          force: needsAcknowledgement && acknowledged,
+        });
+      }
       onDone();
     } catch (error) {
       // git's own words: it knows why better than a paraphrase would.


### PR DESCRIPTION
## Problem

Deleting a worktree whose directory no longer exists failed with:

```
fatal: validation failed, cannot remove working tree: '/private/tmp/pr341-guard/.git' does not exist
```

The stale-row dialog promises "目錄本來就不見了，這只是把 git 的紀錄清掉" but the confirm ran `git worktree remove`, which validates the directory. Apple git 2.50 (what the GUI resolves from the system PATH) hard-fails; newer homebrew gits tolerate it, which is why the gap never showed when testing from a terminal.

## Change

`RemoveWorktreeDialog` routes a `prunable` row through the store's existing `prune` action (`git worktree prune` — the porcelain built for gone directories, version-independent, refreshes the list the same way). Non-stale rows keep the exact remove semantics: force only from the checkbox, optional branch deletion.

## Tests

Written red-first: a prunable row's confirm calls `gitWorktreePrune` and never `gitWorktreeRemove`. Worktrees module 60+ tests green, `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)