### PR TITLE
feat(ports): Port Radar-style panel — stable ordering, project groups, on-device AI

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1625,6 +1625,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
+name = "fm-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30041f6093aab2b756845e7677854bdf5aa8a35ace72d8219c204f4fd98c195"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6018,6 +6028,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clipboard-win",
+ "fm-rs",
  "font-kit",
  "git2",
  "grep-matcher",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,7 @@ rusqlite = "0.32"
 # keyring 3.x ships no credential store by default; each platform must opt into
 # its native backend or every keychain operation fails silently.
 [target.'cfg(target_os = "macos")'.dependencies]
+fm-rs = "0.3"
 keyring = { version = "3", features = ["apple-native"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,7 +38,7 @@ use modules::git::{
 use modules::locale::set_app_languages;
 use modules::menu::set_native_menu;
 use modules::notes::{notes_unwatch, notes_watch, NotesWatchState};
-use modules::ports::{kill_port_process, list_ports, PortsState};
+use modules::ports::{kill_port_process, list_ports, PortsState, ports_ai_available, ports_ai_explain};
 use modules::pr::{gh_available, pr_via_api, pr_via_gh};
 use modules::preview::{
     preview_close, preview_create, preview_history_back, preview_history_forward, preview_navigate,
@@ -387,6 +387,8 @@ pub fn run() {
             ssh_secret_delete,
             system_stats,
             list_ports,
+            ports_ai_available,
+            ports_ai_explain,
             kill_port_process,
             editor_watch_set,
             sessions_index_start,

--- a/src-tauri/src/modules/ports/mod.rs
+++ b/src-tauri/src/modules/ports/mod.rs
@@ -94,6 +94,14 @@ pub fn build_port_info(row: ListenerRow, meta: Option<ProcMeta>) -> PortInfo {
     }
 }
 
+/// A stable presentation order. The OS enumerates listeners in whatever order
+/// it likes, different on every poll; without this the panel reshuffles every
+/// 5 seconds and the user cannot keep their eye on a row.
+pub fn sorted_ports(mut infos: Vec<PortInfo>) -> Vec<PortInfo> {
+    infos.sort_by_key(|i| (i.port, i.pid));
+    infos
+}
+
 /// Default view shows only the current user's services; Show all removes the filter.
 pub fn should_show(info: &PortInfo, show_all: bool) -> bool {
     show_all || info.is_current_user
@@ -193,7 +201,7 @@ pub async fn list_ports(
         .filter(|info| should_show(info, show_all))
         .collect();
 
-    Ok(infos)
+    Ok(sorted_ports(infos))
 }
 
 #[tauri::command]
@@ -239,6 +247,31 @@ mod tests {
 
     fn row(port: u16, pid: u32) -> ListenerRow {
         ListenerRow { port, bind_addr: "127.0.0.1".into(), pid }
+    }
+
+    /// The listener enumeration order changes between polls; the panel must
+    /// not reshuffle every 5 seconds (#388 phase 1). Same rows in any input
+    /// order come out identically ordered.
+    #[test]
+    fn sorted_ports_is_deterministic_across_enumeration_orders() {
+        let mk = |port: u16, pid: u32| PortInfo {
+            port,
+            protocol: "tcp".into(),
+            bind_addr: "127.0.0.1".into(),
+            pid,
+            process_name: "p".into(),
+            command: None,
+            cwd: None,
+            cpu_usage: 0.0,
+            memory_bytes: 0,
+            uptime_secs: 0,
+            is_current_user: true,
+        };
+        let a = sorted_ports(vec![mk(8080, 2), mk(3000, 9), mk(8080, 1)]);
+        let b = sorted_ports(vec![mk(8080, 1), mk(8080, 2), mk(3000, 9)]);
+        let keys: Vec<(u16, u32)> = a.iter().map(|i| (i.port, i.pid)).collect();
+        assert_eq!(keys, vec![(3000, 9), (8080, 1), (8080, 2)]);
+        assert_eq!(a, b);
     }
 
     #[test]

--- a/src-tauri/src/modules/ports/mod.rs
+++ b/src-tauri/src/modules/ports/mod.rs
@@ -156,6 +156,79 @@ impl Default for PortsState {
     }
 }
 
+/// Whether the on-device Apple Intelligence model can answer questions about
+/// a port. Anything but a definite yes is a no: the button simply does not
+/// render, matching how Port Radar gates its AI features to macOS 26+.
+#[tauri::command]
+pub async fn ports_ai_available() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        tauri::async_runtime::spawn_blocking(|| {
+            fm_rs::SystemLanguageModel::new()
+                .map(|m| m.is_available())
+                .unwrap_or(false)
+        })
+        .await
+        .unwrap_or(false)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+/// Ask the on-device model to explain one port's process in plain language:
+/// what it is, whether it is safe to stop. Runs entirely on-device — nothing
+/// about the process leaves the machine.
+#[tauri::command]
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+pub async fn ports_ai_explain(
+    service_label: String,
+    process_name: String,
+    command: Option<String>,
+    cwd: Option<String>,
+    uptime_secs: u64,
+    port: u16,
+    language: String,
+) -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        tauri::async_runtime::spawn_blocking(move || {
+            let model = fm_rs::SystemLanguageModel::new().map_err(|e| e.to_string())?;
+            if !model.is_available() {
+                return Err("apple-intelligence-unavailable".to_string());
+            }
+            let instructions = if language.starts_with("zh") {
+                "你是終端機 app 內建的助手。用兩三句正體中文回答：這個本機監聽的行程是什麼、大概在做什麼、現在停掉它安不安全。語氣直接，不要條列。"
+            } else {
+                "You are a terminal app's built-in helper. In two or three plain sentences: what this locally listening process is, what it is likely doing, and whether stopping it now is safe. Be direct; no bullet lists."
+            };
+            let session = fm_rs::Session::with_instructions(&model, instructions)
+                .map_err(|e| e.to_string())?;
+            let prompt = format!(
+                "Port :{port}
+Service: {service_label}
+Process: {process_name}
+Command: {}
+Working directory: {}
+Uptime: {uptime_secs}s",
+                command.as_deref().unwrap_or("(unknown)"),
+                cwd.as_deref().unwrap_or("(none)"),
+            );
+            let response = session
+                .respond(&prompt, &fm_rs::GenerationOptions::default())
+                .map_err(|e| e.to_string())?;
+            Ok(response.content().to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("apple-intelligence-unavailable".to_string())
+    }
+}
+
 // Async so Tauri runs it off the GUI thread; the listeners + sysinfo reads block.
 #[tauri::command]
 pub async fn list_ports(
@@ -272,6 +345,28 @@ mod tests {
         let keys: Vec<(u16, u32)> = a.iter().map(|i| (i.port, i.pid)).collect();
         assert_eq!(keys, vec![(3000, 9), (8080, 1), (8080, 2)]);
         assert_eq!(a, b);
+    }
+
+    /// Real on-device Apple Intelligence round-trip. Ignored by default: it
+    /// needs macOS 26+ with Apple Intelligence enabled. Run locally with
+    /// `cargo test --lib ports_ai_spike -- --ignored --nocapture`.
+    #[test]
+    #[ignore]
+    #[cfg(target_os = "macos")]
+    fn ports_ai_spike_end_to_end() {
+        let model = fm_rs::SystemLanguageModel::new().expect("model handle");
+        println!("available: {}", model.is_available());
+        if !model.is_available() {
+            return;
+        }
+        let session =
+            fm_rs::Session::with_instructions(&model, "Answer in one short sentence.").unwrap();
+        let response = session
+            .respond("What is a Vite dev server?", &fm_rs::GenerationOptions::default())
+            .unwrap();
+        let text = response.content();
+        println!("response: {text}");
+        assert!(!text.trim().is_empty());
     }
 
     #[test]

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -89,7 +89,10 @@
     "cwd": "Working dir",
     "groupOther": "Other processes",
     "cpu": "CPU",
-    "memory": "Memory"
+    "memory": "Memory",
+    "askAi": "Ask AI what this is",
+    "aiThinking": "AI is thinking…",
+    "aiFailed": "AI could not answer"
   },
   "titleBar": {
     "minimize": "Minimize",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -86,7 +86,10 @@
     "detailsFor": "Details for port {{port}}",
     "bind": "Bind",
     "command": "Command",
-    "cwd": "Working dir"
+    "cwd": "Working dir",
+    "groupOther": "Other processes",
+    "cpu": "CPU",
+    "memory": "Memory"
   },
   "titleBar": {
     "minimize": "Minimize",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -89,7 +89,10 @@
     "cwd": "工作目錄",
     "groupOther": "其他程序",
     "cpu": "CPU",
-    "memory": "記憶體"
+    "memory": "記憶體",
+    "askAi": "問 AI 這是什麼",
+    "aiThinking": "AI 思考中…",
+    "aiFailed": "AI 回答失敗"
   },
   "titleBar": {
     "minimize": "最小化",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -86,7 +86,10 @@
     "detailsFor": "Port {{port}} 詳細資訊",
     "bind": "綁定",
     "command": "指令",
-    "cwd": "工作目錄"
+    "cwd": "工作目錄",
+    "groupOther": "其他程序",
+    "cpu": "CPU",
+    "memory": "記憶體"
   },
   "titleBar": {
     "minimize": "最小化",

--- a/src/modules/ports/PortRow.tsx
+++ b/src/modules/ports/PortRow.tsx
@@ -4,6 +4,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { formatBytes, formatPercent } from "@/modules/sysmon/lib/format";
 import { Tooltip } from "@/components/Tooltip";
 import { formatUptime } from "./lib/format";
+import { classifyService } from "./lib/classifyService";
 import type { PortInfo } from "./lib/portsBridge";
 
 interface PortRowProps {
@@ -20,17 +21,22 @@ export function PortRow({ port, expanded, onToggleExpand, onRequestKill, onOpenT
   const { t } = useTranslation();
   const canKill = port.isCurrentUser;
   const canTerminal = Boolean(port.cwd);
+  const service = classifyService(port);
+  // "Vite dev server" says more than "node"; show the raw name only when it
+  // still adds something (e.g. the label fell back to a runtime).
+  const showRawName = service.label.toLowerCase() !== port.processName.toLowerCase();
 
   return (
     <div className="border-b border-border px-3 py-2 last:border-b-0">
       {/* Line 1: identifier on the left, resource stats on the right. */}
       <div className="flex items-center gap-2 text-sm">
         <span className="shrink-0 font-mono text-xs text-accent">:{port.port}</span>
-        <span className="min-w-0 flex-1 truncate font-medium text-fg">{port.processName}</span>
-        <div className="flex shrink-0 items-center gap-3 text-xs text-fg-subtle">
+        <span className="min-w-0 truncate font-medium text-fg">{service.label}</span>
+        {showRawName && (
+          <span className="min-w-0 shrink truncate text-xs text-fg-subtle">{port.processName}</span>
+        )}
+        <div className="ml-auto flex shrink-0 items-center gap-3 text-xs text-fg-subtle">
           <span className="flex items-center gap-1 whitespace-nowrap"><Clock size={11} /> {formatUptime(port.uptimeSecs)}</span>
-          <span className="flex items-center gap-1 whitespace-nowrap"><Cpu size={11} /> {formatPercent(port.cpuUsage)}</span>
-          <span className="flex items-center gap-1 whitespace-nowrap"><MemoryStick size={11} /> {formatBytes(port.memoryBytes)}</span>
         </div>
         <button
           type="button"
@@ -93,6 +99,10 @@ export function PortRow({ port, expanded, onToggleExpand, onRequestKill, onOpenT
         <dl className="mt-1.5 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 rounded bg-bg-inset px-3 py-2 font-mono text-xs text-fg-muted">
           <dt className="text-fg-subtle">PID</dt>
           <dd>{port.pid}</dd>
+          <dt className="text-fg-subtle">{t("ports.cpu")}</dt>
+          <dd className="flex items-center gap-1"><Cpu size={11} /> {formatPercent(port.cpuUsage)}</dd>
+          <dt className="text-fg-subtle">{t("ports.memory")}</dt>
+          <dd className="flex items-center gap-1"><MemoryStick size={11} /> {formatBytes(port.memoryBytes)}</dd>
           <dt className="text-fg-subtle">{t("ports.bind")}</dt>
           <dd>{port.bindAddr}:{port.port}</dd>
           <dt className="text-fg-subtle">{t("ports.command")}</dt>

--- a/src/modules/ports/PortRow.tsx
+++ b/src/modules/ports/PortRow.tsx
@@ -1,14 +1,18 @@
-import { ChevronRight, Cpu, MemoryStick, Clock, SquareTerminal, X, Copy, SquareArrowOutUpRight } from "lucide-react";
+import { useState } from "react";
+import { ChevronRight, Cpu, MemoryStick, Clock, SquareTerminal, X, Copy, SquareArrowOutUpRight, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { formatBytes, formatPercent } from "@/modules/sysmon/lib/format";
 import { Tooltip } from "@/components/Tooltip";
 import { formatUptime } from "./lib/format";
 import { classifyService } from "./lib/classifyService";
+import { portsAiExplain } from "./lib/portsBridge";
 import type { PortInfo } from "./lib/portsBridge";
 
 interface PortRowProps {
   port: PortInfo;
+  /** On-device Apple Intelligence probe result; false hides the affordance entirely. */
+  aiAvailable: boolean;
   expanded: boolean;
   onToggleExpand: () => void;
   onRequestKill: (port: PortInfo) => void;
@@ -17,8 +21,9 @@ interface PortRowProps {
 
 const ACTION_BTN = "flex h-6 w-6 items-center justify-center rounded text-fg-subtle transition-colors disabled:opacity-30";
 
-export function PortRow({ port, expanded, onToggleExpand, onRequestKill, onOpenTerminal }: PortRowProps) {
-  const { t } = useTranslation();
+export function PortRow({ port, aiAvailable, expanded, onToggleExpand, onRequestKill, onOpenTerminal }: PortRowProps) {
+  const { t, i18n } = useTranslation();
+  const [aiState, setAiState] = useState<{ kind: "idle" } | { kind: "busy" } | { kind: "done"; text: string } | { kind: "failed" }>({ kind: "idle" });
   const canKill = port.isCurrentUser;
   const canTerminal = Boolean(port.cwd);
   const service = classifyService(port);
@@ -109,6 +114,42 @@ export function PortRow({ port, expanded, onToggleExpand, onRequestKill, onOpenT
           <dd className="break-all">{port.command ?? "-"}</dd>
           <dt className="text-fg-subtle">{t("ports.cwd")}</dt>
           <dd className="break-all">{port.cwd ?? "-"}</dd>
+          {aiAvailable && (
+            <>
+              <dt className="flex items-start text-fg-subtle"><Sparkles size={11} /></dt>
+              <dd>
+                {aiState.kind === "done" ? (
+                  <p className="whitespace-pre-wrap font-sans leading-relaxed text-fg">{aiState.text}</p>
+                ) : (
+                  <button
+                    type="button"
+                    disabled={aiState.kind === "busy"}
+                    onClick={() => {
+                      setAiState({ kind: "busy" });
+                      portsAiExplain({
+                        serviceLabel: service.label,
+                        processName: port.processName,
+                        command: port.command,
+                        cwd: port.cwd,
+                        uptimeSecs: port.uptimeSecs,
+                        port: port.port,
+                        language: i18n.language,
+                      })
+                        .then((text) => setAiState({ kind: "done", text }))
+                        .catch(() => setAiState({ kind: "failed" }));
+                    }}
+                    className="text-left text-accent hover:underline disabled:opacity-60"
+                  >
+                    {aiState.kind === "busy"
+                      ? t("ports.aiThinking")
+                      : aiState.kind === "failed"
+                        ? t("ports.aiFailed")
+                        : t("ports.askAi")}
+                  </button>
+                )}
+              </dd>
+            </>
+          )}
         </dl>
       )}
     </div>

--- a/src/modules/ports/PortsPanelView.test.tsx
+++ b/src/modules/ports/PortsPanelView.test.tsx
@@ -31,6 +31,22 @@ beforeEach(() => {
   killPortProcess.mockReset();
 });
 
+describe("PortsPanelView grouping", () => {
+  it("groups ports under project headers, catch-all last, and never reshuffles", async () => {
+    usePorts.mockReturnValue([
+      { ...sample[0], port: 8080, pid: 20, cwd: "/w/beta", processName: "node", command: "node x/vite" },
+      { ...sample[0], port: 3000, pid: 10, cwd: "/w/alpha" },
+      { ...sample[0], port: 631, pid: 30, cwd: null, processName: "cupsd", command: null },
+    ]);
+    render(<PortsPanelView />);
+    const headers = await screen.findAllByRole("heading", { level: 3 });
+    // textContent carries the port count the header shows beside the name.
+    expect(headers.map((h) => h.textContent)).toEqual(["alpha1", "beta1", "Other processes1"]);
+    // The plain-English service label replaces the raw runtime name up front.
+    expect(screen.getByText("Vite dev server")).toBeInTheDocument();
+  });
+});
+
 describe("PortsPanelView kill failure", () => {
   it("reports a failed kill in the app's own dialog, not a native one", async () => {
     killPortProcess.mockRejectedValue(new Error("EPERM"));

--- a/src/modules/ports/PortsPanelView.test.tsx
+++ b/src/modules/ports/PortsPanelView.test.tsx
@@ -4,8 +4,12 @@ import "@/i18n";
 
 const { usePorts } = vi.hoisted(() => ({ usePorts: vi.fn() }));
 vi.mock("./lib/usePorts", () => ({ usePorts }));
-const { killPortProcess } = vi.hoisted(() => ({ killPortProcess: vi.fn() }));
-vi.mock("./lib/portsBridge", () => ({ killPortProcess }));
+const { killPortProcess, portsAiAvailable, portsAiExplain } = vi.hoisted(() => ({
+  killPortProcess: vi.fn(),
+  portsAiAvailable: vi.fn(),
+  portsAiExplain: vi.fn(),
+}));
+vi.mock("./lib/portsBridge", () => ({ killPortProcess, portsAiAvailable, portsAiExplain }));
 
 import { PortsPanelView } from "./PortsPanelView";
 
@@ -29,6 +33,9 @@ beforeEach(() => {
   usePorts.mockReset();
   usePorts.mockReturnValue(sample);
   killPortProcess.mockReset();
+  portsAiAvailable.mockReset();
+  portsAiAvailable.mockResolvedValue(false);
+  portsAiExplain.mockReset();
 });
 
 describe("PortsPanelView grouping", () => {
@@ -44,6 +51,30 @@ describe("PortsPanelView grouping", () => {
     expect(headers.map((h) => h.textContent)).toEqual(["alpha1", "beta1", "Other processes1"]);
     // The plain-English service label replaces the raw runtime name up front.
     expect(screen.getByText("Vite dev server")).toBeInTheDocument();
+  });
+});
+
+describe("PortsPanelView Apple Intelligence", () => {
+  it("offers Ask AI in the expanded row only when the on-device model is available", async () => {
+    portsAiAvailable.mockResolvedValue(true);
+    portsAiExplain.mockResolvedValue("A dev server. Safe to stop.");
+    render(<PortsPanelView />);
+    fireEvent.click(await screen.findByRole("button", { name: /details/i }));
+    const ask = await screen.findByRole("button", { name: /ask ai/i });
+
+    fireEvent.click(ask);
+
+    expect(await screen.findByText("A dev server. Safe to stop.")).toBeInTheDocument();
+    expect(portsAiExplain).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 3000, processName: "node" }),
+    );
+  });
+
+  it("renders no AI affordance at all when the model is unavailable", async () => {
+    portsAiAvailable.mockResolvedValue(false);
+    render(<PortsPanelView />);
+    fireEvent.click(await screen.findByRole("button", { name: /details/i }));
+    expect(screen.queryByRole("button", { name: /ask ai/i })).toBeNull();
   });
 });
 

--- a/src/modules/ports/PortsPanelView.tsx
+++ b/src/modules/ports/PortsPanelView.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useTabsStore } from "@/stores/tabsStore";
@@ -6,7 +6,7 @@ import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { InfoDialog } from "@/components/InfoDialog";
 import { usePorts } from "./lib/usePorts";
 import { groupByProject } from "./lib/classifyService";
-import { killPortProcess, type PortInfo } from "./lib/portsBridge";
+import { killPortProcess, portsAiAvailable, type PortInfo } from "./lib/portsBridge";
 import { PortRow } from "./PortRow";
 
 /**
@@ -23,6 +23,21 @@ export function PortsPanelView() {
   const [killTarget, setKillTarget] = useState<PortInfo | null>(null);
   const [killError, setKillError] = useState<string | null>(null);
   const [expandedPid, setExpandedPid] = useState<number | null>(null);
+  const [aiAvailable, setAiAvailable] = useState(false);
+
+  // One probe per mount: availability only changes with OS settings, and a
+  // false (or failed) probe simply leaves the affordance hidden.
+  useEffect(() => {
+    let live = true;
+    portsAiAvailable()
+      .then((ok) => {
+        if (live) setAiAvailable(ok);
+      })
+      .catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, []);
 
   const list = ports ?? [];
 
@@ -83,6 +98,7 @@ export function PortsPanelView() {
                 <PortRow
                   key={`${port.port}-${port.pid}`}
                   port={port}
+                  aiAvailable={aiAvailable}
                   expanded={expandedPid === port.pid}
                   onToggleExpand={() => setExpandedPid((cur) => (cur === port.pid ? null : port.pid))}
                   onRequestKill={setKillTarget}

--- a/src/modules/ports/PortsPanelView.tsx
+++ b/src/modules/ports/PortsPanelView.tsx
@@ -5,6 +5,7 @@ import { useTabsStore } from "@/stores/tabsStore";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { InfoDialog } from "@/components/InfoDialog";
 import { usePorts } from "./lib/usePorts";
+import { groupByProject } from "./lib/classifyService";
 import { killPortProcess, type PortInfo } from "./lib/portsBridge";
 import { PortRow } from "./PortRow";
 
@@ -69,15 +70,26 @@ export function PortsPanelView() {
         ) : list.length === 0 ? (
           <div className="px-3 py-6 text-center text-sm text-fg-subtle">{t("ports.empty")}</div>
         ) : (
-          list.map((port) => (
-            <PortRow
-              key={`${port.port}-${port.pid}`}
-              port={port}
-              expanded={expandedPid === port.pid}
-              onToggleExpand={() => setExpandedPid((cur) => (cur === port.pid ? null : port.pid))}
-              onRequestKill={setKillTarget}
-              onOpenTerminal={openTerminal}
-            />
+          groupByProject(list).map((group) => (
+            <section key={group.cwd ?? "__other__"}>
+              {/* Port Radar's hierarchy: the project is the anchor a reader
+                  scans for; the rows underneath stay sorted by port, so
+                  nothing moves between polls. */}
+              <h3 className="sticky top-0 flex items-baseline gap-2 border-b border-border bg-bg-elevated px-3 py-1.5 text-xs font-semibold text-fg">
+                {group.name ?? t("ports.groupOther")}
+                <span className="font-normal text-fg-subtle">{group.ports.length}</span>
+              </h3>
+              {group.ports.map((port) => (
+                <PortRow
+                  key={`${port.port}-${port.pid}`}
+                  port={port}
+                  expanded={expandedPid === port.pid}
+                  onToggleExpand={() => setExpandedPid((cur) => (cur === port.pid ? null : port.pid))}
+                  onRequestKill={setKillTarget}
+                  onOpenTerminal={openTerminal}
+                />
+              ))}
+            </section>
           ))
         )}
       </div>

--- a/src/modules/ports/lib/classifyService.test.ts
+++ b/src/modules/ports/lib/classifyService.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { classifyService, groupByProject } from "./classifyService";
+import type { PortInfo } from "./portsBridge";
+
+const info = (over: Partial<PortInfo>): PortInfo => ({
+  port: 3000,
+  protocol: "tcp",
+  bindAddr: "127.0.0.1",
+  pid: 1,
+  processName: "node",
+  command: null,
+  cwd: null,
+  cpuUsage: 0,
+  memoryBytes: 0,
+  uptimeSecs: 0,
+  isCurrentUser: true,
+  ...over,
+});
+
+describe("classifyService — plain-English service labels", () => {
+  it("names the dev servers people actually run", () => {
+    expect(classifyService(info({ command: "node /x/node_modules/.bin/vite --host" })).label).toBe("Vite dev server");
+    expect(classifyService(info({ command: "node /x/node_modules/next/dist/bin/next dev" })).label).toBe("Next.js dev server");
+    expect(classifyService(info({ command: "bun run --bun vite" })).label).toBe("Vite dev server");
+    expect(classifyService(info({ processName: "python3.12", command: "python -m http.server 8000" })).label).toBe("Python server");
+    expect(classifyService(info({ processName: "com.docker.backend", command: "/Applications/Docker.app/..." })).label).toBe("Docker");
+    expect(classifyService(info({ processName: "postgres", command: "postgres -D /usr/local/var" })).label).toBe("PostgreSQL");
+  });
+
+  it("falls back to the runtime, then the raw process name", () => {
+    expect(classifyService(info({ processName: "node", command: "node server.js" })).label).toBe("Node.js");
+    expect(classifyService(info({ processName: "weird-daemon", command: null })).label).toBe("weird-daemon");
+  });
+
+  it("matches case-insensitively and never throws on junk", () => {
+    expect(classifyService(info({ command: "NODE /X/VITE" })).label).toBe("Vite dev server");
+    expect(() => classifyService(info({ processName: "", command: "" }))).not.toThrow();
+  });
+});
+
+describe("groupByProject — stable two-level ordering", () => {
+  it("groups by the cwd basename, projects sorted by name, ports by number", () => {
+    const groups = groupByProject([
+      info({ port: 8080, cwd: "/w/beta" }),
+      info({ port: 3000, cwd: "/w/alpha" }),
+      info({ port: 3001, cwd: "/w/alpha" }),
+    ]);
+    expect(groups.map((g) => g.name)).toEqual(["alpha", "beta"]);
+    expect(groups[0].ports.map((p) => p.port)).toEqual([3000, 3001]);
+  });
+
+  it("puts cwd-less ports into a trailing catch-all group", () => {
+    const groups = groupByProject([info({ port: 631, cwd: null }), info({ port: 3000, cwd: "/w/a" })]);
+    expect(groups.map((g) => g.name)).toEqual(["a", null]);
+    expect(groups[1].ports[0].port).toBe(631);
+  });
+
+  it("is deterministic regardless of input order", () => {
+    const a = groupByProject([info({ port: 1, cwd: "/x/p" }), info({ port: 2, cwd: null }), info({ port: 3, cwd: "/x/q" })]);
+    const b = groupByProject([info({ port: 3, cwd: "/x/q" }), info({ port: 2, cwd: null }), info({ port: 1, cwd: "/x/p" })]);
+    expect(a).toEqual(b);
+  });
+});

--- a/src/modules/ports/lib/classifyService.ts
+++ b/src/modules/ports/lib/classifyService.ts
@@ -1,0 +1,92 @@
+import type { PortInfo } from "./portsBridge";
+
+export interface ServiceKind {
+  /** Plain-English service name, the way Port Radar labels rows. */
+  label: string;
+  /** Stable id for styling (badge colors etc.). */
+  kind: string;
+}
+
+/** Ordered: first match on the full command line wins, then process name. */
+const COMMAND_RULES: Array<[RegExp, ServiceKind]> = [
+  [/vite/i, { label: "Vite dev server", kind: "vite" }],
+  [/next[/\\ ]dist[/\\ ]bin[/\\ ]next|next dev|next start/i, { label: "Next.js dev server", kind: "next" }],
+  [/webpack/i, { label: "Webpack dev server", kind: "webpack" }],
+  [/storybook/i, { label: "Storybook", kind: "storybook" }],
+];
+
+const PROCESS_RULES: Array<[RegExp, ServiceKind]> = [
+  [/^docker|com\.docker/i, { label: "Docker", kind: "docker" }],
+  [/^postgres/i, { label: "PostgreSQL", kind: "postgres" }],
+  [/^redis/i, { label: "Redis", kind: "redis" }],
+  [/^mysqld/i, { label: "MySQL", kind: "mysql" }],
+  [/^python/i, { label: "Python server", kind: "python" }],
+  [/^ruby/i, { label: "Ruby server", kind: "ruby" }],
+  [/^java$/i, { label: "Java service", kind: "java" }],
+  [/^(node|bun|deno)$/i, { label: "", kind: "" }], // runtime fallback below
+];
+
+const RUNTIME_LABELS: Record<string, ServiceKind> = {
+  node: { label: "Node.js", kind: "node" },
+  bun: { label: "Bun", kind: "bun" },
+  deno: { label: "Deno", kind: "deno" },
+};
+
+/**
+ * Turn a raw process into the plain-English label a reader scans for —
+ * "Vite dev server", not "node". Command line beats process name (the
+ * interesting part of `node .../vite` is vite); a known runtime is the next
+ * best answer; the raw process name is the honest last resort.
+ */
+export function classifyService(info: PortInfo): ServiceKind {
+  const command = info.command ?? "";
+  for (const [re, kind] of COMMAND_RULES) {
+    if (re.test(command)) return kind;
+  }
+  const name = info.processName ?? "";
+  for (const [re, kind] of PROCESS_RULES) {
+    if (re.test(name) && kind.label) return kind;
+  }
+  const runtime = RUNTIME_LABELS[name.toLowerCase()];
+  if (runtime) return runtime;
+  return { label: name || "Unknown", kind: "other" };
+}
+
+export interface PortGroup {
+  /** Project directory basename; null for the trailing catch-all group. */
+  name: string | null;
+  cwd: string | null;
+  ports: PortInfo[];
+}
+
+/**
+ * Two stable levels: projects alphabetically (the catch-all last), ports by
+ * number inside each. Combined with the backend's (port, pid) sort this is
+ * what keeps the panel from reshuffling under the reader's eyes.
+ */
+export function groupByProject(ports: PortInfo[]): PortGroup[] {
+  const byCwd = new Map<string, PortGroup>();
+  const orphans: PortInfo[] = [];
+  for (const port of ports) {
+    if (!port.cwd) {
+      orphans.push(port);
+      continue;
+    }
+    const existing = byCwd.get(port.cwd);
+    if (existing) {
+      existing.ports.push(port);
+    } else {
+      const name = port.cwd.replace(/[/\\]+$/, "").split(/[/\\]/).pop() || port.cwd;
+      byCwd.set(port.cwd, { name, cwd: port.cwd, ports: [port] });
+    }
+  }
+  const groups = [...byCwd.values()].sort((a, b) =>
+    (a.name ?? "") < (b.name ?? "") ? -1 : (a.name ?? "") > (b.name ?? "") ? 1 : 0,
+  );
+  for (const group of groups) group.ports.sort((a, b) => a.port - b.port || a.pid - b.pid);
+  if (orphans.length > 0) {
+    orphans.sort((a, b) => a.port - b.port || a.pid - b.pid);
+    groups.push({ name: null, cwd: null, ports: orphans });
+  }
+  return groups;
+}

--- a/src/modules/ports/lib/portsBridge.ts
+++ b/src/modules/ports/lib/portsBridge.ts
@@ -33,3 +33,21 @@ export function fetchPorts(showAll: boolean): Promise<PortInfo[]> {
 export function killPortProcess(port: number, pid: number): Promise<void> {
   return invoke("kill_port_process", { port, pid });
 }
+
+/** Whether the on-device Apple Intelligence model can explain ports (macOS 26+). */
+export function portsAiAvailable(): Promise<boolean> {
+  return invoke<boolean>("ports_ai_available");
+}
+
+/** Plain-language, on-device explanation of one port's process. */
+export function portsAiExplain(args: {
+  serviceLabel: string;
+  processName: string;
+  command: string | null;
+  cwd: string | null;
+  uptimeSecs: number;
+  port: number;
+  language: string;
+}): Promise<string> {
+  return invoke<string>("ports_ai_explain", args);
+}


### PR DESCRIPTION
Reworks the Ports panel along the lines of [Port Radar](https://portradar.devmesh.xyz/), in three self-contained commits plus the headline bug fix.

## 1. The list stops reshuffling (the headline complaint)

`list_ports` passed the OS's arbitrary listener-enumeration order straight through, so the panel reshuffled on every 5s poll and a row could not be followed by eye. The backend now sorts by `(port, pid)`; the frontend grouping adds a second stable level. Deterministic end to end, with tests on both.

## 2. Port Radar-style structure

- `classifyService`: plain-English labels ("Vite dev server", "Next.js dev server", "PostgreSQL", …) — command line beats process name, runtimes as fallback, raw name as the honest last resort
- `groupByProject`: ports bucketed by cwd basename, projects alphabetical as sticky section headers, catch-all "Other processes" last
- Rows lead with the service label + `:port` + uptime; CPU/memory move into the expanded details

## 3. Apple Intelligence (macOS 26+, fully on-device)

- `fm-rs` as a **macOS-only target dependency** (MIT, binds FoundationModels via C FFI, no Swift toolchain needed at build time; Windows/Linux compile a stub that reports unavailable — `cargo check` under `-D warnings` is clean)
- `ports_ai_available` probes the system model once per panel mount; `ports_ai_explain` asks the on-device 3B model what a port's process is and whether stopping it is safe, with the service label / command / cwd / uptime as context and bilingual instructions. Nothing leaves the machine.
- The expanded row grows an "Ask AI" line only when the model is actually available; a failed probe hides the affordance
- Verified live: an `#[ignore]`d spike test drives the real model end to end (passes locally on this machine, ~2s per answer)

## Out of scope (noted for the future)

Cloudflare tunnel sharing, menu-bar residency, and plugging Apple Intelligence into the AI chat panel as a provider (the existing provider abstraction is HTTP-shaped).

## Tests

All red-first: backend sort determinism, classifier cases, two-level grouping stability, grouped headers render, Ask-AI available/unavailable flows. Full vitest suite and `cargo test --lib` green; `RUSTFLAGS="-D warnings" cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)