### PR TITLE
fix(diff): stop giving up on the diff of a big file

### DIFF
--- a/src/modules/diff/DiffTabContent.test.tsx
+++ b/src/modules/diff/DiffTabContent.test.tsx
@@ -281,4 +281,36 @@ describe("DiffTabContent", () => {
     fireEvent.click(screen.getByRole("button", { name: "diffSendToAgent" }));
     expect(await screen.findByRole("menuitem", { name: "diffNoAgentSession" })).toBeDisabled();
   });
+
+  it("diffs a big file precisely when its changes are scattered", async () => {
+    // @codemirror/merge's default diff config gives up on a differing range
+    // past a few thousand characters and marks the whole of it as replaced.
+    // What trips it is not size alone but changes spread out inside one — a
+    // resource file with lines added in four places used to render as the
+    // entire file deleted and added back. 600 lines with four insertion
+    // points is the smallest shape that reproduces it (31 lines falsely
+    // marked deleted before this change).
+    const base = Array.from(
+      { length: 600 },
+      (_, i) => `    const value${i} = computeSomething(${i}, "an argument");`,
+    );
+    const insertAt = new Set([120, 240, 360, 480]);
+    const withAdditions: string[] = [];
+    base.forEach((line, i) => {
+      if (insertAt.has(i)) {
+        withAdditions.push("    const brandNew = 1;", "    const alsoNew = 2;");
+      }
+      withAdditions.push(line);
+    });
+    vi.mocked(gitFileAtRev).mockResolvedValue(base.join("\n") + "\n");
+    vi.mocked(fsReadFile).mockResolvedValue(withAdditions.join("\n") + "\n");
+
+    const { container } = render(<DiffTabContent path="/repo/big.ts" staged={false} />);
+
+    await waitFor(() =>
+      expect(container.querySelectorAll(".cm-merge-b .cm-changedLine").length).toBeGreaterThan(0),
+    );
+    // Nothing was removed, so the old side carries no changed line at all.
+    expect(container.querySelectorAll(".cm-merge-a .cm-changedLine").length).toBe(0);
+  });
 });

--- a/src/modules/diff/DiffTabContent.tsx
+++ b/src/modules/diff/DiffTabContent.tsx
@@ -69,6 +69,28 @@ interface DiffDocs {
  */
 const COLLAPSE_UNCHANGED = { margin: 3, minSize: 5 };
 
+/**
+ * @codemirror/merge defaults to `{ scanLimit: 500 }`, which abandons the
+ * precise diff once a differing range passes 4,000 characters and marks the
+ * whole range replaced past 16,000. That measures the wrong thing: the
+ * algorithm is O(N*D) in the number of differences, so a file with a few
+ * changes spread far apart is cheap to diff exactly and yet trips a limit set
+ * on range size alone. A 13,890-line resource file with 24 added lines came
+ * out as the entire file deleted and added back, against git's own +24 -0.
+ *
+ * Measured on that file (450KB): the default marks 107,763 characters as
+ * deleted in 0.8ms, where an unlimited scan is exact in 11ms.
+ *
+ * So the budget is time, not size. 1000ms sits above the worst case worth
+ * being precise about -- 500 changed lines scattered through a large file,
+ * exact in ~530ms -- and a shorter deadline is not only less precise but
+ * slower, because every range that misses it falls back to a crude match that
+ * costs more on a wide range than finishing the scan would have (300ms
+ * measured at 1653ms, against 411ms unlimited). Two genuinely unrelated large
+ * files, the case the scan limit is there for, give up at ~930ms.
+ */
+const DIFF_CONFIG = { timeout: 1000 };
+
 /** The inline mode's merge extension, rebuilt whenever the bars are reset. */
 function unifiedExtension(original: string) {
   return unifiedMergeView({
@@ -77,6 +99,7 @@ function unifiedExtension(original: string) {
     // The accept/reject controls write to the document; this tab only reads one.
     mergeControls: false,
     collapseUnchanged: COLLAPSE_UNCHANGED,
+    diffConfig: DIFF_CONFIG,
   });
 }
 
@@ -316,6 +339,7 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
             parent,
             gutter: true,
             collapseUnchanged: COLLAPSE_UNCHANGED,
+            diffConfig: DIFF_CONFIG,
           });
           views = { kind: "split", merge };
           // Pin a bottom horizontal scrollbar per side (the native one lives at
@@ -455,7 +479,7 @@ export function DiffTabContent({ path, staged, showClose = false, onClose }: Dif
     if (index < 0) {
       return;
     }
-    views.merge.reconfigure({ collapseUnchanged: COLLAPSE_UNCHANGED });
+    views.merge.reconfigure({ collapseUnchanged: COLLAPSE_UNCHANGED, diffConfig: DIFF_CONFIG });
     for (const view of [views.merge.a, views.merge.b]) {
       const keep = view.state.field(expandedRegions).filter((_, i) => i !== index);
       view.dispatch({


### PR DESCRIPTION
## Problem

A 13,890-line resource file with 24 lines added rendered as the whole file deleted and added back — against a `+24 −0` from `git diff` itself. The panel and the diff tab disagreed about the same change, and the tab was the one that was wrong.

## Root cause

`MergeView` and `unifiedMergeView` default to `{ scanLimit: 500 }`, which `diff()` halves to 250 and then reads as a size limit:

```js
if (scanLimit < 1e9 && Math.min(lenA, lenB) > scanLimit * 16 || …) {
    if (Math.min(lenA, lenB) > scanLimit * 64)
        return [new Change(fromA, toA, fromB, toB)];   // the whole range, replaced
    return crudeMatch(a, fromA, toA, b, fromB, toB);
}
```

So a differing range wider than 4,000 characters gets the imprecise algorithm, and one wider than 16,000 is simply declared replaced end to end. That measures the wrong thing: the algorithm is O(N·D) in the number of *differences*, so a file with a few changes spread far apart is cheap to diff exactly and yet trips a limit set on range size. What reproduces it is scattering, not size — two insertion points in a 4,000-line file are fine, four in a 600-line one are not.

## Changes

`diffConfig: { timeout: 1000 }` on both merge extensions and on the `reconfigure` that rebuilds the collapsed bars. No `scanLimit`, so the size-based bail is off and the budget is time instead.

Measured with `@codemirror/merge`'s own `diff()`:

| case | default `{ scanLimit: 500 }` | `{ timeout: 1000 }` |
| --- | --- | --- |
| 450KB, 13,890 lines, 24 added lines in 8 places | 1 change, **107,763 chars marked deleted**, 0.8ms | 8 changes, 0 falsely deleted, 11ms |
| 574KB, 8,000 lines, 500 scattered changed lines | 1 change, **572,639 chars marked deleted** (the file), 1ms | 1,000 changes, correct, 527ms |
| two unrelated 492KB documents (what the scan limit is for) | 3ms | gives up at 931ms |

1000ms is picked to sit above that middle row, which is the worst case worth being precise about. A shorter deadline is not only less precise but **slower**: every range that misses it falls back to `crudeMatch`, which costs more on a wide range than finishing the scan would have — 300ms measured at 1,653ms against 411ms unlimited.

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec vitest run src/modules/diff/DiffTabContent.test.tsx` — 14 passed, including a new case built from the smallest shape that reproduces this (600 lines, four insertion points). It fails with the old default: 31 lines falsely marked deleted on the old side
- [x] `pnpm exec vitest run` — 2122 passed, 1 failed: `PortsPanelView`, a pre-existing timing flake here rather than anything from this change. Unmodified `master` fails four tests in a full-suite run on this machine (`PortsPanelView`, `DashboardView`, `SessionsTabContent`, `SourceControlView`), and each passes when run on its own
- [x] Not re-checked in the app since the fix — the file above is what turned this up, and the
      regression test reproduces exactly that shape, but the rendered result is worth a look

🤖 Generated with [Claude Code](https://claude.com/claude-code)
