### PR TITLE
fix(git-graph): stop the toolbar controls colliding and line its icons up

### DIFF
--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -16,6 +16,13 @@ interface ComboboxProps {
   size?: "sm" | "md";
   /** Override the text size (trigger and options), e.g. "text-[13px]". */
   textClassName?: string;
+  /**
+   * Replace the trigger's padding preset, e.g. "px-2 py-1" to line the box up
+   * with a neighbouring control that isn't a Combobox. Replaces rather than
+   * appends: two padding utilities in one class list would leave which one
+   * wins up to stylesheet order, not to the caller.
+   */
+  fieldClassName?: string;
   /** Show trigger value and options in full instead of ellipsizing them. */
   noTruncate?: boolean;
 }
@@ -36,6 +43,7 @@ export function Combobox({
   dropUp = false,
   size = "md",
   textClassName,
+  fieldClassName,
   noTruncate = false,
 }: ComboboxProps) {
   const [open, setOpen] = useState(false);
@@ -43,7 +51,7 @@ export function Combobox({
   const dense = size === "sm";
   const textClass = textClassName ?? (dense ? "text-xs" : "text-sm");
   const clipClass = noTruncate ? "whitespace-nowrap" : "truncate";
-  const fieldClass = `${dense ? "px-2 py-0.5" : "px-3 py-2"} ${textClass}`;
+  const fieldClass = `${fieldClassName ?? (dense ? "px-2 py-0.5" : "px-3 py-2")} ${textClass}`;
   const optionClass = `${dense ? "px-2 py-1" : "px-3 py-2"} ${textClass}`;
 
   useEffect(() => {

--- a/src/modules/git-graph/BranchFilter.tsx
+++ b/src/modules/git-graph/BranchFilter.tsx
@@ -92,7 +92,12 @@ export function BranchFilter({
       : `${selected[0]} +${selected.length - 1}`;
 
   return (
-    <div ref={wrapRef} className="relative w-64 shrink-0">
+    // Wide by default so a branch name reads without hovering, but allowed to
+    // give ground: `shrink-0` here meant a crowded toolbar could not reclaim
+    // any of these 16rem, so the filter simply overlapped whatever sat next to
+    // it. The floor keeps it usable rather than letting it collapse to nothing,
+    // and the trigger text truncates on the way down.
+    <div ref={wrapRef} className="relative w-64 min-w-[8rem]">
       <button
         type="button"
         aria-label={labels.ariaLabel}

--- a/src/modules/git-graph/GitGraphToolbar.test.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.test.tsx
@@ -116,6 +116,23 @@ describe("GitGraphToolbar responsive layout", () => {
     expect(screen.queryByLabelText(labels.refresh)).not.toBeInTheDocument();
   });
 
+  it("drops the HEAD button before compact, and the overflow menu carries it again", () => {
+    renderToolbar({ currentBranch: "feature/x" });
+    const switchLabel = `${labels.switchBranch} (${labels.head}: feature/x)`;
+
+    setToolbarWidth(1200);
+    expect(screen.getByRole("button", { name: switchLabel })).toBeInTheDocument();
+
+    // Gone well before the full compact fold: right-clicking a branch chip in
+    // the graph already offers checkout, so nothing here is the only way in.
+    setToolbarWidth(800);
+    expect(screen.queryByRole("button", { name: switchLabel })).not.toBeInTheDocument();
+
+    setToolbarWidth(360);
+    fireEvent.click(screen.getByLabelText(labels.more));
+    expect(screen.getByText(`${labels.head}: feature/x`)).toBeInTheDocument();
+  });
+
   it("keeps the branch dropdown and search reachable when compact", () => {
     renderToolbar();
     setToolbarWidth(360);
@@ -238,6 +255,19 @@ describe("GitGraphToolbar worktree selector", () => {
 
     expect(screen.queryByText(`${labels.worktree}:`)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(labels.worktree)).not.toBeInTheDocument();
+  });
+
+  it("steps aside on a narrow row, where the worktree manager still opens them", () => {
+    renderToolbar({ worktrees: twoWorktrees, currentWorktreePath: "/repos/app" });
+
+    setToolbarWidth(1200);
+    expect(screen.getAllByLabelText(labels.worktree).length).toBeGreaterThan(0);
+
+    // "<folder> (<branch>)" is the widest thing on the row, so it gives way
+    // first — long before the row would actually break.
+    setToolbarWidth(900);
+    expect(screen.queryByLabelText(labels.worktree)).not.toBeInTheDocument();
+    expect(screen.queryByText(`${labels.worktree}:`)).not.toBeInTheDocument();
   });
 
   it("shows the current worktree as the selected value when there are several", () => {

--- a/src/modules/git-graph/GitGraphToolbar.tsx
+++ b/src/modules/git-graph/GitGraphToolbar.tsx
@@ -21,6 +21,22 @@ import type { Branch, CommitOrder } from "./types";
 // begins to crowd in a split panel.
 const COMPACT_WIDTH = 620;
 
+// Two steps before the full compact fold, so the row gives way one control at a
+// time instead of holding everything until it breaks. Both only apply once the
+// toolbar has actually been measured — an unmeasured toolbar renders roomy.
+//
+// Below this the worktree picker steps aside. It is the widest control on the
+// row and the most reproducible elsewhere: the worktree manager opens the same
+// worktrees, so nothing becomes unreachable. Set well above the point where it
+// strictly stops fitting — "<folder> (<branch>)" is long enough that keeping it
+// to the last possible pixel leaves the row correct but uncomfortably packed.
+const WORKTREE_WIDTH = 1000;
+// Below this the "HEAD: <branch>" button goes altogether rather than shrinking
+// to an icon: right-clicking a branch chip in the graph already offers checkout,
+// and below COMPACT_WIDTH the overflow menu carries the button again. An icon
+// here would only be a second, wordless door to something already reachable.
+const HEAD_BUTTON_WIDTH = 900;
+
 interface WorktreeOption {
   label: string;
   path: string;
@@ -158,6 +174,10 @@ export function GitGraphToolbar({
   }, []);
 
   const isCompact = width !== null && width < COMPACT_WIDTH;
+  // Unmeasured (width === null) counts as roomy, same as isCompact above, so
+  // the first paint never flashes a collapsed row.
+  const hasRoomForWorktree = width === null || width >= WORKTREE_WIDTH;
+  const hasRoomForHeadButton = width === null || width >= HEAD_BUTTON_WIDTH;
 
   const locals = branches.filter((b) => !b.isRemote);
   const remotes = branches.filter((b) => b.isRemote);
@@ -214,8 +234,12 @@ export function GitGraphToolbar({
     currentWorktreePath === null
       ? undefined
       : worktreeOptions.find((o) => samePath(o.path, currentWorktreePath));
-  // A single-worktree repo (the common case) hides the control entirely.
-  const showWorktreeControls = showBranchControls && worktreeOptions.length > 1;
+  // A single-worktree repo (the common case) hides the control entirely, and so
+  // does a row too narrow to carry it.
+  const showWorktreeControls =
+    showBranchControls && hasRoomForWorktree && worktreeOptions.length > 1;
+  const worktreeValue =
+    currentWorktree?.label ?? (currentWorktreePath ? basename(currentWorktreePath) : "");
 
   // git refuses `git checkout <branch>` for a branch some other worktree has
   // checked out — disable those menu entries and show where each one lives.
@@ -268,32 +292,58 @@ export function GitGraphToolbar({
         {showWorktreeControls && (
           <div className="flex min-w-0 items-center gap-1.5 text-xs text-fg-subtle">
             <span className="shrink-0">{labels.worktree}:</span>
-            <Combobox
-              value={
-                currentWorktree?.label ??
-                (currentWorktreePath ? basename(currentWorktreePath) : "")
-              }
-              options={worktreeOptions.map((o) => o.label)}
-              onChange={(label) => {
-                const picked = worktreeOptions.find((o) => o.label === label);
-                if (picked && (!currentWorktree || !samePath(picked.path, currentWorktree.path))) {
-                  onSelectWorktree(picked.path);
-                }
-              }}
-              ariaLabel={labels.worktree}
-              textClassName="text-[13px]"
-              noTruncate
-            />
+            {/* The value is "<folder> (<branch>)", so a long branch name makes
+                this the widest thing on the row. It used to opt out of clipping
+                entirely, which dropped the ellipsis *and* the overflow guard
+                that comes with it — the text then painted straight over the
+                remote-branches checkbox beside it.
+
+                The bounds belong on this wrapper, not on the Combobox: the
+                wrapper is the flex item, so it is what the row measures and
+                makes space for. Bounding only the inner box let it outgrow the
+                wrapper and paint over a neighbour the layout still believed had
+                room. The floor keeps the picker readable instead of letting it
+                collapse to its chevron; the full value is on hover. */}
+            <Tooltip label={worktreeValue} className="min-w-[8rem] max-w-[14rem]">
+              <Combobox
+                value={worktreeValue}
+                options={worktreeOptions.map((o) => o.label)}
+                onChange={(label) => {
+                  const picked = worktreeOptions.find((o) => o.label === label);
+                  if (
+                    picked &&
+                    (!currentWorktree || !samePath(picked.path, currentWorktree.path))
+                  ) {
+                    onSelectWorktree(picked.path);
+                  }
+                }}
+                ariaLabel={labels.worktree}
+                // Matched to the branch filter's trigger sitting right next to
+                // it — same radius, border, padding and type size, so the two
+                // read as one pair of controls, not two unrelated boxes.
+                size="sm"
+                fieldClassName="px-2 py-1"
+                textClassName="text-[13px]"
+                // Fill the wrapper, which is where the bounds live, and keep
+                // min-w-0 so the trigger text can ellipsize instead of holding
+                // a min-content floor and pushing back out through it.
+                className="min-w-0 flex-1"
+              />
+            </Tooltip>
           </div>
         )}
 
         {!isCompact && (
-          <label className="flex cursor-pointer select-none items-center gap-1.5 text-xs text-fg-muted">
+          // shrink-0 + nowrap: squeezed, this label used to wrap mid-word, and
+          // the second line grew the whole row — which read as the icons on the
+          // right sitting too high rather than as a wrapped label. It keeps its
+          // width now; below COMPACT_WIDTH it moves into the overflow menu.
+          <label className="flex shrink-0 cursor-pointer select-none items-center gap-1.5 whitespace-nowrap text-xs text-fg-muted">
             <input
               type="checkbox"
               checked={includeRemotes}
               onChange={(e) => onToggleRemotes(e.target.checked)}
-              className="accent-accent"
+              className="shrink-0 accent-accent"
             />
             <span>{labels.showRemoteBranches}</span>
           </label>
@@ -344,7 +394,12 @@ export function GitGraphToolbar({
         )}
 
         {isCompact ? (
-          <div className="relative">
+          // flex, not a plain block: the Tooltip wrapper is inline-flex, and an
+          // inline box in a block sits on the text baseline with the strut's
+          // descender space left under it. That padded the wrapper a few px
+          // taller than the icon, and items-center then centred the wrapper —
+          // leaving this icon riding higher than its unwrapped neighbours.
+          <div className="relative flex items-center">
             <Tooltip label={labels.more}>
               <button
                 type="button"
@@ -363,7 +418,12 @@ export function GitGraphToolbar({
                   onClick={() => setOverflowOpen(false)}
                   aria-hidden="true"
                 />
-                <div className="absolute right-0 z-30 mt-1 w-52 rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg">
+                {/* top-full, not the static position: the wrapper is a flex
+                    container, and a flex container aligns an absolutely
+                    positioned child's static position with align-items — so
+                    `items-center` would hang this menu off the button's
+                    midpoint and float it up over the tab bar. */}
+                <div className="absolute right-0 top-full z-30 mt-1 w-52 rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg">
                   <button
                     type="button"
                     aria-label={switchBranchLabel}
@@ -419,7 +479,7 @@ export function GitGraphToolbar({
           </div>
         ) : (
           <>
-            <div className="relative">
+            <div className="relative flex items-center">
               <Tooltip label={labels.displayOptions}>
                 <button
                   type="button"
@@ -437,7 +497,7 @@ export function GitGraphToolbar({
                     onClick={() => setOptionsOpen(false)}
                     aria-hidden="true"
                   />
-                  <div className="absolute right-0 z-30 mt-1 w-48 rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg">
+                  <div className="absolute right-0 top-full z-30 mt-1 w-48 rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg">
                     {toggles.map((t) => (
                       <ToggleRow key={t.label} {...t} />
                     ))}
@@ -471,21 +531,25 @@ export function GitGraphToolbar({
               </button>
             </Tooltip>
 
-            <div className="relative">
-              <Tooltip label={labels.switchBranch}>
-                <button
-                  type="button"
-                  aria-label={switchBranchLabel}
-                  aria-expanded={branchMenuOpen}
-                  disabled={branches.length === 0}
-                  onClick={() => setBranchMenuOpen((v) => !v)}
-                  className="ml-1 whitespace-nowrap rounded px-1 py-0.5 font-mono text-[11px] text-fg-subtle hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
-                >
-                  {labels.head}: {currentBranch}
-                </button>
-              </Tooltip>
-              {branchMenu}
-            </div>
+            {hasRoomForHeadButton && (
+              <div className="relative flex items-center">
+                {/* The tooltip carries the branch name in full, so a long one
+                    stays readable once the label itself is ellipsized. */}
+                <Tooltip label={switchBranchLabel}>
+                  <button
+                    type="button"
+                    aria-label={switchBranchLabel}
+                    aria-expanded={branchMenuOpen}
+                    disabled={branches.length === 0}
+                    onClick={() => setBranchMenuOpen((v) => !v)}
+                    className="ml-1 max-w-[14rem] truncate rounded px-1 py-0.5 font-mono text-[11px] text-fg-subtle hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
+                  >
+                    {labels.head}: {currentBranch}
+                  </button>
+                </Tooltip>
+                {branchMenu}
+              </div>
+            )}
           </>
         )}
       </div>
@@ -584,7 +648,7 @@ function BranchMenu({
       <div className="fixed inset-0 z-20" onClick={onClose} aria-hidden="true" />
       <div
         role="menu"
-        className="absolute right-0 z-30 mt-1 max-h-72 w-56 overflow-y-auto rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg"
+        className="absolute right-0 top-full z-30 mt-1 max-h-72 w-56 overflow-y-auto rounded-md border border-border-strong bg-bg-elevated p-1 shadow-lg"
       >
         {locals.map((b) => {
           const otherWorktree =


### PR DESCRIPTION
Fixes #331. Takes the layout half of #329 without closing it — the branch-switching rework proposed there (status-bar indicator, centred branch panel, removing these controls outright) is untouched.

## Problem

Three controls on the Git Graph toolbar could grow without limit, so a long branch name broke the row rather than being clipped by it:

- The worktree picker's value is `<folder> (<branch>)`. With a branch like `feature/help-center-manual-list-part-a` it painted straight over the "Show remote branches" checkbox beside it — and swallowed that label's clicks, so the text could not be clicked to toggle.
- The branch filter refused to give up any of its width, overlapping its neighbour and eating the "W" of "Worktree:".
- "Show remote branches" wrapped mid-word when squeezed. The second line grew the whole row, which reads as the icons on the right sitting too high rather than as a wrapped label.

Separately (#331), the display-options and HEAD buttons sat about 4px above the search, refresh and fetch icons next to them.

## Root cause

`noTruncate` on the worktree picker swaps `truncate` for a bare `whitespace-nowrap`. `truncate` bundles the ellipsis together with `overflow: hidden`, so opting out of the ellipsis also removed the guard that kept the text inside its box. The picker is positioned, so the spill painted — and took pointer events — above the static label next to it.

The branch filter was `w-64 shrink-0`: a fixed 16rem that a crowded row could never reclaim.

The icon offset is a baseline artefact. Only those two buttons are wrapped in a positioning div, and `Tooltip` renders as `inline-flex`. An inline box in a block sits on the text baseline with the strut's descender space left beneath it, so those wrappers measured a few px taller than the icon inside them, and `items-center` then centred the wrapper rather than the icon.

## Changes

- Bound and ellipsize the worktree picker, with the full value on the app's `Tooltip` — not a native `title`, which the macOS WebView often will not show at all. The bounds go on the wrapper rather than the box inside it: the wrapper is the flex item, so it is what the row measures and reserves space for. Bounding only the inner box lets it outgrow the wrapper and paint over a neighbour the layout still believes has room.
- Match the picker's padding to the branch filter beside it, through a new `fieldClassName` that *replaces* the size preset instead of appending to it — two padding utilities in one class list leave the winner up to stylesheet order rather than to the caller.
- Give both pickers an 8rem floor instead of a hard `shrink-0`, so they yield width under pressure but stay readable rather than collapsing to a chevron.
- Keep "Show remote branches" on one line, and stop the checkbox itself being squeezed away.
- Make the two positioning wrappers flex so their icons line up. That costs their menus the static position they were relying on — a flex container aligns an absolutely positioned child's static position with `align-items`, which floated them up over the tab bar — so each menu now anchors explicitly with `top-full`.
- Let the row give way one control at a time rather than holding everything until it breaks: the worktree picker steps aside first (the worktree manager opens the same worktrees), then the HEAD button. That button is dropped rather than shrunk to an icon — right-clicking a branch chip already offers checkout, and below the compact threshold the overflow menu carries the button again, so an icon would only be a second wordless door to something already reachable.

Deliberately not done, so this stays a layout fix: the worktree picker keeps its `<folder> (<branch>)` label and is not removed, and "Show remote branches" stays in place instead of moving into the gear popover. Both are proposals in #329 and are behaviour changes rather than layout ones.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 2129 passed (232 files), including two new cases: the worktree picker steps aside on a narrow row, and the HEAD button disappears before the compact fold while the overflow menu still carries it.
- [x] Manual, against a repo with a long branch name: the picker ellipsizes instead of overlapping, its hover shows the full value, "Show remote branches" stays on one line and toggles when its text is clicked, the row keeps a single-line height, and the five toolbar icons share one baseline (verified by pixel-measuring a screenshot before and after).
- [x] Manual: each of the three menus (overflow, display options, branch) opens under its button rather than over the tab bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
