### PR TITLE
fix(preview): load Windows drive paths in built-in preview

### DIFF
--- a/CHANGELOG-NEXT.md
+++ b/CHANGELOG-NEXT.md
@@ -1,5 +1,7 @@
 ## 正體中文
+- fix(preview): 修正 Windows 磁碟路徑無法載入內建預覽
 - fix(git-graph): 搜尋提交時保留完整線圖，並可逐筆導覽符合結果
 
 ## English
+- fix(preview): load Windows drive paths in the built-in preview
 - fix(git-graph): keep full graph context while navigating commit search matches

--- a/src/lib/windowsPath.test.ts
+++ b/src/lib/windowsPath.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { normalizeWindowsDrivePath } from "./windowsPath";
+
+describe("normalizeWindowsDrivePath", () => {
+  it("converts a native drive path to forward slashes", () => {
+    expect(normalizeWindowsDrivePath("C:\\Users\\me\\site\\index.html")).toBe(
+      "C:/Users/me/site/index.html",
+    );
+  });
+
+  it("removes the leading slash from a file URL drive path", () => {
+    expect(normalizeWindowsDrivePath("/C:/Users/me/site/index.html")).toBe(
+      "C:/Users/me/site/index.html",
+    );
+  });
+
+  it("returns null for paths without an absolute drive letter", () => {
+    expect(normalizeWindowsDrivePath("relative\\file.html")).toBeNull();
+    expect(normalizeWindowsDrivePath("/Users/me/file.html")).toBeNull();
+  });
+});

--- a/src/lib/windowsPath.ts
+++ b/src/lib/windowsPath.ts
@@ -1,0 +1,5 @@
+/** Normalize an absolute Windows drive path, or return null for other paths. */
+export function normalizeWindowsDrivePath(path: string): string | null {
+  const normalized = path.replace(/\\/g, "/").replace(/^\/(?=[a-zA-Z]:\/)/, "");
+  return /^[a-zA-Z]:\//.test(normalized) ? normalized : null;
+}

--- a/src/modules/explorer/lib/dragEntry.test.ts
+++ b/src/modules/explorer/lib/dragEntry.test.ts
@@ -45,6 +45,12 @@ describe("fileUrl", () => {
   it("prefixes file://", () => {
     expect(fileUrl("/x/index.html")).toBe("file:///x/index.html");
   });
+
+  it("normalizes a Windows drive path into a standard file URL", () => {
+    expect(fileUrl("C:\\Users\\me\\site\\index.html", true)).toBe(
+      "file:///C:/Users/me/site/index.html",
+    );
+  });
 });
 
 describe("getDraggedEntry / setDraggedEntry", () => {

--- a/src/modules/explorer/lib/dragEntry.ts
+++ b/src/modules/explorer/lib/dragEntry.ts
@@ -7,6 +7,8 @@
  */
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { create } from "zustand";
+import { IS_WINDOWS } from "@/lib/platform";
+import { normalizeWindowsDrivePath } from "@/lib/windowsPath";
 import { useTabsStore } from "@/stores/tabsStore";
 import { nearestTabInsertion, tabRectsInTabBar } from "@/components/lib/tabBarDrop";
 
@@ -259,7 +261,13 @@ export function markdownLink(name: string, path: string): string {
   return `[${name}](${path})`;
 }
 
-/** A file:// URL for showing a dropped file in the web preview. */
-export function fileUrl(path: string): string {
+/** A file:// URL for showing a local file in the web preview. */
+export function fileUrl(path: string, isWindows: boolean = IS_WINDOWS): string {
+  if (isWindows) {
+    const drivePath = normalizeWindowsDrivePath(path);
+    if (drivePath) {
+      return `file:///${drivePath}`;
+    }
+  }
   return `file://${path}`;
 }

--- a/src/modules/preview/lib/resolvePreviewSrc.test.ts
+++ b/src/modules/preview/lib/resolvePreviewSrc.test.ts
@@ -15,6 +15,24 @@ describe("resolvePreviewSrc", () => {
     expect(resolvePreviewSrc("file:///x/index.html")).toBe(assetUrl("/x/index.html"));
   });
 
+  it("routes Windows drive URLs through the Windows asset host", () => {
+    expect(resolvePreviewSrc("file:///C:/Users/me/site/index.html", true)).toBe(
+      "http://asset.localhost/C%3A/Users/me/site/index.html",
+    );
+  });
+
+  it("normalizes legacy Windows file URLs with backslashes", () => {
+    expect(resolvePreviewSrc("file://C:\\Users\\me\\site\\index.html", true)).toBe(
+      "http://asset.localhost/C%3A/Users/me/site/index.html",
+    );
+  });
+
+  it("routes bare Windows drive paths through the Windows asset host", () => {
+    expect(resolvePreviewSrc("C:\\Users\\me\\site\\index.html", true)).toBe(
+      "http://asset.localhost/C%3A/Users/me/site/index.html",
+    );
+  });
+
   it("routes a bare absolute path through the asset protocol", () => {
     expect(resolvePreviewSrc("/Users/me/page.html")).toBe(assetUrl("/Users/me/page.html"));
   });

--- a/src/modules/preview/lib/resolvePreviewSrc.ts
+++ b/src/modules/preview/lib/resolvePreviewSrc.ts
@@ -1,7 +1,11 @@
+import { IS_WINDOWS } from "@/lib/platform";
+import { normalizeWindowsDrivePath } from "@/lib/windowsPath";
+
 // The webview loads local files through Tauri's asset protocol. On macOS/Linux
-// that scheme is `asset://localhost/<path>` (Windows/Android use
-// `http://asset.localhost/`, which this macOS app never hits).
+// that scheme is `asset://localhost/<path>`; on Windows it is
+// `http://asset.localhost/<path>`.
 const ASSET_ORIGIN = "asset://localhost";
+const WINDOWS_ASSET_ORIGIN = "http://asset.localhost";
 
 function fileUrlToPath(url: string): string {
   const withoutScheme = url.replace(/^file:\/\//i, "");
@@ -33,18 +37,32 @@ function toAssetUrl(path: string): string {
   return `${ASSET_ORIGIN}/%2F${segments.join("/")}`;
 }
 
+function toWindowsAssetUrl(path: string): string {
+  const segments = path.split("/").filter((seg) => seg !== "").map(encodeURIComponent);
+  return `${WINDOWS_ASSET_ORIGIN}/${segments.join("/")}`;
+}
+
 /**
  * Turn whatever lands in the preview's address bar (a typed path, a typed URL,
  * or a dropped file's `file://` url) into a src the WebView's iframe can load.
  *
- * WKWebView refuses to load raw `file://` from the app's own (custom-scheme)
- * origin, so local paths must go through the asset protocol. Real web URLs and
- * already-converted asset URLs pass through untouched.
+ * The app's webview loads local files through Tauri's asset protocol rather
+ * than navigating raw `file://` URLs. Real web URLs and already-converted
+ * asset URLs pass through untouched.
  */
-export function resolvePreviewSrc(input: string): string {
+export function resolvePreviewSrc(input: string, isWindows: boolean = IS_WINDOWS): string {
   const value = input.trim();
   if (value.startsWith("file://")) {
-    return toAssetUrl(fileUrlToPath(value));
+    const path = fileUrlToPath(value);
+    const windowsPath = isWindows ? normalizeWindowsDrivePath(path) : null;
+    if (windowsPath) {
+      return toWindowsAssetUrl(windowsPath);
+    }
+    return toAssetUrl(path);
+  }
+  const windowsPath = isWindows ? normalizeWindowsDrivePath(value) : null;
+  if (windowsPath) {
+    return toWindowsAssetUrl(windowsPath);
   }
   if (value.startsWith("/")) {
     return toAssetUrl(value);


### PR DESCRIPTION
## Summary
- Normalize Windows drive paths into standard file URLs and forward-slash paths.
- Resolve Windows preview files through the Tauri asset host at http://asset.localhost, preserving path segments for relative assets.
- Keep the Rust preview scheme allowlist unchanged; Windows path behavior is parameterized and covered on macOS.

Closes #353

## Verification
- pnpm typecheck
- pnpm exec vitest run src/lib/windowsPath.test.ts src/modules/explorer src/modules/preview (190 tests)
- Code review: spec and Windows/Tauri standards pass.