### PR TITLE
feat(ports): lead the action row with Ask AI and render answers as markdown

### DIFF
--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -90,9 +90,10 @@
     "groupOther": "Other processes",
     "cpu": "CPU",
     "memory": "Memory",
-    "askAi": "Ask AI what this is",
+    "askAi": "Ask AI",
     "aiThinking": "AI is thinking…",
-    "aiFailed": "AI could not answer"
+    "aiFailed": "AI could not answer",
+    "askAiFor": "Ask AI about port {{port}}"
   },
   "titleBar": {
     "minimize": "Minimize",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -90,9 +90,10 @@
     "groupOther": "其他程序",
     "cpu": "CPU",
     "memory": "記憶體",
-    "askAi": "問 AI 這是什麼",
+    "askAi": "詢問 AI",
     "aiThinking": "AI 思考中…",
-    "aiFailed": "AI 回答失敗"
+    "aiFailed": "AI 回答失敗",
+    "askAiFor": "詢問 AI：{{port}}"
   },
   "titleBar": {
     "minimize": "最小化",

--- a/src/modules/ports/PortRow.tsx
+++ b/src/modules/ports/PortRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { ChevronRight, Cpu, MemoryStick, Clock, SquareTerminal, X, Copy, SquareArrowOutUpRight, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -7,6 +7,12 @@ import { Tooltip } from "@/components/Tooltip";
 import { formatUptime } from "./lib/format";
 import { classifyService } from "./lib/classifyService";
 import { portsAiExplain } from "./lib/portsBridge";
+
+// Markdown renderer shared with the AI chat; lazy so react-markdown stays out
+// of the eager bundle — a plain-text fallback covers the load beat.
+const ChatMarkdown = lazy(() =>
+  import("@/modules/ai/ChatMarkdown").then((m) => ({ default: m.ChatMarkdown })),
+);
 import type { PortInfo } from "./lib/portsBridge";
 
 interface PortRowProps {
@@ -15,13 +21,15 @@ interface PortRowProps {
   aiAvailable: boolean;
   expanded: boolean;
   onToggleExpand: () => void;
+  /** Expand without toggling — Ask AI opens the row to show its answer. */
+  onExpand: () => void;
   onRequestKill: (port: PortInfo) => void;
   onOpenTerminal: (port: PortInfo) => void;
 }
 
 const ACTION_BTN = "flex h-6 w-6 items-center justify-center rounded text-fg-subtle transition-colors disabled:opacity-30";
 
-export function PortRow({ port, aiAvailable, expanded, onToggleExpand, onRequestKill, onOpenTerminal }: PortRowProps) {
+export function PortRow({ port, aiAvailable, expanded, onToggleExpand, onExpand, onRequestKill, onOpenTerminal }: PortRowProps) {
   const { t, i18n } = useTranslation();
   const [aiState, setAiState] = useState<{ kind: "idle" } | { kind: "busy" } | { kind: "done"; text: string } | { kind: "failed" }>({ kind: "idle" });
   const canKill = port.isCurrentUser;
@@ -56,6 +64,34 @@ export function PortRow({ port, aiAvailable, expanded, onToggleExpand, onRequest
 
       {/* Line 2: actions, each with a tooltip explaining the icon. */}
       <div className="mt-1.5 flex items-center justify-end gap-1">
+        {aiAvailable && (
+          <Tooltip label={t("ports.askAi")} side="top">
+            <button
+              type="button"
+              aria-label={t("ports.askAiFor", { port: port.port })}
+              disabled={aiState.kind === "busy"}
+              onClick={() => {
+                onExpand();
+                if (aiState.kind === "busy" || aiState.kind === "done") return;
+                setAiState({ kind: "busy" });
+                portsAiExplain({
+                  serviceLabel: service.label,
+                  processName: port.processName,
+                  command: port.command,
+                  cwd: port.cwd,
+                  uptimeSecs: port.uptimeSecs,
+                  port: port.port,
+                  language: i18n.language,
+                })
+                  .then((text) => setAiState({ kind: "done", text }))
+                  .catch(() => setAiState({ kind: "failed" }));
+              }}
+              className={`${ACTION_BTN} hover:text-accent`}
+            >
+              <Sparkles size={14} />
+            </button>
+          </Tooltip>
+        )}
         <Tooltip label={t("ports.openBrowser")} side="top">
           <button
             type="button"
@@ -114,38 +150,20 @@ export function PortRow({ port, aiAvailable, expanded, onToggleExpand, onRequest
           <dd className="break-all">{port.command ?? "-"}</dd>
           <dt className="text-fg-subtle">{t("ports.cwd")}</dt>
           <dd className="break-all">{port.cwd ?? "-"}</dd>
-          {aiAvailable && (
+          {aiState.kind !== "idle" && (
             <>
               <dt className="flex items-start text-fg-subtle"><Sparkles size={11} /></dt>
               <dd>
-                {aiState.kind === "done" ? (
-                  <p className="whitespace-pre-wrap font-sans leading-relaxed text-fg">{aiState.text}</p>
+                {aiState.kind === "busy" ? (
+                  <span className="text-fg-subtle">{t("ports.aiThinking")}</span>
+                ) : aiState.kind === "failed" ? (
+                  <span className="text-danger">{t("ports.aiFailed")}</span>
                 ) : (
-                  <button
-                    type="button"
-                    disabled={aiState.kind === "busy"}
-                    onClick={() => {
-                      setAiState({ kind: "busy" });
-                      portsAiExplain({
-                        serviceLabel: service.label,
-                        processName: port.processName,
-                        command: port.command,
-                        cwd: port.cwd,
-                        uptimeSecs: port.uptimeSecs,
-                        port: port.port,
-                        language: i18n.language,
-                      })
-                        .then((text) => setAiState({ kind: "done", text }))
-                        .catch(() => setAiState({ kind: "failed" }));
-                    }}
-                    className="text-left text-accent hover:underline disabled:opacity-60"
-                  >
-                    {aiState.kind === "busy"
-                      ? t("ports.aiThinking")
-                      : aiState.kind === "failed"
-                        ? t("ports.aiFailed")
-                        : t("ports.askAi")}
-                  </button>
+                  <div className="font-sans text-xs leading-relaxed text-fg">
+                    <Suspense fallback={<p className="whitespace-pre-wrap">{aiState.text}</p>}>
+                      <ChatMarkdown content={aiState.text} />
+                    </Suspense>
+                  </div>
                 )}
               </dd>
             </>

--- a/src/modules/ports/PortsPanelView.test.tsx
+++ b/src/modules/ports/PortsPanelView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/i18n";
 
@@ -55,16 +55,22 @@ describe("PortsPanelView grouping", () => {
 });
 
 describe("PortsPanelView Apple Intelligence", () => {
-  it("offers Ask AI in the expanded row only when the on-device model is available", async () => {
+  it("leads the action row with Ask AI, expands the row, and renders the styled answer", async () => {
     portsAiAvailable.mockResolvedValue(true);
-    portsAiExplain.mockResolvedValue("A dev server. Safe to stop.");
-    render(<PortsPanelView />);
-    fireEvent.click(await screen.findByRole("button", { name: /details/i }));
+    portsAiExplain.mockResolvedValue("A dev server. **Safe** to stop.");
+    const { container } = render(<PortsPanelView />);
+
+    // The trigger lives on the always-visible action row, first position —
+    // no expanding needed to reach it.
     const ask = await screen.findByRole("button", { name: /ask ai/i });
+    const openBrowser = screen.getByRole("button", { name: /browser/i });
+    expect(ask.compareDocumentPosition(openBrowser) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     fireEvent.click(ask);
 
-    expect(await screen.findByText("A dev server. Safe to stop.")).toBeInTheDocument();
+    // The row auto-expands and the answer renders as markdown, not raw text.
+    expect(await screen.findByText(/A dev server/)).toBeInTheDocument();
+    await waitFor(() => expect(container.querySelector("strong")?.textContent).toBe("Safe"));
     expect(portsAiExplain).toHaveBeenCalledWith(
       expect.objectContaining({ port: 3000, processName: "node" }),
     );

--- a/src/modules/ports/PortsPanelView.tsx
+++ b/src/modules/ports/PortsPanelView.tsx
@@ -101,6 +101,7 @@ export function PortsPanelView() {
                   aiAvailable={aiAvailable}
                   expanded={expandedPid === port.pid}
                   onToggleExpand={() => setExpandedPid((cur) => (cur === port.pid ? null : port.pid))}
+                  onExpand={() => setExpandedPid(port.pid)}
                   onRequestKill={setKillTarget}
                   onOpenTerminal={openTerminal}
                 />


### PR DESCRIPTION
Follow-up to #388, from maintainer review of the shipped UI:

- The Ask-AI trigger moves from the expanded details to the **first position of the always-visible action row** (Sparkles icon, "詢問 AI" tooltip); clicking auto-expands the row to show the answer
- Answers render as **markdown** through the AI chat's ChatMarkdown, lazy-loaded so react-markdown stays out of the eager bundle (plain-text Suspense fallback)
- No model ⇒ still no affordance anywhere

Tests updated red-first: the trigger precedes the browser button in DOM order without expanding, the row auto-expands, `**Safe**` renders as a real `<strong>`, and the unavailable case renders nothing. Ports module green, typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)