### PR TITLE
feat(git-graph): keep a row for the working tree above the newest commit

### DIFF
--- a/src/i18n/locales/en/gitGraph.json
+++ b/src/i18n/locales/en/gitGraph.json
@@ -75,7 +75,8 @@
     "deleteRemoteOn": "Delete branch on {{remote}}… (git push --delete)",
     "copyBranchName": "Copy branch name",
     "copyTagName": "Copy tag name",
-    "openWorktree": "Open worktree for this branch"
+    "openWorktree": "Open worktree for this branch",
+    "openInSourceControl": "Open in Source Control"
   },
   "modal": {
     "cancel": "Cancel",
@@ -102,5 +103,13 @@
       "message": "Delete {{name}} on the remote? This cannot be undone.",
       "confirm": "Delete"
     }
+  },
+  "uncommitted": {
+    "title": "Uncommitted changes",
+    "clean": "No uncommitted changes",
+    "summary": "{{staged}} staged · {{unstaged}} unstaged",
+    "relativeTo": "against {{hash}}",
+    "stagedTitle": "Staged",
+    "unstagedTitle": "Unstaged"
   }
 }

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -15,6 +15,8 @@
     "uncommittedDescription": "Keep a row for your working tree at the top of the graph.",
     "uncommittedRowLabel": "Show uncommitted changes at the top of the graph",
     "uncommittedRowHint": "The row stays put whether or not anything is uncommitted, so committing never shifts the graph under the pointer. Turn it off and the first row is the newest commit again.",
+    "uncommittedWhenCleanLabel": "Keep the row when nothing is uncommitted",
+    "uncommittedWhenCleanHint": "On, a clean tree still gets a quiet row and the graph never moves. Off, the row only appears when something is uncommitted — so the graph shifts by a row each time you commit or change a file.",
     "refsTitle": "Branch labels",
     "refsDescription": "How the Git Graph condenses the branch and tag chips on a commit row.",
     "mergeLocalRemoteLabel": "Merge a branch with its remotes",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -11,6 +11,10 @@
     "about": "About"
   },
   "gitGraph": {
+    "uncommittedTitle": "Uncommitted changes",
+    "uncommittedDescription": "Keep a row for your working tree at the top of the graph.",
+    "uncommittedRowLabel": "Show uncommitted changes at the top of the graph",
+    "uncommittedRowHint": "The row stays put whether or not anything is uncommitted, so committing never shifts the graph under the pointer. Turn it off and the first row is the newest commit again.",
     "refsTitle": "Branch labels",
     "refsDescription": "How the Git Graph condenses the branch and tag chips on a commit row.",
     "mergeLocalRemoteLabel": "Merge a branch with its remotes",

--- a/src/i18n/locales/zh-Hant/gitGraph.json
+++ b/src/i18n/locales/zh-Hant/gitGraph.json
@@ -75,7 +75,8 @@
     "deleteRemoteOn": "刪除 {{remote}} 上的分支… (git push --delete)",
     "copyBranchName": "複製分支名稱",
     "copyTagName": "複製標籤名稱",
-    "openWorktree": "為這個分支開 worktree"
+    "openWorktree": "為這個分支開 worktree",
+    "openInSourceControl": "到原始碼控制側欄"
   },
   "modal": {
     "cancel": "取消",
@@ -102,5 +103,13 @@
       "message": "確定要在遠端刪除 {{name}}？此動作無法復原",
       "confirm": "刪除"
     }
+  },
+  "uncommitted": {
+    "title": "未提交的變更",
+    "clean": "沒有未提交的變更",
+    "summary": "已暫存 {{staged}} · 未暫存 {{unstaged}}",
+    "relativeTo": "相對於 {{hash}}",
+    "stagedTitle": "已暫存",
+    "unstagedTitle": "未暫存"
   }
 }

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -15,6 +15,8 @@
     "uncommittedDescription": "在圖的最上方常駐一列，顯示工作區的狀態。",
     "uncommittedRowLabel": "在圖最上方顯示未提交的變更",
     "uncommittedRowHint": "不論有沒有未提交的東西，這一列都在，所以提交時整張圖不會在游標底下跳動。關掉之後，圖的第一列就是最新的 commit。",
+    "uncommittedWhenCleanLabel": "沒有未提交的變更時也保留這一列",
+    "uncommittedWhenCleanHint": "開啟時，工作區乾淨也會留一列安靜的列，整張圖不會移動。關閉時只在有未提交的變更才出現——代價是每次提交或改動檔案，整張圖都會上下位移一列。",
     "refsTitle": "分支標籤",
     "refsDescription": "Git Graph 在 commit 列上如何精簡分支與標籤 chip。",
     "mergeLocalRemoteLabel": "同名的本地與遠端分支合併成一顆",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -11,6 +11,10 @@
     "about": "關於"
   },
   "gitGraph": {
+    "uncommittedTitle": "未提交的變更",
+    "uncommittedDescription": "在圖的最上方常駐一列，顯示工作區的狀態。",
+    "uncommittedRowLabel": "在圖最上方顯示未提交的變更",
+    "uncommittedRowHint": "不論有沒有未提交的東西，這一列都在，所以提交時整張圖不會在游標底下跳動。關掉之後，圖的第一列就是最新的 commit。",
     "refsTitle": "分支標籤",
     "refsDescription": "Git Graph 在 commit 列上如何精簡分支與標籤 chip。",
     "mergeLocalRemoteLabel": "同名的本地與遠端分支合併成一顆",

--- a/src/lib/gitPath.test.ts
+++ b/src/lib/gitPath.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { diffHeaderPath, stripGitPathSide, unquoteGitPath } from "./gitPath";
+
+describe("unquoteGitPath", () => {
+  it("leaves an unquoted path alone", () => {
+    expect(unquoteGitPath("src/a.ts")).toBe("src/a.ts");
+  });
+
+  it("leaves a path alone when only one end is quoted", () => {
+    expect(unquoteGitPath('"src/a.ts')).toBe('"src/a.ts');
+  });
+
+  it("decodes the simple C escapes", () => {
+    expect(unquoteGitPath('"a\\tb"')).toBe("a\tb");
+    expect(unquoteGitPath('"a\\"b"')).toBe('a"b');
+    expect(unquoteGitPath('"a\\\\b"')).toBe("a\\b");
+  });
+
+  it("decodes octal escapes as UTF-8 bytes rather than one at a time", () => {
+    // Each CJK character is three bytes, and decoding them singly yields
+    // mojibake rather than the character — the bytes have to be collected and
+    // decoded together.
+    expect(unquoteGitPath('"\\344\\270\\255\\346\\226\\207.ts"')).toBe("中文.ts");
+  });
+
+  it("decodes a run of bytes that is interrupted by a plain character", () => {
+    expect(unquoteGitPath('"\\344\\270\\255x\\346\\226\\207"')).toBe("中x文");
+  });
+
+  it("keeps a trailing lone backslash rather than dropping it", () => {
+    expect(unquoteGitPath('"a\\"')).toBe("a\\");
+  });
+});
+
+describe("stripGitPathSide", () => {
+  it("drops the side prefix", () => {
+    expect(stripGitPathSide("b/src/a.ts", "b/")).toBe("src/a.ts");
+    expect(stripGitPathSide("a/src/a.ts", "a/")).toBe("src/a.ts");
+  });
+
+  it("unquotes before looking for the prefix", () => {
+    expect(stripGitPathSide('"b/\\344\\270\\255\\346\\226\\207.ts"', "b/")).toBe("中文.ts");
+  });
+
+  it("leaves a path that does not carry the prefix", () => {
+    expect(stripGitPathSide("/dev/null", "b/")).toBe("/dev/null");
+  });
+});
+
+describe("diffHeaderPath", () => {
+  it("reads the new side out of a header", () => {
+    expect(diffHeaderPath("diff --git a/src/a.ts b/src/a.ts")).toBe("src/a.ts");
+  });
+
+  it("reads the new name of a rename, not the old one", () => {
+    expect(diffHeaderPath("diff --git a/old.ts b/new.ts")).toBe("new.ts");
+  });
+
+  it("reads a quoted, escaped path", () => {
+    expect(
+      diffHeaderPath(
+        'diff --git "a/\\344\\270\\255\\346\\226\\207.ts" "b/\\344\\270\\255\\346\\226\\207.ts"',
+      ),
+    ).toBe("中文.ts");
+  });
+
+  it("takes the last b/ so a path starting with b/ does not split early", () => {
+    expect(diffHeaderPath("diff --git a/b/x.ts b/b/x.ts")).toBe("b/x.ts");
+  });
+
+  it("splits in the wrong place for a path holding a space and b/", () => {
+    // Documented, not desired: the two halves are separated by " b/" and a
+    // path may contain that, with nothing in the header to tell them apart.
+    // Callers that have the file's own `+++ b/` line prefer it for this
+    // reason; `parseDiffStats` does exactly that.
+    expect(diffHeaderPath("diff --git a/x b/y.ts b/x b/y.ts")).toBe("y.ts");
+  });
+
+  it("answers null for a line with no new side to read", () => {
+    expect(diffHeaderPath("diff --git a/only.ts")).toBeNull();
+  });
+});

--- a/src/lib/gitPath.ts
+++ b/src/lib/gitPath.ts
@@ -1,0 +1,94 @@
+/**
+ * Reading the paths git writes into diff output.
+ *
+ * Two surfaces need this and they cannot line up by accident: `git_status` goes
+ * through libgit2 and hands back raw UTF-8 paths, while `git_diff` shells out
+ * to git itself, which quotes a path holding anything non-ASCII. Comparing one
+ * against the other without undoing the quoting silently matches nothing — and
+ * for a diff, nothing is indistinguishable from "this file did not change".
+ */
+
+/** C-style escapes git may use inside a quoted path. */
+const SIMPLE_ESCAPES: Record<string, string> = {
+  a: "\x07",
+  b: "\b",
+  t: "\t",
+  n: "\n",
+  v: "\v",
+  f: "\f",
+  r: "\r",
+  "\\": "\\",
+  '"': '"',
+};
+
+/**
+ * Unquote a path git wrote with `core.quotePath` on. Git emits non-ASCII
+ * UTF-8 bytes as three-digit octal escapes, so decode those bytes together
+ * rather than leaving them in the repo-relative lookup key.
+ */
+export function unquoteGitPath(path: string): string {
+  if (!path.startsWith('"') || !path.endsWith('"')) {
+    return path;
+  }
+  const body = path.slice(1, -1);
+  const output: string[] = [];
+  const octalBytes: number[] = [];
+  const flushOctalBytes = () => {
+    if (octalBytes.length > 0) {
+      output.push(new TextDecoder("utf-8").decode(new Uint8Array(octalBytes)));
+      octalBytes.length = 0;
+    }
+  };
+
+  for (let i = 0; i < body.length; i += 1) {
+    if (body[i] !== "\\") {
+      flushOctalBytes();
+      output.push(body[i]);
+      continue;
+    }
+
+    const escaped = body[i + 1];
+    if (escaped === undefined) {
+      flushOctalBytes();
+      output.push("\\");
+      continue;
+    }
+
+    if (/^[0-7]$/.test(escaped)) {
+      const octal = body.slice(i + 1, i + 4).match(/^[0-7]{1,3}/)?.[0];
+      if (octal) {
+        octalBytes.push(Number.parseInt(octal, 8));
+        i += octal.length;
+        continue;
+      }
+    }
+
+    flushOctalBytes();
+    output.push(SIMPLE_ESCAPES[escaped] ?? escaped);
+    i += 1;
+  }
+
+  flushOctalBytes();
+  return output.join("");
+}
+
+/** Drop the a/ or b/ git puts in front of a path, quotes stripped first. */
+export function stripGitPathSide(target: string, side: "a/" | "b/"): string {
+  const bare = unquoteGitPath(target);
+  return bare.startsWith(side) ? bare.slice(2) : bare;
+}
+
+/**
+ * The new-side path out of a `diff --git a/x b/x` header. Both halves carry the
+ * same name for everything but a rename, and a path holding " b/" would fool
+ * the split — so a caller holding the file's own `+++ b/` line should prefer
+ * that and treat this as the provisional answer.
+ */
+export function diffHeaderPath(line: string): string | null {
+  const rest = line.slice("diff --git ".length);
+  const split = Math.max(rest.lastIndexOf(' "b/'), rest.lastIndexOf(" b/"));
+  if (split < 0) {
+    return null;
+  }
+  return stripGitPathSide(rest.slice(split + 1).trim(), "b/");
+}

--- a/src/modules/diff/AllChangesTabContent.test.tsx
+++ b/src/modules/diff/AllChangesTabContent.test.tsx
@@ -178,7 +178,10 @@ describe("AllChangesTabContent", () => {
     const section = container.querySelector<HTMLElement>('[data-diff-file="w:new.ts"]');
     expect(within(section!).getByText("+2")).toBeInTheDocument();
     expect(within(section!).getByText("−0")).toBeInTheDocument();
-    expect(screen.getAllByText("+2").length).toBe(2);
+    // Awaited, not asserted outright: the page total is not measured here but
+    // reported up by the section that measured it, so it lands a render after
+    // the section's own number and after the merge view this test waited for.
+    await waitFor(() => expect(screen.getAllByText("+2").length).toBe(2));
   });
 
   it("folds a file that changes more lines than the page can carry", async () => {

--- a/src/modules/diff/lib/parseDiffStats.ts
+++ b/src/modules/diff/lib/parseDiffStats.ts
@@ -8,6 +8,7 @@
  * comparison itself is built from two full documents, the same way the
  * single-file tab does it. This is only the scan.
  */
+import { diffHeaderPath, stripGitPathSide } from "@/lib/gitPath";
 
 /** Where one hunk sits, and how tall it reads. */
 export interface DiffHunk {
@@ -27,91 +28,6 @@ export interface FileDiffStats {
 
 const HUNK = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
 
-/** C-style escapes git may use inside a quoted path. */
-const SIMPLE_ESCAPES: Record<string, string> = {
-  a: "\x07",
-  b: "\b",
-  t: "\t",
-  n: "\n",
-  v: "\v",
-  f: "\f",
-  r: "\r",
-  "\\": "\\",
-  '"': '"',
-};
-
-/**
- * Unquote a path git wrote with `core.quotePath` on. Git emits non-ASCII
- * UTF-8 bytes as three-digit octal escapes, so decode those bytes together
- * rather than leaving them in the repo-relative lookup key.
- */
-function unquote(path: string): string {
-  if (!path.startsWith('"') || !path.endsWith('"')) {
-    return path;
-  }
-  const body = path.slice(1, -1);
-  const output: string[] = [];
-  const octalBytes: number[] = [];
-  const flushOctalBytes = () => {
-    if (octalBytes.length > 0) {
-      output.push(new TextDecoder("utf-8").decode(new Uint8Array(octalBytes)));
-      octalBytes.length = 0;
-    }
-  };
-
-  for (let i = 0; i < body.length; i += 1) {
-    if (body[i] !== "\\") {
-      flushOctalBytes();
-      output.push(body[i]);
-      continue;
-    }
-
-    const escaped = body[i + 1];
-    if (escaped === undefined) {
-      flushOctalBytes();
-      output.push("\\");
-      continue;
-    }
-
-    if (/^[0-7]$/.test(escaped)) {
-      const octal = body.slice(i + 1, i + 4).match(/^[0-7]{1,3}/)?.[0];
-      if (octal) {
-        octalBytes.push(Number.parseInt(octal, 8));
-        i += octal.length;
-        continue;
-      }
-    }
-
-    flushOctalBytes();
-    output.push(SIMPLE_ESCAPES[escaped] ?? escaped);
-    i += 1;
-  }
-
-  flushOctalBytes();
-  return output.join("");
-}
-
-/** Drop the a/ or b/ git puts in front of a path, quotes stripped first. */
-function stripSide(target: string, side: "a/" | "b/"): string {
-  const bare = unquote(target);
-  return bare.startsWith(side) ? bare.slice(2) : bare;
-}
-
-/**
- * The new-side path out of a `diff --git a/x b/x` header. Both halves carry
- * the same name for everything but a rename, and a path holding " b/" would
- * fool the split — but this is only the provisional key, overwritten by the
- * file's own `+++ b/` line whenever the diff has one (everything except a
- * binary file).
- */
-function headerPath(line: string): string | null {
-  const rest = line.slice("diff --git ".length);
-  const split = Math.max(rest.lastIndexOf(' "b/'), rest.lastIndexOf(" b/"));
-  if (split < 0) {
-    return null;
-  }
-  return stripSide(rest.slice(split + 1).trim(), "b/");
-}
 
 /**
  * Split one `git diff` into per-file stats, keyed by repo-relative path with
@@ -162,7 +78,7 @@ export function parseDiffStats(diff: string): Map<string, FileDiffStats> {
     inHunk = false;
     if (line.startsWith("diff --git ")) {
       flush();
-      path = headerPath(line);
+      path = diffHeaderPath(line);
       stats = { added: 0, deleted: 0, binary: false, hunks: [] };
       continue;
     }
@@ -174,7 +90,7 @@ export function parseDiffStats(diff: string): Map<string, FileDiffStats> {
     if (line.startsWith("+++ ")) {
       const target = line.slice(4).trim();
       if (target !== "/dev/null") {
-        path = stripSide(target, "b/");
+        path = stripGitPathSide(target, "b/");
       }
       continue;
     }
@@ -185,7 +101,7 @@ export function parseDiffStats(diff: string): Map<string, FileDiffStats> {
       }
       // Only used when the new side turns out to be /dev/null; the +++ line
       // below overwrites it otherwise.
-      path = stripSide(target, "a/");
+      path = stripGitPathSide(target, "a/");
       continue;
     }
     if (line.startsWith("Binary files ") || line.startsWith("GIT binary patch")) {

--- a/src/modules/git-graph/CommitDetailsPanel.test.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.test.tsx
@@ -262,7 +262,11 @@ describe("CommitDetailsPanel compare mode", () => {
 describe("CommitDetailsPanel working-tree mode", () => {
   beforeEach(() => {
     localStorage.clear();
+    // Call history matters here — one test counts how often a side is read —
+    // and this file's mocks are module-level, so they carry over otherwise.
+    vi.mocked(gitDiff).mockClear();
     vi.mocked(gitDiff).mockResolvedValue("");
+    vi.mocked(fsReadFile).mockClear();
     vi.mocked(fsReadFile).mockResolvedValue("");
   });
 
@@ -276,16 +280,20 @@ describe("CommitDetailsPanel working-tree mode", () => {
   };
 
   function renderWorkspace(uncommitted: typeof STATUS | null = STATUS) {
-    render(
+    const ui = (status: typeof STATUS | null) => (
       <CommitDetailsPanel
         repo="/repo"
         selection={{ mode: "workspace" }}
         onClose={() => {}}
-        uncommitted={uncommitted}
+        uncommitted={status}
         headHash="abc1234"
         labels={LABELS}
-      />,
+      />
     );
+    const view = render(ui(uncommitted));
+    return {
+      rerender: (status: typeof STATUS | null) => view.rerender(ui(status)),
+    };
   }
 
   it("splits the files into staged and unstaged groups", async () => {
@@ -336,5 +344,70 @@ describe("CommitDetailsPanel working-tree mode", () => {
     renderWorkspace();
     fireEvent.click(await screen.findByText("src/b.ts"));
     await waitFor(() => expect(gitDiff).toHaveBeenCalledWith("/repo", false));
+  });
+
+  const THREE_UNSTAGED = {
+    branch: "main",
+    staged: [] as typeof STATUS.staged,
+    unstaged: [
+      { path: "src/b.ts", staged: false, status: "M" },
+      { path: "src/c.ts", staged: false, status: "M" },
+      { path: "src/d.ts", staged: false, status: "M" },
+    ],
+  };
+
+  it("reads a side once however many of its files are opened", async () => {
+    // `git_diff` answers for a whole side at a time, so asking again per row
+    // re-runs the subprocess and re-scans the entire diff — a cost that grows
+    // with the repository rather than with the file being read.
+    renderWorkspace(THREE_UNSTAGED);
+    await screen.findByText("src/b.ts");
+    await waitFor(() => expect(gitDiff).toHaveBeenCalledWith("/repo", false));
+    fireEvent.click(screen.getByText("src/c.ts"));
+    fireEvent.click(screen.getByText("src/d.ts"));
+    fireEvent.click(screen.getByText("src/b.ts"));
+    await waitFor(() => expect(screen.getByText("src/b.ts")).toBeInTheDocument());
+    expect(vi.mocked(gitDiff).mock.calls).toHaveLength(1);
+  });
+
+  it("reads each side once, not one read shared between them", async () => {
+    renderWorkspace();
+    await screen.findByText("src/a.ts");
+    await waitFor(() => expect(gitDiff).toHaveBeenCalledWith("/repo", true));
+    fireEvent.click(screen.getByText("src/b.ts"));
+    await waitFor(() => expect(gitDiff).toHaveBeenCalledWith("/repo", false));
+    fireEvent.click(screen.getByText("src/a.ts"));
+    await waitFor(() => expect(screen.getByText("src/a.ts")).toBeInTheDocument());
+    expect(vi.mocked(gitDiff).mock.calls).toHaveLength(2);
+  });
+
+  it("re-reads the diff once the status has been refreshed", async () => {
+    // Held for the life of one status, not for the life of the panel: a commit
+    // or an edit elsewhere has to reach the file the reader is looking at.
+    const { rerender } = renderWorkspace(THREE_UNSTAGED);
+    await screen.findByText("src/b.ts");
+    await waitFor(() => expect(gitDiff).toHaveBeenCalledTimes(1));
+    rerender({ ...THREE_UNSTAGED });
+    fireEvent.click(screen.getByText("src/c.ts"));
+    await waitFor(() => expect(gitDiff).toHaveBeenCalledTimes(2));
+  });
+
+  it("renders the section of a file whose name git had to escape", async () => {
+    // `git diff` escapes a non-ASCII path under `core.quotePath`, while the
+    // path here came from `git_status` via libgit2 and is raw UTF-8.
+    vi.mocked(gitDiff).mockResolvedValue(
+      [
+        'diff --git "a/src/\\344\\270\\255\\346\\226\\207.ts" "b/src/\\344\\270\\255\\346\\226\\207.ts"',
+        "@@ -1 +1 @@",
+        "+新的一行",
+        "",
+      ].join("\n"),
+    );
+    renderWorkspace({
+      branch: "main",
+      staged: [] as typeof STATUS.staged,
+      unstaged: [{ path: "src/中文.ts", staged: false, status: "M" }],
+    });
+    expect(await screen.findByText("+新的一行")).toBeInTheDocument();
   });
 });

--- a/src/modules/git-graph/CommitDetailsPanel.test.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.test.tsx
@@ -8,6 +8,8 @@ import {
   gitCommitRangeFiles,
   gitCommitRangeFileDiff,
 } from "./lib/gitGraphBridge";
+import { gitDiff } from "@/modules/source-control/lib/gitBridge";
+import { fsReadFile } from "@/modules/explorer/lib/fsBridge";
 import type { CommitNode } from "./types";
 
 vi.mock("./lib/gitGraphBridge", () => ({
@@ -15,6 +17,15 @@ vi.mock("./lib/gitGraphBridge", () => ({
   gitCommitFileDiff: vi.fn().mockResolvedValue(""),
   gitCommitRangeFiles: vi.fn(),
   gitCommitRangeFileDiff: vi.fn().mockResolvedValue(""),
+}));
+
+// Only the two calls the working-tree mode makes; the panel takes nothing else
+// from either module at runtime (the rest are types).
+vi.mock("@/modules/source-control/lib/gitBridge", () => ({
+  gitDiff: vi.fn().mockResolvedValue(""),
+}));
+vi.mock("@/modules/explorer/lib/fsBridge", () => ({
+  fsReadFile: vi.fn().mockResolvedValue(""),
 }));
 
 const LABELS = {
@@ -37,6 +48,11 @@ const LABELS = {
   viewFlat: "Flat view",
   expandFolder: (name: string) => `Expand ${name}`,
   collapseFolder: (name: string) => `Collapse ${name}`,
+  uncommittedTitle: "Uncommitted changes",
+  uncommittedClean: "No uncommitted changes",
+  relativeTo: (hash: string) => `against ${hash}`,
+  stagedTitle: "Staged",
+  unstagedTitle: "Unstaged",
 };
 
 const COMMIT: CommitNode = {
@@ -240,5 +256,85 @@ describe("CommitDetailsPanel compare mode", () => {
 
     expect(await screen.findByText("No diff")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "AI Explain" })).not.toBeInTheDocument();
+  });
+});
+
+describe("CommitDetailsPanel working-tree mode", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(gitDiff).mockResolvedValue("");
+    vi.mocked(fsReadFile).mockResolvedValue("");
+  });
+
+  const STATUS = {
+    branch: "main",
+    staged: [{ path: "src/a.ts", staged: true, status: "M" }],
+    unstaged: [
+      { path: "src/b.ts", staged: false, status: "M" },
+      { path: "src/new.ts", staged: false, status: "?" },
+    ],
+  };
+
+  function renderWorkspace(uncommitted: typeof STATUS | null = STATUS) {
+    render(
+      <CommitDetailsPanel
+        repo="/repo"
+        selection={{ mode: "workspace" }}
+        onClose={() => {}}
+        uncommitted={uncommitted}
+        headHash="abc1234"
+        labels={LABELS}
+      />,
+    );
+  }
+
+  it("splits the files into staged and unstaged groups", async () => {
+    renderWorkspace();
+    expect(await screen.findByText("Staged (1)")).toBeInTheDocument();
+    expect(screen.getByText("Unstaged (2)")).toBeInTheDocument();
+    expect(screen.getByText("src/a.ts")).toBeInTheDocument();
+    expect(screen.getByText("src/b.ts")).toBeInTheDocument();
+  });
+
+  it("titles the header and says which commit the changes sit on", async () => {
+    renderWorkspace();
+    // Awaited so the first file's diff load settles inside act(); the header is
+    // already on screen before it.
+    await screen.findByText("Staged (1)");
+    expect(screen.getByText("Uncommitted changes")).toBeInTheDocument();
+    expect(screen.getByText("against abc1234")).toBeInTheDocument();
+  });
+
+  it("has no AI tab — there is no commit to explain", async () => {
+    renderWorkspace();
+    await screen.findByText("Staged (1)");
+    expect(screen.queryByRole("button", { name: "AI Explain" })).not.toBeInTheDocument();
+  });
+
+  it("says the tree is clean rather than showing an empty list", () => {
+    renderWorkspace({ branch: "main", staged: [], unstaged: [] });
+    expect(screen.getByText("No uncommitted changes")).toBeInTheDocument();
+  });
+
+  it("reads an untracked file off disk instead of asking git to diff it", async () => {
+    // `git diff` never mentions an untracked file, so slicing its section would
+    // give nothing and the panel would claim there is no difference.
+    vi.mocked(fsReadFile).mockResolvedValue("fresh\n");
+    renderWorkspace();
+    fireEvent.click(await screen.findByText("src/new.ts"));
+    await waitFor(() => expect(fsReadFile).toHaveBeenCalledWith("/repo/src/new.ts"));
+    expect(await screen.findByText("+fresh")).toBeInTheDocument();
+  });
+
+  it("asks for the staged side when a staged file is picked", async () => {
+    renderWorkspace();
+    await screen.findByText("src/a.ts");
+    await waitFor(() => expect(gitDiff).toHaveBeenCalledWith("/repo", true));
+  });
+
+  it("asks for the unstaged side when an unstaged tracked file is picked", async () => {
+    renderWorkspace();
+    fireEvent.click(await screen.findByText("src/b.ts"));
+    await waitFor(() => expect(gitDiff).toHaveBeenCalledWith("/repo", false));
   });
 });

--- a/src/modules/git-graph/CommitDetailsPanel.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.tsx
@@ -15,7 +15,7 @@ import {
   gitCommitRangeFileDiff,
 } from "./lib/gitGraphBridge";
 import { parseDiffLines } from "./lib/parseDiff";
-import { sliceFileDiff, untrackedDiffLines } from "./lib/uncommittedDiff";
+import { splitFileDiffs, untrackedDiffLines } from "./lib/uncommittedDiff";
 import { useVirtualRows } from "./lib/useVirtualRows";
 import { DiffView } from "./DiffView";
 import { DiffExplain } from "./DiffExplain";
@@ -312,6 +312,48 @@ export function CommitDetailsPanel({
     () => (isWorkspace ? (uncommitted?.unstaged ?? NO_FILES) : NO_FILES),
     [isWorkspace, uncommitted],
   );
+  // One `git diff` per side per status, not per file. The panel renders one
+  // file's section out of a whole-side answer, so reading it per click meant a
+  // subprocess and a full re-scan of the diff for every row the reader touched
+  // — the cost of both grows with the repository, not with the file.
+  //
+  // `uncommitted` is a fresh object on every reload, so its identity is the
+  // generation: a status refresh invalidates this without needing a counter.
+  // Checked where it is read rather than cleared from an effect, so it cannot
+  // depend on the order two effects happen to be declared in.
+  const sideDiffs = useRef<{
+    repo: string;
+    status: GitStatus | null | undefined;
+    sides: Map<boolean, Promise<Map<string, string>>>;
+  }>({ repo: "", status: undefined, sides: new Map() });
+
+  const readSideDiff = useCallback(
+    (staged: boolean): Promise<Map<string, string>> => {
+      const cache = sideDiffs.current;
+      if (cache.repo !== repo || cache.status !== uncommitted) {
+        sideDiffs.current = { repo, status: uncommitted, sides: new Map() };
+      }
+      const { sides } = sideDiffs.current;
+      const cached = sides.get(staged);
+      if (cached) {
+        return cached;
+      }
+      // The promise itself is cached, not its result, so clicks that land while
+      // one is still in flight join it instead of starting another.
+      const pending = gitDiff(repo, staged)
+        .then(splitFileDiffs)
+        .catch((e: unknown) => {
+          // A failure must not outlive its reload: cached, it would leave the
+          // panel empty until the next refresh for one transient error.
+          sides.delete(staged);
+          throw e;
+        });
+      sides.set(staged, pending);
+      return pending;
+    },
+    [repo, uncommitted],
+  );
+
   const [details, setDetails] = useState<CommitDetails | null>(null);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   // Which side of the working tree `selectedFile` was picked from; null outside
@@ -433,7 +475,9 @@ export function CommitDetailsPanel({
           ? fsReadFile(`${repo}/${selectedFile}`).then((contents) =>
               untrackedDiffLines(selectedFile, contents),
             )
-          : gitDiff(repo, side).then((all) => parseDiffLines(sliceFileDiff(all, selectedFile)));
+          : readSideDiff(side).then((byPath) =>
+              parseDiffLines(byPath.get(selectedFile) ?? ""),
+            );
       request
         .then((lines) => {
           if (!cancelled) {
@@ -472,7 +516,7 @@ export function CommitDetailsPanel({
     return () => {
       cancelled = true;
     };
-  }, [repo, selection, selectedFile, selectedStaged, stagedFiles, unstagedFiles]);
+  }, [repo, selection, selectedFile, selectedStaged, stagedFiles, unstagedFiles, readSideDiff]);
 
   // Window the changed-files list inside the left column's single scroll
   // container: the metadata/message header scrolls with it, so the list is

--- a/src/modules/git-graph/CommitDetailsPanel.tsx
+++ b/src/modules/git-graph/CommitDetailsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, FolderTree, List, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Resizer } from "@/components/Resizer";
@@ -6,6 +6,8 @@ import { Tooltip } from "@/components/Tooltip";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 import { buildFileTree, type TreeNode } from "@/lib/fileTree";
 import { useCollapsedPaths } from "@/lib/useCollapsedPaths";
+import { fsReadFile } from "@/modules/explorer/lib/fsBridge";
+import { gitDiff, type FileStatus, type GitStatus } from "@/modules/source-control/lib/gitBridge";
 import {
   gitCommitDetails,
   gitCommitFileDiff,
@@ -13,6 +15,7 @@ import {
   gitCommitRangeFileDiff,
 } from "./lib/gitGraphBridge";
 import { parseDiffLines } from "./lib/parseDiff";
+import { sliceFileDiff, untrackedDiffLines } from "./lib/uncommittedDiff";
 import { useVirtualRows } from "./lib/useVirtualRows";
 import { DiffView } from "./DiffView";
 import { DiffExplain } from "./DiffExplain";
@@ -40,6 +43,14 @@ export interface CommitDetailsLabels {
   /** "Expand {{name}}" / "Collapse {{name}}" — {{name}} is filled by the caller. */
   expandFolder: (name: string) => string;
   collapseFolder: (name: string) => string;
+  /** Header title while the working tree is selected — it has no hash to show. */
+  uncommittedTitle: string;
+  /** Shown in place of the file list when nothing is uncommitted. */
+  uncommittedClean: string;
+  /** "against {{hash}}" — which commit the uncommitted changes sit on top of. */
+  relativeTo: (hash: string) => string;
+  stagedTitle: string;
+  unstagedTitle: string;
 }
 
 interface CommitDetailsPanelProps {
@@ -47,6 +58,14 @@ interface CommitDetailsPanelProps {
   selection: GraphSelection;
   onClose: () => void;
   labels: CommitDetailsLabels;
+  /**
+   * The working tree, for the `workspace` selection. Passed in rather than
+   * fetched here so the row in the graph and this list can never disagree
+   * about how many files are staged — they read the same fetch.
+   */
+  uncommitted?: GitStatus | null;
+  /** Short hash of HEAD, for the "against <hash>" subtitle. */
+  headHash?: string | null;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -57,6 +76,10 @@ const STATUS_COLORS: Record<string, string> = {
   C: "text-accent",
   T: "text-fg-muted",
 };
+
+// Shared empty list so the working-tree arrays keep a stable identity when
+// there is nothing to show; they are effect dependencies.
+const NO_FILES: FileStatus[] = [];
 
 // Fixed row height for the changed-files list, so it can be windowed the same
 // way as the diff. A commit touching thousands of files would otherwise mount
@@ -160,26 +183,149 @@ function DetailsTreeRows({
   );
 }
 
-export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitDetailsPanelProps) {
+/**
+ * One labelled group of working-tree files (staged, or unstaged).
+ *
+ * Deliberately not windowed like the commit path above it. That list is
+ * windowed because a single commit can touch thousands of files; a working tree
+ * holding thousands of uncommitted files is a different situation entirely, and
+ * the Source Control sidebar renders the same data unwindowed. Sharing the
+ * commit path's `useVirtualRows` would have meant one window spanning two
+ * lists, which it is not built for.
+ */
+function WorkspaceFilesGroup({
+  title,
+  side,
+  files,
+  viewMode,
+  collapsed,
+  onToggleCollapse,
+  selectedFile,
+  selectedStaged,
+  onSelectFile,
+  labels,
+}: {
+  title: string;
+  /** Which side this group is: true for staged, false for unstaged. */
+  side: boolean;
+  files: FileStatus[];
+  viewMode: FilesViewMode;
+  collapsed: Set<string>;
+  onToggleCollapse: (path: string) => void;
+  selectedFile: string | null;
+  selectedStaged: boolean | null;
+  onSelectFile: (file: FileStatus) => void;
+  labels: Pick<CommitDetailsLabels, "expandFolder" | "collapseFolder">;
+}) {
+  if (files.length === 0) {
+    return null;
+  }
+  // A path can sit in both groups at once — staged, then edited again — so the
+  // selected row is identified by its side as well as its path.
+  const isSelectedSide = selectedStaged === side;
+  const isPicked = (file: FileStatus): boolean =>
+    isSelectedSide && selectedFile === file.path;
+  return (
+    <div className="mt-2">
+      <div className="text-[13px] font-medium text-fg-subtle">
+        {title} ({files.length})
+      </div>
+      {viewMode === "flat" ? (
+        <div className="mt-0.5">
+          {files.map((f) => (
+            <button
+              key={f.path}
+              type="button"
+              onClick={() => onSelectFile(f)}
+              style={{ height: `${FILE_ROW_HEIGHT}px` }}
+              className={`flex w-full items-center gap-2 rounded px-2 text-left font-mono text-[13px] ${
+                isPicked(f) ? "bg-bg-elevated text-fg" : "text-fg-muted hover:bg-bg-elevated/50"
+              }`}
+            >
+              <span
+                className={`w-3 shrink-0 font-semibold ${STATUS_COLORS[f.status] ?? "text-fg-muted"}`}
+              >
+                {f.status}
+              </span>
+              <span className="truncate">{f.path}</span>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-0.5">
+          <DetailsTreeRows
+            nodes={buildFileTree(files)}
+            depth={0}
+            collapsed={collapsed}
+            onToggleCollapse={onToggleCollapse}
+            selectedFile={isSelectedSide ? selectedFile : null}
+            onSelectFile={(path) => {
+              const picked = files.find((f) => f.path === path);
+              if (picked) {
+                onSelectFile(picked);
+              }
+            }}
+            labels={labels}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CommitDetailsPanel({
+  repo,
+  selection,
+  onClose,
+  labels,
+  uncommitted,
+  headHash,
+}: CommitDetailsPanelProps) {
   const isCompare = selection.mode === "compare";
+  const isWorkspace = selection.mode === "workspace";
   // Non-null only in single mode; used for the author/date/message block and
   // the AI-explain tab, both of which only make sense for one commit.
   const singleCommit = selection.mode === "single" ? selection.commit : null;
   const rangeKey =
-    selection.mode === "single" ? selection.commit.hash : `${selection.from.hash}..${selection.to.hash}`;
+    selection.mode === "single"
+      ? selection.commit.hash
+      : selection.mode === "compare"
+        ? `${selection.from.hash}..${selection.to.hash}`
+        : "workspace";
+  // The working tree has no hash of its own, so its header carries a title and
+  // says which commit it sits on top of instead.
   const headerHash =
-    selection.mode === "single" ? selection.commit.hash : `${selection.from.hash} .. ${selection.to.hash}`;
+    selection.mode === "single"
+      ? selection.commit.hash
+      : selection.mode === "compare"
+        ? `${selection.from.hash} .. ${selection.to.hash}`
+        : labels.uncommittedTitle;
+  // Memoized, and falling back to a shared constant rather than a fresh []:
+  // both arrays are effect dependencies below, and a new identity per render
+  // would re-run the diff loader every render — which sets state, which
+  // renders again.
+  const stagedFiles = useMemo(
+    () => (isWorkspace ? (uncommitted?.staged ?? NO_FILES) : NO_FILES),
+    [isWorkspace, uncommitted],
+  );
+  const unstagedFiles = useMemo(
+    () => (isWorkspace ? (uncommitted?.unstaged ?? NO_FILES) : NO_FILES),
+    [isWorkspace, uncommitted],
+  );
   const [details, setDetails] = useState<CommitDetails | null>(null);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  // Which side of the working tree `selectedFile` was picked from; null outside
+  // workspace mode, where a path identifies a file on its own.
+  const [selectedStaged, setSelectedStaged] = useState<boolean | null>(null);
   const [diffLines, setDiffLines] = useState<DiffLine[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [diffText, setDiffText] = useState("");
   const [tab, setTab] = useState<"diff" | "ai">("diff");
   // `tab` is state, so it can still read "ai" on the render where `selection`
-  // just flipped to compare mode (the effect that resets it to "diff" hasn't
-  // run yet). Fall back to "diff" here so the content below never tries to
-  // render the AI tab (and dereference `singleCommit`) while isCompare.
-  const activeTab = isCompare ? "diff" : tab;
+  // just flipped to compare or workspace mode (the effect that resets it to
+  // "diff" hasn't run yet). Fall back to "diff" here so the content below never
+  // tries to render the AI tab (and dereference `singleCommit`) without one.
+  const activeTab = isCompare || isWorkspace ? "diff" : tab;
   const [filesViewMode, setFilesViewMode] = useState<FilesViewMode>(() =>
     localStorage.getItem(FILES_VIEW_MODE_KEY) === "folder" ? "folder" : "flat",
   );
@@ -218,8 +364,14 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
     setError(null);
     setDetails(null);
     setSelectedFile(null);
+    setSelectedStaged(null);
     setDiffLines([]);
     resetCollapsedFolders();
+    if (selection.mode === "workspace") {
+      // The working tree's files arrive as a prop, already fetched for the row
+      // in the graph. Nothing to load here.
+      return;
+    }
     const request =
       selection.mode === "single"
         ? gitCommitDetails(repo, selection.commit.hash)
@@ -245,6 +397,20 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
     };
   }, [repo, selection, resetCollapsedFolders]);
 
+  // Open the first working-tree file once, when there is one and nothing is
+  // picked yet. Kept out of the loader effect above so a status refresh does
+  // not yank the reader back to the top of the list.
+  useEffect(() => {
+    if (selection.mode !== "workspace" || selectedFile !== null) {
+      return;
+    }
+    const first = stagedFiles[0] ?? unstagedFiles[0];
+    if (first) {
+      setSelectedFile(first.path);
+      setSelectedStaged(first.staged);
+    }
+  }, [selection.mode, selectedFile, stagedFiles, unstagedFiles]);
+
   // Lazily load the selected file's diff (both parsed lines and raw text), and
   // reset to the Diff tab when the file changes.
   useEffect(() => {
@@ -255,6 +421,37 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
       return;
     }
     let cancelled = false;
+    if (selection.mode === "workspace") {
+      const side = selectedStaged === true;
+      const status = (side ? stagedFiles : unstagedFiles).find(
+        (f) => f.path === selectedFile,
+      )?.status;
+      // An untracked file is absent from `git diff` entirely, so its content is
+      // read straight off disk and rendered as one added hunk.
+      const request: Promise<DiffLine[]> =
+        status === "?"
+          ? fsReadFile(`${repo}/${selectedFile}`).then((contents) =>
+              untrackedDiffLines(selectedFile, contents),
+            )
+          : gitDiff(repo, side).then((all) => parseDiffLines(sliceFileDiff(all, selectedFile)));
+      request
+        .then((lines) => {
+          if (!cancelled) {
+            // The AI tab is hidden in workspace mode, so no raw text is needed.
+            setDiffText("");
+            setDiffLines(lines);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setDiffText("");
+            setDiffLines([]);
+          }
+        });
+      return () => {
+        cancelled = true;
+      };
+    }
     const request =
       selection.mode === "single"
         ? gitCommitFileDiff(repo, selection.commit.hash, selectedFile)
@@ -275,7 +472,7 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
     return () => {
       cancelled = true;
     };
-  }, [repo, selection, selectedFile]);
+  }, [repo, selection, selectedFile, selectedStaged, stagedFiles, unstagedFiles]);
 
   // Window the changed-files list inside the left column's single scroll
   // container: the metadata/message header scrolls with it, so the list is
@@ -296,9 +493,18 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
     <div className="flex h-full flex-col overflow-hidden bg-bg">
       <div className="flex items-center justify-between border-b border-border bg-bg-inset px-3 py-1.5">
         <div className="flex items-center gap-2">
-          <span className="select-all font-mono text-xs font-semibold text-accent">
+          <span
+            className={`font-mono text-xs font-semibold text-accent ${
+              isWorkspace ? "" : "select-all"
+            }`}
+          >
             {headerHash}
           </span>
+          {isWorkspace && headHash && (
+            <span className="font-mono text-[11px] text-fg-subtle">
+              {labels.relativeTo(headHash)}
+            </span>
+          )}
           {isCompare && (
             <span className="rounded border border-accent/40 bg-accent/15 px-1.5 py-0.5 text-[11px] font-medium text-accent">
               {labels.compareBadge}
@@ -346,7 +552,9 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
           )}
           <div className="mt-2 flex items-center justify-between text-[13px] font-medium text-fg-subtle">
             <span>
-              {labels.changedFiles} ({details?.files.length ?? 0})
+              {isWorkspace
+                ? `${labels.changedFiles} (${stagedFiles.length + unstagedFiles.length})`
+                : `${labels.changedFiles} (${details?.files.length ?? 0})`}
             </span>
             <Tooltip label={filesViewMode === "flat" ? labels.viewFolder : labels.viewFlat}>
               <button
@@ -359,7 +567,44 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
               </button>
             </Tooltip>
           </div>
-          {details && files.length === 0 ? (
+          {isWorkspace ? (
+            stagedFiles.length + unstagedFiles.length === 0 ? (
+              <div className="mt-1 text-[13px] text-fg-subtle">{labels.uncommittedClean}</div>
+            ) : (
+              <div ref={fileListRef}>
+                <WorkspaceFilesGroup
+                  title={labels.stagedTitle}
+                  side
+                  files={stagedFiles}
+                  viewMode={filesViewMode}
+                  collapsed={collapsedFolders}
+                  onToggleCollapse={toggleDetailsFolder}
+                  selectedFile={selectedFile}
+                  selectedStaged={selectedStaged}
+                  onSelectFile={(f) => {
+                    setSelectedFile(f.path);
+                    setSelectedStaged(f.staged);
+                  }}
+                  labels={labels}
+                />
+                <WorkspaceFilesGroup
+                  title={labels.unstagedTitle}
+                  side={false}
+                  files={unstagedFiles}
+                  viewMode={filesViewMode}
+                  collapsed={collapsedFolders}
+                  onToggleCollapse={toggleDetailsFolder}
+                  selectedFile={selectedFile}
+                  selectedStaged={selectedStaged}
+                  onSelectFile={(f) => {
+                    setSelectedFile(f.path);
+                    setSelectedStaged(f.staged);
+                  }}
+                  labels={labels}
+                />
+              </div>
+            )
+          ) : details && files.length === 0 ? (
             <div className="mt-1 text-[13px] text-fg-subtle">{labels.noChanges}</div>
           ) : filesViewMode === "flat" ? (
             <div
@@ -429,7 +674,7 @@ export function CommitDetailsPanel({ repo, selection, onClose, labels }: CommitD
                 >
                   {labels.diffTab}
                 </button>
-                {!isCompare && (
+                {!isCompare && !isWorkspace && (
                   <button
                     type="button"
                     onClick={() => setTab("ai")}

--- a/src/modules/git-graph/GitGraph.test.tsx
+++ b/src/modules/git-graph/GitGraph.test.tsx
@@ -551,9 +551,8 @@ describe("GitGraph working-tree row keyboard navigation", () => {
     expect(onSelectCommit).toHaveBeenCalledWith(commits[0], { shiftKey: false });
   });
 
-  it("ignores ArrowUp and the Shift combos on the working-tree row", () => {
-    // There is no row above it, and the Shift keys walk commit ancestry, which
-    // the working tree is not part of.
+  it("ignores ArrowUp and Shift+ArrowUp on the working-tree row", () => {
+    // Nothing sits above it, and Shift+Up has no line to follow from there.
     const onSelectCommit = vi.fn();
     render(
       <GitGraph
@@ -567,8 +566,95 @@ describe("GitGraph working-tree row keyboard navigation", () => {
     );
     const scroller = container("msg c");
     fireEvent.keyDown(scroller, { key: "ArrowUp" });
-    fireEvent.keyDown(scroller, { key: "ArrowDown", shiftKey: true });
     fireEvent.keyDown(scroller, { key: "ArrowUp", shiftKey: true });
     expect(onSelectCommit).not.toHaveBeenCalled();
+  });
+
+  describe("following the dashed segment", () => {
+    // HEAD is the second row: another branch has a newer commit, so the row
+    // below the working tree and the commit its line runs to are different.
+    const head = commit("head", [], "msg head");
+    head.refs = [{ name: "master", kind: "head" }];
+    const withHead = [commit("newer", ["head"], "msg newer"), head];
+
+    it("Shift+ArrowDown goes to HEAD, not to the row underneath", () => {
+      const onSelectCommit = vi.fn();
+      render(
+        <GitGraph
+          commits={withHead}
+          selection={{ mode: "workspace" }}
+          onSelectCommit={onSelectCommit}
+          onSelectWorkspace={vi.fn()}
+          uncommitted={{ staged: 1, unstaged: 0 }}
+          labels={ROW_LABELS}
+        />,
+      );
+      fireEvent.keyDown(container("msg newer"), { key: "ArrowDown", shiftKey: true });
+      expect(onSelectCommit).toHaveBeenCalledWith(head, { shiftKey: false });
+    });
+
+    it("plain ArrowDown still moves by row", () => {
+      const onSelectCommit = vi.fn();
+      render(
+        <GitGraph
+          commits={withHead}
+          selection={{ mode: "workspace" }}
+          onSelectCommit={onSelectCommit}
+          onSelectWorkspace={vi.fn()}
+          uncommitted={{ staged: 1, unstaged: 0 }}
+          labels={ROW_LABELS}
+        />,
+      );
+      fireEvent.keyDown(container("msg newer"), { key: "ArrowDown" });
+      expect(onSelectCommit).toHaveBeenCalledWith(withHead[0], { shiftKey: false });
+    });
+
+    it("Shift+ArrowUp from HEAD follows the segment back to the row", () => {
+      const onSelectWorkspace = vi.fn();
+      render(
+        <GitGraph
+          commits={withHead}
+          selection={{ mode: "single", commit: head }}
+          onSelectCommit={vi.fn()}
+          onSelectWorkspace={onSelectWorkspace}
+          uncommitted={{ staged: 1, unstaged: 0 }}
+          labels={ROW_LABELS}
+        />,
+      );
+      fireEvent.keyDown(container("msg newer"), { key: "ArrowUp", shiftKey: true });
+      expect(onSelectWorkspace).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not follow it from a commit that is not HEAD", () => {
+      const onSelectWorkspace = vi.fn();
+      render(
+        <GitGraph
+          commits={withHead}
+          selection={{ mode: "single", commit: withHead[0] }}
+          onSelectCommit={vi.fn()}
+          onSelectWorkspace={onSelectWorkspace}
+          uncommitted={{ staged: 1, unstaged: 0 }}
+          labels={ROW_LABELS}
+        />,
+      );
+      fireEvent.keyDown(container("msg newer"), { key: "ArrowUp", shiftKey: true });
+      expect(onSelectWorkspace).not.toHaveBeenCalled();
+    });
+
+    it("does not follow it when the row is switched off", () => {
+      const onSelectWorkspace = vi.fn();
+      render(
+        <GitGraph
+          commits={withHead}
+          selection={{ mode: "single", commit: head }}
+          onSelectCommit={vi.fn()}
+          onSelectWorkspace={onSelectWorkspace}
+          uncommitted={null}
+          labels={ROW_LABELS}
+        />,
+      );
+      fireEvent.keyDown(container("msg newer"), { key: "ArrowUp", shiftKey: true });
+      expect(onSelectWorkspace).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/modules/git-graph/GitGraph.test.tsx
+++ b/src/modules/git-graph/GitGraph.test.tsx
@@ -1,8 +1,12 @@
 import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { GitGraph } from "./GitGraph";
+import { DEFAULT_GEOMETRY, laneX } from "./lib/graphLayout";
 import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore";
 import type { CommitNode } from "./types";
+
+/** Node buttons are positioned by their centre less the radius plus a 2px ring. */
+const NODE_OFFSET = 8;
 
 const LABELS = {
   emptyTitle: "No commits",
@@ -361,5 +365,210 @@ describe("GitGraph compare-mode highlighting", () => {
     const rowB = screen.getByText("msg b").closest("div[class*='absolute']");
     expect(rowC!.className).toContain("border-border-strong");
     expect(rowB!.className).toContain("border-border-strong");
+  });
+});
+
+describe("GitGraph working-tree row", () => {
+  const commits = [commit("c", ["b"], "msg c"), commit("b", [], "msg b")];
+
+  const ROW_LABELS = {
+    emptyTitle: "No commits",
+    emptyHint: "",
+    loadMore: "Load more",
+    refHint: "{{name}}",
+    uncommittedTitle: "Uncommitted changes",
+    uncommittedClean: "No uncommitted changes",
+    uncommittedSummary: (staged: number, unstaged: number) =>
+      `${staged} staged · ${unstaged} unstaged`,
+  } as never;
+
+  function renderRow(
+    props: Partial<Parameters<typeof GitGraph>[0]> = {},
+  ): Record<string, ReturnType<typeof vi.fn>> {
+    const onSelectCommit = vi.fn();
+    const onSelectWorkspace = vi.fn();
+    const onWorkspaceContextMenu = vi.fn();
+    render(
+      <GitGraph
+        commits={commits}
+        selection={null}
+        onSelectCommit={onSelectCommit}
+        onSelectWorkspace={onSelectWorkspace}
+        onWorkspaceContextMenu={onWorkspaceContextMenu}
+        uncommitted={{ staged: 3, unstaged: 4 }}
+        labels={ROW_LABELS}
+        {...props}
+      />,
+    );
+    return { onSelectCommit, onSelectWorkspace, onWorkspaceContextMenu };
+  }
+
+  it("is left out entirely when the setting is off", () => {
+    renderRow({ uncommitted: null });
+    expect(screen.queryByText("Uncommitted changes")).not.toBeInTheDocument();
+    expect(screen.queryByText("No uncommitted changes")).not.toBeInTheDocument();
+  });
+
+  it("puts the lanes back exactly when the setting is off", () => {
+    // HEAD taking the leftmost lane exists to serve the dashed segment, so it
+    // has to go when the row does — switching a feature off cannot leave every
+    // branch shifted sideways.
+    const head = commit("head", [], "msg head");
+    head.refs = [{ name: "master", kind: "head" }];
+    const withHead = [commit("newer", ["head"], "msg newer"), head];
+    // Node buttons carry their left offset inline; the working tree's is the
+    // only one with an accessible name, so the commits are the rest.
+    const commitNodeLefts = (): string[] =>
+      Array.from(document.querySelectorAll<HTMLElement>("button[class*='rounded-full']"))
+        .filter((n) => n.getAttribute("aria-label") !== "Uncommitted changes")
+        .map((n) => n.style.left);
+    const lane0 = `${laneX(0, DEFAULT_GEOMETRY) - NODE_OFFSET}px`;
+
+    const { unmount } = render(
+      <GitGraph
+        commits={withHead}
+        selection={null}
+        onSelectCommit={vi.fn()}
+        uncommitted={null}
+        labels={ROW_LABELS}
+      />,
+    );
+    expect(commitNodeLefts()[0]).toBe(lane0);
+    unmount();
+
+    render(
+      <GitGraph
+        commits={withHead}
+        selection={null}
+        onSelectCommit={vi.fn()}
+        onSelectWorkspace={vi.fn()}
+        uncommitted={{ staged: 0, unstaged: 1 }}
+        labels={ROW_LABELS}
+      />,
+    );
+    // Row on: the newest commit gives the leftmost track up to HEAD.
+    expect(commitNodeLefts()[0]).not.toBe(lane0);
+    expect(screen.getByLabelText("Uncommitted changes").style.left).toBe(lane0);
+  });
+
+  it("shows the counts beside the message, not in the author column", () => {
+    renderRow();
+    const row = screen.getByText("Uncommitted changes").closest("div[class*='absolute']")!;
+    expect(row).toHaveTextContent("3 staged · 4 unstaged");
+    // The author/time column is what tells a reader this is not a commit, so
+    // it has to stay empty.
+    expect(row.querySelectorAll("svg")).toHaveLength(0);
+  });
+
+  it("stays put but goes quiet when the tree is clean", () => {
+    // Not removed: dropping the row the moment the tree went clean would jump
+    // the whole graph up a row on every commit.
+    renderRow({ uncommitted: { staged: 0, unstaged: 0 } });
+    expect(screen.getByText("No uncommitted changes")).toBeInTheDocument();
+    expect(screen.queryByText(/staged ·/)).not.toBeInTheDocument();
+  });
+
+  it("selects the working tree from the row and from its node", () => {
+    const { onSelectWorkspace } = renderRow();
+    fireEvent.click(screen.getByText("Uncommitted changes").closest("div[class*='absolute']")!);
+    expect(onSelectWorkspace).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByLabelText("Uncommitted changes"));
+    expect(onSelectWorkspace).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens its own context menu rather than the commit one", () => {
+    const { onWorkspaceContextMenu, onSelectCommit } = renderRow();
+    const row = screen.getByText("Uncommitted changes").closest("div[class*='absolute']")!;
+    fireEvent.contextMenu(row, { clientX: 40, clientY: 60 });
+    expect(onWorkspaceContextMenu).toHaveBeenCalledWith(40, 60);
+    expect(onSelectCommit).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitGraph working-tree row keyboard navigation", () => {
+  const commits = [commit("c", ["b"], "msg c"), commit("b", [], "msg b")];
+
+  const ROW_LABELS = {
+    emptyTitle: "No commits",
+    emptyHint: "",
+    loadMore: "Load more",
+    refHint: "{{name}}",
+    uncommittedTitle: "Uncommitted changes",
+    uncommittedClean: "No uncommitted changes",
+    uncommittedSummary: () => "",
+  } as never;
+
+  it("ArrowUp from the newest commit steps onto the working-tree row", () => {
+    const onSelectWorkspace = vi.fn();
+    const onSelectCommit = vi.fn();
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: commits[0] }}
+        onSelectCommit={onSelectCommit}
+        onSelectWorkspace={onSelectWorkspace}
+        uncommitted={{ staged: 1, unstaged: 0 }}
+        labels={ROW_LABELS}
+      />,
+    );
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp" });
+    expect(onSelectWorkspace).toHaveBeenCalledTimes(1);
+    expect(onSelectCommit).not.toHaveBeenCalled();
+  });
+
+  it("ArrowUp still clamps at the top when the row is switched off", () => {
+    const onSelectWorkspace = vi.fn();
+    const onSelectCommit = vi.fn();
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "single", commit: commits[0] }}
+        onSelectCommit={onSelectCommit}
+        onSelectWorkspace={onSelectWorkspace}
+        uncommitted={null}
+        labels={ROW_LABELS}
+      />,
+    );
+    fireEvent.keyDown(container("msg c"), { key: "ArrowUp" });
+    expect(onSelectWorkspace).not.toHaveBeenCalled();
+    expect(onSelectCommit).not.toHaveBeenCalled();
+  });
+
+  it("ArrowDown from the working-tree row lands on the newest commit", () => {
+    const onSelectCommit = vi.fn();
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "workspace" }}
+        onSelectCommit={onSelectCommit}
+        onSelectWorkspace={vi.fn()}
+        uncommitted={{ staged: 1, unstaged: 0 }}
+        labels={ROW_LABELS}
+      />,
+    );
+    fireEvent.keyDown(container("msg c"), { key: "ArrowDown" });
+    expect(onSelectCommit).toHaveBeenCalledWith(commits[0], { shiftKey: false });
+  });
+
+  it("ignores ArrowUp and the Shift combos on the working-tree row", () => {
+    // There is no row above it, and the Shift keys walk commit ancestry, which
+    // the working tree is not part of.
+    const onSelectCommit = vi.fn();
+    render(
+      <GitGraph
+        commits={commits}
+        selection={{ mode: "workspace" }}
+        onSelectCommit={onSelectCommit}
+        onSelectWorkspace={vi.fn()}
+        uncommitted={{ staged: 1, unstaged: 0 }}
+        labels={ROW_LABELS}
+      />,
+    );
+    const scroller = container("msg c");
+    fireEvent.keyDown(scroller, { key: "ArrowUp" });
+    fireEvent.keyDown(scroller, { key: "ArrowDown", shiftKey: true });
+    fireEvent.keyDown(scroller, { key: "ArrowUp", shiftKey: true });
+    expect(onSelectCommit).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Clock, GitBranch, User } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
-import type { CommitNode, CommitRef, GraphSelection } from "./types";
+import type {
+  CommitNode,
+  CommitRef,
+  GraphSelection,
+  UncommittedSummary,
+} from "./types";
 import { RefChipStrip } from "./RefChipStrip";
 import { DEFAULT_REF_CHIP_OPTIONS, type RefChipOptions } from "./lib/refChips";
 import {
@@ -10,6 +15,7 @@ import {
   edgePath,
   firstParentRowIndex,
   laneContinuationRowIndex,
+  laneX,
 } from "./lib/graphLayout";
 import { isCurrentCommit } from "./lib/currentCommit";
 import { BRANCH_COLORS } from "./lib/branchColors";
@@ -21,6 +27,12 @@ export interface GitGraphLabels {
   loadMore: string;
   refHint: string;
   moreRefs: string;
+  /** Message on the working-tree row while something is uncommitted. */
+  uncommittedTitle: string;
+  /** Message on the working-tree row while the tree is clean. */
+  uncommittedClean: string;
+  /** "3 staged · 4 unstaged", appended after the title. */
+  uncommittedSummary: (staged: number, unstaged: number) => string;
 }
 
 interface GitGraphProps {
@@ -39,12 +51,35 @@ interface GitGraphProps {
   refChipOptions?: RefChipOptions;
   hasMore?: boolean;
   onLoadMore?: () => void;
+  /**
+   * Counts for the working-tree row above the newest commit. `null` leaves the
+   * row out altogether — that is the setting being off, not a clean tree; a
+   * clean tree is `{ staged: 0, unstaged: 0 }` and still draws a (quiet) row.
+   */
+  uncommitted?: UncommittedSummary | null;
+  onSelectWorkspace?: () => void;
+  onWorkspaceContextMenu?: (x: number, y: number) => void;
   labels: GitGraphLabels;
 }
 
 const NODE_RADIUS = 6;
 const ROW_HEIGHT = DEFAULT_GEOMETRY.rowHeight;
 const PADDING_TOP = DEFAULT_GEOMETRY.paddingTop;
+
+/**
+ * Path from the working-tree node down to HEAD: straight along its own track,
+ * then one bend into HEAD's lane in the final row. Same shape as a branch tail
+ * rejoining a trunk in `edgePath`, kept separate because this one is not an
+ * edge — it has no parent/child to look up and must not take a lane colour.
+ */
+function uncommittedPath(x: number, y: number, headX: number, headY: number): string {
+  if (headX === x) {
+    return `M ${x} ${y} L ${x} ${headY}`;
+  }
+  const bend = Math.min(ROW_HEIGHT, headY - y);
+  const turn = headY - bend;
+  return `M ${x} ${y} L ${x} ${turn} C ${x} ${turn + bend * 0.5}, ${headX} ${headY - bend * 0.5}, ${headX} ${headY}`;
+}
 
 export function GitGraph({
   commits,
@@ -55,6 +90,9 @@ export function GitGraph({
   refChipOptions = DEFAULT_REF_CHIP_OPTIONS,
   hasMore = false,
   onLoadMore,
+  uncommitted = null,
+  onSelectWorkspace,
+  onWorkspaceContextMenu,
   labels,
 }: GitGraphProps) {
   // All hooks run unconditionally before any early return so the hook order
@@ -77,8 +115,32 @@ export function GitGraph({
     return () => observer.disconnect();
   }, []);
 
-  const { layouts, edges } = useMemo(() => computeGraphLayout(commits), [commits]);
+  const showUncommitted = uncommitted !== null;
+  // The working-tree row is made room for by starting the commits one row
+  // lower, rather than by shifting each drawn coordinate. Every y the graph
+  // uses — nodes, rows, edge endpoints, the keyboard's scroll-into-view — comes
+  // out of computeGraphLayout, so moving its origin moves all of them at once
+  // and the row itself stays outside the lane and colour bookkeeping.
+  const rowOffset = showUncommitted ? ROW_HEIGHT : 0;
+  const geometry = useMemo(
+    () => ({ ...DEFAULT_GEOMETRY, paddingTop: PADDING_TOP + rowOffset }),
+    [rowOffset],
+  );
+  // HEAD takes the leftmost lane, so the working tree's dashed segment runs
+  // straight down that lane into it and the branches that only happen to be
+  // newer bend out to the right instead.
+  //
+  // Only while the row is drawn. The reordering exists to serve that segment,
+  // and switching the row off has to put the graph back exactly as it was —
+  // otherwise turning a feature off still leaves every lane moved.
+  const headHash = useMemo(() => commits.find(isCurrentCommit)?.hash, [commits]);
+  const layoutHead = showUncommitted ? headHash : undefined;
+  const { layouts, edges } = useMemo(
+    () => computeGraphLayout(commits, geometry, layoutHead),
+    [commits, geometry, layoutHead],
+  );
 
+  const isWorkspaceSelected = selection?.mode === "workspace";
   const activeHash =
     selection?.mode === "single"
       ? selection.commit.hash
@@ -108,7 +170,23 @@ export function GitGraph({
   }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
-    if (commits.length === 0 || !activeHash) {
+    if (commits.length === 0) {
+      return;
+    }
+    // The working-tree row is stepped on and off by position, not by the hash
+    // walk below: it has no hash, so `commits.findIndex` would answer -1 for it
+    // and every arrow key would fall through and do nothing. Its only exit is
+    // down onto the newest commit — there is no row above it, and the Shift
+    // combos (walk to first parent, follow a lane) are about commit ancestry,
+    // which the working tree has no place in.
+    if (isWorkspaceSelected) {
+      if (event.key === "ArrowDown" && !event.shiftKey) {
+        event.preventDefault();
+        onSelectCommit(commits[0], { shiftKey: false });
+      }
+      return;
+    }
+    if (!activeHash) {
       return;
     }
     const currentIndex = commits.findIndex((c) => c.hash === activeHash);
@@ -127,6 +205,12 @@ export function GitGraph({
       }
     } else if (event.key === "ArrowUp" && !event.shiftKey) {
       event.preventDefault();
+      // Off the top of the commits and onto the working-tree row, when it is
+      // drawn. Without this the selection would just stick at index 0.
+      if (currentIndex === 0 && showUncommitted && onSelectWorkspace) {
+        onSelectWorkspace();
+        return;
+      }
       const targetIndex = Math.max(currentIndex - 1, 0);
       if (targetIndex !== currentIndex || isComparing) {
         onSelectCommit(commits[targetIndex], { shiftKey: false });
@@ -194,16 +278,40 @@ export function GitGraph({
     }
   }, [activeHash, layouts]);
 
-  const svgHeight = commits.length * ROW_HEIGHT + PADDING_TOP * 2 - 20;
+  // Stepping onto the working-tree row brings it into view. It lives above the
+  // first commit, so that is simply the top; the hash-keyed effect above can't
+  // do this one because the row has no hash to key on.
+  useEffect(() => {
+    if (isWorkspaceSelected && scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
+  }, [isWorkspaceSelected]);
+
+  const svgHeight = commits.length * ROW_HEIGHT + rowOffset + PADDING_TOP * 2 - 20;
+  // Commit `i` is drawn at PADDING_TOP + rowOffset + i * ROW_HEIGHT, so the
+  // offset comes back out before scroll position is turned into an index.
   const visibleStart = Math.max(
     0,
-    Math.floor((viewport.scrollTop - PADDING_TOP) / ROW_HEIGHT) - 12,
+    Math.floor((viewport.scrollTop - PADDING_TOP - rowOffset) / ROW_HEIGHT) - 12,
   );
   const visibleEnd = Math.min(
     commits.length,
-    Math.ceil((viewport.scrollTop + viewport.height + PADDING_TOP) / ROW_HEIGHT) + 12,
+    Math.ceil((viewport.scrollTop + viewport.height + PADDING_TOP - rowOffset) / ROW_HEIGHT) + 12,
   );
   const visibleCommits = commits.slice(visibleStart, visibleEnd);
+
+  // The dashed segment runs down to HEAD, which is what uncommitted changes are
+  // relative to — not necessarily the first row, since the graph can show newer
+  // commits from other branches above it. The node sits in HEAD's own lane, so
+  // the segment is a straight vertical line down that lane and passes behind
+  // any node on the way exactly as every other lane line already does (nodes
+  // are z-10, the tracks z-[1]).
+  const headLayout = headHash ? layouts[headHash] : undefined;
+  // Directly above HEAD, which now owns the leftmost lane; lane 0 is the
+  // fallback for a page that does not contain HEAD at all.
+  const uncommittedX = headLayout?.x ?? laneX(0, geometry);
+  const uncommittedY = PADDING_TOP;
+  const isDirty = uncommitted !== null && uncommitted.staged + uncommitted.unstaged > 0;
 
   if (commits.length === 0) {
     return (
@@ -262,7 +370,57 @@ export function GitGraph({
                   />
                 );
               })}
+              {/* Working tree → HEAD. Dashed and in the accent rather than a
+                  lane colour, so it reads as "not history yet": straight down
+                  its own track, then bending into HEAD in the last row. Drawn
+                  after the lane lines so the bend, which crosses into HEAD's
+                  lane, stays visible over the solid line already there. */}
+              {showUncommitted && headLayout && (
+                <path
+                  d={uncommittedPath(uncommittedX, uncommittedY, headLayout.x, headLayout.y)}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeDasharray="3 4"
+                  className={isDirty ? "text-accent opacity-70" : "text-fg-subtle opacity-40"}
+                />
+              )}
             </svg>
+
+            {/* Working-tree node: hollow with a dashed ring, so it cannot be
+                mistaken for either of the filled kinds — HEAD (accent + glow)
+                or a commit (its lane's colour). */}
+            {showUncommitted && (
+              <Tooltip label={labels.uncommittedTitle}>
+                <button
+                  type="button"
+                  aria-label={labels.uncommittedTitle}
+                  onClick={() => {
+                    scrollRef.current?.focus();
+                    onSelectWorkspace?.();
+                  }}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    onWorkspaceContextMenu?.(e.clientX, e.clientY);
+                  }}
+                  style={{
+                    left: `${uncommittedX - NODE_RADIUS - 2}px`,
+                    top: `${uncommittedY - NODE_RADIUS - 2}px`,
+                    width: `${(NODE_RADIUS + 2) * 2}px`,
+                    height: `${(NODE_RADIUS + 2) * 2}px`,
+                  }}
+                  className={`absolute z-10 flex items-center justify-center rounded-full transition-all focus:outline-none ${
+                    isWorkspaceSelected ? "scale-125 ring-4 ring-accent/30" : "hover:scale-110"
+                  }`}
+                >
+                  <span
+                    className={`h-3 w-3 rounded-full border-2 border-dashed bg-bg ${
+                      isDirty ? "border-accent" : "border-fg-subtle opacity-60"
+                    }`}
+                  />
+                </button>
+              </Tooltip>
+            )}
 
             {/* Commit nodes positioned over the SVG */}
             {visibleCommits.map((commit) => {
@@ -310,6 +468,53 @@ export function GitGraph({
 
           {/* Commit rows aligned with their node y */}
           <div className="flex-1 pr-4">
+            {showUncommitted && (
+              <div
+                onClick={() => {
+                  scrollRef.current?.focus();
+                  onSelectWorkspace?.();
+                }}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  onWorkspaceContextMenu?.(e.clientX, e.clientY);
+                }}
+                style={{
+                  height: `${ROW_HEIGHT}px`,
+                  top: `${uncommittedY - ROW_HEIGHT / 2}px`,
+                }}
+                className={`absolute left-0 right-4 flex cursor-pointer items-center justify-between rounded border py-1 pl-[112px] pr-3 transition-all ${
+                  isWorkspaceSelected
+                    ? "border-border-strong bg-bg-elevated/60 text-fg shadow-sm"
+                    : "border-transparent text-fg-muted hover:bg-bg-elevated/40 hover:text-fg"
+                }`}
+              >
+                <div className="flex items-center space-x-3 overflow-hidden pr-2">
+                  {/* Placeholder in the hash column, dimmed and the same width,
+                      so the columns still line up down the whole list. */}
+                  <span className="font-mono text-xs font-semibold text-fg-subtle opacity-50">
+                    •••••••
+                  </span>
+                  <span
+                    className={`truncate font-sans text-[13px] font-medium ${
+                      isDirty ? "text-fg" : "text-fg-subtle"
+                    }`}
+                  >
+                    {isDirty ? labels.uncommittedTitle : labels.uncommittedClean}
+                  </span>
+                  {/* Counts sit right after the message, not out in the
+                      author/time column: that column belongs to things the
+                      working tree does not have, and numbers parked at the far
+                      end of a wide row read as unrelated to their label. */}
+                  {isDirty && uncommitted && (
+                    <span className="shrink-0 font-mono text-[11px] text-fg-muted">
+                      {labels.uncommittedSummary(uncommitted.staged, uncommitted.unstaged)}
+                    </span>
+                  )}
+                </div>
+                {/* The author/time column stays empty — the cheapest signal
+                    there is that this row is not a commit. */}
+              </div>
+            )}
             {visibleCommits.map((commit) => {
               const layout = layouts[commit.hash];
               if (!layout) {

--- a/src/modules/git-graph/GitGraph.tsx
+++ b/src/modules/git-graph/GitGraph.tsx
@@ -175,15 +175,29 @@ export function GitGraph({
     }
     // The working-tree row is stepped on and off by position, not by the hash
     // walk below: it has no hash, so `commits.findIndex` would answer -1 for it
-    // and every arrow key would fall through and do nothing. Its only exit is
-    // down onto the newest commit — there is no row above it, and the Shift
-    // combos (walk to first parent, follow a lane) are about commit ancestry,
-    // which the working tree has no place in.
+    // and every arrow key would fall through and do nothing.
+    //
+    // Plain arrows move by row, Shift follows the line. So a plain Down lands
+    // on the row underneath — the newest commit — while Shift+Down follows the
+    // dashed segment to HEAD, which is what the working tree actually sits on
+    // and where that segment is drawn to. Those are the same row in the common
+    // case and different ones as soon as another branch has newer commits;
+    // taking the keyboard down to the newest commit while the line clearly ran
+    // somewhere else was the graph and the keys telling different stories.
     if (isWorkspaceSelected) {
       if (event.key === "ArrowDown" && !event.shiftKey) {
         event.preventDefault();
         onSelectCommit(commits[0], { shiftKey: false });
+        return;
       }
+      if (event.key === "ArrowDown" && event.shiftKey) {
+        const head = commits.find(isCurrentCommit);
+        if (head) {
+          event.preventDefault();
+          onSelectCommit(head, { shiftKey: false });
+        }
+      }
+      // Nothing sits above this row, and Shift+Up has no line to follow.
       return;
     }
     if (!activeHash) {
@@ -235,6 +249,15 @@ export function GitGraph({
       const targetIndex = laneContinuationRowIndex(edges, currentIndex);
       if (targetIndex !== null) {
         onSelectCommit(commits[targetIndex], { shiftKey: false });
+      } else if (
+        showUncommitted &&
+        onSelectWorkspace &&
+        commits[currentIndex].hash === headHash
+      ) {
+        // Only the dashed segment continues HEAD's lane upward — no commit
+        // does, since that lane is reserved — and following the line is what
+        // this key means. Checked after a real continuation, never instead.
+        onSelectWorkspace();
       } else if (isComparing) {
         onSelectCommit(commits[currentIndex], { shiftKey: false });
       }

--- a/src/modules/git-graph/GitGraphTabContent.test.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.test.tsx
@@ -9,6 +9,8 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 vi.mock("@/modules/source-control/lib/gitBridge", () => ({
   gitResolveRepo: vi.fn().mockResolvedValue("/repo"),
+  // Read on every reload for the working-tree row's counts.
+  gitStatus: vi.fn().mockResolvedValue({ branch: "main", staged: [], unstaged: [] }),
 }));
 
 vi.mock("./lib/gitGraphBridge", () => ({

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -36,6 +36,7 @@ import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore"
 import { filterCommits } from "./lib/filterCommits";
 import { buildCommitMenu, buildRefMenu, buildWorkingTreeMenu } from "./lib/contextMenuItems";
 import { isCurrentCommit } from "./lib/currentCommit";
+import { uncommittedRowSummary } from "./lib/uncommittedRow";
 import { splitRemoteRef } from "./lib/remoteRef";
 import type { RefChipOptions } from "./lib/refChips";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -86,6 +87,7 @@ export function GitGraphTabContent() {
   const rootPath = useWorkspaceStore((s) => s.rootPath);
   const gitGraphRefs = useSettingsStore((s) => s.gitGraphRefs);
   const showUncommittedRow = useSettingsStore((s) => s.gitGraphUncommittedRow);
+  const keepRowWhenClean = useSettingsStore((s) => s.gitGraphUncommittedWhenClean);
 
   const [repo, setRepo] = useState<string | null>(null);
   const [resolved, setResolved] = useState(false);
@@ -494,12 +496,13 @@ export function GitGraphTabContent() {
       t("uncommitted.summary", { staged, unstaged }),
   };
 
-  // `null` means the row is switched off. A clean tree still gets a row, just a
-  // quiet one — dropping it whenever the tree went clean would jump the whole
-  // graph up one row on every commit, right under the pointer.
-  const uncommittedSummary: UncommittedSummary | null = showUncommittedRow
-    ? { staged: status?.staged.length ?? 0, unstaged: status?.unstaged.length ?? 0 }
-    : null;
+  // `null` means no row at all — either the feature is off, or the tree is
+  // clean and the reader asked not to keep a row for that.
+  const uncommittedSummary: UncommittedSummary | null = uncommittedRowSummary(
+    status,
+    showUncommittedRow,
+    keepRowWhenClean,
+  );
   // Which commit the uncommitted changes sit on top of. Found by its ref rather
   // than assumed to be the first row: a branch filter or a detached HEAD can
   // leave HEAD further down the list, or off it entirely.

--- a/src/modules/git-graph/GitGraphTabContent.tsx
+++ b/src/modules/git-graph/GitGraphTabContent.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { GitCommit } from "lucide-react";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import { Resizer } from "@/components/Resizer";
-import { gitResolveRepo } from "@/modules/source-control/lib/gitBridge";
+import { gitResolveRepo, gitStatus, type GitStatus } from "@/modules/source-control/lib/gitBridge";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useTabsStore } from "@/stores/tabsStore";
 import { useUiStore } from "@/stores/uiStore";
@@ -34,12 +34,21 @@ import {
 import { GitGraphToolbar, type GitGraphToolbarLabels } from "./GitGraphToolbar";
 import { usePendingGraphSelectionStore } from "./lib/pendingGraphSelectionStore";
 import { filterCommits } from "./lib/filterCommits";
-import { buildCommitMenu, buildRefMenu } from "./lib/contextMenuItems";
+import { buildCommitMenu, buildRefMenu, buildWorkingTreeMenu } from "./lib/contextMenuItems";
+import { isCurrentCommit } from "./lib/currentCommit";
 import { splitRemoteRef } from "./lib/remoteRef";
 import type { RefChipOptions } from "./lib/refChips";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { withMinDuration } from "@/lib/withMinDuration";
-import type { Branch, CommitNode, CommitRef, CommitOrder, GraphOptions, GraphSelection } from "./types";
+import type {
+  Branch,
+  CommitNode,
+  CommitRef,
+  CommitOrder,
+  GraphOptions,
+  GraphSelection,
+  UncommittedSummary,
+} from "./types";
 
 const PAGE_SIZE = 200;
 // Local git reloads finish almost instantly; keep the busy spinner up at least
@@ -48,7 +57,10 @@ const MIN_BUSY_MS = 400;
 
 type MenuTarget =
   | { type: "commit"; commit: CommitNode; x: number; y: number }
-  | { type: "ref"; ref: CommitRef; remotes: CommitRef[]; x: number; y: number };
+  | { type: "ref"; ref: CommitRef; remotes: CommitRef[]; x: number; y: number }
+  // No payload: the working-tree row has neither a hash to copy nor a ref to
+  // act on, which is also why it cannot reuse the commit menu.
+  | { type: "workingTree"; x: number; y: number };
 
 interface ModalState {
   title: string;
@@ -73,12 +85,16 @@ export function GitGraphTabContent() {
   const { t } = useTranslation("gitGraph");
   const rootPath = useWorkspaceStore((s) => s.rootPath);
   const gitGraphRefs = useSettingsStore((s) => s.gitGraphRefs);
+  const showUncommittedRow = useSettingsStore((s) => s.gitGraphUncommittedRow);
 
   const [repo, setRepo] = useState<string | null>(null);
   const [resolved, setResolved] = useState(false);
   const [commits, setCommits] = useState<CommitNode[]>([]);
   const [branches, setBranches] = useState<Branch[]>([]);
   const [worktrees, setWorktrees] = useState<WorktreeItem[]>([]);
+  // The working tree, feeding both the top row's counts and the details
+  // panel's file list — one fetch so the two can never disagree.
+  const [status, setStatus] = useState<GitStatus | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [limit, setLimit] = useState(PAGE_SIZE);
   const [selection, setSelection] = useState<GraphSelection | null>(null);
@@ -127,22 +143,27 @@ export function GitGraphTabContent() {
   const reload = useCallback(
     async (repoPath: string, nextLimit: number, opts: GraphOptions) => {
       try {
-        const [log, branchList, worktreeList] = await Promise.all([
+        const [log, branchList, worktreeList, workingTree] = await Promise.all([
           gitGraphLog(repoPath, nextLimit, opts),
           gitBranches(repoPath),
           // Refetched on every reload so the selector's branch labels track
           // in-app checkouts and `git worktree add/remove` runs in the app's
           // own terminal; a failure just hides the selector.
           gitWorktreeList(repoPath).catch((): WorktreeItem[] => []),
+          // Own catch, like the worktree list: a status walk that fails should
+          // quiet the top row, not blank the whole graph.
+          gitStatus(repoPath).catch((): GitStatus | null => null),
         ]);
         setCommits(log.commits);
         setHasMore(log.hasMore);
         setBranches(branchList);
         setWorktrees(worktreeList);
+        setStatus(workingTree);
       } catch (err: unknown) {
         setCommits([]);
         setBranches([]);
         setWorktrees([]);
+        setStatus(null);
         setHasMore(false);
         setError(getErrorMessage(err));
       }
@@ -467,7 +488,22 @@ export function GitGraphTabContent() {
     loadMore: t("loadMore"),
     refHint: t("refHint"),
     moreRefs: t("moreRefs"),
+    uncommittedTitle: t("uncommitted.title"),
+    uncommittedClean: t("uncommitted.clean"),
+    uncommittedSummary: (staged: number, unstaged: number) =>
+      t("uncommitted.summary", { staged, unstaged }),
   };
+
+  // `null` means the row is switched off. A clean tree still gets a row, just a
+  // quiet one — dropping it whenever the tree went clean would jump the whole
+  // graph up one row on every commit, right under the pointer.
+  const uncommittedSummary: UncommittedSummary | null = showUncommittedRow
+    ? { staged: status?.staged.length ?? 0, unstaged: status?.unstaged.length ?? 0 }
+    : null;
+  // Which commit the uncommitted changes sit on top of. Found by its ref rather
+  // than assumed to be the first row: a branch filter or a detached HEAD can
+  // leave HEAD further down the list, or off it entirely.
+  const headHash = commits.find(isCurrentCommit)?.hash ?? null;
 
   const detailsLabels: CommitDetailsLabels = {
     author: t("details.author"),
@@ -489,6 +525,11 @@ export function GitGraphTabContent() {
     viewFlat: t("details.viewFlat"),
     expandFolder: (name: string) => t("details.expandFolder", { name }),
     collapseFolder: (name: string) => t("details.collapseFolder", { name }),
+    uncommittedTitle: t("uncommitted.title"),
+    uncommittedClean: t("uncommitted.clean"),
+    relativeTo: (hash: string) => t("uncommitted.relativeTo", { hash }),
+    stagedTitle: t("uncommitted.stagedTitle"),
+    unstagedTitle: t("uncommitted.unstagedTitle"),
   };
 
   const openCreateBranchModal = (commit: CommitNode) =>
@@ -557,6 +598,21 @@ export function GitGraphTabContent() {
         onResetHard: () => void runAction(() => gitReset(repo!, commit.hash, "hard")),
         onCopyHash: () => void navigator.clipboard.writeText(commit.hash),
         onCopySubject: () => void navigator.clipboard.writeText(commit.message),
+      },
+    );
+
+  // The working-tree row's menu. "Refresh" reuses the toolbar's own label and
+  // reload rather than introducing a second word (and a second path) for the
+  // same thing.
+  const workingTreeMenuItems = (): ContextMenuItem[] =>
+    buildWorkingTreeMenu(
+      {
+        openSourceControl: t("menu.openInSourceControl"),
+        refresh: t("toolbar.refresh"),
+      },
+      {
+        onOpenSourceControl: () => useUiStore.getState().activatePanel("sourceControl"),
+        onRefresh: () => void runAction(async () => {}),
       },
     );
 
@@ -685,6 +741,9 @@ export function GitGraphTabContent() {
             refChipOptions={refChipOptions}
             hasMore={hasMore}
             onLoadMore={loadMore}
+            uncommitted={uncommittedSummary}
+            onSelectWorkspace={() => setSelection({ mode: "workspace" })}
+            onWorkspaceContextMenu={(x, y) => setMenu({ type: "workingTree", x, y })}
             labels={labels}
           />
         </div>
@@ -702,6 +761,8 @@ export function GitGraphTabContent() {
                 repo={repo}
                 selection={selection}
                 onClose={() => setSelection(null)}
+                uncommitted={status}
+                headHash={headHash}
                 labels={detailsLabels}
               />
             </div>
@@ -714,7 +775,9 @@ export function GitGraphTabContent() {
           const items =
             menu.type === "commit"
               ? commitMenuItems(menu.commit)
-              : refMenuItems(menu.ref, menu.remotes);
+              : menu.type === "ref"
+                ? refMenuItems(menu.ref, menu.remotes)
+                : workingTreeMenuItems();
           // A detached HEAD, a stash and an unknown ref have no applicable
           // actions; skip the menu rather than flashing an empty one.
           if (items.length === 0) {

--- a/src/modules/git-graph/lib/contextMenuItems.test.ts
+++ b/src/modules/git-graph/lib/contextMenuItems.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildCommitMenu,
   buildRefMenu,
+  buildWorkingTreeMenu,
   type CommitMenuActions,
   type CommitMenuLabels,
   type RefMenuActions,
@@ -223,5 +224,35 @@ describe("buildCommitMenu", () => {
     items.find((i) => i.id === "copySubject")?.onSelect();
     expect(actions.onCopyHash).toHaveBeenCalledTimes(1);
     expect(actions.onCopySubject).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("buildWorkingTreeMenu", () => {
+  const labels = { openSourceControl: "Open in Source Control", refresh: "Refresh" };
+
+  it("offers only the two actions the working tree can actually do", () => {
+    // Nothing from the commit menu applies: there is no hash to copy and
+    // nothing to check out. Staging/stashing/discarding all wait on backend
+    // capabilities the app does not have yet.
+    const items = buildWorkingTreeMenu(labels, {
+      onOpenSourceControl: vi.fn(),
+      onRefresh: vi.fn(),
+    });
+    expect(items.map((i) => i.id)).toEqual(["openSourceControl", "refresh"]);
+    expect(items.map((i) => i.label)).toEqual(["Open in Source Control", "Refresh"]);
+    // One group, so no separator is drawn between two items that belong together.
+    expect(new Set(items.map((i) => i.group))).toEqual(new Set([0]));
+    expect(items.some((i) => i.danger)).toBe(false);
+  });
+
+  it("wires each item to its own action", () => {
+    const onOpenSourceControl = vi.fn();
+    const onRefresh = vi.fn();
+    const items = buildWorkingTreeMenu(labels, { onOpenSourceControl, onRefresh });
+    items.find((i) => i.id === "openSourceControl")?.onSelect();
+    expect(onOpenSourceControl).toHaveBeenCalledTimes(1);
+    expect(onRefresh).not.toHaveBeenCalled();
+    items.find((i) => i.id === "refresh")?.onSelect();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/modules/git-graph/lib/contextMenuItems.ts
+++ b/src/modules/git-graph/lib/contextMenuItems.ts
@@ -298,3 +298,46 @@ export function buildRefMenu(
   // Stash and unknown refs have no applicable actions.
   return [];
 }
+
+export interface WorkingTreeMenuLabels {
+  openSourceControl: string;
+  refresh: string;
+}
+
+export interface WorkingTreeMenuActions {
+  onOpenSourceControl: () => void;
+  onRefresh: () => void;
+}
+
+/**
+ * The working-tree row's own menu, deliberately not the commit one: there is no
+ * hash to copy and nothing to check out, so most of that menu would be either
+ * broken or meaningless here.
+ *
+ * Two items in this first version. The obvious further ones each need a
+ * capability the app does not have yet — staging everything wants a batch
+ * stage with a failure policy, stashing wants a stash *push* (only reading
+ * `refs/stash` exists today), and discarding everything wants both a new
+ * command and a decision about untracked files.
+ */
+export function buildWorkingTreeMenu(
+  labels: WorkingTreeMenuLabels,
+  actions: WorkingTreeMenuActions,
+): ContextMenuItem[] {
+  return [
+    {
+      id: "openSourceControl",
+      label: labels.openSourceControl,
+      icon: FolderGit2,
+      group: 0,
+      onSelect: actions.onOpenSourceControl,
+    },
+    {
+      id: "refresh",
+      label: labels.refresh,
+      icon: RotateCcw,
+      group: 0,
+      onSelect: actions.onRefresh,
+    },
+  ];
+}

--- a/src/modules/git-graph/lib/graphLayout.test.ts
+++ b/src/modules/git-graph/lib/graphLayout.test.ts
@@ -284,3 +284,36 @@ describe("laneContinuationRowIndex", () => {
     expect(laneContinuationRowIndex(edges, 2)).toBe(0); // a -> m, straight
   });
 });
+
+describe("computeGraphLayout head lane", () => {
+  // Two branches are newer than the one checked out — the everyday shape when
+  // the graph shows all branches.
+  const commits = [commit("newer", ["head"]), commit("other", ["head"]), commit("head", [])];
+
+  it("gives HEAD the leftmost lane and bends the newer branches out", () => {
+    const { layouts } = computeGraphLayout(commits, DEFAULT_GEOMETRY, "head");
+    expect(layouts["head"].lane).toBe(0);
+    expect(layouts["newer"].lane).toBeGreaterThan(0);
+    expect(layouts["other"].lane).toBeGreaterThan(0);
+  });
+
+  it("leaves the lanes alone when no head is named", () => {
+    // The sidebar's compact graph passes none, and must keep its old shape.
+    const { layouts } = computeGraphLayout(commits, DEFAULT_GEOMETRY);
+    expect(layouts["newer"].lane).toBe(0);
+  });
+
+  it("does not strand a lane on a head outside this page", () => {
+    // A branch filter can hide HEAD entirely; reserving a lane for a hash that
+    // never arrives would leave an empty column down the whole graph.
+    const { layouts } = computeGraphLayout(commits, DEFAULT_GEOMETRY, "not-loaded");
+    expect(layouts["newer"].lane).toBe(0);
+  });
+
+  it("is a no-op when HEAD is already the newest commit", () => {
+    const headFirst = [commit("head", ["old"]), commit("old", [])];
+    const { layouts } = computeGraphLayout(headFirst, DEFAULT_GEOMETRY, "head");
+    expect(layouts["head"].lane).toBe(0);
+    expect(layouts["old"].lane).toBe(0);
+  });
+});

--- a/src/modules/git-graph/lib/graphLayout.ts
+++ b/src/modules/git-graph/lib/graphLayout.ts
@@ -77,6 +77,7 @@ export function laneX(lane: number, geometry: GraphGeometry): number {
 export function computeGraphLayout(
   commits: readonly GraphLayoutCommit[],
   geometry: GraphGeometry = DEFAULT_GEOMETRY,
+  headHash?: string,
 ): GraphLayout {
   const layouts: Record<string, CommitLayout> = {};
 
@@ -131,6 +132,17 @@ export function computeGraphLayout(
     laneColors.push(pickColor());
     return activeLanes.length - 1;
   };
+
+  // Reserve the leftmost lane for HEAD before anything claims it, so the branch
+  // you are on runs down the left edge and the branches that merely have newer
+  // commits bend out to the right. Without this, lane 0 goes to whatever commit
+  // happens to be newest — often another branch entirely — and the line you
+  // most want to follow is the one pushed aside. Only when HEAD is actually in
+  // this page: seeding a hash that never arrives would strand an empty lane.
+  if (headHash && commits.some((c) => c.hash === headHash)) {
+    activeLanes.push(headHash);
+    laneColors.push(pickColor());
+  }
 
   commits.forEach((commit, index) => {
     const y = geometry.paddingTop + index * geometry.rowHeight;

--- a/src/modules/git-graph/lib/uncommittedDiff.test.ts
+++ b/src/modules/git-graph/lib/uncommittedDiff.test.ts
@@ -67,6 +67,38 @@ describe("sliceFileDiff", () => {
     expect(sliceFileDiff(quoted, "src/od d.ts")).toContain("+x");
   });
 
+  it("finds a non-ASCII path git escaped as octal bytes", () => {
+    // `core.quotePath` is on by default, so every CJK filename reaches us as
+    // octal escapes — while the path to look up came from libgit2 and is raw
+    // UTF-8. Matching literally found nothing here, and nothing is what this
+    // function also returns for a file that genuinely did not change, so the
+    // panel said "no difference" for the file in front of you.
+    const escaped = [
+      'diff --git "a/src/\\344\\270\\255\\346\\226\\207.ts" "b/src/\\344\\270\\255\\346\\226\\207.ts"',
+      "index 111..222 100644",
+      "@@ -1 +1 @@",
+      "+新的一行",
+      "",
+    ].join("\n");
+    const out = sliceFileDiff(escaped, "src/中文.ts");
+    expect(out).toContain("+新的一行");
+  });
+
+  it("finds a non-ASCII path in among files that did not need quoting", () => {
+    const mixed = [
+      'diff --git "a/\\346\\227\\245\\346\\234\\254\\350\\252\\236.ts" "b/\\346\\227\\245\\346\\234\\254\\350\\252\\236.ts"',
+      "@@ -1 +1 @@",
+      "+jp",
+      "diff --git a/plain.ts b/plain.ts",
+      "@@ -1 +1 @@",
+      "+plain",
+      "",
+    ].join("\n");
+    expect(sliceFileDiff(mixed, "日本語.ts")).toContain("+jp");
+    expect(sliceFileDiff(mixed, "日本語.ts")).not.toContain("+plain");
+    expect(sliceFileDiff(mixed, "plain.ts")).toContain("+plain");
+  });
+
   it("still finds the header when the line carries a trailing CR", () => {
     // git ends its own header lines with \n, so this should not come from
     // `git_diff` — but a header that misses by one invisible byte returns

--- a/src/modules/git-graph/lib/uncommittedDiff.test.ts
+++ b/src/modules/git-graph/lib/uncommittedDiff.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { sliceFileDiff, untrackedDiffLines } from "./uncommittedDiff";
+
+const TWO_FILES = [
+  "diff --git a/src/a.ts b/src/a.ts",
+  "index 111..222 100644",
+  "--- a/src/a.ts",
+  "+++ b/src/a.ts",
+  "@@ -1,2 +1,2 @@",
+  "-old a",
+  "+new a",
+  "diff --git a/src/b.ts b/src/b.ts",
+  "index 333..444 100644",
+  "--- a/src/b.ts",
+  "+++ b/src/b.ts",
+  "@@ -1 +1 @@",
+  "-old b",
+  "+new b",
+  "",
+].join("\n");
+
+describe("sliceFileDiff", () => {
+  it("cuts the first file's section without bleeding into the next", () => {
+    const out = sliceFileDiff(TWO_FILES, "src/a.ts");
+    expect(out).toBe(
+      [
+        "diff --git a/src/a.ts b/src/a.ts",
+        "index 111..222 100644",
+        "--- a/src/a.ts",
+        "+++ b/src/a.ts",
+        "@@ -1,2 +1,2 @@",
+        "-old a",
+        "+new a",
+        "",
+      ].join("\n"),
+    );
+    expect(out).not.toContain("b.ts");
+  });
+
+  it("cuts the last file's section, which no later header terminates", () => {
+    const out = sliceFileDiff(TWO_FILES, "src/b.ts");
+    expect(out).toContain("+new b");
+    expect(out).not.toContain("a.ts");
+  });
+
+  it("answers empty for a path the diff never mentions", () => {
+    // The honest answer for an untracked file, or one changed on the other
+    // side (staged vs unstaged) than the diff being sliced.
+    expect(sliceFileDiff(TWO_FILES, "src/never.ts")).toBe("");
+    expect(sliceFileDiff("", "src/a.ts")).toBe("");
+    expect(sliceFileDiff(TWO_FILES, "")).toBe("");
+  });
+
+  it("does not match a path that is only a suffix of another", () => {
+    // "a.ts" must not pull out "src/a.ts": the header is matched on the whole
+    // b-side path, not on any trailing fragment of it.
+    expect(sliceFileDiff(TWO_FILES, "a.ts")).toBe("");
+  });
+
+  it("finds a path git had to quote", () => {
+    const quoted = [
+      'diff --git "a/src/od d.ts" "b/src/od d.ts"',
+      "@@ -1 +1 @@",
+      "+x",
+      "",
+    ].join("\n");
+    expect(sliceFileDiff(quoted, "src/od d.ts")).toContain("+x");
+  });
+
+  it("still finds the header when the line carries a trailing CR", () => {
+    // git ends its own header lines with \n, so this should not come from
+    // `git_diff` — but a header that misses by one invisible byte returns
+    // nothing, and nothing looks exactly like "no changes on this side".
+    const crlf = TWO_FILES.split("\n").join("\r\n");
+    const out = sliceFileDiff(crlf, "src/a.ts");
+    expect(out).toContain("+new a");
+    expect(out).not.toContain("b.ts");
+  });
+
+  it("finds a rename under the name the caller knows it by", () => {
+    // The b-side is the new path, which is what the file list shows.
+    const renamed = [
+      "diff --git a/src/old.ts b/src/new.ts",
+      "similarity index 90%",
+      "rename from src/old.ts",
+      "rename to src/new.ts",
+      "",
+    ].join("\n");
+    expect(sliceFileDiff(renamed, "src/new.ts")).toContain("rename to src/new.ts");
+    expect(sliceFileDiff(renamed, "src/old.ts")).toBe("");
+  });
+});
+
+describe("untrackedDiffLines", () => {
+  it("renders the whole file as one added hunk", () => {
+    const lines = untrackedDiffLines("src/new.ts", "one\ntwo\n");
+    expect(lines.map((l) => l.kind)).toEqual(["meta", "meta", "hunk", "add", "add"]);
+    expect(lines[2].text).toBe("@@ -0,0 +1,2 @@");
+    expect(lines.slice(3).map((l) => l.text)).toEqual(["+one", "+two"]);
+  });
+
+  it("does not invent a line for the trailing newline", () => {
+    expect(untrackedDiffLines("a.txt", "only\n").filter((l) => l.kind === "add")).toHaveLength(1);
+  });
+
+  it("handles an empty new file", () => {
+    const lines = untrackedDiffLines("empty.txt", "");
+    expect(lines.filter((l) => l.kind === "add")).toHaveLength(0);
+    expect(lines[2].text).toBe("@@ -0,0 +1,0 @@");
+  });
+});

--- a/src/modules/git-graph/lib/uncommittedDiff.test.ts
+++ b/src/modules/git-graph/lib/uncommittedDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sliceFileDiff, untrackedDiffLines } from "./uncommittedDiff";
+import { sliceFileDiff, splitFileDiffs, untrackedDiffLines } from "./uncommittedDiff";
 
 const TWO_FILES = [
   "diff --git a/src/a.ts b/src/a.ts",
@@ -120,6 +120,95 @@ describe("sliceFileDiff", () => {
     ].join("\n");
     expect(sliceFileDiff(renamed, "src/new.ts")).toContain("rename to src/new.ts");
     expect(sliceFileDiff(renamed, "src/old.ts")).toBe("");
+  });
+});
+
+describe("splitFileDiffs", () => {
+  it("keys every section by its path in one pass", () => {
+    const byPath = splitFileDiffs(TWO_FILES);
+    expect([...byPath.keys()]).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(byPath.get("src/a.ts")).toContain("+new a");
+    expect(byPath.get("src/a.ts")).not.toContain("b.ts");
+    expect(byPath.get("src/b.ts")).toContain("+new b");
+  });
+
+  it("agrees with slicing one file at a time", () => {
+    const byPath = splitFileDiffs(TWO_FILES);
+    for (const path of ["src/a.ts", "src/b.ts"]) {
+      expect(byPath.get(path)).toBe(sliceFileDiff(TWO_FILES, path));
+    }
+  });
+
+  it("prefers the +++ line over the header for a path holding a space", () => {
+    // The header's two halves are split on " b/", which this path contains;
+    // the +++ line names it without that ambiguity.
+    const awkward = [
+      "diff --git a/x b/y.ts b/x b/y.ts",
+      "--- a/x b/y.ts",
+      "+++ b/x b/y.ts",
+      "@@ -1 +1 @@",
+      "+v",
+      "",
+    ].join("\n");
+    expect([...splitFileDiffs(awkward).keys()]).toEqual(["x b/y.ts"]);
+  });
+
+  it("keys a deleted file by its old path, the way git status does", () => {
+    const deleted = [
+      "diff --git a/gone.ts b/gone.ts",
+      "deleted file mode 100644",
+      "--- a/gone.ts",
+      "+++ /dev/null",
+      "@@ -1 +0,0 @@",
+      "-x",
+      "",
+    ].join("\n");
+    expect([...splitFileDiffs(deleted).keys()]).toEqual(["gone.ts"]);
+  });
+
+  it("keys a rename under its new name", () => {
+    const renamed = [
+      "diff --git a/old.ts b/new.ts",
+      "similarity index 90%",
+      "rename from old.ts",
+      "rename to new.ts",
+      "--- a/old.ts",
+      "+++ b/new.ts",
+      "@@ -1 +1 @@",
+      "+v",
+      "",
+    ].join("\n");
+    expect([...splitFileDiffs(renamed).keys()]).toEqual(["new.ts"]);
+  });
+
+  it("keeps a binary file, which has no ---/+++ pair to read", () => {
+    const binary = [
+      "diff --git a/logo.png b/logo.png",
+      "index 111..222 100644",
+      "Binary files a/logo.png and b/logo.png differ",
+      "",
+    ].join("\n");
+    expect([...splitFileDiffs(binary).keys()]).toEqual(["logo.png"]);
+  });
+
+  it("is not derailed by a diff of a diff", () => {
+    // Every line inside a hunk body carries a +/-/space prefix, so the `+++`
+    // and `diff --git` below belong to the content, not to this diff. The
+    // scan for the path stops at the first @@ for exactly this reason.
+    const nested = [
+      "diff --git a/patch.diff b/patch.diff",
+      "--- a/patch.diff",
+      "+++ b/patch.diff",
+      "@@ -1,2 +1,2 @@",
+      "+++ b/somewhere/else.ts",
+      "+@@ -9 +9 @@",
+      "",
+    ].join("\n");
+    expect([...splitFileDiffs(nested).keys()]).toEqual(["patch.diff"]);
+  });
+
+  it("answers an empty map for an empty diff", () => {
+    expect(splitFileDiffs("").size).toBe(0);
   });
 });
 

--- a/src/modules/git-graph/lib/uncommittedDiff.ts
+++ b/src/modules/git-graph/lib/uncommittedDiff.ts
@@ -1,0 +1,72 @@
+import type { DiffLine } from "../types";
+
+/**
+ * Pull one file's section out of a multi-file unified diff.
+ *
+ * `git_diff` answers for a whole side of the working tree at once — there is no
+ * per-file working-tree diff command, and the details panel renders parsed
+ * unified-diff text rather than the two file contents the diff *tab* compares.
+ * So the file is cut out here instead of asking git again per row.
+ *
+ * Returns "" when the file has no section, which is the honest answer for a
+ * path git reports as changed on the other side (staged vs unstaged) or for an
+ * untracked file — `git diff` never mentions those. See `untrackedDiffLines`.
+ */
+export function sliceFileDiff(diff: string, path: string): string {
+  if (diff === "" || path === "") {
+    return "";
+  }
+  const lines = diff.split("\n");
+  // git writes the header as `diff --git a/<old> b/<new>`, quoting the path
+  // when it holds characters that need escaping. Match on the b-side so a
+  // rename is found under the name the caller knows it by, and accept either
+  // the bare or the quoted form.
+  //
+  // A trailing \r is tolerated. git terminates its own header lines with \n, so
+  // this should not arise from `git_diff` — but a header that misses by one
+  // invisible byte returns nothing, and nothing is indistinguishable from "this
+  // file genuinely has no changes on this side". Not worth leaving a silently
+  // empty panel to that.
+  const withoutCr = (line: string): string =>
+    line.endsWith("\r") ? line.slice(0, -1) : line;
+  const isHeaderFor = (line: string): boolean => {
+    const bare = withoutCr(line);
+    return (
+      bare.startsWith("diff --git ") &&
+      (bare.endsWith(` b/${path}`) || bare.endsWith(` "b/${path}"`))
+    );
+  };
+
+  const start = lines.findIndex(isHeaderFor);
+  if (start === -1) {
+    return "";
+  }
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i].startsWith("diff --git ")) {
+      end = i;
+      break;
+    }
+  }
+  const section = lines.slice(start, end).join("\n");
+  return section === "" ? "" : `${section}\n`;
+}
+
+/**
+ * Build an all-additions diff for a file git will not diff at all.
+ *
+ * An untracked file is absent from `git diff` output, so slicing gives nothing
+ * and the panel would say "no difference" for the single most common case there
+ * is — a file you just created. Its whole content *is* the change, so render it
+ * as one added hunk rather than showing the reader an empty panel.
+ */
+export function untrackedDiffLines(path: string, contents: string): DiffLine[] {
+  const body = contents.endsWith("\n") ? contents.slice(0, -1) : contents;
+  const rows = body === "" ? [] : body.split("\n");
+  return [
+    { kind: "meta", text: `diff --git a/${path} b/${path}` },
+    { kind: "meta", text: "new file" },
+    { kind: "hunk", text: `@@ -0,0 +1,${rows.length} @@` },
+    ...rows.map((text): DiffLine => ({ kind: "add", text: `+${text}` })),
+  ];
+}

--- a/src/modules/git-graph/lib/uncommittedDiff.ts
+++ b/src/modules/git-graph/lib/uncommittedDiff.ts
@@ -1,56 +1,108 @@
-import { diffHeaderPath } from "@/lib/gitPath";
+import { diffHeaderPath, stripGitPathSide } from "@/lib/gitPath";
 import type { DiffLine } from "../types";
 
 /**
- * Pull one file's section out of a multi-file unified diff.
+ * A trailing \r is tolerated throughout. git terminates its own header lines
+ * with \n, so this should not arise from `git_diff` — but a header that misses
+ * by one invisible byte yields nothing, and nothing is indistinguishable from
+ * "this file genuinely has no changes on this side". Not worth leaving a
+ * silently empty panel to that.
+ */
+const withoutCr = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line);
+
+/**
+ * The path one section belongs to, read the way the rest of the app reads it.
+ *
+ * The `diff --git a/x b/x` header is only provisional: its two halves are
+ * separated by " b/" and a path may contain that. The file's own `+++ b/` line
+ * is unambiguous, so prefer it, and fall back to the a-side for a deleted file
+ * (whose new side is /dev/null) — which is the name `git status` uses too.
+ *
+ * Only the lines before the first hunk are read, so a `+++` inside a hunk body
+ * cannot be mistaken for the header. A binary file has neither and keeps the
+ * header's answer.
+ */
+function sectionPath(lines: readonly string[], start: number, end: number): string | null {
+  let fromOldSide: string | null = null;
+  for (let i = start + 1; i < end; i++) {
+    const line = withoutCr(lines[i]);
+    if (line.startsWith("@@ ")) {
+      break;
+    }
+    if (line.startsWith("+++ ")) {
+      const target = line.slice(4).trim();
+      if (target !== "/dev/null") {
+        return stripGitPathSide(target, "b/");
+      }
+      break;
+    }
+    if (line.startsWith("--- ")) {
+      const target = line.slice(4).trim();
+      if (target !== "/dev/null") {
+        fromOldSide = stripGitPathSide(target, "a/");
+      }
+    }
+  }
+  return fromOldSide ?? diffHeaderPath(withoutCr(lines[start]));
+}
+
+/**
+ * Cut a multi-file unified diff into one section per file, keyed by the path
+ * `git status` reports the file under.
  *
  * `git_diff` answers for a whole side of the working tree at once — there is no
  * per-file working-tree diff command, and the details panel renders parsed
  * unified-diff text rather than the two file contents the diff *tab* compares.
- * So the file is cut out here instead of asking git again per row.
+ * So the files are cut out here instead of asking git again per row.
+ *
+ * Splitting the whole answer at once, rather than scanning it again for each
+ * file the reader clicks, is what keeps a large repository cheap: the caller
+ * holds this map for as long as the status it came from is current.
+ */
+export function splitFileDiffs(diff: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  if (diff === "") {
+    return sections;
+  }
+  const lines = diff.split("\n");
+  const starts: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (withoutCr(lines[i]).startsWith("diff --git ")) {
+      starts.push(i);
+    }
+  }
+  for (let s = 0; s < starts.length; s++) {
+    const start = starts[s];
+    const end = s + 1 < starts.length ? starts[s + 1] : lines.length;
+    const path = sectionPath(lines, start, end);
+    // First section wins: a well-formed diff names each file once, and taking
+    // the first keeps this identical to reading the diff top to bottom.
+    if (path === null || path === "" || sections.has(path)) {
+      continue;
+    }
+    const section = lines.slice(start, end).join("\n");
+    if (section !== "") {
+      sections.set(path, `${section}\n`);
+    }
+  }
+  return sections;
+}
+
+/**
+ * One file's section out of a multi-file unified diff.
  *
  * Returns "" when the file has no section, which is the honest answer for a
  * path git reports as changed on the other side (staged vs unstaged) or for an
  * untracked file — `git diff` never mentions those. See `untrackedDiffLines`.
+ *
+ * Reading more than one file out of the same diff should go through
+ * `splitFileDiffs` and keep the map, rather than calling this once per file.
  */
 export function sliceFileDiff(diff: string, path: string): string {
   if (diff === "" || path === "") {
     return "";
   }
-  const lines = diff.split("\n");
-  // git writes the header as `diff --git a/<old> b/<new>`. Match on the b-side
-  // so a rename is found under the name the caller knows it by, and read that
-  // side through the same unquoting the rest of the app uses: `git_diff` shells
-  // out to git, which escapes a non-ASCII path under `core.quotePath`, while
-  // the caller's path came from libgit2 and is raw UTF-8. Comparing the two
-  // literally matches nothing for every CJK filename there is — and here
-  // nothing reads as "this file has no changes on this side".
-  //
-  // A trailing \r is tolerated. git terminates its own header lines with \n, so
-  // this should not arise from `git_diff` — but a header that misses by one
-  // invisible byte returns nothing, and nothing is indistinguishable from "this
-  // file genuinely has no changes on this side". Not worth leaving a silently
-  // empty panel to that.
-  const withoutCr = (line: string): string =>
-    line.endsWith("\r") ? line.slice(0, -1) : line;
-  const isHeaderFor = (line: string): boolean => {
-    const bare = withoutCr(line);
-    return bare.startsWith("diff --git ") && diffHeaderPath(bare) === path;
-  };
-
-  const start = lines.findIndex(isHeaderFor);
-  if (start === -1) {
-    return "";
-  }
-  let end = lines.length;
-  for (let i = start + 1; i < lines.length; i++) {
-    if (lines[i].startsWith("diff --git ")) {
-      end = i;
-      break;
-    }
-  }
-  const section = lines.slice(start, end).join("\n");
-  return section === "" ? "" : `${section}\n`;
+  return splitFileDiffs(diff).get(path) ?? "";
 }
 
 /**

--- a/src/modules/git-graph/lib/uncommittedDiff.ts
+++ b/src/modules/git-graph/lib/uncommittedDiff.ts
@@ -1,3 +1,4 @@
+import { diffHeaderPath } from "@/lib/gitPath";
 import type { DiffLine } from "../types";
 
 /**
@@ -17,10 +18,13 @@ export function sliceFileDiff(diff: string, path: string): string {
     return "";
   }
   const lines = diff.split("\n");
-  // git writes the header as `diff --git a/<old> b/<new>`, quoting the path
-  // when it holds characters that need escaping. Match on the b-side so a
-  // rename is found under the name the caller knows it by, and accept either
-  // the bare or the quoted form.
+  // git writes the header as `diff --git a/<old> b/<new>`. Match on the b-side
+  // so a rename is found under the name the caller knows it by, and read that
+  // side through the same unquoting the rest of the app uses: `git_diff` shells
+  // out to git, which escapes a non-ASCII path under `core.quotePath`, while
+  // the caller's path came from libgit2 and is raw UTF-8. Comparing the two
+  // literally matches nothing for every CJK filename there is — and here
+  // nothing reads as "this file has no changes on this side".
   //
   // A trailing \r is tolerated. git terminates its own header lines with \n, so
   // this should not arise from `git_diff` — but a header that misses by one
@@ -31,10 +35,7 @@ export function sliceFileDiff(diff: string, path: string): string {
     line.endsWith("\r") ? line.slice(0, -1) : line;
   const isHeaderFor = (line: string): boolean => {
     const bare = withoutCr(line);
-    return (
-      bare.startsWith("diff --git ") &&
-      (bare.endsWith(` b/${path}`) || bare.endsWith(` "b/${path}"`))
-    );
+    return bare.startsWith("diff --git ") && diffHeaderPath(bare) === path;
   };
 
   const start = lines.findIndex(isHeaderFor);

--- a/src/modules/git-graph/lib/uncommittedRow.test.ts
+++ b/src/modules/git-graph/lib/uncommittedRow.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { GitStatus } from "@/modules/source-control/lib/gitBridge";
+import { uncommittedRowSummary } from "./uncommittedRow";
+
+const clean: GitStatus = { branch: "main", staged: [], unstaged: [] };
+const dirty: GitStatus = {
+  branch: "main",
+  staged: [{ path: "a.ts", staged: true, status: "M" }],
+  unstaged: [
+    { path: "b.ts", staged: false, status: "M" },
+    { path: "new.ts", staged: false, status: "?" },
+  ],
+};
+
+describe("uncommittedRowSummary", () => {
+  it("counts both sides", () => {
+    expect(uncommittedRowSummary(dirty, true, true)).toEqual({ staged: 1, unstaged: 2 });
+  });
+
+  it("is nothing at all when the row is switched off", () => {
+    expect(uncommittedRowSummary(dirty, false, true)).toBeNull();
+    expect(uncommittedRowSummary(clean, false, false)).toBeNull();
+  });
+
+  it("keeps a zero row for a clean tree by default", () => {
+    // The quiet row is what stops the graph jumping a row on every commit.
+    expect(uncommittedRowSummary(clean, true, true)).toEqual({ staged: 0, unstaged: 0 });
+  });
+
+  it("drops the row on a clean tree when asked to", () => {
+    expect(uncommittedRowSummary(clean, true, false)).toBeNull();
+  });
+
+  it("still shows a dirty tree when clean rows are dropped", () => {
+    expect(uncommittedRowSummary(dirty, true, false)).toEqual({ staged: 1, unstaged: 2 });
+  });
+
+  it("treats a status that has not arrived as nothing to show, not as clean", () => {
+    // Otherwise the row would blink in and out on every reload while the
+    // keep-when-clean setting is off.
+    expect(uncommittedRowSummary(null, true, false)).toBeNull();
+    // With the default it stays put, counting zero until the status lands.
+    expect(uncommittedRowSummary(null, true, true)).toEqual({ staged: 0, unstaged: 0 });
+  });
+});

--- a/src/modules/git-graph/lib/uncommittedRow.ts
+++ b/src/modules/git-graph/lib/uncommittedRow.ts
@@ -1,0 +1,32 @@
+import type { GitStatus } from "@/modules/source-control/lib/gitBridge";
+import type { UncommittedSummary } from "../types";
+
+/**
+ * What the graph's top row should show, or `null` for no row at all.
+ *
+ * Two settings meet here. `showRow` is the feature itself. `keepWhenClean`
+ * decides what a clean tree looks like: kept, the row stays as a quiet line and
+ * the graph never moves; dropped, the row appears and disappears and the whole
+ * graph shifts a row every time you commit or touch a file — which is why
+ * keeping it is the default, and why anyone turning that off is choosing the
+ * movement deliberately.
+ *
+ * A status that has not arrived yet counts as "nothing to show" rather than as
+ * a clean tree, so the row does not blink into view and back out on every
+ * reload while `keepWhenClean` is off.
+ */
+export function uncommittedRowSummary(
+  status: GitStatus | null,
+  showRow: boolean,
+  keepWhenClean: boolean,
+): UncommittedSummary | null {
+  if (!showRow) {
+    return null;
+  }
+  const staged = status?.staged.length ?? 0;
+  const unstaged = status?.unstaged.length ?? 0;
+  if (!keepWhenClean && staged + unstaged === 0) {
+    return null;
+  }
+  return { staged, unstaged };
+}

--- a/src/modules/git-graph/types.ts
+++ b/src/modules/git-graph/types.ts
@@ -16,13 +16,30 @@ export interface CommitNode {
 }
 
 /**
- * What the Git Graph commit list currently has selected: one commit, or two
- * commits being compared. `from`/`to` are ordered older/newer by list
- * position, not by click order.
+ * What the Git Graph commit list currently has selected: one commit, two
+ * commits being compared, or the working tree. `from`/`to` are ordered
+ * older/newer by list position, not by click order.
+ *
+ * The working-tree variant carries nothing. It has no hash to identify it by,
+ * and giving it a payload (the head it sits on, its file counts) would freeze
+ * a copy that goes stale the moment the graph reloads. Everything the panel
+ * needs about the working tree arrives as props, freshly fetched; this stays a
+ * plain answer to "what is selected", which is also why it survives a reload
+ * that no longer finds any particular hash.
  */
 export type GraphSelection =
   | { mode: "single"; commit: CommitNode }
-  | { mode: "compare"; from: CommitNode; to: CommitNode };
+  | { mode: "compare"; from: CommitNode; to: CommitNode }
+  | { mode: "workspace" };
+
+/**
+ * How much is uncommitted, for the graph's top row. Counts only — the row shows
+ * "staged 3 · unstaged 4" and nothing that would need the paths themselves.
+ */
+export interface UncommittedSummary {
+  staged: number;
+  unstaged: number;
+}
 
 /** A page of graph commits plus whether more history exists past `commits`. */
 export interface GraphLog {

--- a/src/modules/settings/GitGraphSettingsSection.tsx
+++ b/src/modules/settings/GitGraphSettingsSection.tsx
@@ -16,6 +16,8 @@ export function GitGraphSettingsSection() {
   const setRefs = useSettingsStore((s) => s.setGitGraphRefs);
   const uncommittedRow = useSettingsStore((s) => s.gitGraphUncommittedRow);
   const setUncommittedRow = useSettingsStore((s) => s.setGitGraphUncommittedRow);
+  const whenClean = useSettingsStore((s) => s.gitGraphUncommittedWhenClean);
+  const setWhenClean = useSettingsStore((s) => s.setGitGraphUncommittedWhenClean);
 
   return (
     <section>
@@ -36,7 +38,25 @@ export function GitGraphSettingsSection() {
         />
         {t("gitGraph.uncommittedRowLabel")}
       </label>
-      <p className="mb-6 ml-6 text-xs text-fg-muted">{t("gitGraph.uncommittedRowHint")}</p>
+      <p className="mb-3 ml-6 text-xs text-fg-muted">{t("gitGraph.uncommittedRowHint")}</p>
+
+      <label
+        className={`mb-1 ml-6 flex items-center gap-2 text-sm ${
+          uncommittedRow ? "text-fg" : "text-fg-subtle"
+        }`}
+      >
+        <input
+          type="checkbox"
+          checked={whenClean}
+          disabled={!uncommittedRow}
+          onChange={(e) => setWhenClean(e.target.checked)}
+          className="h-4 w-4 accent-accent disabled:opacity-50"
+        />
+        {t("gitGraph.uncommittedWhenCleanLabel")}
+      </label>
+      <p className="mb-6 ml-12 text-xs text-fg-muted">
+        {t("gitGraph.uncommittedWhenCleanHint")}
+      </p>
 
       <label className="mb-1 block text-sm font-medium text-fg">{t("gitGraph.refsTitle")}</label>
       <p className="mb-2 text-xs text-fg-muted">{t("gitGraph.refsDescription")}</p>

--- a/src/modules/settings/GitGraphSettingsSection.tsx
+++ b/src/modules/settings/GitGraphSettingsSection.tsx
@@ -14,12 +14,29 @@ export function GitGraphSettingsSection() {
   const { t } = useTranslation("settings");
   const refs = useSettingsStore((s) => s.gitGraphRefs);
   const setRefs = useSettingsStore((s) => s.setGitGraphRefs);
+  const uncommittedRow = useSettingsStore((s) => s.gitGraphUncommittedRow);
+  const setUncommittedRow = useSettingsStore((s) => s.setGitGraphUncommittedRow);
 
   return (
     <section>
       <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-fg-subtle">
         {t("sections.gitGraph")}
       </h2>
+
+      <label className="mb-1 block text-sm font-medium text-fg">
+        {t("gitGraph.uncommittedTitle")}
+      </label>
+      <p className="mb-2 text-xs text-fg-muted">{t("gitGraph.uncommittedDescription")}</p>
+      <label className="mb-1 flex items-center gap-2 text-sm text-fg">
+        <input
+          type="checkbox"
+          checked={uncommittedRow}
+          onChange={(e) => setUncommittedRow(e.target.checked)}
+          className="h-4 w-4 accent-accent"
+        />
+        {t("gitGraph.uncommittedRowLabel")}
+      </label>
+      <p className="mb-6 ml-6 text-xs text-fg-muted">{t("gitGraph.uncommittedRowHint")}</p>
 
       <label className="mb-1 block text-sm font-medium text-fg">{t("gitGraph.refsTitle")}</label>
       <p className="mb-2 text-xs text-fg-muted">{t("gitGraph.refsDescription")}</p>

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -88,6 +88,12 @@ interface SettingsState {
   workspaceCard: WorkspaceCardBlocks;
   /** How the Git Graph condenses a commit row's ref chips. */
   gitGraphRefs: GitGraphRefSettings;
+  /**
+   * Keep a row for the working tree above the newest commit in the Git Graph.
+   * Flat rather than folded into `gitGraphRefs`: that group is specifically the
+   * ref-chip condensing options, and this has nothing to do with chips.
+   */
+  gitGraphUncommittedRow: boolean;
   /** Where workspace cards source PR data. */
   prSource: WorkspacePrSource;
   /** Default flags appended to the `claude` command when launched from the launcher. */
@@ -157,6 +163,7 @@ interface SettingsState {
   setNotesFolderPath: (path: string | null) => void;
   setWorkspaceCardBlock: (key: keyof WorkspaceCardBlocks, value: boolean) => void;
   setGitGraphRefs: (patch: Partial<GitGraphRefSettings>) => void;
+  setGitGraphUncommittedRow: (value: boolean) => void;
   setPrSource: (source: WorkspacePrSource) => void;
   setClaudeFlags: (flags: string) => void;
   setCodexFlags: (flags: string) => void;
@@ -249,6 +256,7 @@ export const useSettingsStore = create<SettingsState>()(
       notesFolderPath: null,
       workspaceCard: DEFAULT_WORKSPACE_CARD,
       gitGraphRefs: DEFAULT_GIT_GRAPH_REFS,
+      gitGraphUncommittedRow: true,
       prSource: "auto",
       claudeFlags: "",
       codexFlags: "",
@@ -303,6 +311,7 @@ export const useSettingsStore = create<SettingsState>()(
         set((state) => ({
           gitGraphRefs: normalizeGitGraphRefs({ ...state.gitGraphRefs, ...patch }),
         })),
+      setGitGraphUncommittedRow: (value) => set({ gitGraphUncommittedRow: value }),
       setPrSource: (prSource) => set({ prSource }),
       setClaudeFlags: (claudeFlags) => set({ claudeFlags }),
       setCodexFlags: (codexFlags) => set({ codexFlags }),

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -94,6 +94,12 @@ interface SettingsState {
    * ref-chip condensing options, and this has nothing to do with chips.
    */
   gitGraphUncommittedRow: boolean;
+  /**
+   * Keep that row while the working tree is clean. Off, it only appears when
+   * something is uncommitted — which means the graph shifts a row every time
+   * you commit or touch a file, so this is on by default.
+   */
+  gitGraphUncommittedWhenClean: boolean;
   /** Where workspace cards source PR data. */
   prSource: WorkspacePrSource;
   /** Default flags appended to the `claude` command when launched from the launcher. */
@@ -164,6 +170,7 @@ interface SettingsState {
   setWorkspaceCardBlock: (key: keyof WorkspaceCardBlocks, value: boolean) => void;
   setGitGraphRefs: (patch: Partial<GitGraphRefSettings>) => void;
   setGitGraphUncommittedRow: (value: boolean) => void;
+  setGitGraphUncommittedWhenClean: (value: boolean) => void;
   setPrSource: (source: WorkspacePrSource) => void;
   setClaudeFlags: (flags: string) => void;
   setCodexFlags: (flags: string) => void;
@@ -257,6 +264,7 @@ export const useSettingsStore = create<SettingsState>()(
       workspaceCard: DEFAULT_WORKSPACE_CARD,
       gitGraphRefs: DEFAULT_GIT_GRAPH_REFS,
       gitGraphUncommittedRow: true,
+      gitGraphUncommittedWhenClean: true,
       prSource: "auto",
       claudeFlags: "",
       codexFlags: "",
@@ -312,6 +320,8 @@ export const useSettingsStore = create<SettingsState>()(
           gitGraphRefs: normalizeGitGraphRefs({ ...state.gitGraphRefs, ...patch }),
         })),
       setGitGraphUncommittedRow: (value) => set({ gitGraphUncommittedRow: value }),
+      setGitGraphUncommittedWhenClean: (value) =>
+        set({ gitGraphUncommittedWhenClean: value }),
       setPrSource: (prSource) => set({ prSource }),
       setClaudeFlags: (claudeFlags) => set({ claudeFlags }),
       setCodexFlags: (codexFlags) => set({ codexFlags }),


### PR DESCRIPTION
## Problem

The Git Graph gave no sign that anything was uncommitted. Its first row was always HEAD, so the state you are actually in — "HEAD plus the seven files I have not committed yet" — was the one thing missing from the view whose whole job is showing where you are. Finding out meant leaving the tab for the Source Control sidebar.

Closes #399.

## Changes

**A working-tree row above the newest commit.** Its node is hollow with a dashed ring, so it reads as neither of the filled kinds (HEAD's glowing accent, a commit's lane colour), and the segment down to HEAD is dashed and in the accent — "not history yet". The row is drawn on every reload and switches between a loud and a quiet form on what `git_status` reports, rather than appearing and disappearing: dropping it whenever the tree went clean would shift the graph up a row at the exact moment you commit, and back down when you touch a file, under the pointer every time. A permanent row costs one row of height instead.

Room is made by starting the commits one row lower. Every y the graph draws — nodes, rows, edge endpoints, the keyboard's scroll-into-view — comes out of `computeGraphLayout`, so moving its origin moves all of them together, and the row itself stays outside the lane and colour bookkeeping. Only the total height and the virtualization window take the offset by hand.

**HEAD holds the leftmost lane.** Lane 0 used to go to whichever commit happened to be newest, which with all branches shown is often a branch you are not on: the line you most want to follow got pushed right while someone else's newer work ran down the left edge. Reserving HEAD's lane before the walk is also what lets the dashed segment be a straight, unobstructed line rather than something buried under a branch that merely happens to be newer. Only when HEAD is on the page — seeding a hash that never arrives would leave an empty column the height of the graph, and a branch filter can hide HEAD entirely. Callers that name no head (the sidebar's compact history graph) keep the previous lanes exactly.

**A working-tree details panel.** Selecting the row splits the files into staged and unstaged, keeps the folder/flat toggle, replaces the author/date block with a title and the commit the changes sit on, and drops the AI tab, there being no commit to explain. Its file list and the row's counts come from one fetch, so they cannot disagree. There is no per-file working-tree diff command, so one file's diff is cut out of `git_diff`'s whole-side answer rather than asking git again per row — matching on the b-side of the `diff --git` header, quoted or not, since that is the name a rename is listed under. Untracked files need the other half: `git diff` never mentions them, so their whole content becomes one added hunk, otherwise the panel would report "no difference" for the single most common case there is.

**`GraphSelection` gains a `workspace` variant carrying nothing.** The working tree has no hash, and a sentinel one would have leaked into the lane layout, the ref chips and the commit filter, each needing to know it was fake. Nothing is also a payload that cannot go stale, so the selection survives a reload.

**Keyboard.** Plain arrows step onto the row from the newest commit and back down off it. Shift follows the drawn line: `Shift+Down` from the row goes to HEAD, where plain `Down` goes to the newest commit — the same row until another branch has newer commits, and different ones the moment it does. `Shift+Up` reaches the row only when no commit continues HEAD's lane, and the check runs after a real continuation rather than instead of one, so it cannot swallow a case with somewhere else to go.

**Its own context menu**, two items for now (open Source Control, refresh). There is no hash to copy and nothing to check out; the remaining items each need a capability that does not exist yet — a batch stage with a failure policy, a stash *push*, a discard command plus a decision about untracked files.

**Two settings**, both on by default. `gitGraphUncommittedRow` off restores the previous first row exactly. `gitGraphUncommittedWhenClean`, nested under it and disabled with it, drops the row on a clean tree for anyone who would rather not pay a row of height for a line that says "nothing here" — the movement described above is why the default is the other way. The decision is one function with three inputs rather than a condition in the tab, with a boundary worth naming: a status that has not arrived yet counts as nothing to show, not as a clean tree, so the row does not blink in and out on every reload while this is off.

## Test plan

- [x] `npx pnpm exec tsc --noEmit`
- [x] `npx pnpm exec vitest run` — 238 files, 2216 tests, all passing
- [x] Every `t("…")` literal in the touched components resolved against `src/i18n/locales/en` (109 keys, 0 missing) — component tests mock `t` as identity, so a missing key is invisible to the suite
- [x] Manual: staged, unstaged, untracked and clean states; both settings on and off in all four combinations; arrow and Shift+arrow navigation onto and off the row; the row's context menu; a repo where another branch is newer than HEAD, to confirm HEAD keeps lane 0 and the dashed segment stays straight

🤖 Generated with [Claude Code](https://claude.com/claude-code)
