### PR TITLE
feat(ai): Apple Intelligence as a default-model provider

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod modules;
 use tauri::Manager;
 
 use modules::ai::ai_chat;
+use modules::ai::ai_apple_available;
 use modules::appearance::{appearance_remove_background_image, appearance_save_background_image};
 use modules::claude_progress::{
     claude_progress_unwatch, claude_progress_watch, claude_session_title, ClaudeProgressState,
@@ -347,6 +348,7 @@ pub fn run() {
             preview_history_forward,
             preview_close,
             ai_chat,
+            ai_apple_available,
             terminal_history_save,
             terminal_history_load,
             terminal_history_delete,

--- a/src-tauri/src/modules/ai/mod.rs
+++ b/src-tauri/src/modules/ai/mod.rs
@@ -25,6 +25,12 @@ pub async fn ai_chat(
         return Err("No model selected — choose or type a model in the chat header.".to_string());
     }
 
+    // Apple Intelligence is not an HTTP provider: no key, no URL, the whole
+    // exchange stays on-device via FoundationModels.
+    if kind == "apple" {
+        return apple_chat(messages).await;
+    }
+
     let key = secrets::get_key(&provider)?.unwrap_or_default();
     let request = build_request(&kind, &base_url, &model, &messages, &key)?;
 
@@ -49,3 +55,55 @@ pub async fn ai_chat(
     let value: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
     parse_response(&kind, &value)
 }
+
+/// Whether the on-device Apple Intelligence model can serve as a provider.
+#[tauri::command]
+pub async fn ai_apple_available() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        tauri::async_runtime::spawn_blocking(|| {
+            fm_rs::SystemLanguageModel::new()
+                .map(|m| m.is_available())
+                .unwrap_or(false)
+        })
+        .await
+        .unwrap_or(false)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+async fn apple_chat(messages: Vec<ChatMessage>) -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        tauri::async_runtime::spawn_blocking(move || {
+            let model = fm_rs::SystemLanguageModel::new().map_err(|e| e.to_string())?;
+            if !model.is_available() {
+                return Err("Apple Intelligence is not available on this Mac.".to_string());
+            }
+            let (instructions, prompt) = build_apple_parts(&messages);
+            let session = if instructions.is_empty() {
+                fm_rs::Session::new(&model)
+            } else {
+                fm_rs::Session::with_instructions(&model, &instructions)
+            }
+            .map_err(|e| e.to_string())?;
+            let response = session
+                .respond(&prompt, &fm_rs::GenerationOptions::default())
+                .map_err(|e| e.to_string())?;
+            Ok(response.content().to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("Apple Intelligence is only available on macOS.".to_string())
+    }
+}
+
+#[cfg(target_os = "macos")]
+use provider::apple_prompt_parts as build_apple_parts;

--- a/src-tauri/src/modules/ai/provider.rs
+++ b/src-tauri/src/modules/ai/provider.rs
@@ -11,6 +11,32 @@ pub struct ChatMessage {
     pub content: String,
 }
 
+/// Fold an OpenAI-style message array into what FoundationModels wants: the
+/// system turns joined as session instructions, everything else rendered as a
+/// transcript ending in the newest user ask. The on-device session is created
+/// per request, so prior turns travel inside the prompt.
+pub fn apple_prompt_parts(messages: &[ChatMessage]) -> (String, String) {
+    let mut instructions: Vec<&str> = Vec::new();
+    let mut transcript: Vec<String> = Vec::new();
+    for message in messages {
+        match message.role.as_str() {
+            "system" => instructions.push(&message.content),
+            "assistant" => transcript.push(format!("Assistant: {}", message.content)),
+            _ => transcript.push(format!("User: {}", message.content)),
+        }
+    }
+    // The last user line stands bare so the model answers it rather than the
+    // transcript; strip our own prefix from it.
+    if let Some(last) = transcript.pop() {
+        let bare = match last.strip_prefix("User: ") {
+            Some(b) => b.to_string(),
+            None => last,
+        };
+        transcript.push(bare);
+    }
+    (instructions.join("\n"), transcript.join("\n"))
+}
+
 pub struct ProviderRequest {
     pub url: String,
     pub headers: Vec<(String, String)>,
@@ -167,6 +193,29 @@ pub fn parse_response(kind: &str, value: &Value) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn apple_prompt_folds_system_into_instructions_and_history_into_prompt() {
+        let messages = vec![
+            ChatMessage { role: "system".into(), content: "Be brief.".into() },
+            ChatMessage { role: "user".into(), content: "hi".into() },
+            ChatMessage { role: "assistant".into(), content: "hello".into() },
+            ChatMessage { role: "user".into(), content: "explain X".into() },
+        ];
+        let (instructions, prompt) = apple_prompt_parts(&messages);
+        assert_eq!(instructions, "Be brief.");
+        assert!(prompt.contains("User: hi"));
+        assert!(prompt.contains("Assistant: hello"));
+        assert!(prompt.ends_with("explain X"));
+    }
+
+    #[test]
+    fn apple_prompt_without_system_or_history_is_just_the_ask() {
+        let messages = vec![ChatMessage { role: "user".into(), content: "just this".into() }];
+        let (instructions, prompt) = apple_prompt_parts(&messages);
+        assert_eq!(instructions, "");
+        assert_eq!(prompt, "just this");
+    }
 
     fn msgs() -> Vec<ChatMessage> {
         vec![

--- a/src-tauri/src/modules/ai/provider.rs
+++ b/src-tauri/src/modules/ai/provider.rs
@@ -15,6 +15,10 @@ pub struct ChatMessage {
 /// system turns joined as session instructions, everything else rendered as a
 /// transcript ending in the newest user ask. The on-device session is created
 /// per request, so prior turns travel inside the prompt.
+// Consumed by the macOS arm of ai_chat; on other targets only the unit tests
+// touch it, which a plain `cargo check -D warnings` cannot see (windows-tauri
+// skill, rule 6).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub fn apple_prompt_parts(messages: &[ChatMessage]) -> (String, String) {
     let mut instructions: Vec<&str> = Vec::new();
     let mut transcript: Vec<String> = Vec::new();

--- a/src/modules/ai/AIView.tsx
+++ b/src/modules/ai/AIView.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Bot, KeyRound, Paperclip, SendHorizontal, SquareTerminal, Trash2, X } from "lucide-react";
 import { useChatStore } from "./store/chatStore";
-import { providerById, PROVIDERS } from "./lib/providers";
+import { CHAT_PROVIDERS } from "./lib/providers";
+import { resolveChatTarget } from "./store/chatStore";
 import { secretsHasKey, secretsSetKey } from "./lib/aiBridge";
 import { buildAttachmentsBlock, type AttachedFile } from "./lib/attachments";
 import { buildActiveFileBlock, buildTerminalBlock } from "./lib/context";
@@ -128,7 +129,19 @@ export function AIView() {
   // store, while workspaceStore.activeFile was never updated on tab navigation.
   const activeFile = useTabsStore((s) => activeEditorPath(s.tabs, s.activeId));
 
-  const provider = providerById(providerId);
+  const chatProviderId = useChatStore((s) => s.chatProviderId);
+  const chatModel = useChatStore((s) => s.chatModel);
+  const setChatProvider = useChatStore((s) => s.setChatProvider);
+  const setChatModel = useChatStore((s) => s.setChatModel);
+  // While the default is Apple Intelligence the panel shows and edits the
+  // chat-only fallback pair; otherwise it edits the shared default, as ever.
+  const appleDefault = providerId === "apple";
+  const { provider, model: effectiveModel } = resolveChatTarget({
+    providerId,
+    model,
+    chatProviderId,
+    chatModel,
+  });
   const [hasKey, setHasKey] = useState(true);
   const [input, setInput] = useState("");
   const listRef = useRef<HTMLDivElement>(null);
@@ -192,19 +205,24 @@ export function AIView() {
         <Bot size={16} className="shrink-0 text-accent" />
         <Combobox
           value={provider.label}
-          options={PROVIDERS.map((p) => p.label)}
+          options={CHAT_PROVIDERS.map((p) => p.label)}
           onChange={(label) => {
-            const next = PROVIDERS.find((p) => p.label === label);
-            if (next) setProvider(next.id);
+            const next = CHAT_PROVIDERS.find((p) => p.label === label);
+            if (!next) return;
+            if (appleDefault) {
+              setChatProvider(next.id);
+            } else {
+              setProvider(next.id);
+            }
           }}
           ariaLabel={t("provider")}
           className="min-w-0 flex-1"
           textClassName="text-[13px]"
         />
         <Combobox
-          value={model}
+          value={effectiveModel}
           options={provider.models}
-          onChange={setModel}
+          onChange={appleDefault ? setChatModel : setModel}
           ariaLabel={t("model")}
           editable
           placeholder={t("modelPlaceholder")}

--- a/src/modules/ai/lib/aiBridge.ts
+++ b/src/modules/ai/lib/aiBridge.ts
@@ -31,3 +31,8 @@ export function secretsDeleteKey(provider: string): Promise<void> {
 export function secretsHasKey(provider: string): Promise<boolean> {
   return invoke<boolean>("secrets_has_key", { provider });
 }
+
+/** Whether the on-device Apple Intelligence model can serve as a provider. */
+export function aiAppleAvailable(): Promise<boolean> {
+  return invoke<boolean>("ai_apple_available");
+}

--- a/src/modules/ai/lib/providers.test.ts
+++ b/src/modules/ai/lib/providers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  CHAT_PROVIDERS,
   CUSTOM_PROVIDER_ID,
   PROVIDERS,
   providerById,
@@ -54,5 +55,21 @@ describe("resolveBaseUrl", () => {
     const custom = providerById(CUSTOM_PROVIDER_ID);
     expect(resolveBaseUrl(custom, undefined)).toBe(custom.baseUrl);
     expect(resolveBaseUrl(custom, null)).toBe(custom.baseUrl);
+  });
+});
+
+describe("Apple Intelligence provider", () => {
+  it("exists as a keyless on-device preset", () => {
+    const apple = providerById("apple");
+    expect(apple.kind).toBe("apple");
+    expect(apple.needsKey).toBe(false);
+    expect(apple.models).toEqual(["on-device"]);
+  });
+
+  it("is offered everywhere except the chat panel", () => {
+    expect(PROVIDERS.some((p) => p.id === "apple")).toBe(true);
+    expect(CHAT_PROVIDERS.some((p) => p.id === "apple")).toBe(false);
+    // Nothing else is filtered out.
+    expect(CHAT_PROVIDERS.length).toBe(PROVIDERS.length - 1);
   });
 });

--- a/src/modules/ai/lib/providers.ts
+++ b/src/modules/ai/lib/providers.ts
@@ -1,4 +1,4 @@
-export type ProviderKind = "openai" | "anthropic" | "google";
+export type ProviderKind = "openai" | "anthropic" | "google" | "apple";
 
 /** Provider id whose base URL the user supplies, for any OpenAI-compatible server. */
 export const CUSTOM_PROVIDER_ID = "custom";
@@ -87,6 +87,17 @@ export const PROVIDERS: ProviderPreset[] = [
     needsKey: false,
   },
   {
+    id: "apple",
+    label: "Apple Intelligence",
+    kind: "apple",
+    // Not an HTTP provider: the Rust side answers on-device via
+    // FoundationModels, so there is no URL and no key. macOS 26+ only; the
+    // settings UI hides this preset when the model probe says unavailable.
+    baseUrl: "",
+    models: ["on-device"],
+    needsKey: false,
+  },
+  {
     id: CUSTOM_PROVIDER_ID,
     label: "Custom (OpenAI-compatible)",
     kind: "openai",
@@ -120,3 +131,11 @@ export function resolveBaseUrl(
   // Tolerate a missing value from unhydrated/older persisted state.
   return (customBaseUrl ?? "").trim() || provider.baseUrl;
 }
+
+/**
+ * The providers the chat panel offers. Apple Intelligence is deliberately not
+ * one of them: the 3B on-device model is the default for background tasks
+ * (commit messages, diff explains, completion), not the conversational
+ * assistant — chat quality and its 4k-token window do not fit long sessions.
+ */
+export const CHAT_PROVIDERS: ProviderPreset[] = PROVIDERS.filter((p) => p.id !== "apple");

--- a/src/modules/ai/store/chatStore.test.ts
+++ b/src/modules/ai/store/chatStore.test.ts
@@ -30,6 +30,26 @@ beforeEach(() => {
 });
 
 describe("chatStore.send base URL resolution", () => {
+  it("routes chat away from an Apple Intelligence default", async () => {
+    // The on-device model is a background-tasks default, not the assistant's
+    // conversational model: chat silently uses the fallback pair instead.
+    useChatStore.setState({ providerId: "apple", model: "on-device" });
+    await useChatStore.getState().send("hi", "");
+    expect(aiChat).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "openai", kind: "openai" }),
+    );
+  });
+
+  it("chat fallback switching never touches the default provider", async () => {
+    useChatStore.setState({ providerId: "apple", model: "on-device" });
+    useChatStore.getState().setChatProvider("groq");
+    await useChatStore.getState().send("hi", "");
+    expect(aiChat).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "groq", model: "llama-3.3-70b-versatile" }),
+    );
+    expect(useChatStore.getState().providerId).toBe("apple");
+  });
+
   it("sends the user's custom base URL when the custom provider is selected", async () => {
     useChatStore.setState({
       providerId: CUSTOM_PROVIDER_ID,

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -18,6 +18,9 @@ function getErrorMessage(error: unknown): string {
 interface ChatState {
   providerId: string;
   model: string;
+  /** Chat-only provider used while the default is Apple Intelligence. */
+  chatProviderId: string | null;
+  chatModel: string | null;
   /** User-supplied base URL for the custom OpenAI-compatible provider. */
   customBaseUrl: string;
   messages: ChatMessage[];
@@ -27,12 +30,33 @@ interface ChatState {
   attachedPaths: string[];
   setProvider: (id: string) => void;
   setModel: (model: string) => void;
+  setChatProvider: (id: string) => void;
+  setChatModel: (model: string) => void;
   setCustomBaseUrl: (url: string) => void;
   send: (text: string, systemPrompt: string) => Promise<void>;
   clear: () => void;
   attachPath: (path: string) => void;
   removeAttached: (path: string) => void;
   clearAttached: () => void;
+}
+
+/**
+ * What the chat panel actually talks to. An Apple Intelligence default is for
+ * background tasks; the assistant falls back to the persisted chat-only pair
+ * (seeded with OpenAI) and switching in the panel edits that pair, never the
+ * default.
+ */
+export function resolveChatTarget(state: {
+  providerId: string;
+  model: string;
+  chatProviderId: string | null;
+  chatModel: string | null;
+}): { provider: ReturnType<typeof providerById>; model: string } {
+  if (state.providerId !== "apple") {
+    return { provider: providerById(state.providerId), model: state.model };
+  }
+  const provider = providerById(state.chatProviderId ?? "openai");
+  return { provider, model: state.chatModel ?? provider.models[0] ?? "" };
 }
 
 export const CHAT_STORAGE_KEY = "tempoterm-chat";
@@ -42,6 +66,8 @@ export const useChatStore = create<ChatState>()(
     (set, get) => ({
       providerId: PROVIDERS[0].id,
       model: PROVIDERS[0].models[0],
+      chatProviderId: null,
+      chatModel: null,
       customBaseUrl: providerById(CUSTOM_PROVIDER_ID).baseUrl,
       messages: [],
       sending: false,
@@ -63,6 +89,13 @@ export const useChatStore = create<ChatState>()(
 
       setModel: (model) => set({ model }),
 
+      setChatProvider: (id) => {
+        const provider = providerById(id);
+        set({ chatProviderId: provider.id, chatModel: provider.models[0] ?? "" });
+      },
+
+      setChatModel: (model) => set({ chatModel: model }),
+
       setCustomBaseUrl: (url) => set({ customBaseUrl: url }),
 
       send: async (text, systemPrompt) => {
@@ -70,8 +103,8 @@ export const useChatStore = create<ChatState>()(
         if (!trimmed || get().sending) {
           return;
         }
-        const { providerId, model, customBaseUrl, messages } = get();
-        const provider = providerById(providerId);
+        const { customBaseUrl, messages } = get();
+        const { provider, model } = resolveChatTarget(get());
         const payload = composeMessages(systemPrompt, messages, trimmed);
 
         set({
@@ -119,6 +152,8 @@ export const useChatStore = create<ChatState>()(
       partialize: (state) => ({
         providerId: state.providerId,
         model: state.model,
+        chatProviderId: state.chatProviderId,
+        chatModel: state.chatModel,
         customBaseUrl: state.customBaseUrl,
         attachedPaths: state.attachedPaths,
       }),

--- a/src/modules/settings/AiSettingsSection.tsx
+++ b/src/modules/settings/AiSettingsSection.tsx
@@ -6,13 +6,36 @@ import { useChatStore } from "@/modules/ai/store/chatStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { Combobox } from "@/components/Combobox";
 import {
+  aiAppleAvailable,
   secretsDeleteKey,
   secretsHasKey,
   secretsSetKey,
 } from "@/modules/ai/lib/aiBridge";
 
+/**
+ * Providers the settings page offers: Apple Intelligence appears only where
+ * the on-device model actually answers (macOS 26+, Apple Intelligence on);
+ * elsewhere — Windows included — the option simply does not exist.
+ */
+function useVisibleProviders() {
+  const [appleOk, setAppleOk] = useState(false);
+  useEffect(() => {
+    let live = true;
+    aiAppleAvailable()
+      .then((ok) => {
+        if (live) setAppleOk(ok);
+      })
+      .catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, []);
+  return PROVIDERS.filter((p) => p.id !== "apple" || appleOk);
+}
+
 function DefaultModelRow() {
   const { t } = useTranslation("settings");
+  const visibleProviders = useVisibleProviders();
   const providerId = useChatStore((s) => s.providerId);
   const model = useChatStore((s) => s.model);
   const customBaseUrl = useChatStore((s) => s.customBaseUrl);
@@ -28,9 +51,9 @@ function DefaultModelRow() {
       <div className="flex flex-wrap gap-2">
         <Combobox
           value={provider.label}
-          options={PROVIDERS.map((p) => p.label)}
+          options={visibleProviders.map((p) => p.label)}
           onChange={(label) => {
-            const next = PROVIDERS.find((p) => p.label === label);
+            const next = visibleProviders.find((p) => p.label === label);
             if (next) setProvider(next.id);
           }}
           ariaLabel={t("aiModel.provider")}
@@ -178,6 +201,7 @@ function ProviderKeyRow({ id, label, needsKey }: { id: string; label: string; ne
 }
 
 export function AiSettingsSection() {
+  const keyListProviders = useVisibleProviders();
   const { t } = useTranslation("settings");
   return (
     <section>
@@ -192,7 +216,7 @@ export function AiSettingsSection() {
       <label className="mb-1 block text-sm font-medium text-fg">{t("aiKeys.title")}</label>
       <p className="mb-2 text-xs text-fg-muted">{t("aiKeys.description")}</p>
       <div>
-        {PROVIDERS.map((provider) => (
+        {keyListProviders.map((provider) => (
           <ProviderKeyRow
             key={provider.id}
             id={provider.id}


### PR DESCRIPTION
Follows the feasibility review: every AI feature funnels through the one-shot `ai_chat`, which fits FoundationModels exactly.

## Rust

`kind == "apple"` branches `ai_chat` away from HTTP entirely — no key, no URL, the exchange stays on-device via the `fm-rs` binding already carried for the Ports panel (#388). System turns fold into session instructions and history renders as a transcript ending in the bare newest ask (`apple_prompt_parts`, unit-tested). `ai_apple_available` probes the model; non-macOS builds compile stubs that report unavailable.

## Frontend

- **Settings**: the Apple Intelligence preset (keyless, `on-device` model) appears in the default-model dropdown and the key list only where the probe answers yes — **Windows never sees the option**. Selecting it routes commit messages, diff explains and inline completion through the on-device model.
- **Chat panel deliberately excludes it** (`CHAT_PROVIDERS`): the 3B on-device model is a background-tasks default, not the conversational assistant. With an Apple default the panel shows and edits a persisted chat-only fallback pair (seeded OpenAI) and never touches the default (`resolveChatTarget`, store-tested).

## Feature coverage (from the feasibility matrix)

Commit messages (≤12k chars), diff explains (≤12k, bilingual), inline completion (2-message FIM) and the Ports Ask-AI all fit the on-device 4k-token window; attachments are text-only in this app, so the binding's no-images limit is moot. Long chat is exactly what the exclusion above addresses.

## Tests

Red-first throughout: apple preset shape, CHAT_PROVIDERS exclusion, chat routing away from an Apple default without touching it, prompt folding on the Rust side. Full vitest suite and `cargo test --lib` green; `RUSTFLAGS="-D warnings" cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)