### PR TITLE
fix(diff): line the gutter icons up with the line number

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -464,10 +464,14 @@ textarea:focus-visible,
   display: flex;
   align-items: center;
   justify-content: center;
-  /* The gutter element carries the row's height as an inline style, so filling
-     it is what actually centres the icon — without this the marker is only as
-     tall as the glyph and sits against the top of the row. */
-  height: 100%;
+  /* The gutter element carries the whole line block's height as an inline
+     style, so one text row is the box to centre in — filling the element
+     centres on the block instead, which drops the icon below the line's number
+     whenever that block is taller than a row (a wrapped line, a line with a
+     comment card, a line the merge view padded for alignment). Without a
+     height at all the marker is only as tall as the glyph and sits against the
+     top of the row. */
+  height: 1lh;
   padding: 0 2px;
   color: var(--color-fg-subtle);
 }

--- a/src/modules/diff/lib/diffCommentsExtension.ts
+++ b/src/modules/diff/lib/diffCommentsExtension.ts
@@ -207,12 +207,17 @@ const commentTheme = EditorView.baseTheme({
     opacity: "0",
     color: "var(--color-accent)",
   },
-  // Fills the row so the icon is centred in it, not parked at the top.
+  // One text row tall, so the icon centres on the line's first row and sits
+  // level with that line's number in the gutter one column over. Filling the
+  // element instead centres the icon on the whole line block, which drops it
+  // below the number as soon as a block is taller than one row: a wrapped long
+  // line, a line carrying a comment card or the draft box, or a line the merge
+  // view padded out to keep the two sides aligned.
   ".cm-diff-comment-gutter .cm-gutterElement > span": {
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    height: "100%",
+    height: "1lh",
   },
   ".cm-diff-comment-gutter .cm-gutterElement:hover": {
     opacity: "1",


### PR DESCRIPTION
## Problem

In a diff pane, the comment icon and the fold/unfold arrows can sit well below the line they belong to, while that line's number stays put in the gutter one column over.

Reported on a wrapped line: line 900 wrapped onto several rows, its number sat on the first row, and the comment bubble floated down near the middle of the wrapped block.

## Root cause

Both markers fill their gutter element and centre inside it:

```css
display: flex;
align-items: center;
height: 100%;   /* the whole line block */
```

A gutter element's inline height is the height of the entire **line block**, not of one text row. For a plain one-row line those are the same thing, which is why this looked right when it was written (#393). They diverge as soon as a block is taller than a row, and then centring puts the icon at the middle of the block while `lineNumbers()` keeps the number on the first row.

Three things make a block taller than one row:

- word wrap turned on, on a long line
- a saved comment card or the draft box rendered under the line
- the spacer `@codemirror/merge` inserts to keep the two sides of a split aligned (`Decoration.widget({ block: true, side: -1 })`, dist/index.js:915)

## Changes

- `diffCommentsExtension.ts` and the `.cm-diff-fold` / `.cm-diff-unfold` rules in `index.css` both take **one text row** as the box to centre in (`height: 1lh`) instead of the whole element.
- Comments at both sites updated to say why one row is the right box, so the next reader does not restore `100%` to "fix" an icon sitting against the top of a row.

`1lh` is exact here rather than an approximation: the diff editors set font family on `.cm-content, .cm-gutters, .cm-scroller` and font size on the editor root, and neither the app nor CodeMirror's base theme sets a `line-height` on the gutters, so a row resolves to the same height in the gutter as in the content.

## Testing

Typecheck clean, full suite green (2127 tests).

No test added. The assertion here is a rendered position and jsdom has no layout engine to measure one, so a test could only assert the injected `height: 1lh` back, which restates the diff without pinning the behaviour. Verified by eye instead, on the case from the report.

To reproduce before / after: open a diff pane, turn on word wrap, and hover the comment gutter on a line long enough to wrap.

## Notes

Pre-existing, from #393 rather than from any of #400 / #401 / #402. Worth having in before #397 lands, since a stacked all-changes view puts many more tall blocks on screen at once.