### PR TITLE
fix(git-graph): tell two lanes apart by lane, not by the column they collapsed onto

### DIFF
--- a/src/modules/git-graph/lib/graphLayout.test.ts
+++ b/src/modules/git-graph/lib/graphLayout.test.ts
@@ -191,6 +191,7 @@ describe("edgePath", () => {
       px: 20,
       py: 56,
       lane: 0,
+      parentLane: 0,
       childIndex: 0,
       parentIndex: 1,
       colorIndex: 0,
@@ -205,6 +206,7 @@ describe("edgePath", () => {
       px: 34,
       py: 92,
       lane: 0,
+      parentLane: 1,
       childIndex: 0,
       parentIndex: 2,
       colorIndex: 0,
@@ -212,6 +214,24 @@ describe("edgePath", () => {
     const path = edgePath(edge, 36);
     expect(path.startsWith("M 20 20 C")).toBe(true);
     expect(path).toContain("L 34 92");
+  });
+
+  it("bends between two lanes that laneX collapsed onto the same column", () => {
+    // Clamped, lanes 6 and 7 share an x — deciding on x would skip the bend.
+    const x = laneX(6, DEFAULT_GEOMETRY);
+    expect(x).toBe(laneX(7, DEFAULT_GEOMETRY));
+    const edge: GraphEdge = {
+      cx: x,
+      cy: 20,
+      px: x,
+      py: 92,
+      lane: 6,
+      parentLane: 7,
+      childIndex: 0,
+      parentIndex: 2,
+      colorIndex: 0,
+    };
+    expect(edgePath(edge, 36)).toContain("C");
   });
 
   it("keeps a branch tail in its own lane and bends into the trunk only at the parent", () => {
@@ -222,6 +242,7 @@ describe("edgePath", () => {
       px: 20,
       py: 92,
       lane: 1,
+      parentLane: 0,
       childIndex: 0,
       parentIndex: 2,
       colorIndex: 1,
@@ -282,5 +303,36 @@ describe("laneContinuationRowIndex", () => {
     const commits = [commit("m", ["a", "b"]), commit("b", ["a"]), commit("a", [])];
     const { edges } = computeGraphLayout(commits);
     expect(laneContinuationRowIndex(edges, 2)).toBe(0); // a -> m, straight
+  });
+
+  it("skips a bend between two lanes that laneX collapsed onto one column", () => {
+    // Row 0 bends in from lane 7, row 1 continues lane 6 straight. All three
+    // share an x, so picking by x returns row 0 — it comes first.
+    const x = laneX(6, DEFAULT_GEOMETRY);
+    const edges: GraphEdge[] = [
+      {
+        cx: x,
+        cy: 20,
+        px: x,
+        py: 92,
+        lane: 7,
+        parentLane: 6,
+        childIndex: 0,
+        parentIndex: 2,
+        colorIndex: 1,
+      },
+      {
+        cx: x,
+        cy: 56,
+        px: x,
+        py: 92,
+        lane: 6,
+        parentLane: 6,
+        childIndex: 1,
+        parentIndex: 2,
+        colorIndex: 0,
+      },
+    ];
+    expect(laneContinuationRowIndex(edges, 2)).toBe(1);
   });
 });

--- a/src/modules/git-graph/lib/graphLayout.ts
+++ b/src/modules/git-graph/lib/graphLayout.ts
@@ -45,7 +45,12 @@ export interface GraphEdge {
   cy: number;
   px: number;
   py: number;
+  /**
+   * Both ends' lanes. `cx === px` cannot stand in for `lane === parentLane`:
+   * `laneX` collapses every lane past `maxLane` onto one column.
+   */
   lane: number;
+  parentLane: number;
   childIndex: number;
   parentIndex: number;
   /** Branch colour id of the line (the branch side of a merge/branch bend). */
@@ -201,6 +206,7 @@ export function computeGraphLayout(
         px: parent.x,
         py: parent.y,
         lane: child.lane,
+        parentLane: parent.lane,
         childIndex: index,
         parentIndex: parent.index,
         colorIndex,
@@ -246,14 +252,16 @@ export function laneContinuationRowIndex(
   edges: readonly GraphEdge[],
   index: number,
 ): number | null {
-  const edge = edges.find((e) => e.parentIndex === index && e.cx === e.px);
+  const edge = edges.find(
+    (e) => e.parentIndex === index && e.lane === e.parentLane,
+  );
   return edge ? edge.childIndex : null;
 }
 
 /** SVG path data for one edge: a straight track, or a bend into the parent lane. */
 export function edgePath(edge: GraphEdge, rowHeight: number): string {
   const { cx, cy, px, py } = edge;
-  if (px === cx) {
+  if (edge.lane === edge.parentLane) {
     return `M ${cx} ${cy} L ${px} ${py}`;
   }
   const bend = Math.min(rowHeight, py - cy);


### PR DESCRIPTION
## Problem

`GraphEdge` carries only pixel coordinates, and two places ask "are both ends
in the same lane?" by comparing them:

```ts
// edgePath
if (px === cx) { return `M ${cx} ${cy} L ${px} ${py}`; }

// laneContinuationRowIndex
const edge = edges.find((e) => e.parentIndex === index && e.cx === e.px);
```

`laneX` clamps every lane past `maxLane` (5) onto one column, so lanes 5, 6,
7 and 8 all resolve to x = 98. The comparison answers yes for a line that
crosses between two of them:

- `edgePath` draws the crossing as a straight track rather than a bend, so
  the line runs down a lane that is not its own, in its own branch colour.
- `laneContinuationRowIndex` reports the crossing as the lane's straight
  continuation, and it is found before the real one — so `Shift+Up` follows
  the line onto a commit from another branch.

## Root cause

The edge knows where its ends were drawn, not which lanes they belong to,
and `laneX` is not injective past `maxLane`.

## Changes

- `GraphEdge` carries `parentLane` alongside `lane`; `computeGraphLayout`
  fills it from the parent layout it has already resolved.
- `edgePath` and `laneContinuationRowIndex` compare lanes instead of x.

No change to `laneX` — collapsing wide lanes onto the last column is
deliberate, and widening the gutter is #418. This only stops the collapsed
coordinate being read back as a lane identity.

## Not visible yet, but not by much

Laid out over the ref set the graph actually walks (`build_log_refs()` —
`--branches --remotes --tags`), this repo reaches lane index 7 while only six
columns exist: **44 commit nodes are drawn at x = 98**, which lanes 5, 6 and 7
share. None of the edges between those lanes bends today, which is the only
reason the two comparisons still agree with the lanes they stand in for.

#407 hit the same collapse from the other side, where four stashes were
enough to draw a parent/child line between two siblings.

## Test plan

- [x] `npx pnpm exec tsc --noEmit` — clean
- [x] `npx pnpm exec vitest run` — 2172 passed. One unrelated flake in
      `PortsPanelView.test.tsx` (a `waitFor` timeout under full-suite load);
      passes on its own.
- [x] Two new cases in `graphLayout.test.ts`, both verified to fail with the
      old `cx === px` comparisons restored and the other 23 still passing:
      `edgePath` bends between two collapsed lanes, and
      `laneContinuationRowIndex` skips the collapsed bend for the real
      continuation.
- [x] `git merge-tree upstream/master` and `git merge-tree` against #415's
      branch — both clean.

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
