### PR TITLE
docs: add the #386 fix to CHANGELOG-NEXT

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -4,6 +4,7 @@
 
 ### fix
 
+- 修正 Worktree 面板無法移除「目錄已不存在」項目的問題。先前按移除會執行 git worktree remove，部分 git 版本（如 Apple Git 2.50）會因驗證目錄失敗而報錯；現改走 git worktree prune，任何版本都能把殘留紀錄清掉，一般 worktree 的移除行為不變 (#386)
 ### 貢獻者
 
 ## English
@@ -12,4 +13,5 @@
 
 ### fix
 
+- Fix the Worktrees panel failing to remove an entry whose directory no longer exists. The remove button ran git worktree remove, which some git versions (e.g. Apple Git 2.50) reject with a validation error for a gone directory; stale rows now go through git worktree prune, which clears the record on every version, while normal removals keep their exact semantics (#386)
 ### Contributors


### PR DESCRIPTION
First entry of the 0.3.7 cycle: the stale-worktree prune fix (#386).

🤖 Generated with [Claude Code](https://claude.com/claude-code)