### PR TITLE
fix(diff): take the gutter hint down when its icon is destroyed

### DIFF
--- a/src/modules/diff/lib/gutterHint.test.ts
+++ b/src/modules/diff/lib/gutterHint.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withGutterHint } from "./gutterHint";
+
+function icon() {
+  const el = document.createElement("span");
+  document.body.appendChild(el);
+  return withGutterHint(el, "Add Comment");
+}
+
+const hints = () => document.querySelectorAll(".cm-gutter-hint");
+
+describe("withGutterHint", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the label while the pointer is on the icon", () => {
+    const el = icon();
+
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(hints().length).toBe(1);
+    expect(document.querySelector(".cm-gutter-hint")?.textContent).toBe("Add Comment");
+
+    el.dispatchEvent(new MouseEvent("mouseleave"));
+    expect(hints().length).toBe(0);
+  });
+
+  it("takes the hint down when the icon is destroyed under the pointer", () => {
+    const el = icon();
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(hints().length).toBe(1);
+
+    // What the all-changes view does when a file scrolls out of its mounted
+    // window: the whole editor goes, so mouseleave never fires.
+    el.remove();
+    expect(hints().length).toBe(1);
+
+    vi.advanceTimersByTime(300);
+    expect(hints().length).toBe(0);
+  });
+
+  it("stops checking once the hint is down", () => {
+    const el = icon();
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    el.dispatchEvent(new MouseEvent("mouseleave"));
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/modules/diff/lib/gutterHint.ts
+++ b/src/modules/diff/lib/gutterHint.ts
@@ -5,9 +5,17 @@
  * tooltip, and `title` is unreliable in the macOS WebView. Styling lives in
  * index.css as `.cm-gutter-hint`.
  */
+/** How often an open hint checks that its icon is still in the document. */
+const ORPHAN_CHECK_MS = 250;
+
 export function withGutterHint<T extends HTMLElement>(el: T, label: string): T {
   let tip: HTMLElement | null = null;
+  let orphanCheck: number | null = null;
   const hide = () => {
+    if (orphanCheck !== null) {
+      window.clearInterval(orphanCheck);
+      orphanCheck = null;
+    }
     tip?.remove();
     tip = null;
   };
@@ -22,6 +30,15 @@ export function withGutterHint<T extends HTMLElement>(el: T, label: string): T {
     const rect = el.getBoundingClientRect();
     tip.style.left = `${rect.right + 6}px`;
     tip.style.top = `${rect.top + rect.height / 2 - tip.offsetHeight / 2}px`;
+    // The icon can be destroyed with the pointer still on it — the editors
+    // rebuild, or in the all-changes view a file scrolls out of the mounted
+    // window entirely. A removed element never fires mouseleave, so without
+    // this the hint is stranded on the body for the rest of the session.
+    orphanCheck = window.setInterval(() => {
+      if (!el.isConnected) {
+        hide();
+      }
+    }, ORPHAN_CHECK_MS);
   });
   el.addEventListener("mouseleave", hide);
   el.addEventListener("mousedown", hide);


### PR DESCRIPTION
## Problem

The hover hint the gutter icons grew in #393 is a fixed-position element on the body, taken down by the icon's own `mouseleave`. An icon removed from the document while the pointer is still on it never fires one, so the hint stays on screen for the rest of the session.

The diff tab re-reads both sides whenever the window regains focus, which rebuilds the editors — so alt-tabbing away with the pointer parked on a comment "+" or a fold arrow is enough to strand one.

## Changes

- While a hint is up it checks that its icon is still `isConnected` and takes itself down when it isn't. The interval exists only for as long as the hint does, and every path that already hid the hint (`mouseleave`, `mousedown`) clears it.
- `gutterHint.test.ts` is new: the label shows and hides on hover, an icon destroyed under the pointer takes its hint with it, and nothing is left ticking afterwards.

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec vitest run src/modules/diff/lib/gutterHint.test.ts` — 3 passed; the orphan case fails without this change (the hint is still in the document after the icon goes)
- [x] `pnpm exec vitest run` — 2124 passed, 1 failed: `PortsPanelView`, which is a pre-existing timing flake on my machine rather than anything from this change. Unmodified `master` fails four tests in a full-suite run here (`PortsPanelView`, `DashboardView`, `SessionsTabContent`, `SourceControlView`) and each passes when run on its own
- [x] Not verified by hand — the automated case covers the mechanism (an icon removed from the
      document while its hint is up), but a hover-then-alt-tab is worth one pair of eyes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
