### PR TITLE
fix(diff): size the diff type from the font setting

### DIFF
--- a/src/modules/diff/DiffTabContent.test.tsx
+++ b/src/modules/diff/DiffTabContent.test.tsx
@@ -29,6 +29,7 @@ import { useDiffCommentStore } from "./lib/diffCommentStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { useSessionStatusStore } from "@/modules/claude-progress/lib/sessionStatusStore";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { DEFAULT_FONT_SIZE, useFontStore } from "@/stores/fontStore";
 import { leaf } from "@/modules/terminal/lib/terminalLayout";
 
 describe("DiffTabContent", () => {
@@ -39,6 +40,7 @@ describe("DiffTabContent", () => {
     useSessionStatusStore.setState({ statuses: {}, agents: {}, sessionIds: {} });
     // Most tests are not about the one-time hint; dedicated cases flip it back.
     useSettingsStore.setState({ diffCommentHintSeen: true, diffUnified: false });
+    useFontStore.setState({ fontSize: DEFAULT_FONT_SIZE });
   });
 
   it("compares index vs working tree for an unstaged diff", async () => {
@@ -106,6 +108,21 @@ describe("DiffTabContent", () => {
     await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeNull());
     expect(container.querySelector(".diff-inline-view .cm-editor")).toBeTruthy();
     expect(container.querySelector(".cm-deletedChunk")).toBeTruthy();
+  });
+
+  it("sets the diff type size from the font setting", async () => {
+    useFontStore.setState({ fontSize: 20 });
+    vi.mocked(gitFileAtRev).mockResolvedValue("old line\n");
+    vi.mocked(fsReadFile).mockResolvedValue("new line\n");
+
+    const { container } = render(<DiffTabContent path="/repo/a.ts" staged={false} />);
+
+    await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeTruthy());
+    // The size lands in the theme CodeMirror injects, not on the elements.
+    const css = Array.from(document.querySelectorAll("style"))
+      .map((tag) => tag.textContent ?? "")
+      .join("");
+    expect(css).toContain("font-size: 20px");
   });
 
   it("folds expanded unchanged regions back up", async () => {

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -102,6 +102,7 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
   const containerRef = useRef<HTMLDivElement>(null);
   const viewsRef = useRef<DiffViews | null>(null);
   const fontFamily = useFontStore(selectTerminalFontFamily);
+  const fontSize = useFontStore((s) => s.fontSize);
   const themeId = useSettingsStore((s) => s.themeId);
   // Shares the editor's word-wrap setting so both surfaces toggle together.
   const wordWrap = useSettingsStore((s) => s.wordWrap);
@@ -256,11 +257,13 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
           // Localizes the collapsed-region bar ("$ unchanged lines").
           EditorState.phrases.of({ "$ unchanged lines": t("diffUnchangedLines") }),
           editorSyntaxTheme(themeId),
-          // Fixed 13px to match the Git Graph diff view's type size. Height and
-          // scrolling belong to the outer .cm-mergeView container (the merge
-          // package forces the editors themselves to auto height).
+          // Reads code, so it follows the configured font size like an editor
+          // pane rather than pinning its own (the store's 13px default is the
+          // Git Graph diff view's type size, so nothing moves out of the box).
+          // Height and scrolling belong to the outer .cm-mergeView container
+          // (the merge package forces the editors themselves to auto height).
           EditorView.theme({
-            "&": { fontSize: "13px" },
+            "&": { fontSize: `${fontSize}px` },
             ".cm-content, .cm-gutters, .cm-scroller": { fontFamily },
           }),
           lineNumbers(),
@@ -364,7 +367,7 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
         views?.view.destroy();
       }
     };
-  }, [docs, path, themeId, fontFamily, wordWrap, unified]);
+  }, [docs, path, themeId, fontFamily, fontSize, wordWrap, unified]);
 
   // Push the current comment set and draft into both editors whenever either
   // changes (or the MergeView was rebuilt). The extension renders from these


### PR DESCRIPTION
## Problem

The diff tab pins its editors at 13px:

```ts
EditorView.theme({ "&": { fontSize: "13px" }, ... })
```

So the Fonts setting sizes every other code surface — editor panes, terminals — and leaves the diff behind. Size the app up to 20px and the diff still reads at 13.

## Changes

- `DiffTabContent` reads `fontSize` from the font store, the same way an editor pane does (`EditorTabContent.tsx:126`), and rebuilds its views when it changes.
- 13px is the store's default (`DEFAULT_FONT_SIZE`), which is also the Git Graph diff view's type size, so nothing moves out of the box.

Scope is the diff tab's editor surface only. The Git Graph diff view and the commit details panel keep their fixed type: those are panel chrome sized around a fixed 20px virtual row, not a code-reading surface.

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec vitest run src/modules/diff/DiffTabContent.test.tsx` — 14 passed, including a new case that sets the store to 20px and asserts the injected theme carries it
- [x] `pnpm exec vitest run` — 2122 passed. One unrelated flake in `PortsPanelView.test.tsx` under full-suite load; it passes on its own and is untouched by this change
- [x] Not verified by hand yet — the automated case covers the mechanism, but a look at Fonts → size 20 with a diff tab open is worth one pair of eyes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
