### PR TITLE
feat(source-control): make the panel the all-changes page's table of contents

### DIFF
--- a/src/i18n/locales/en/sourceControl.json
+++ b/src/i18n/locales/en/sourceControl.json
@@ -22,6 +22,7 @@
   "generating": "Generating…",
   "refresh": "Refresh",
   "allChanges": "All Changes",
+  "allChangesClose": "Close All Changes",
   "allChangesUncommitted": "(uncommitted)",
   "allChangesFileCount": "{{count}} files",
   "allChangesBinary": "Binary file — not shown",

--- a/src/i18n/locales/zh-Hant/sourceControl.json
+++ b/src/i18n/locales/zh-Hant/sourceControl.json
@@ -22,6 +22,7 @@
   "generating": "產生中⋯",
   "refresh": "重新整理",
   "allChanges": "所有變更",
+  "allChangesClose": "關閉所有變更",
   "allChangesUncommitted": "（未 commit）",
   "allChangesFileCount": "{{count}} 個檔案",
   "allChangesBinary": "二進位檔，不顯示內容",

--- a/src/modules/diff/AllChangesTabContent.test.tsx
+++ b/src/modules/diff/AllChangesTabContent.test.tsx
@@ -37,6 +37,7 @@ import { fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useDiffCommentStore } from "./lib/diffCommentStore";
+import { useAllChangesLinkStore } from "./lib/allChangesLinkStore";
 
 /**
  * The n/N counter, whichever numbers it holds. Its left-hand number is read
@@ -68,6 +69,7 @@ describe("AllChangesTabContent", () => {
     useWorkspaceStore.setState({ rootPath: "/repo" });
     useDiffCommentStore.setState({ comments: [] });
     useSettingsStore.setState({ diffUnified: false });
+    useAllChangesLinkStore.setState({ file: null });
     vi.mocked(gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitDiff).mockResolvedValue("");
     vi.mocked(gitFileAtRev).mockResolvedValue("");
@@ -412,5 +414,53 @@ describe("AllChangesTabContent", () => {
     render(<AllChangesTabContent />);
 
     await waitFor(() => expect(screen.getByText("noChanges")).toBeInTheDocument());
+  });
+
+  it("opens a file the panel asks for, and clears the request", async () => {
+    vi.mocked(gitStatus).mockResolvedValue({
+      branch: "main",
+      staged: [],
+      unstaged: [{ path: "src/a.ts", staged: false, status: "M" }],
+    });
+    vi.mocked(gitDiff).mockImplementation(async (_repo, staged) =>
+      staged ? "" : diffFor("src/a.ts"),
+    );
+
+    const { container } = render(<AllChangesTabContent />);
+    await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "allChangesCollapseFile" }));
+    await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeNull());
+
+    // Clicking that row in the panel means "show me this file", so a file the
+    // reader had shut comes back rather than landing them on a bare header.
+    act(() => {
+      useAllChangesLinkStore.getState().request({ rel: "src/a.ts", staged: false });
+    });
+
+    await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeTruthy());
+    expect(useAllChangesLinkStore.getState().file).toBeNull();
+  });
+
+  it("drops a request for a file it does not carry", async () => {
+    vi.mocked(gitStatus).mockResolvedValue({
+      branch: "main",
+      staged: [],
+      unstaged: [{ path: "src/a.ts", staged: false, status: "M" }],
+    });
+    vi.mocked(gitDiff).mockImplementation(async (_repo, staged) =>
+      staged ? "" : diffFor("src/a.ts"),
+    );
+
+    const { container } = render(<AllChangesTabContent />);
+    await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeTruthy());
+
+    act(() => {
+      useAllChangesLinkStore.getState().request({ rel: "src/gone.ts", staged: false });
+    });
+
+    // Dropped rather than left pending, or it would fire at some unrelated
+    // moment after the next rescan.
+    await waitFor(() => expect(useAllChangesLinkStore.getState().file).toBeNull());
   });
 });

--- a/src/modules/diff/AllChangesTabContent.test.tsx
+++ b/src/modules/diff/AllChangesTabContent.test.tsx
@@ -63,13 +63,16 @@ function diffFor(path: string) {
   ].join("\n");
 }
 
+/** The pane the tests mount their page into. */
+const PANE = "leaf-1";
+
 describe("AllChangesTabContent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useWorkspaceStore.setState({ rootPath: "/repo" });
     useDiffCommentStore.setState({ comments: [] });
     useSettingsStore.setState({ diffUnified: false });
-    useAllChangesLinkStore.setState({ file: null, showing: null, rescan: 0 });
+    useAllChangesLinkStore.setState({ file: {}, showing: {}, rescan: {} });
     vi.mocked(gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitDiff).mockResolvedValue("");
     vi.mocked(gitFileAtRev).mockResolvedValue("");
@@ -89,7 +92,7 @@ describe("AllChangesTabContent", () => {
     vi.mocked(gitFileAtRev).mockResolvedValue("keep\ngone\n");
     vi.mocked(fsReadFile).mockResolvedValue("keep\none\ntwo\nthree\n");
 
-    const { container } = render(<AllChangesTabContent />);
+    const { container } = render(<AllChangesTabContent paneId={PANE} />);
 
     // One scan per side: `git diff` compares against one of them, never both.
     await waitFor(() => expect(gitDiff).toHaveBeenCalledTimes(2));
@@ -133,7 +136,7 @@ describe("AllChangesTabContent", () => {
       ],
     });
 
-    const { container } = render(<AllChangesTabContent />);
+    const { container } = render(<AllChangesTabContent paneId={PANE} />);
 
     await waitFor(() =>
       expect(container.querySelectorAll("[data-diff-file]").length).toBe(4),
@@ -152,7 +155,7 @@ describe("AllChangesTabContent", () => {
       unstaged: [{ path: "b.ts", staged: false, status: "M" }],
     });
 
-    render(<AllChangesTabContent />);
+    render(<AllChangesTabContent paneId={PANE} />);
 
     // Staged: HEAD against the index. Working tree: the index against the file.
     await waitFor(() => expect(gitFileAtRev).toHaveBeenCalledWith("/repo", "HEAD", "a.ts"));
@@ -172,7 +175,7 @@ describe("AllChangesTabContent", () => {
     vi.mocked(gitFileAtRev).mockResolvedValue("");
     vi.mocked(fsReadFile).mockResolvedValue("one\ntwo\n");
 
-    const { container } = render(<AllChangesTabContent />);
+    const { container } = render(<AllChangesTabContent paneId={PANE} />);
 
     await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeTruthy());
     // Counted off the documents, since the scan had nothing to say about it —
@@ -204,7 +207,7 @@ describe("AllChangesTabContent", () => {
           ].join("\n"),
     );
 
-    const { container } = render(<AllChangesTabContent />);
+    const { container } = render(<AllChangesTabContent paneId={PANE} />);
 
     await waitFor(() => expect(screen.getByText("allChangesFolded:500")).toBeInTheDocument());
     // Folded means not read at all: no documents fetched, no editors built.
@@ -229,7 +232,7 @@ describe("AllChangesTabContent", () => {
       staged ? "" : diffFor("src/a.ts"),
     );
 
-    const { container } = render(<AllChangesTabContent />);
+    const { container } = render(<AllChangesTabContent paneId={PANE} />);
 
     await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeTruthy());
     expect(counter(1)).toBeInTheDocument();
@@ -266,7 +269,7 @@ describe("AllChangesTabContent", () => {
       staged ? "" : diffFor("src/a.ts") + diffFor("src/b.ts") + diffFor("src/c.ts"),
     );
 
-    const { container } = render(<AllChangesTabContent />);
+    const { container } = render(<AllChangesTabContent paneId={PANE} />);
     // Wait for the editors, not just the sections: the page registers the
     // handles it measures against as they are built.
     await waitFor(() => expect(container.querySelectorAll(".cm-mergeView").length).toBe(3));
@@ -312,7 +315,7 @@ describe("AllChangesTabContent", () => {
     vi.mocked(gitFileAtRev).mockResolvedValue("keep\ngone\n");
     vi.mocked(fsReadFile).mockResolvedValue("keep\none\n");
 
-    const { container } = render(<AllChangesTabContent />);
+    const { container } = render(<AllChangesTabContent paneId={PANE} />);
     await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeTruthy());
     const readsBefore = vi.mocked(fsReadFile).mock.calls.length;
 
@@ -345,7 +348,7 @@ describe("AllChangesTabContent", () => {
           ].join("\n"),
     );
 
-    const { container } = render(<AllChangesTabContent />);
+    const { container } = render(<AllChangesTabContent paneId={PANE} />);
 
     await waitFor(() => expect(screen.getByText("allChangesBinary")).toBeInTheDocument());
     expect(container.querySelector(".cm-mergeView")).toBeNull();
@@ -384,7 +387,7 @@ describe("AllChangesTabContent", () => {
           ].join("\n"),
     );
 
-    render(<AllChangesTabContent />);
+    render(<AllChangesTabContent paneId={PANE} />);
 
     // Two hunks in the first file and one in the second: the navigation walks
     // the page, not a file.
@@ -404,14 +407,14 @@ describe("AllChangesTabContent", () => {
   it("says so when the workspace is not a repository", async () => {
     vi.mocked(gitResolveRepo).mockResolvedValue(null);
 
-    render(<AllChangesTabContent />);
+    render(<AllChangesTabContent paneId={PANE} />);
 
     await waitFor(() => expect(screen.getByText("noRepo")).toBeInTheDocument());
     expect(gitStatus).not.toHaveBeenCalled();
   });
 
   it("says so when nothing has changed", async () => {
-    render(<AllChangesTabContent />);
+    render(<AllChangesTabContent paneId={PANE} />);
 
     await waitFor(() => expect(screen.getByText("noChanges")).toBeInTheDocument());
   });
@@ -426,7 +429,7 @@ describe("AllChangesTabContent", () => {
       staged ? "" : diffFor("src/a.ts"),
     );
 
-    const { container } = render(<AllChangesTabContent />);
+    const { container } = render(<AllChangesTabContent paneId={PANE} />);
     await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeTruthy());
 
     fireEvent.click(screen.getByRole("button", { name: "allChangesCollapseFile" }));
@@ -435,11 +438,11 @@ describe("AllChangesTabContent", () => {
     // Clicking that row in the panel means "show me this file", so a file the
     // reader had shut comes back rather than landing them on a bare header.
     act(() => {
-      useAllChangesLinkStore.getState().request({ rel: "src/a.ts", staged: false });
+      useAllChangesLinkStore.getState().request(PANE, { rel: "src/a.ts", staged: false });
     });
 
     await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeTruthy());
-    expect(useAllChangesLinkStore.getState().file).toBeNull();
+    expect(useAllChangesLinkStore.getState().file[PANE]).toBeUndefined();
   });
 
   it("drops a request for a file it does not carry", async () => {
@@ -452,15 +455,15 @@ describe("AllChangesTabContent", () => {
       staged ? "" : diffFor("src/a.ts"),
     );
 
-    const { container } = render(<AllChangesTabContent />);
+    const { container } = render(<AllChangesTabContent paneId={PANE} />);
     await waitFor(() => expect(container.querySelector(".cm-mergeView")).toBeTruthy());
 
     act(() => {
-      useAllChangesLinkStore.getState().request({ rel: "src/gone.ts", staged: false });
+      useAllChangesLinkStore.getState().request(PANE, { rel: "src/gone.ts", staged: false });
     });
 
     // Dropped rather than left pending, or it would fire at some unrelated
     // moment after the next rescan.
-    await waitFor(() => expect(useAllChangesLinkStore.getState().file).toBeNull());
+    await waitFor(() => expect(useAllChangesLinkStore.getState().file[PANE]).toBeUndefined());
   });
 });

--- a/src/modules/diff/AllChangesTabContent.test.tsx
+++ b/src/modules/diff/AllChangesTabContent.test.tsx
@@ -69,7 +69,7 @@ describe("AllChangesTabContent", () => {
     useWorkspaceStore.setState({ rootPath: "/repo" });
     useDiffCommentStore.setState({ comments: [] });
     useSettingsStore.setState({ diffUnified: false });
-    useAllChangesLinkStore.setState({ file: null });
+    useAllChangesLinkStore.setState({ file: null, showing: null, rescan: 0 });
     vi.mocked(gitResolveRepo).mockResolvedValue("/repo");
     vi.mocked(gitDiff).mockResolvedValue("");
     vi.mocked(gitFileAtRev).mockResolvedValue("");

--- a/src/modules/diff/AllChangesTabContent.tsx
+++ b/src/modules/diff/AllChangesTabContent.tsx
@@ -28,6 +28,13 @@ import {
 } from "./DiffFileSection";
 
 interface AllChangesTabContentProps {
+  /**
+   * The pane this page is in. Everything it publishes to the panel is filed
+   * under it: a split mounts two of these pages, and one global entry each
+   * would have them overwriting one another's mark and clearing it on the way
+   * out.
+   */
+  paneId: string;
   /** Show the shared pane close button (the tab is split). */
   showClose?: boolean;
   onClose?: () => void;
@@ -97,7 +104,11 @@ function toChangedFile(
  * have their editors built, the rest holding their place at the height the
  * scan predicts (or the height they last measured).
  */
-export function AllChangesTabContent({ showClose = false, onClose }: AllChangesTabContentProps) {
+export function AllChangesTabContent({
+  paneId,
+  showClose = false,
+  onClose,
+}: AllChangesTabContentProps) {
   const { t } = useTranslation("sourceControl");
   const { t: tEditor } = useTranslation("editor");
   const rootPath = useWorkspaceStore((s) => s.rootPath);
@@ -118,7 +129,7 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
   // The panel's refresh button asks for a rescan too: while this page has the
   // pane, that button is the only refresh control on screen, and the panel's
   // list and this one have to move together.
-  const rescan = useAllChangesLinkStore((s) => s.rescan);
+  const rescan = useAllChangesLinkStore((s) => s.rescan[paneId] ?? 0);
   // Either trigger moves this, and both only ever count up.
   const reloadKey = refreshKey + rescan;
   const [sendMenu, setSendMenu] = useState<{ x: number; y: number } | null>(null);
@@ -517,7 +528,7 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
       const file = ordered[Math.max(0, at - 1)];
       useAllChangesLinkStore
         .getState()
-        .setShowing(file ? { rel: file.rel, staged: file.staged } : null);
+        .setShowing(paneId, file ? { rel: file.rel, staged: file.staged } : null);
     });
   }, [changes.length, changeTop, ordered, sectionTop]);
 
@@ -546,7 +557,7 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
       if (scrollFrame.current) {
         cancelAnimationFrame(scrollFrame.current);
       }
-      useAllChangesLinkStore.getState().setShowing(null);
+      useAllChangesLinkStore.getState().forget(paneId);
     },
     [],
   );
@@ -610,7 +621,7 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
     return true;
   }, []);
 
-  const requested = useAllChangesLinkStore((s) => s.file);
+  const requested = useAllChangesLinkStore((s) => s.file[paneId]);
   useEffect(() => {
     // Wait for the scan: there are no sections to scroll to before it lands.
     if (!requested || ordered.length === 0) {
@@ -620,7 +631,7 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
     // Consumed either way. A row for a file this page does not carry (a stale
     // click, or one raced with a rescan) is dropped rather than left to fire
     // at some unrelated moment later.
-    useAllChangesLinkStore.getState().consume();
+    useAllChangesLinkStore.getState().consume(paneId);
   }, [requested, ordered, scrollToSection]);
 
   useEffect(() => {

--- a/src/modules/diff/AllChangesTabContent.tsx
+++ b/src/modules/diff/AllChangesTabContent.tsx
@@ -115,6 +115,12 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
   const [files, setFiles] = useState<ChangedFiles | null>(null);
   const [error, setError] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  // The panel's refresh button asks for a rescan too: while this page has the
+  // pane, that button is the only refresh control on screen, and the panel's
+  // list and this one have to move together.
+  const rescan = useAllChangesLinkStore((s) => s.rescan);
+  // Either trigger moves this, and both only ever count up.
+  const reloadKey = refreshKey + rescan;
   const [sendMenu, setSendMenu] = useState<{ x: number; y: number } | null>(null);
 
   // Which files have their editors up, which oversized ones the reader opened
@@ -234,7 +240,7 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
     return () => {
       cancelled = true;
     };
-  }, [repo, refreshKey]);
+  }, [repo, reloadKey]);
 
   const ordered = useMemo(
     () => (files ? [...files.staged, ...files.unstaged] : []),
@@ -683,7 +689,7 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
             onCounted={onCounted}
             onDraft={onDraft}
             narrow={narrow}
-            reloadKey={refreshKey}
+            reloadKey={reloadKey}
           />
         ))}
       </>

--- a/src/modules/diff/AllChangesTabContent.tsx
+++ b/src/modules/diff/AllChangesTabContent.tsx
@@ -462,6 +462,22 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
   // The counter follows the page rather than only the buttons: scrolling by
   // hand, or being scrolled by a click in the Source Control panel, moves it
   // too, so prev/next always carries on from what is actually on screen.
+  /** Where a file's section starts inside the page's scrollable content. */
+  const sectionTop = useCallback(
+    (root: HTMLElement, index: number): number | null => {
+      const element = ordered[index] && elementsRef.current.get(ordered[index].key);
+      if (!element) {
+        return null;
+      }
+      // The section, never its header: the header is sticky, so its rect
+      // reports where it is pinned rather than where it belongs.
+      return (
+        root.scrollTop + element.getBoundingClientRect().top - root.getBoundingClientRect().top
+      );
+    },
+    [ordered],
+  );
+
   const scrollFrame = useRef(0);
   const trackPosition = useCallback(() => {
     // Cancel and re-schedule, rather than skipping while one is pending. A
@@ -481,8 +497,25 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
       }
       const top = root.scrollTop + LANDING_GAP + 4;
       setPosition(changeAtViewportTop(changes.length, top, (i) => changeTop(root, i)));
+      // The panel marks the row the reader is on, which is the file at the top
+      // of the page — the same question the counter asks, one level up, so it
+      // takes the same lazy binary search over an ordered list. The topmost
+      // *file* rather than the file owning the topmost change: a file with no
+      // change to navigate to, folded or binary, is still one you can be
+      // looking straight at.
+      const file = ordered[changeAtViewportTop(ordered.length, top, (i) => sectionTop(root, i)) - 1];
+      useAllChangesLinkStore
+        .getState()
+        .setShowing(file ? { rel: file.rel, staged: file.staged } : null);
     });
-  }, [changes.length, changeTop]);
+  }, [changes.length, changeTop, ordered, sectionTop]);
+
+  // Mark the first file as soon as there is a list, without waiting for a
+  // scroll, and let the mark go when this page does — the panel falls back to
+  // whichever diff pane is in front, as it did before.
+  useEffect(() => {
+    trackPosition();
+  }, [trackPosition]);
 
   // Coming back to a window that was hidden brings no scroll event with it,
   // and no frame ran while it was away to take a reading, so one is taken on
@@ -502,6 +535,7 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
       if (scrollFrame.current) {
         cancelAnimationFrame(scrollFrame.current);
       }
+      useAllChangesLinkStore.getState().setShowing(null);
     },
     [],
   );

--- a/src/modules/diff/AllChangesTabContent.tsx
+++ b/src/modules/diff/AllChangesTabContent.tsx
@@ -18,6 +18,7 @@ import { useSettingsStore } from "@/stores/settingsStore";
 import { changedLines, parseDiffStats, type FileDiffStats } from "./lib/parseDiffStats";
 import { agentTargetMenuItems } from "./lib/sendComments";
 import { changeAtViewportTop } from "./lib/changeAtTop";
+import { useAllChangesLinkStore } from "./lib/allChangesLinkStore";
 import { useUnsentCommentCount } from "./lib/useDiffComments";
 import {
   DiffFileSection,
@@ -61,6 +62,14 @@ interface ChangedFiles {
   unstaged: ChangedFile[];
 }
 
+/**
+ * A file staged and then edited again appears in both sections, as two
+ * independent comparisons, so the side is part of its identity.
+ */
+export function sectionKey(rel: string, staged: boolean): string {
+  return `${staged ? "s" : "w"}:${rel}`;
+}
+
 function toChangedFile(
   repo: string,
   file: { path: string; status: string },
@@ -68,7 +77,7 @@ function toChangedFile(
   stats: Map<string, FileDiffStats>,
 ): ChangedFile {
   return {
-    key: `${staged ? "s" : "w"}:${file.path}`,
+    key: sectionKey(file.path, staged),
     rel: file.path,
     path: `${repo}/${file.path}`,
     staged,
@@ -524,6 +533,50 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
     }
     setPending(target);
   }, []);
+
+  /**
+   * Put a file's header at the top of the page. Used by the Source Control
+   * panel: while this page is in front, clicking a row scrolls here instead of
+   * opening a diff tab of its own.
+   */
+  const scrollToSection = useCallback((key: string) => {
+    const root = scrollRef.current;
+    const element = elementsRef.current.get(key);
+    if (!root || !element) {
+      return false;
+    }
+    setMounted((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
+    // A file the reader had shut opens again: they just asked for it, and
+    // landing on a bare header reads as nothing having happened. A file folded
+    // for its size keeps its own control — that one is about weight, not about
+    // having been read.
+    setCollapsed((prev) => {
+      if (!prev.has(key)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+    root.scrollTop = Math.max(
+      0,
+      root.scrollTop + element.getBoundingClientRect().top - root.getBoundingClientRect().top,
+    );
+    return true;
+  }, []);
+
+  const requested = useAllChangesLinkStore((s) => s.file);
+  useEffect(() => {
+    // Wait for the scan: there are no sections to scroll to before it lands.
+    if (!requested || ordered.length === 0) {
+      return;
+    }
+    scrollToSection(sectionKey(requested.rel, requested.staged));
+    // Consumed either way. A row for a file this page does not carry (a stale
+    // click, or one raced with a rescan) is dropped rather than left to fire
+    // at some unrelated moment later.
+    useAllChangesLinkStore.getState().consume();
+  }, [requested, ordered, scrollToSection]);
 
   useEffect(() => {
     if (!pending) {

--- a/src/modules/diff/AllChangesTabContent.tsx
+++ b/src/modules/diff/AllChangesTabContent.tsx
@@ -509,7 +509,12 @@ export function AllChangesTabContent({ showClose = false, onClose }: AllChangesT
       // *file* rather than the file owning the topmost change: a file with no
       // change to navigate to, folded or binary, is still one you can be
       // looking straight at.
-      const file = ordered[changeAtViewportTop(ordered.length, top, (i) => sectionTop(root, i)) - 1];
+      // Clamped, unlike the counter above: "before the first change" is a
+      // real place for a navigation cursor to be, but a reader sitting at the
+      // top of the page is looking at the first file, not at no file — and the
+      // panel would mark nothing until they scrolled past the group heading.
+      const at = changeAtViewportTop(ordered.length, top, (i) => sectionTop(root, i));
+      const file = ordered[Math.max(0, at - 1)];
       useAllChangesLinkStore
         .getState()
         .setShowing(file ? { rel: file.rel, staged: file.staged } : null);

--- a/src/modules/diff/allChangesPanelLink.test.tsx
+++ b/src/modules/diff/allChangesPanelLink.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/i18n";
+
+vi.mock("@/modules/source-control/lib/gitBridge", () => ({
+  gitResolveRepo: vi.fn().mockResolvedValue("/repo"),
+  gitStatus: vi.fn(),
+  gitDiff: vi.fn().mockResolvedValue(""),
+  gitLog: vi.fn().mockResolvedValue([]),
+  gitFileAtRev: vi.fn().mockResolvedValue(""),
+  gitStage: vi.fn().mockResolvedValue(undefined),
+  gitUnstage: vi.fn().mockResolvedValue(undefined),
+  gitCommit: vi.fn().mockResolvedValue(undefined),
+  gitPush: vi.fn().mockResolvedValue(undefined),
+  gitRestoreFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/modules/source-control/lib/aiCommit", () => ({
+  generateCommitMessage: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("@/modules/explorer/lib/fsBridge", () => ({
+  fsReadFile: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("@/modules/terminal/lib/terminalBus", () => ({
+  pasteToTerminal: vi.fn(),
+}));
+
+import { gitDiff, gitStatus } from "@/modules/source-control/lib/gitBridge";
+import { SourceControlView } from "@/modules/source-control/SourceControlView";
+import { AllChangesTabContent } from "./AllChangesTabContent";
+import { useAllChangesLinkStore } from "./lib/allChangesLinkStore";
+import { useTabsStore } from "@/stores/tabsStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+const FILES = ["src/a.ts", "src/b.ts", "src/c.ts"];
+
+function diffFor(path: string) {
+  return [
+    `diff --git a/${path} b/${path}`,
+    `--- a/${path}`,
+    `+++ b/${path}`,
+    "@@ -1,2 +1,3 @@",
+    " keep",
+    "-gone",
+    "+one",
+    "+two",
+    "",
+  ].join("\n");
+}
+
+/**
+ * jsdom lays nothing out, so the page's reading of "which file is at the top"
+ * would always come back the same. Each section is given a position of its
+ * own, a hundred pixels apart, and the page is given a scroll position that
+ * moves through them.
+ */
+function layOut(root: HTMLElement) {
+  let scrollTop = 0;
+  Object.defineProperty(root, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value;
+    },
+  });
+  root.getBoundingClientRect = () => ({ top: 0, bottom: 500, height: 500 }) as DOMRect;
+  const sections = Array.from(root.querySelectorAll<HTMLElement>("[data-diff-file]"));
+  sections.forEach((section, index) => {
+    section.getBoundingClientRect = () =>
+      ({ top: index * 100 - scrollTop, bottom: index * 100 - scrollTop + 100 }) as DOMRect;
+  });
+  return {
+    scrollTo(value: number) {
+      scrollTop = value;
+      fireEvent.scroll(root);
+    },
+  };
+}
+
+/**
+ * The tree shows a file by its own name, the flat list by its whole path, and
+ * the name can appear more than once (the row and its tooltip), so this takes
+ * the first one that sits in a row.
+ */
+const rowFor = (path: string, mode: string) => {
+  const label = mode === "flat" ? path : (path.split("/").pop() ?? path);
+  const rows = screen
+    .getAllByText(label)
+    .map((element) => element.closest("li"))
+    .filter((row): row is HTMLLIElement => row !== null);
+  return rows[0];
+};
+
+describe("the Source Control panel beside the all-changes page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useWorkspaceStore.getState().setRoot("/repo");
+    useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+    useAllChangesLinkStore.setState({ file: null, showing: null, rescan: 0 });
+    vi.mocked(gitStatus).mockResolvedValue({
+      branch: "main",
+      staged: [],
+      unstaged: FILES.map((path) => ({ path, staged: false, status: "M" })),
+    });
+    vi.mocked(gitDiff).mockImplementation(async (_repo, staged) =>
+      staged ? "" : FILES.map(diffFor).join(""),
+    );
+  });
+
+  it.each([
+    ["flat", "flat"],
+    ["folder", "folder"],
+  ])("marks the row of the file the page has scrolled to (%s view)", async (_label, mode) => {
+    // The panel remembers its own view mode, and the tree renders its rows
+    // through a different path from the flat list.
+    localStorage.setItem("tempoterm-sourcecontrol-view-mode", mode);
+    const { container } = render(
+      <>
+        <SourceControlView />
+        <AllChangesTabContent />
+      </>,
+    );
+
+    // The page has the pane in front, which is what puts the panel in this
+    // mode at all.
+    useTabsStore.getState().openAllChangesTab();
+
+    await waitFor(() => expect(container.querySelectorAll("[data-diff-file]").length).toBe(3));
+    const page = container.querySelector<HTMLElement>(".overflow-auto");
+    const view = layOut(page!);
+
+    // At the top of the page, the first file is the one being read.
+    view.scrollTo(0);
+    await waitFor(() => expect(rowFor("src/a.ts", mode)).toHaveAttribute("aria-current", "true"));
+    expect(rowFor("src/b.ts", mode)).not.toHaveAttribute("aria-current");
+
+    // Scrolling past the first section hands the mark to the second.
+    view.scrollTo(150);
+    await waitFor(() => expect(rowFor("src/b.ts", mode)).toHaveAttribute("aria-current", "true"));
+    expect(rowFor("src/a.ts", mode)).not.toHaveAttribute("aria-current");
+
+    view.scrollTo(250);
+    await waitFor(() => expect(rowFor("src/c.ts", mode)).toHaveAttribute("aria-current", "true"));
+  });
+});

--- a/src/modules/diff/allChangesPanelLink.test.tsx
+++ b/src/modules/diff/allChangesPanelLink.test.tsx
@@ -145,4 +145,45 @@ describe("the Source Control panel beside the all-changes page", () => {
     view.scrollTo(250);
     await waitFor(() => expect(rowFor("src/c.ts", mode)).toHaveAttribute("aria-current", "true"));
   });
+
+  it("marks the folder instead when the file inside it is shut away", async () => {
+    localStorage.setItem("tempoterm-sourcecontrol-view-mode", "folder");
+    const { container } = render(
+      <>
+        <SourceControlView />
+        <AllChangesTabContent />
+      </>,
+    );
+    useTabsStore.getState().openAllChangesTab();
+    await waitFor(() => expect(container.querySelectorAll("[data-diff-file]").length).toBe(3));
+
+    // Shut the folder the files live in. Its rows leave the DOM with it, so
+    // there is nothing left for the page to mark.
+    fireEvent.click(await screen.findByRole("button", { name: "Collapse src" }));
+    // (the page renders the name in its own headers too, so this asks the
+    // panel specifically: no row, no `li`.)
+    expect(rowFor("src/a.ts", "folder")).toBeUndefined();
+
+    const page = container.querySelector<HTMLElement>(".overflow-auto");
+    const view = layOut(page!);
+    view.scrollTo(0);
+
+    // The folder takes the mark on their behalf: the tree still says where the
+    // reader is, at the granularity that is actually on screen.
+    // The page shows the directory in its own headers, so the folder row is
+    // found by its toggle rather than by the text.
+    const folder = screen.getByRole("button", { name: "Expand src" }).closest("li");
+    await waitFor(() => expect(folder).toHaveAttribute("aria-current", "true"));
+
+    // Opening it hands the mark back to the file, rather than marking both.
+    fireEvent.click(screen.getByRole("button", { name: "Expand src" }));
+    await waitFor(() => expect(rowFor("src/b.ts", "folder")).toBeTruthy());
+    view.scrollTo(150);
+    await waitFor(() =>
+      expect(rowFor("src/b.ts", "folder")).toHaveAttribute("aria-current", "true"),
+    );
+    expect(
+      screen.getByRole("button", { name: "Collapse src" }).closest("li"),
+    ).not.toHaveAttribute("aria-current");
+  });
 });

--- a/src/modules/diff/allChangesPanelLink.test.tsx
+++ b/src/modules/diff/allChangesPanelLink.test.tsx
@@ -31,7 +31,7 @@ import { gitDiff, gitStatus } from "@/modules/source-control/lib/gitBridge";
 import { SourceControlView } from "@/modules/source-control/SourceControlView";
 import { AllChangesTabContent } from "./AllChangesTabContent";
 import { useAllChangesLinkStore } from "./lib/allChangesLinkStore";
-import { useTabsStore } from "@/stores/tabsStore";
+import { activeAllChangesPane, useTabsStore } from "@/stores/tabsStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 const FILES = ["src/a.ts", "src/b.ts", "src/c.ts"];
@@ -93,13 +93,28 @@ const rowFor = (path: string, mode: string) => {
   return rows[0];
 };
 
+/**
+ * The page is mounted into the pane the tab actually opened, because that is
+ * the pane the panel pairs itself with: the link between them is keyed on it,
+ * so a page mounted under any other name would be talking to nobody.
+ */
+function openThePage(): string {
+  useTabsStore.getState().openAllChangesTab();
+  const { tabs, activeId } = useTabsStore.getState();
+  const pane = activeAllChangesPane(tabs, activeId);
+  if (!pane) {
+    throw new Error("the all-changes page did not open");
+  }
+  return pane;
+}
+
 describe("the Source Control panel beside the all-changes page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
     useWorkspaceStore.getState().setRoot("/repo");
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
-    useAllChangesLinkStore.setState({ file: null, showing: null, rescan: 0 });
+    useAllChangesLinkStore.setState({ file: {}, showing: {}, rescan: {} });
     vi.mocked(gitStatus).mockResolvedValue({
       branch: "main",
       staged: [],
@@ -110,6 +125,39 @@ describe("the Source Control panel beside the all-changes page", () => {
     );
   });
 
+  it("keeps two pages apart, and lets one close without taking the other's mark", async () => {
+    // A split mounts two of these pages at once. They scroll independently,
+    // so a single global mark would be whichever scrolled last, and either
+    // one closing would clear it for both.
+    const left = openThePage();
+    const right = "leaf-second";
+    const { unmount } = render(<AllChangesTabContent paneId={left} />);
+    render(<AllChangesTabContent paneId={right} />);
+
+    const store = useAllChangesLinkStore.getState();
+    store.setShowing(left, { rel: "src/a.ts", staged: false });
+    store.setShowing(right, { rel: "src/b.ts", staged: false });
+    expect(useAllChangesLinkStore.getState().showing).toEqual({
+      [left]: { rel: "src/a.ts", staged: false },
+      [right]: { rel: "src/b.ts", staged: false },
+    });
+
+    // A request goes to the page it was made for, and is consumed there.
+    store.request(right, { rel: "src/c.ts", staged: false });
+    expect(useAllChangesLinkStore.getState().file[left]).toBeUndefined();
+
+    unmount();
+
+    // The page that stayed keeps its mark; only the one that went is gone.
+    await waitFor(() =>
+      expect(useAllChangesLinkStore.getState().showing[left]).toBeUndefined(),
+    );
+    expect(useAllChangesLinkStore.getState().showing[right]).toEqual({
+      rel: "src/b.ts",
+      staged: false,
+    });
+  });
+
   it.each([
     ["flat", "flat"],
     ["folder", "folder"],
@@ -117,16 +165,13 @@ describe("the Source Control panel beside the all-changes page", () => {
     // The panel remembers its own view mode, and the tree renders its rows
     // through a different path from the flat list.
     localStorage.setItem("tempoterm-sourcecontrol-view-mode", mode);
+    const pane = openThePage();
     const { container } = render(
       <>
         <SourceControlView />
-        <AllChangesTabContent />
+        <AllChangesTabContent paneId={pane} />
       </>,
     );
-
-    // The page has the pane in front, which is what puts the panel in this
-    // mode at all.
-    useTabsStore.getState().openAllChangesTab();
 
     await waitFor(() => expect(container.querySelectorAll("[data-diff-file]").length).toBe(3));
     const page = container.querySelector<HTMLElement>(".overflow-auto");
@@ -148,13 +193,13 @@ describe("the Source Control panel beside the all-changes page", () => {
 
   it("marks the folder instead when the file inside it is shut away", async () => {
     localStorage.setItem("tempoterm-sourcecontrol-view-mode", "folder");
+    const pane = openThePage();
     const { container } = render(
       <>
         <SourceControlView />
-        <AllChangesTabContent />
+        <AllChangesTabContent paneId={pane} />
       </>,
     );
-    useTabsStore.getState().openAllChangesTab();
     await waitFor(() => expect(container.querySelectorAll("[data-diff-file]").length).toBe(3));
 
     // Shut the folder the files live in. Its rows leave the DOM with it, so

--- a/src/modules/diff/lib/allChangesLinkStore.ts
+++ b/src/modules/diff/lib/allChangesLinkStore.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+
+/** The file a click on a Source Control row is asking to be scrolled to. */
+export interface AllChangesFile {
+  /** Repo-relative path, as `gitStatus` reports it. */
+  rel: string;
+  /** Which of the two sections the row came from. */
+  staged: boolean;
+}
+
+interface AllChangesLinkState {
+  file: AllChangesFile | null;
+  /** Ask the all-changes page to scroll to this file once it can. */
+  request: (file: AllChangesFile) => void;
+  /** Read and clear the pending file; null if nothing is pending. */
+  consume: () => AllChangesFile | null;
+}
+
+/**
+ * The link between the Source Control panel and the all-changes page. The page
+ * is a singleton per space (openAllChangesTab always focuses the one tab), so
+ * there is no per-tab PaneContent field to route this through; the Git Graph
+ * tab's pending commit selection has the same shape and the same reason.
+ *
+ * Clearing on consume is what lets the same row be clicked twice: the second
+ * request is a real state change because the first left the field null.
+ */
+export const useAllChangesLinkStore = create<AllChangesLinkState>((set, get) => ({
+  file: null,
+  request: (file) => set({ file }),
+  consume: () => {
+    const file = get().file;
+    set({ file: null });
+    return file;
+  },
+}));

--- a/src/modules/diff/lib/allChangesLinkStore.ts
+++ b/src/modules/diff/lib/allChangesLinkStore.ts
@@ -9,60 +9,95 @@ export interface AllChangesFile {
 }
 
 interface AllChangesLinkState {
-  /** Panel to page: scroll to this file. A one-shot request. */
-  file: AllChangesFile | null;
-  /** Ask the all-changes page to scroll to this file once it can. */
-  request: (file: AllChangesFile) => void;
-  /** Read and clear the pending file; null if nothing is pending. */
-  consume: () => AllChangesFile | null;
+  /** Panel to page, by pane: scroll to this file. A one-shot request. */
+  file: Readonly<Record<string, AllChangesFile>>;
+  /** Ask one page to scroll to this file once it can. */
+  request: (pane: string, file: AllChangesFile) => void;
+  /** Read and clear that page's pending file; null if nothing is pending. */
+  consume: (pane: string) => AllChangesFile | null;
 
   /**
-   * Page to panel: the file at the top of the page as it is read, so the
-   * panel can mark the row the reader is on. Standing state, not a request —
-   * null while no such page is up.
+   * Page to panel, by pane: the file at the top of each page as it is read,
+   * so the panel can mark the row the reader is on. Standing state, not a
+   * request — a pane with no entry has no such page up.
    */
-  showing: AllChangesFile | null;
-  setShowing: (file: AllChangesFile | null) => void;
+  showing: Readonly<Record<string, AllChangesFile>>;
+  setShowing: (pane: string, file: AllChangesFile | null) => void;
 
   /**
-   * Panel to page: rescan the working tree. Bumped by the panel's refresh
-   * button, which is the only refresh control on screen while that page has
-   * the pane — the two are reading one list, so they reload together or they
-   * disagree side by side.
+   * Panel to page, by pane: rescan the working tree. Bumped by the panel's
+   * refresh button, which is the only refresh control on screen while that
+   * page has the pane — the two are reading one list, so they reload together
+   * or they disagree side by side.
    */
-  rescan: number;
-  requestRescan: () => void;
+  rescan: Readonly<Record<string, number>>;
+  requestRescan: (pane: string) => void;
+
+  /** Drop everything a pane published, as it goes. */
+  forget: (pane: string) => void;
 }
 
 /**
- * The link between the Source Control panel and the all-changes page. The page
+ * The link between the Source Control panel and the all-changes page. The tab
  * is a singleton per space (openAllChangesTab always focuses the one tab), so
  * there is no per-tab PaneContent field to route this through; the Git Graph
  * tab's pending commit selection has the same shape and the same reason.
  *
+ * Keyed by pane, though, because a tab is not a pane: split one and two
+ * all-changes pages are mounted at once, each scrolling its own way. Held
+ * globally with one entry each, a second page overwrites the first's mark and
+ * closing either clears a mark still on screen. The panel reads the entry of
+ * whichever pane is in front, which is the page its rows belong to.
+ *
  * Clearing on consume is what lets the same row be clicked twice: the second
- * request is a real state change because the first left the field null.
+ * request is a real state change because the first left the entry empty.
  */
 export const useAllChangesLinkStore = create<AllChangesLinkState>((set, get) => ({
-  file: null,
-  request: (file) => set({ file }),
-  consume: () => {
-    const file = get().file;
-    set({ file: null });
+  file: {},
+  request: (pane, file) => set((state) => ({ file: { ...state.file, [pane]: file } })),
+  consume: (pane) => {
+    const file = get().file[pane] ?? null;
+    if (file) {
+      set((state) => {
+        const next = { ...state.file };
+        delete next[pane];
+        return { file: next };
+      });
+    }
     return file;
   },
 
-  rescan: 0,
-  requestRescan: () => set((state) => ({ rescan: state.rescan + 1 })),
+  rescan: {},
+  requestRescan: (pane) =>
+    set((state) => ({ rescan: { ...state.rescan, [pane]: (state.rescan[pane] ?? 0) + 1 } })),
 
-  showing: null,
-  setShowing: (file) => {
+  showing: {},
+  setShowing: (pane, file) => {
     // Written as the page scrolls, so it must not churn: an unchanged value
     // would re-render the panel on every frame.
-    const had = get().showing;
+    const had = get().showing[pane] ?? null;
     if (had?.rel === file?.rel && had?.staged === file?.staged) {
       return;
     }
-    set({ showing: file });
+    set((state) => {
+      const next = { ...state.showing };
+      if (file) {
+        next[pane] = file;
+      } else {
+        delete next[pane];
+      }
+      return { showing: next };
+    });
   },
+
+  forget: (pane) =>
+    set((state) => {
+      const file = { ...state.file };
+      const showing = { ...state.showing };
+      const rescan = { ...state.rescan };
+      delete file[pane];
+      delete showing[pane];
+      delete rescan[pane];
+      return { file, showing, rescan };
+    }),
 }));

--- a/src/modules/diff/lib/allChangesLinkStore.ts
+++ b/src/modules/diff/lib/allChangesLinkStore.ts
@@ -9,11 +9,20 @@ export interface AllChangesFile {
 }
 
 interface AllChangesLinkState {
+  /** Panel to page: scroll to this file. A one-shot request. */
   file: AllChangesFile | null;
   /** Ask the all-changes page to scroll to this file once it can. */
   request: (file: AllChangesFile) => void;
   /** Read and clear the pending file; null if nothing is pending. */
   consume: () => AllChangesFile | null;
+
+  /**
+   * Page to panel: the file at the top of the page as it is read, so the
+   * panel can mark the row the reader is on. Standing state, not a request —
+   * null while no such page is up.
+   */
+  showing: AllChangesFile | null;
+  setShowing: (file: AllChangesFile | null) => void;
 }
 
 /**
@@ -32,5 +41,16 @@ export const useAllChangesLinkStore = create<AllChangesLinkState>((set, get) => 
     const file = get().file;
     set({ file: null });
     return file;
+  },
+
+  showing: null,
+  setShowing: (file) => {
+    // Written as the page scrolls, so it must not churn: an unchanged value
+    // would re-render the panel on every frame.
+    const had = get().showing;
+    if (had?.rel === file?.rel && had?.staged === file?.staged) {
+      return;
+    }
+    set({ showing: file });
   },
 }));

--- a/src/modules/diff/lib/allChangesLinkStore.ts
+++ b/src/modules/diff/lib/allChangesLinkStore.ts
@@ -23,6 +23,15 @@ interface AllChangesLinkState {
    */
   showing: AllChangesFile | null;
   setShowing: (file: AllChangesFile | null) => void;
+
+  /**
+   * Panel to page: rescan the working tree. Bumped by the panel's refresh
+   * button, which is the only refresh control on screen while that page has
+   * the pane — the two are reading one list, so they reload together or they
+   * disagree side by side.
+   */
+  rescan: number;
+  requestRescan: () => void;
 }
 
 /**
@@ -42,6 +51,9 @@ export const useAllChangesLinkStore = create<AllChangesLinkState>((set, get) => 
     set({ file: null });
     return file;
   },
+
+  rescan: 0,
+  requestRescan: () => set((state) => ({ rescan: state.rescan + 1 })),
 
   showing: null,
   setShowing: (file) => {

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -42,7 +42,7 @@ describe("SourceControlView row interactions", () => {
     vi.mocked(gitBridge.gitStatus).mockResolvedValue(STATUS_ONE_MODIFIED);
     useWorkspaceStore.getState().setRoot("/repo");
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
-    useAllChangesLinkStore.setState({ file: null, showing: null });
+    useAllChangesLinkStore.setState({ file: null, showing: null, rescan: 0 });
   });
 
   it("opens the all-changes tab from the panel toolbar", async () => {
@@ -132,6 +132,17 @@ describe("SourceControlView row interactions", () => {
       useAllChangesLinkStore.getState().setShowing(null);
     });
     expect(screen.getByText("src/a.ts").closest("li")).not.toHaveAttribute("aria-current");
+  });
+
+  it("reloads the all-changes page along with itself", async () => {
+    render(<SourceControlView />);
+    await screen.findByText("src/a.ts");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    // Both are reading one list from one status call, so a refresh that moved
+    // only the panel would leave the two disagreeing side by side.
+    await waitFor(() => expect(useAllChangesLinkStore.getState().rescan).toBe(1));
   });
 
   it("opens a diff tab when a changed file row is clicked", async () => {

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/i18n";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -42,7 +42,7 @@ describe("SourceControlView row interactions", () => {
     vi.mocked(gitBridge.gitStatus).mockResolvedValue(STATUS_ONE_MODIFIED);
     useWorkspaceStore.getState().setRoot("/repo");
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
-    useAllChangesLinkStore.setState({ file: null });
+    useAllChangesLinkStore.setState({ file: null, showing: null });
   });
 
   it("opens the all-changes tab from the panel toolbar", async () => {
@@ -112,6 +112,26 @@ describe("SourceControlView row interactions", () => {
     // Away from that pane and it is back.
     fireEvent.click(screen.getByRole("button", { name: "All Changes" }));
     expect(await screen.findByPlaceholderText("Commit message")).toBeInTheDocument();
+  });
+
+  it("marks the row the all-changes page is showing", async () => {
+    render(<SourceControlView />);
+    const row = await screen.findByText("src/a.ts");
+    // Nothing marked: no diff pane in front, and no page reporting a file.
+    expect(row.closest("li")).not.toHaveAttribute("aria-current");
+
+    fireEvent.click(screen.getByRole("button", { name: "All Changes" }));
+    act(() => {
+      useAllChangesLinkStore.getState().setShowing({ rel: "src/a.ts", staged: false });
+    });
+
+    expect(screen.getByText("src/a.ts").closest("li")).toHaveAttribute("aria-current", "true");
+
+    // The mark is the page's while that page is in front; it goes with it.
+    act(() => {
+      useAllChangesLinkStore.getState().setShowing(null);
+    });
+    expect(screen.getByText("src/a.ts").closest("li")).not.toHaveAttribute("aria-current");
   });
 
   it("opens a diff tab when a changed file row is clicked", async () => {

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -66,6 +66,31 @@ describe("SourceControlView row interactions", () => {
     expect(useTabsStore.getState().tabs).toHaveLength(0);
   });
 
+  it("shows on the entry button whether the page is the pane in front", async () => {
+    render(<SourceControlView />);
+    const button = await screen.findByRole("button", { name: "All Changes" });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(button);
+    // In front: the state that also takes the commit box away, so it is the
+    // one the button most needs to account for.
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveAccessibleName("Close All Changes");
+
+    // Open, but the reader has gone elsewhere. The button speaks about the
+    // pane in front, so it reads the same as shut -- and clicking it comes
+    // back to the page rather than closing it.
+    const pageId = useTabsStore.getState().tabs[0].id;
+    act(() => {
+      useTabsStore.getState().openEditorTab("/repo/src/a.ts");
+    });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(button).toHaveAccessibleName("All Changes");
+
+    fireEvent.click(button);
+    expect(useTabsStore.getState().activeId).toBe(pageId);
+  });
+
   it("scrolls the all-changes page to a row instead of opening a tab", async () => {
     render(<SourceControlView />);
     fireEvent.click(await screen.findByRole("button", { name: "All Changes" }));
@@ -109,8 +134,9 @@ describe("SourceControlView row interactions", () => {
     expect(screen.getByText("main")).toBeInTheDocument();
     expect(screen.getByText("src/a.ts")).toBeInTheDocument();
 
-    // Away from that pane and it is back.
-    fireEvent.click(screen.getByRole("button", { name: "All Changes" }));
+    // Away from that pane and it is back. The button says "Close" while the
+    // page is in front, which is when it is indeed the way out.
+    fireEvent.click(screen.getByRole("button", { name: "Close All Changes" }));
     expect(await screen.findByPlaceholderText("Commit message")).toBeInTheDocument();
   });
 

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -25,6 +25,7 @@ import * as gitBridge from "./lib/gitBridge";
 import type { GitStatus } from "./lib/gitBridge";
 import { useTabsStore } from "@/stores/tabsStore";
 import { usePendingGraphSelectionStore } from "@/modules/git-graph/lib/pendingGraphSelectionStore";
+import { useAllChangesLinkStore } from "@/modules/diff/lib/allChangesLinkStore";
 
 const STATUS_ONE_MODIFIED: GitStatus = {
   branch: "main",
@@ -41,6 +42,7 @@ describe("SourceControlView row interactions", () => {
     vi.mocked(gitBridge.gitStatus).mockResolvedValue(STATUS_ONE_MODIFIED);
     useWorkspaceStore.getState().setRoot("/repo");
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
+    useAllChangesLinkStore.setState({ file: null });
   });
 
   it("opens the all-changes tab from the panel toolbar", async () => {
@@ -50,6 +52,66 @@ describe("SourceControlView row interactions", () => {
     const tabs = useTabsStore.getState().tabs;
     expect(tabs).toHaveLength(1);
     expect(tabs[0].kind).toBe("all-changes");
+  });
+
+  it("shuts the all-changes tab from the same button that opened it", async () => {
+    render(<SourceControlView />);
+    const button = await screen.findByRole("button", { name: "All Changes" });
+
+    fireEvent.click(button);
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+
+    // In front already, so the button is the way out too.
+    fireEvent.click(button);
+    expect(useTabsStore.getState().tabs).toHaveLength(0);
+  });
+
+  it("scrolls the all-changes page to a row instead of opening a tab", async () => {
+    render(<SourceControlView />);
+    fireEvent.click(await screen.findByRole("button", { name: "All Changes" }));
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+
+    fireEvent.click(await screen.findByText("src/a.ts"));
+
+    // No second tab: the page in front is asked to scroll to the file.
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    expect(useAllChangesLinkStore.getState().file).toEqual({
+      rel: "src/a.ts",
+      staged: false,
+    });
+  });
+
+  it("keeps the right-click route to a single-file diff tab", async () => {
+    render(<SourceControlView />);
+    fireEvent.click(await screen.findByRole("button", { name: "All Changes" }));
+
+    fireEvent.contextMenu(await screen.findByText("src/a.ts"));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Show Diff" }));
+
+    const tabs = useTabsStore.getState().tabs;
+    expect(tabs.map((t) => t.kind)).toEqual(["all-changes", "diff"]);
+    expect(useAllChangesLinkStore.getState().file).toBeNull();
+  });
+
+  it("stands the commit box down while the all-changes page is in front", async () => {
+    render(<SourceControlView />);
+    // Wait for the status to land, so the branch row and the list are up.
+    await screen.findByText("src/a.ts");
+    expect(screen.getByPlaceholderText("Commit message")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "All Changes" }));
+
+    // Nothing is committed from that page, and the box costs the file list
+    // room it is being read against.
+    expect(screen.queryByPlaceholderText("Commit message")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Commit" })).toBeNull();
+    // The branch row and the file list stay exactly where they were.
+    expect(screen.getByText("main")).toBeInTheDocument();
+    expect(screen.getByText("src/a.ts")).toBeInTheDocument();
+
+    // Away from that pane and it is back.
+    fireEvent.click(screen.getByRole("button", { name: "All Changes" }));
+    expect(await screen.findByPlaceholderText("Commit message")).toBeInTheDocument();
   });
 
   it("opens a diff tab when a changed file row is clicked", async () => {

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -23,7 +23,7 @@ vi.mock("./lib/aiCommit", () => ({
 import { SourceControlView } from "./SourceControlView";
 import * as gitBridge from "./lib/gitBridge";
 import type { GitStatus } from "./lib/gitBridge";
-import { useTabsStore } from "@/stores/tabsStore";
+import { activeAllChangesPane, useTabsStore } from "@/stores/tabsStore";
 import { usePendingGraphSelectionStore } from "@/modules/git-graph/lib/pendingGraphSelectionStore";
 import { useAllChangesLinkStore } from "@/modules/diff/lib/allChangesLinkStore";
 
@@ -32,6 +32,10 @@ const STATUS_ONE_MODIFIED: GitStatus = {
   staged: [],
   unstaged: [{ path: "src/a.ts", staged: false, status: "M" }],
 };
+
+/** The pane the all-changes page opened into, which is what the link is keyed on. */
+const pane = () =>
+  activeAllChangesPane(useTabsStore.getState().tabs, useTabsStore.getState().activeId) ?? "";
 
 describe("SourceControlView row interactions", () => {
   beforeEach(() => {
@@ -42,7 +46,7 @@ describe("SourceControlView row interactions", () => {
     vi.mocked(gitBridge.gitStatus).mockResolvedValue(STATUS_ONE_MODIFIED);
     useWorkspaceStore.getState().setRoot("/repo");
     useTabsStore.setState({ tabs: [], activeId: null, spaces: [], activeSpaceId: null });
-    useAllChangesLinkStore.setState({ file: null, showing: null, rescan: 0 });
+    useAllChangesLinkStore.setState({ file: {}, showing: {}, rescan: {} });
   });
 
   it("opens the all-changes tab from the panel toolbar", async () => {
@@ -100,7 +104,7 @@ describe("SourceControlView row interactions", () => {
 
     // No second tab: the page in front is asked to scroll to the file.
     expect(useTabsStore.getState().tabs).toHaveLength(1);
-    expect(useAllChangesLinkStore.getState().file).toEqual({
+    expect(useAllChangesLinkStore.getState().file[pane()]).toEqual({
       rel: "src/a.ts",
       staged: false,
     });
@@ -115,7 +119,7 @@ describe("SourceControlView row interactions", () => {
 
     const tabs = useTabsStore.getState().tabs;
     expect(tabs.map((t) => t.kind)).toEqual(["all-changes", "diff"]);
-    expect(useAllChangesLinkStore.getState().file).toBeNull();
+    expect(useAllChangesLinkStore.getState().file[pane()]).toBeUndefined();
   });
 
   it("stands the commit box down while the all-changes page is in front", async () => {
@@ -148,27 +152,31 @@ describe("SourceControlView row interactions", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "All Changes" }));
     act(() => {
-      useAllChangesLinkStore.getState().setShowing({ rel: "src/a.ts", staged: false });
+      useAllChangesLinkStore.getState().setShowing(pane(), { rel: "src/a.ts", staged: false });
     });
 
     expect(screen.getByText("src/a.ts").closest("li")).toHaveAttribute("aria-current", "true");
 
     // The mark is the page's while that page is in front; it goes with it.
     act(() => {
-      useAllChangesLinkStore.getState().setShowing(null);
+      useAllChangesLinkStore.getState().setShowing(pane(), null);
     });
     expect(screen.getByText("src/a.ts").closest("li")).not.toHaveAttribute("aria-current");
   });
 
   it("reloads the all-changes page along with itself", async () => {
     render(<SourceControlView />);
+    // The rescan goes to the page the panel is paired with, so there has to
+    // be one: a split can hold two, and only the one in front is being read
+    // alongside these rows.
+    fireEvent.click(await screen.findByRole("button", { name: "All Changes" }));
     await screen.findByText("src/a.ts");
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
 
     // Both are reading one list from one status call, so a refresh that moved
     // only the panel would leave the two disagreeing side by side.
-    await waitFor(() => expect(useAllChangesLinkStore.getState().rescan).toBe(1));
+    await waitFor(() => expect(useAllChangesLinkStore.getState().rescan[pane()]).toBe(1));
   });
 
   it("brings the marked row back into view, and only when it has left", async () => {
@@ -187,7 +195,7 @@ describe("SourceControlView row interactions", () => {
       expect(scrollIntoView).not.toHaveBeenCalled();
 
       act(() => {
-        useAllChangesLinkStore.getState().setShowing({ rel: "src/a.ts", staged: false });
+        useAllChangesLinkStore.getState().setShowing(pane(), { rel: "src/a.ts", staged: false });
       });
 
       expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -145,6 +145,31 @@ describe("SourceControlView row interactions", () => {
     await waitFor(() => expect(useAllChangesLinkStore.getState().rescan).toBe(1));
   });
 
+  it("brings the marked row back into view, and only when it has left", async () => {
+    // jsdom has no layout, so the browser's own "already visible, do nothing"
+    // cannot be exercised here; what is asserted is that the row asks, with
+    // the nearest-edge options that leave a visible row alone.
+    // The suite's setup already stubs this on HTMLElement, which shadows any
+    // spy left on Element itself (src/test/setup.ts).
+    const scrollIntoView = vi.fn();
+    const original = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    try {
+      render(<SourceControlView />);
+      await screen.findByText("src/a.ts");
+      fireEvent.click(screen.getByRole("button", { name: "All Changes" }));
+      expect(scrollIntoView).not.toHaveBeenCalled();
+
+      act(() => {
+        useAllChangesLinkStore.getState().setShowing({ rel: "src/a.ts", staged: false });
+      });
+
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });
+    } finally {
+      HTMLElement.prototype.scrollIntoView = original;
+    }
+  });
+
   it("opens a diff tab when a changed file row is clicked", async () => {
     render(<SourceControlView />);
     fireEvent.click(await screen.findByText("src/a.ts"));

--- a/src/modules/source-control/SourceControlView.test.tsx
+++ b/src/modules/source-control/SourceControlView.test.tsx
@@ -170,6 +170,29 @@ describe("SourceControlView row interactions", () => {
     }
   });
 
+  it("lists the flat view in the tree's order, not the order status reports", async () => {
+    localStorage.setItem("tempoterm-sourcecontrol-view-mode", "flat");
+    vi.mocked(gitBridge.gitStatus).mockResolvedValue({
+      branch: "main",
+      staged: [],
+      unstaged: [
+        { path: "root-b.md", staged: false, status: "M" },
+        { path: "src/zeta.ts", staged: false, status: "M" },
+        { path: "root-a.md", staged: false, status: "M" },
+        { path: "src/alpha.ts", staged: false, status: "M" },
+      ],
+    });
+
+    const { container } = render(<SourceControlView />);
+    await screen.findByText("src/alpha.ts");
+
+    // A directory's changes together, then the root's — the same order the
+    // folder view and the all-changes page put them in.
+    expect(
+      Array.from(container.querySelectorAll("li")).map((li) => li.textContent?.trim()),
+    ).toEqual(["Msrc/alpha.ts", "Msrc/zeta.ts", "Mroot-a.md", "Mroot-b.md"]);
+  });
+
   it("opens a diff tab when a changed file row is clicked", async () => {
     render(<SourceControlView />);
     fireEvent.click(await screen.findByText("src/a.ts"));

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -417,6 +417,122 @@ function basename(path: string): string {
  * Recursively renders one level of a changed-files tree: folder headers with
  * a collapse toggle and a subtree-wide action button, file rows via StatusRow.
  */
+/**
+ * One folder in the tree: its header, and its children when it is open.
+ *
+ * Split out of FileTreeRows so it can hold a subscription of its own. A
+ * collapsed folder renders none of its files, so when the all-changes page
+ * scrolls into one of them there is no row to mark and the panel goes quiet
+ * about where the reader is. The folder takes the mark instead: the tree says
+ * where you are at whatever granularity is on screen -- the folder while it is
+ * shut, the file once it is open.
+ *
+ * Opening it by itself was the other option and is worse. Scrolling is
+ * continuous, so it would not be one folder opening but every folder the
+ * reader passes, and by the end of a long page the tree they had arranged is
+ * fully expanded. Collapse state belongs to the reader (#380), which is the
+ * same reason this feature leaves the panel's sections alone.
+ */
+function FolderRow({
+  node,
+  depth,
+  isCollapsed,
+  onToggleCollapse,
+  actionIcon: ActionIcon,
+  folderActionLabel,
+  onFolderAction,
+  followsPage,
+  children,
+}: {
+  node: TreeNode<FileStatus> & { kind: "folder" };
+  depth: number;
+  isCollapsed: boolean;
+  onToggleCollapse: (path: string) => void;
+  actionIcon: typeof Plus;
+  folderActionLabel: string;
+  onFolderAction: (paths: string[]) => void;
+  followsPage?: boolean;
+  children: ReactNode;
+}) {
+  const { t } = useTranslation("sourceControl");
+  const rowRef = useRef<HTMLLIElement>(null);
+
+  // A boolean per folder row, for the same reason StatusRow asks per file: a
+  // reading taken at the top would re-render the whole tree every time the
+  // page crossed into another file.
+  const holdsShownFile = useAllChangesLinkStore((s) =>
+    s.showing ? s.showing.rel.startsWith(`${node.path}/`) : false,
+  );
+  // Only while shut. Open, the file's own row carries the mark and marking the
+  // folder too would say the same thing twice.
+  const onPage = Boolean(followsPage) && isCollapsed && holdsShownFile;
+
+  useEffect(() => {
+    if (onPage) {
+      rowRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }, [onPage]);
+
+  return (
+    <li ref={rowRef} aria-current={onPage ? "true" : undefined}>
+      <div
+        style={{ paddingLeft: `${depth * 14 + 12}px` }}
+        className={`group flex items-center gap-1 py-1 pr-3 text-sm ${
+          onPage ? "bg-bg-elevated" : "hover:bg-bg-elevated/60 focus-within:bg-bg-elevated/60"
+        }`}
+      >
+        {/* The whole label — chevron, icon and name — is the toggle, the
+            way the section headers and the Git Graph details tree work.
+            Aiming for the 13px chevron alone was the only way to open a
+            folder here. The subtree action stays a sibling button, so it
+            never toggles the folder it acts on. Hover is the row
+            background only, never a text colour: in this list a bright
+            label means "this is the file you are viewing" (StatusRow's
+            active row), and nothing else. */}
+        <button
+          type="button"
+          onClick={() => onToggleCollapse(node.path)}
+          aria-label={
+            isCollapsed
+              ? t("expandFolder", { name: node.path })
+              : t("collapseFolder", { name: node.path })
+          }
+          className="flex min-w-0 flex-1 items-center gap-1 text-left text-fg-subtle"
+        >
+          {isCollapsed ? (
+            <ChevronRight size={13} className="shrink-0" />
+          ) : (
+            <ChevronDown size={13} className="shrink-0" />
+          )}
+          <Folder size={13} className="shrink-0" />
+          <Tooltip label={node.path} className="min-w-0 flex-1">
+            <span className={`min-w-0 flex-1 truncate ${onPage ? "text-fg" : "text-fg-muted"}`}>
+              {node.name}
+            </span>
+          </Tooltip>
+        </button>
+        {/* Permanently revealed, like the section headers: folder rows
+            have no context menu to fall back on for pointers with no
+            hover, and one icon costs little of the width the file rows'
+            hover-reveal exists to reclaim. */}
+        <RowActions revealed>
+          <Tooltip label={`${folderActionLabel}: ${node.path}`}>
+            <button
+              type="button"
+              aria-label={`${folderActionLabel}: ${node.path}`}
+              onClick={() => onFolderAction(collectDescendantFiles(node).map((f) => f.path))}
+              className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
+            >
+              <ActionIcon size={14} />
+            </button>
+          </Tooltip>
+        </RowActions>
+      </div>
+      {!isCollapsed && <ul>{children}</ul>}
+    </li>
+  );
+}
+
 function FileTreeRows({
   nodes,
   depth,
@@ -448,7 +564,6 @@ function FileTreeRows({
   activePath?: string | null;
   followsPage?: boolean;
 }) {
-  const { t } = useTranslation("sourceControl");
   return (
     <>
       {nodes.map((node) => {
@@ -475,78 +590,35 @@ function FileTreeRows({
           );
         }
         const isCollapsed = collapsed.has(node.path);
-        return (
-          <li key={node.path}>
-            <div
-              style={{ paddingLeft: `${depth * 14 + 12}px` }}
-              className="group flex items-center gap-1 py-1 pr-3 text-sm hover:bg-bg-elevated/60 focus-within:bg-bg-elevated/60"
-            >
-              {/* The whole label — chevron, icon and name — is the toggle, the
-                  way the section headers and the Git Graph details tree work.
-                  Aiming for the 13px chevron alone was the only way to open a
-                  folder here. The subtree action stays a sibling button, so it
-                  never toggles the folder it acts on. Hover is the row
-                  background only, never a text colour: in this list a bright
-                  label means "this is the file you are viewing" (StatusRow's
-                  active row), and nothing else. */}
-              <button
-                type="button"
-                onClick={() => onToggleCollapse(node.path)}
-                aria-label={
-                  isCollapsed
-                    ? t("expandFolder", { name: node.path })
-                    : t("collapseFolder", { name: node.path })
-                }
-                className="flex min-w-0 flex-1 items-center gap-1 text-left text-fg-subtle"
-              >
-                {isCollapsed ? (
-                  <ChevronRight size={13} className="shrink-0" />
-                ) : (
-                  <ChevronDown size={13} className="shrink-0" />
-                )}
-                <Folder size={13} className="shrink-0" />
-                <Tooltip label={node.path} className="min-w-0 flex-1">
-                  <span className="min-w-0 flex-1 truncate text-fg-muted">{node.name}</span>
-                </Tooltip>
-              </button>
-              {/* Permanently revealed, like the section headers: folder rows
-                  have no context menu to fall back on for pointers with no
-                  hover, and one icon costs little of the width the file rows'
-                  hover-reveal exists to reclaim. */}
-              <RowActions revealed>
-                <Tooltip label={`${folderActionLabel}: ${node.path}`}>
-                  <button
-                    type="button"
-                    aria-label={`${folderActionLabel}: ${node.path}`}
-                    onClick={() => onFolderAction(collectDescendantFiles(node).map((f) => f.path))}
-                    className="rounded p-0.5 text-fg-subtle hover:bg-border-strong hover:text-fg"
-                  >
-                    <ActionIcon size={14} />
-                  </button>
-                </Tooltip>
-              </RowActions>
-            </div>
-            {!isCollapsed && (
-              <ul>
-                <FileTreeRows
-                  nodes={node.children}
-                  depth={depth + 1}
-                  collapsed={collapsed}
-                  onToggleCollapse={onToggleCollapse}
-                  repoPath={repoPath}
-                  actionIcon={ActionIcon}
-                  actionLabel={actionLabel}
-                  folderActionLabel={folderActionLabel}
-                  onFileAction={onFileAction}
-                  onFolderAction={onFolderAction}
-                  onFileOpen={onFileOpen}
-                  onRequestDiscard={onRequestDiscard}
-                  activePath={activePath}
-                  followsPage={followsPage}
-                />
-              </ul>
-            )}
-          </li>
+return (
+          <FolderRow
+            key={node.path}
+            node={node}
+            depth={depth}
+            isCollapsed={isCollapsed}
+            onToggleCollapse={onToggleCollapse}
+            actionIcon={ActionIcon}
+            folderActionLabel={folderActionLabel}
+            onFolderAction={onFolderAction}
+            followsPage={followsPage}
+          >
+            <FileTreeRows
+              nodes={node.children}
+              depth={depth + 1}
+              collapsed={collapsed}
+              onToggleCollapse={onToggleCollapse}
+              repoPath={repoPath}
+              actionIcon={ActionIcon}
+              actionLabel={actionLabel}
+              folderActionLabel={folderActionLabel}
+              onFileAction={onFileAction}
+              onFolderAction={onFolderAction}
+              onFileOpen={onFileOpen}
+              onRequestDiscard={onRequestDiscard}
+              activePath={activePath}
+              followsPage={followsPage}
+            />
+          </FolderRow>
         );
       })}
     </>

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -703,6 +703,10 @@ export function SourceControlView() {
   // While the all-changes page is the pane in front, this panel is its table
   // of contents rather than a way of opening more tabs.
   const allChangesInFront = useTabsStore((s) => allChangesPaneActive(s.tabs, s.activeId));
+  // Read as two primitives for the same reason as the diff pane above: a
+  // selector returning a fresh object would re-render on every store change.
+  const showingRel = useAllChangesLinkStore((s) => s.showing?.rel ?? null);
+  const showingStaged = useAllChangesLinkStore((s) => s.showing?.staged ?? false);
   // Which row is "the one on screen": the diff in the foreground pane. Read as
   // two primitives — a selector returning a fresh {path, staged} object would
   // never compare equal, re-rendering the panel on every store change.
@@ -780,10 +784,17 @@ export function SourceControlView() {
   // Rows key off repo-relative paths; the diff pane carries an absolute one.
   // A diff opened from somewhere else (another repo, the git graph) simply
   // matches no row.
-  const activeRelPath =
+  const diffRelPath =
     repoPath && activeDiffPath?.startsWith(`${repoPath}/`)
       ? activeDiffPath.slice(repoPath.length + 1)
       : null;
+  // #364's "the file you are viewing" mark, extended to the all-changes page:
+  // there the file being viewed is the one at the top of it, which the page
+  // reports as it is scrolled. Without this the mark simply went out whenever
+  // that page was in front, which is the one place the panel is being read as
+  // a table of contents.
+  const activeRelPath = allChangesInFront ? showingRel : diffRelPath;
+  const activeStaged = allChangesInFront ? showingStaged : activeDiffStaged;
 
   const canCommit = message.trim().length > 0 && (status?.staged.length ?? 0) > 0;
   const hasStaged = (status?.staged.length ?? 0) > 0;
@@ -979,7 +990,7 @@ export function SourceControlView() {
                     })
                   }
                   onFileOpen={(path) => openDiff(path, true)}
-                  activePath={activeDiffStaged ? activeRelPath : null}
+                  activePath={activeStaged ? activeRelPath : null}
                   repoPath={repoPath ?? ""}
                 />
               )}
@@ -1029,7 +1040,7 @@ export function SourceControlView() {
                   }
                   onFileOpen={(path) => openDiff(path, false)}
                   onRequestDiscard={setDiscardTarget}
-                  activePath={activeDiffStaged ? null : activeRelPath}
+                  activePath={activeStaged ? null : activeRelPath}
                   repoPath={repoPath ?? ""}
                 />
               ))}

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -622,6 +622,7 @@ function FileList({
         onFileOpen={onFileOpen}
         onRequestDiscard={onRequestDiscard}
         activePath={activePath}
+        followsPage={followsPage}
       />
     </ul>
   );

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -741,6 +741,10 @@ export function SourceControlView() {
       return;
     }
     setRefreshing(true);
+    // Whatever else is reading this repo reloads with it: the all-changes page
+    // shows the same list, from the same status call, and a refresh that moved
+    // only one of them would leave the two disagreeing side by side.
+    useAllChangesLinkStore.getState().requestRescan();
     try {
       await withMinDuration(
         (async () => {

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -51,7 +51,8 @@ import { generateCommitMessage } from "./lib/aiCommit";
 import { withMinDuration } from "@/lib/withMinDuration";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { STATUS_COLOR } from "./lib/fileStatus";
-import { activeDiffPane, useTabsStore } from "@/stores/tabsStore";
+import { activeDiffPane, allChangesPaneActive, useTabsStore } from "@/stores/tabsStore";
+import { useAllChangesLinkStore } from "@/modules/diff/lib/allChangesLinkStore";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 import { computeHistoryGraphLayout, HISTORY_GRAPH_GEOMETRY } from "./lib/commitGraph";
 
@@ -153,7 +154,10 @@ function StatusRow({
       label: t("menuShowDiff"),
       icon: GitCompare,
       group: 0,
-      onSelect: () => onOpen(file.path),
+      // Deliberately not onOpen: a left click follows the all-changes page
+      // when that is in front, and this is the way to the single-file tab
+      // that stays put. Same direct store call as the two items above.
+      onSelect: () => useTabsStore.getState().openDiffTab(absPath, file.staged),
     },
     {
       id: "stageAction",
@@ -695,7 +699,10 @@ export function SourceControlView() {
   const model = useChatStore((s) => s.model);
   const customBaseUrl = useChatStore((s) => s.customBaseUrl);
   const openDiffTab = useTabsStore((s) => s.openDiffTab);
-  const openAllChangesTab = useTabsStore((s) => s.openAllChangesTab);
+  const toggleAllChangesTab = useTabsStore((s) => s.toggleAllChangesTab);
+  // While the all-changes page is the pane in front, this panel is its table
+  // of contents rather than a way of opening more tabs.
+  const allChangesInFront = useTabsStore((s) => allChangesPaneActive(s.tabs, s.activeId));
   // Which row is "the one on screen": the diff in the foreground pane. Read as
   // two primitives — a selector returning a fresh {path, staged} object would
   // never compare equal, re-rendering the panel on every store change.
@@ -710,11 +717,19 @@ export function SourceControlView() {
   // absolute path so it can resolve the repo on its own.
   const openDiff = useCallback(
     (path: string, staged: boolean) => {
+      // With the all-changes page in front, a row scrolls it to that file
+      // instead of opening a tab per file, which is the whole point of that
+      // page. The right-click menu's "Show Diff" still opens the single-file
+      // tab, so nothing is only reachable one way.
+      if (allChangesInFront) {
+        useAllChangesLinkStore.getState().request({ rel: path, staged });
+        return;
+      }
       if (repoPath) {
         openDiffTab(`${repoPath}/${path}`, staged);
       }
     },
-    [repoPath, openDiffTab],
+    [allChangesInFront, repoPath, openDiffTab],
   );
 
   const refresh = useCallback(async () => {
@@ -824,7 +839,7 @@ export function SourceControlView() {
             <button
               type="button"
               aria-label={t("allChanges")}
-              onClick={() => openAllChangesTab()}
+              onClick={() => toggleAllChangesTab()}
               className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
             >
               <FileDiff size={14} />
@@ -861,60 +876,68 @@ export function SourceControlView() {
         </div>
       )}
 
-      <div className="px-3 pb-3">
-        <div className="relative">
-          <textarea
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            placeholder={t("commitPlaceholder")}
-            rows={2}
-            className="w-full resize-none rounded-md border border-border bg-bg px-2 py-1.5 pr-9 text-sm text-fg outline-none focus:border-accent"
-          />
-          <Tooltip label={t("aiGenerate")} className="absolute right-1.5 top-1.5">
+      {/* The commit box steps out while the all-changes page is in front:
+          nothing is committed from there, and the message box and buttons
+          together take a fixed ~76px off the file list that page is being
+          read against. It comes straight back when the page does not have
+          the pane. Nothing else about the panel moves -- no section is
+          collapsed for the reader (#380), no control is relocated. */}
+      {!allChangesInFront && (
+        <div className="px-3 pb-3">
+          <div className="relative">
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder={t("commitPlaceholder")}
+              rows={2}
+              className="w-full resize-none rounded-md border border-border bg-bg px-2 py-1.5 pr-9 text-sm text-fg outline-none focus:border-accent"
+            />
+            <Tooltip label={t("aiGenerate")} className="absolute right-1.5 top-1.5">
+              <button
+                type="button"
+                disabled={!hasStaged || generating}
+                onClick={() => void aiGenerate()}
+                aria-label={t("aiGenerate")}
+                className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {generating ? (
+                  <Loader2 size={15} className="animate-spin" />
+                ) : (
+                  <Sparkles size={15} />
+                )}
+              </button>
+            </Tooltip>
+          </div>
+          <div className="mt-2 flex gap-2">
             <button
               type="button"
-              disabled={!hasStaged || generating}
-              onClick={() => void aiGenerate()}
-              aria-label={t("aiGenerate")}
-              className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
+              disabled={!canCommit}
+              onClick={() =>
+                void withRepo(async (repo) => {
+                  await gitCommit(repo, message);
+                  setMessage("");
+                })
+              }
+              className="flex-1 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
             >
-              {generating ? (
-                <Loader2 size={15} className="animate-spin" />
-              ) : (
-                <Sparkles size={15} />
-              )}
+              {t("commit")}
             </button>
-          </Tooltip>
+            <button
+              type="button"
+              disabled={pushing}
+              onClick={() => void doPush()}
+              className="flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm text-fg-muted transition-colors hover:border-border-strong hover:text-fg disabled:opacity-40"
+            >
+              {pushing ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <UploadCloud size={14} />
+              )}
+              {t("push")}
+            </button>
+          </div>
         </div>
-        <div className="mt-2 flex gap-2">
-          <button
-            type="button"
-            disabled={!canCommit}
-            onClick={() =>
-              void withRepo(async (repo) => {
-                await gitCommit(repo, message);
-                setMessage("");
-              })
-            }
-            className="flex-1 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            {t("commit")}
-          </button>
-          <button
-            type="button"
-            disabled={pushing}
-            onClick={() => void doPush()}
-            className="flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm text-fg-muted transition-colors hover:border-border-strong hover:text-fg disabled:opacity-40"
-          >
-            {pushing ? (
-              <Loader2 size={14} className="animate-spin" />
-            ) : (
-              <UploadCloud size={14} />
-            )}
-            {t("push")}
-          </button>
-        </div>
-      </div>
+      )}
 
       <div className="flex min-h-0 flex-1 flex-col">
         <div className="min-h-0 flex-1 overflow-y-auto">

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -42,7 +42,12 @@ import {
   type GitStatus,
 } from "./lib/gitBridge";
 import { Tooltip } from "@/components/Tooltip";
-import { buildFileTree, collectDescendantFiles, type TreeNode } from "@/lib/fileTree";
+import {
+  buildFileTree,
+  collectDescendantFiles,
+  flattenFileTree,
+  type TreeNode,
+} from "@/lib/fileTree";
 import { useCollapsedPaths } from "@/lib/useCollapsedPaths";
 import { usePendingGraphSelectionStore } from "@/modules/git-graph/lib/pendingGraphSelectionStore";
 import { edgePath } from "@/modules/git-graph/lib/graphLayout";
@@ -588,7 +593,12 @@ function FileList({
   if (viewMode === "flat") {
     return (
       <ul>
-        {files.map((file) => (
+        {/* Ordered by the same tree the folder view draws, just without the
+            folder rows: one directory's changes stay together instead of
+            landing wherever status happened to report them, and the flat
+            list, the folder view and the all-changes page then read as one
+            index rather than three sorts of the same files. */}
+        {flattenFileTree(buildFileTree(files)).map((file) => (
           <StatusRow
             key={file.path}
             file={file}

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -894,12 +894,27 @@ export function SourceControlView() {
           {t("title")}
         </span>
         <div className="flex items-center gap-0.5">
-          <Tooltip label={t("allChanges")}>
+          {/* Filled while the page is the pane in front, which is the state
+              worth showing: that is when this panel stops opening tabs and
+              starts following the page, and when the commit box steps out.
+              Something has to account for that, and this button is the only
+              thing on screen that can. Open-but-behind is deliberately drawn
+              the same as shut -- the button speaks about the pane in front,
+              not about what exists somewhere in the space. Same on/off looks
+              as the wrap button in DiffTabContent, and the icon never changes:
+              it is the all-changes tab's own icon, and that match is what
+              makes the button legible in the first place. */}
+          <Tooltip label={allChangesInFront ? t("allChangesClose") : t("allChanges")}>
             <button
               type="button"
-              aria-label={t("allChanges")}
+              aria-label={allChangesInFront ? t("allChangesClose") : t("allChanges")}
+              aria-pressed={allChangesInFront}
               onClick={() => toggleAllChangesTab()}
-              className="rounded p-1 text-fg-muted hover:bg-bg-elevated hover:text-fg"
+              className={`rounded p-1 ${
+                allChangesInFront
+                  ? "bg-bg-elevated text-fg"
+                  : "text-fg-muted hover:bg-bg-elevated hover:text-fg"
+              }`}
             >
               <FileDiff size={14} />
             </button>

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -111,6 +111,7 @@ function StatusRow({
   onOpen,
   onRequestDiscard,
   active = false,
+  followsPage = false,
   indent = 0,
 }: {
   file: FileStatus;
@@ -126,6 +127,11 @@ function StatusRow({
   /** This file's diff is the one on screen: the row stays highlighted and
    * keeps its actions out without needing hover. */
   active?: boolean;
+  /**
+   * The all-changes page has the pane in front, so this row takes its mark
+   * from what that page is showing rather than from a diff pane.
+   */
+  followsPage?: boolean;
   /** Tree depth for indentation; 0 (default) matches flat mode's spacing. */
   indent?: number;
 }) {
@@ -133,6 +139,31 @@ function StatusRow({
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const discardable = onRequestDiscard && file.status !== "?";
   const absPath = `${repoPath}/${file.path}`;
+  const rowRef = useRef<HTMLLIElement>(null);
+
+  /**
+   * Asked here, per row, rather than handed down from the panel: the file the
+   * all-changes page is showing changes as it is scrolled, and a mark read at
+   * the top would re-render every row (and the commit graph under them) each
+   * time the page crossed into another file. A selector returning a boolean
+   * re-renders the two rows that actually change hands and nothing else.
+   */
+  const isShownByPage = useAllChangesLinkStore(
+    (s) => s.showing?.rel === file.path && s.showing?.staged === file.staged,
+  );
+  const onPage = followsPage && isShownByPage;
+  const marked = active || onPage;
+
+  // A mark you cannot see says nothing, and with dozens of files it leaves the
+  // list within a screenful of scrolling. "nearest" is the whole point: a row
+  // already in view is left alone, so the list does not chase the page while
+  // the reader is looking at it, and one that has gone off the edge comes back
+  // by the shortest distance rather than jumping to the middle.
+  useEffect(() => {
+    if (onPage) {
+      rowRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }, [onPage]);
 
   const menuItems: ContextMenuItem[] = [
     {
@@ -208,10 +239,11 @@ function StatusRow({
         e.preventDefault();
         setMenu({ x: e.clientX, y: e.clientY });
       }}
-      aria-current={active ? "true" : undefined}
+      ref={rowRef}
+      aria-current={marked ? "true" : undefined}
       style={{ paddingLeft: `${indent * 14 + 12}px` }}
       className={`group flex cursor-pointer items-center py-1 pr-3 text-sm ${
-        active ? "bg-bg-elevated" : "hover:bg-bg-elevated/60 focus-within:bg-bg-elevated/60"
+        marked ? "bg-bg-elevated" : "hover:bg-bg-elevated/60 focus-within:bg-bg-elevated/60"
       }`}
     >
       <span
@@ -222,11 +254,11 @@ function StatusRow({
         {file.status}
       </span>
       <Tooltip label={file.path} className="min-w-0 flex-1">
-        <span className={`min-w-0 flex-1 truncate ${active ? "text-fg" : "text-fg-muted"}`}>
+        <span className={`min-w-0 flex-1 truncate ${marked ? "text-fg" : "text-fg-muted"}`}>
           {displayPath ?? file.path}
         </span>
       </Tooltip>
-      <RowActions revealed={active}>
+      <RowActions revealed={marked}>
         {discardable && (
           <Tooltip label={t("discard")}>
             <button
@@ -394,6 +426,7 @@ function FileTreeRows({
   onFileOpen,
   onRequestDiscard,
   activePath,
+  followsPage,
 }: {
   nodes: TreeNode<FileStatus>[];
   depth: number;
@@ -408,6 +441,7 @@ function FileTreeRows({
   onFileOpen: (path: string) => void;
   onRequestDiscard?: (path: string) => void;
   activePath?: string | null;
+  followsPage?: boolean;
 }) {
   const { t } = useTranslation("sourceControl");
   return (
@@ -430,6 +464,7 @@ function FileTreeRows({
               onOpen={onFileOpen}
               onRequestDiscard={onRequestDiscard}
               active={node.file.path === activePath}
+              followsPage={followsPage}
               indent={depth}
             />
           );
@@ -502,6 +537,7 @@ function FileTreeRows({
                   onFileOpen={onFileOpen}
                   onRequestDiscard={onRequestDiscard}
                   activePath={activePath}
+                  followsPage={followsPage}
                 />
               </ul>
             )}
@@ -530,6 +566,7 @@ function FileList({
   onFileOpen,
   onRequestDiscard,
   activePath,
+  followsPage,
 }: {
   files: FileStatus[];
   viewMode: ViewMode;
@@ -544,6 +581,7 @@ function FileList({
   /** Repo-relative path of the file whose diff is on screen, if it is in this
    * list — the staged and unstaged lists never claim it at the same time. */
   activePath?: string | null;
+  followsPage?: boolean;
 }) {
   const { collapsed, toggle: toggleFolder } = useCollapsedPaths();
 
@@ -561,6 +599,7 @@ function FileList({
             onOpen={onFileOpen}
             onRequestDiscard={onRequestDiscard}
             active={file.path === activePath}
+            followsPage={followsPage}
           />
         ))}
       </ul>
@@ -703,10 +742,6 @@ export function SourceControlView() {
   // While the all-changes page is the pane in front, this panel is its table
   // of contents rather than a way of opening more tabs.
   const allChangesInFront = useTabsStore((s) => allChangesPaneActive(s.tabs, s.activeId));
-  // Read as two primitives for the same reason as the diff pane above: a
-  // selector returning a fresh object would re-render on every store change.
-  const showingRel = useAllChangesLinkStore((s) => s.showing?.rel ?? null);
-  const showingStaged = useAllChangesLinkStore((s) => s.showing?.staged ?? false);
   // Which row is "the one on screen": the diff in the foreground pane. Read as
   // two primitives — a selector returning a fresh {path, staged} object would
   // never compare equal, re-rendering the panel on every store change.
@@ -792,13 +827,11 @@ export function SourceControlView() {
     repoPath && activeDiffPath?.startsWith(`${repoPath}/`)
       ? activeDiffPath.slice(repoPath.length + 1)
       : null;
-  // #364's "the file you are viewing" mark, extended to the all-changes page:
-  // there the file being viewed is the one at the top of it, which the page
-  // reports as it is scrolled. Without this the mark simply went out whenever
-  // that page was in front, which is the one place the panel is being read as
-  // a table of contents.
-  const activeRelPath = allChangesInFront ? showingRel : diffRelPath;
-  const activeStaged = allChangesInFront ? showingStaged : activeDiffStaged;
+  // #364's mark for a diff pane. The all-changes page's own mark is asked for
+  // by each row instead (see StatusRow), so that scrolling that page does not
+  // re-render the whole panel every time it crosses into another file.
+  const activeRelPath = diffRelPath;
+  const activeStaged = activeDiffStaged;
 
   const canCommit = message.trim().length > 0 && (status?.staged.length ?? 0) > 0;
   const hasStaged = (status?.staged.length ?? 0) > 0;
@@ -995,6 +1028,7 @@ export function SourceControlView() {
                   }
                   onFileOpen={(path) => openDiff(path, true)}
                   activePath={activeStaged ? activeRelPath : null}
+                  followsPage={allChangesInFront}
                   repoPath={repoPath ?? ""}
                 />
               )}
@@ -1045,6 +1079,7 @@ export function SourceControlView() {
                   onFileOpen={(path) => openDiff(path, false)}
                   onRequestDiscard={setDiscardTarget}
                   activePath={activeStaged ? null : activeRelPath}
+                  followsPage={allChangesInFront}
                   repoPath={repoPath ?? ""}
                 />
               ))}

--- a/src/modules/source-control/SourceControlView.tsx
+++ b/src/modules/source-control/SourceControlView.tsx
@@ -56,7 +56,7 @@ import { generateCommitMessage } from "./lib/aiCommit";
 import { withMinDuration } from "@/lib/withMinDuration";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { STATUS_COLOR } from "./lib/fileStatus";
-import { activeDiffPane, allChangesPaneActive, useTabsStore } from "@/stores/tabsStore";
+import { activeAllChangesPane, activeDiffPane, useTabsStore } from "@/stores/tabsStore";
 import { useAllChangesLinkStore } from "@/modules/diff/lib/allChangesLinkStore";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 import { computeHistoryGraphLayout, HISTORY_GRAPH_GEOMETRY } from "./lib/commitGraph";
@@ -153,9 +153,11 @@ function StatusRow({
    * time the page crossed into another file. A selector returning a boolean
    * re-renders the two rows that actually change hands and nothing else.
    */
-  const isShownByPage = useAllChangesLinkStore(
-    (s) => s.showing?.rel === file.path && s.showing?.staged === file.staged,
-  );
+  const pane = useTabsStore((s) => activeAllChangesPane(s.tabs, s.activeId));
+  const isShownByPage = useAllChangesLinkStore((s) => {
+    const showing = pane ? s.showing[pane] : undefined;
+    return showing?.rel === file.path && showing?.staged === file.staged;
+  });
   const onPage = followsPage && isShownByPage;
   const marked = active || onPage;
 
@@ -460,9 +462,11 @@ function FolderRow({
   // A boolean per folder row, for the same reason StatusRow asks per file: a
   // reading taken at the top would re-render the whole tree every time the
   // page crossed into another file.
-  const holdsShownFile = useAllChangesLinkStore((s) =>
-    s.showing ? s.showing.rel.startsWith(`${node.path}/`) : false,
-  );
+  const pane = useTabsStore((s) => activeAllChangesPane(s.tabs, s.activeId));
+  const holdsShownFile = useAllChangesLinkStore((s) => {
+    const showing = pane ? s.showing[pane] : undefined;
+    return showing ? showing.rel.startsWith(`${node.path}/`) : false;
+  });
   // Only while shut. Open, the file's own row carries the mark and marking the
   // folder too would say the same thing twice.
   const onPage = Boolean(followsPage) && isCollapsed && holdsShownFile;
@@ -824,7 +828,8 @@ export function SourceControlView() {
   const toggleAllChangesTab = useTabsStore((s) => s.toggleAllChangesTab);
   // While the all-changes page is the pane in front, this panel is its table
   // of contents rather than a way of opening more tabs.
-  const allChangesInFront = useTabsStore((s) => allChangesPaneActive(s.tabs, s.activeId));
+  const allChangesPane = useTabsStore((s) => activeAllChangesPane(s.tabs, s.activeId));
+  const allChangesInFront = allChangesPane !== null;
   // Which row is "the one on screen": the diff in the foreground pane. Read as
   // two primitives — a selector returning a fresh {path, staged} object would
   // never compare equal, re-rendering the panel on every store change.
@@ -843,15 +848,17 @@ export function SourceControlView() {
       // instead of opening a tab per file, which is the whole point of that
       // page. The right-click menu's "Show Diff" still opens the single-file
       // tab, so nothing is only reachable one way.
-      if (allChangesInFront) {
-        useAllChangesLinkStore.getState().request({ rel: path, staged });
+      // The page in front, not "a page somewhere": a split can hold two, and
+      // the rows being clicked belong to the one being looked at.
+      if (allChangesPane) {
+        useAllChangesLinkStore.getState().request(allChangesPane, { rel: path, staged });
         return;
       }
       if (repoPath) {
         openDiffTab(`${repoPath}/${path}`, staged);
       }
     },
-    [allChangesInFront, repoPath, openDiffTab],
+    [allChangesPane, repoPath, openDiffTab],
   );
 
   const refresh = useCallback(async () => {
@@ -862,7 +869,14 @@ export function SourceControlView() {
     // Whatever else is reading this repo reloads with it: the all-changes page
     // shows the same list, from the same status call, and a refresh that moved
     // only one of them would leave the two disagreeing side by side.
-    useAllChangesLinkStore.getState().requestRescan();
+    // Read at the moment of pressing, not closed over: this callback is
+    // memoised on the repo, and the pane in front changes far more often than
+    // that -- captured, it would still be the answer from the first render.
+    const { tabs, activeId } = useTabsStore.getState();
+    const pane = activeAllChangesPane(tabs, activeId);
+    if (pane) {
+      useAllChangesLinkStore.getState().requestRescan(pane);
+    }
     try {
       await withMinDuration(
         (async () => {

--- a/src/modules/terminal/PaneTabContent.tsx
+++ b/src/modules/terminal/PaneTabContent.tsx
@@ -566,6 +566,7 @@ export function PaneTabContent({ tab }: { tab: Tab }) {
                   />
                 ) : pane.content.kind === "all-changes" ? (
                   <AllChangesTabContent
+                    paneId={pane.id}
                     showClose={multiple}
                     onClose={() => requestClosePane(pane.id)}
                   />

--- a/src/stores/tabsStore.test.ts
+++ b/src/stores/tabsStore.test.ts
@@ -409,6 +409,34 @@ describe("tabsStore", () => {
     expect(useTabsStore.getState().activeId).toBe(a1);
   });
 
+  it("toggles the all-changes tab from one control", () => {
+    const opened = useTabsStore.getState().toggleAllChangesTab();
+    expect(opened).not.toBeNull();
+    expect(activeTab().kind).toBe("all-changes");
+
+    // Not in front: focused rather than closed.
+    const other = useTabsStore.getState().newTerminalTab();
+    expect(useTabsStore.getState().activeId).toBe(other);
+    expect(useTabsStore.getState().toggleAllChangesTab()).toBe(opened);
+    expect(useTabsStore.getState().activeId).toBe(opened);
+    expect(useTabsStore.getState().tabs).toHaveLength(2);
+
+    // In front: the way out.
+    expect(useTabsStore.getState().toggleAllChangesTab()).toBeNull();
+    expect(useTabsStore.getState().tabs.map((t) => t.id)).toEqual([other]);
+  });
+
+  it("focuses rather than closes an all-changes tab that has been split", () => {
+    const id = useTabsStore.getState().openAllChangesTab();
+    useTabsStore.getState().splitActivePane("row");
+    expect(useTabsStore.getState().activeId).toBe(id);
+
+    // Closing the tab would take the pane split alongside it down too, so a
+    // split one is only ever focused.
+    expect(useTabsStore.getState().toggleAllChangesTab()).not.toBeNull();
+    expect(useTabsStore.getState().tabs.some((t) => t.id === id)).toBe(true);
+  });
+
   it("does not dedupe an editor tab once it has been split", () => {
     const first = useTabsStore.getState().openEditorTab("/a/b.ts");
     useTabsStore

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -287,11 +287,28 @@ export function allChangesPaneActive(
   tabs: readonly Tab[],
   activeId: string | null,
 ): boolean {
+  return activeAllChangesPane(tabs, activeId) !== null;
+}
+
+/**
+ * Which pane the all-changes page in front is, by leaf id, or null when the
+ * pane in front is something else.
+ *
+ * A split can have two of those pages mounted at once, each scrolled its own
+ * way, so "is one in front" is not enough to pair the panel with a page: the
+ * panel's rows belong to exactly one of them, and this says which.
+ */
+export function activeAllChangesPane(
+  tabs: readonly Tab[],
+  activeId: string | null,
+): string | null {
   const tab = tabs.find((t) => t.id === activeId);
   if (!tab) {
-    return false;
+    return null;
   }
-  return findPaneContent(tab.paneTree, tab.activeLeafId)?.kind === "all-changes";
+  return findPaneContent(tab.paneTree, tab.activeLeafId)?.kind === "all-changes"
+    ? tab.activeLeafId
+    : null;
 }
 
 export function tabHasDirtyEditor(

--- a/src/stores/tabsStore.ts
+++ b/src/stores/tabsStore.ts
@@ -99,6 +99,12 @@ interface TabsState {
   openPreviewTab: (url: string) => string;
   openGitGraphTab: () => string;
   openAllChangesTab: () => string;
+  /**
+   * The panel's entry button, which is the way out as well as the way in:
+   * closes the all-changes tab when it is the one in front, otherwise opens or
+   * focuses it. Returns the tab id, or null when it closed one.
+   */
+  toggleAllChangesTab: () => string | null;
   openDiffTab: (path: string, staged: boolean) => string;
   /** Open the AI sessions browser tab (singleton per space). */
   openSessionsTab: () => string;
@@ -268,6 +274,24 @@ export function activeDiffPane(
   }
   const content = findPaneContent(tab.paneTree, tab.activeLeafId);
   return content?.kind === "diff" ? { path: content.path, staged: content.staged } : null;
+}
+
+/**
+ * Whether the pane in front is the all-changes page: same rule as
+ * `activeDiffPane` (the active leaf of the active tab, so a split reports its
+ * focused pane). The Source Control panel reads this to decide whether a row
+ * click scrolls that page or opens a diff tab of its own, and whether its
+ * commit box is worth the room.
+ */
+export function allChangesPaneActive(
+  tabs: readonly Tab[],
+  activeId: string | null,
+): boolean {
+  const tab = tabs.find((t) => t.id === activeId);
+  if (!tab) {
+    return false;
+  }
+  return findPaneContent(tab.paneTree, tab.activeLeafId)?.kind === "all-changes";
 }
 
 export function tabHasDirtyEditor(
@@ -715,6 +739,19 @@ export const useTabsStore = create<TabsState>()(
     };
     set((state) => ({ tabs: [...state.tabs, tab], activeId: id }));
     return id;
+  },
+
+  toggleAllChangesTab: () => {
+    const { tabs, activeId } = get();
+    const active = tabs.find((t) => t.id === activeId);
+    // Only the shape openAllChangesTab would have reused is closed again, so
+    // the button never takes a split tab's other panes down with it. A split
+    // one falls through and is merely focused.
+    if (active && singleLeafContentEquals(active, { kind: "all-changes" })) {
+      get().closeTab(active.id);
+      return null;
+    }
+    return get().openAllChangesTab();
   },
 
   openSessionsTab: () => {


### PR DESCRIPTION
Part of #397, the second of the three pieces, on top of #406 now that it has landed.

## Problem

#406 put every uncommitted change on one page, and left the Source Control panel beside it doing nothing useful: clicking a row opened a separate diff tab of its own, so the two surfaces showed the same files and disagreed about which one you were reading. A long page also gave no way back to a file except scrolling for it.

## Changes

While the all-changes page is the pane in front, the panel becomes its index rather than a second way in.

- **Clicking a row scrolls the page** to that file instead of opening a tab of its own.
- **The row the page is on is marked**, and it follows the scroll — including the first file while the page still sits at its top, and the enclosing folder when the file itself is collapsed out of sight in the tree view.
- **The panel's refresh button rescans both**, since while that page has the pane it is the only refresh control on screen.
- **The flat list is ordered the way the tree draws it**, so the panel and the page are one index of one comparison rather than two differently sorted lists of the same files.

The marking is read per row rather than by handing every row the answer, so a page scroll re-renders one row instead of the whole list.

## Test plan

`src/modules/diff/allChangesPanelLink.test.tsx` covers the pairing from both sides: a click scrolls rather than opening a tab, the mark follows the page, and the folder takes the mark when the file inside it is shut away. The Source Control suite covers the ordering and the shared refresh.

`tsc` clean. Full suite: 2170 pass, with two `PortsPanelView` tests failing only under a loaded parallel run and passing 16/16 in isolation — they fail the same way on master.
